### PR TITLE
Ensure DLC graph I/O name same as ONNX for QDQ models

### DIFF
--- a/onnxruntime/core/providers/qnn-abi/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/opbuilder/simple_op_builder.cc
@@ -86,9 +86,12 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_chan_quant, quant_axis));
     RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone DQ op with per-channel quantization");
 
-    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization) {
-      RETURN_IF(qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name),
-                "QNN EP is configured to not take DQ nodes that generate a graph output.");
+    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
+        qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name)) {
+      // Map internal (quantized) tensor name to original name in ONNX
+      qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
+                                              /*external=*/node_unit.Outputs()[0].name);
+      return MAKE_EP_FAIL("QNN EP is configured to not take DQ nodes that generate a graph output.");
     }
   }
 
@@ -98,9 +101,12 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Outputs()[0], is_per_chan_quant, quant_axis));
     RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone Q op with per-channel quantization");
 
-    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization) {
-      RETURN_IF(qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name),
-                "QNN EP is configured to not take Q nodes that consume a graph input.");
+    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
+        qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
+      // Map internal (quantized) tensor name to original name in ONNX
+      qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
+                                              /*external=*/node_unit.Inputs()[0].name);
+      return MAKE_EP_FAIL("QNN EP is configured to not take Q nodes that consume a graph input.");
     }
   }
 

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_def.h
@@ -296,6 +296,18 @@ class QnnTensorWrapper {
 
   const std::string& GetName() const { return tensor_name_; }
 
+  const std::string& GetResolvedTensorName() const {
+    return tensor_name_override_.empty() ? tensor_name_ : tensor_name_override_;
+  }
+
+  void SetResolvedTensorName(const std::string& resolved_name) {
+    if (resolved_name.empty() || tensor_name_override_ == resolved_name) {
+      return;
+    }
+    tensor_name_override_ = resolved_name;
+    SetQnnTensorName(qnn_tensor_, tensor_name_override_.c_str());
+  }
+
   Qnn_TensorType_t GetTensorType() const { return GetQnnTensorType(qnn_tensor_); }
   Qnn_DataType_t GetTensorDataType() const { return GetQnnTensorDataType(qnn_tensor_); }
   uint32_t GetTensorRank() const { return static_cast<uint32_t>(dimensions_.size()); }
@@ -306,24 +318,26 @@ class QnnTensorWrapper {
                             const std::string& node_name,
                             std::unordered_map<std::string, bool>& tensors_created_table,
                             std::string& error_msg) {
-    return CreateTensorInQnnGraph(qnn_interface, graph, node_name, tensor_name_,
+    return CreateTensorInQnnGraph(qnn_interface, graph, node_name, GetResolvedTensorName(),
                                   qnn_tensor_, tensors_created_table, error_msg);
   }
 
  private:
   void SwapOther(QnnTensorWrapper&& other) noexcept {
     std::swap(tensor_name_, other.tensor_name_);
+    std::swap(tensor_name_override_, other.tensor_name_override_);
     std::swap(dimensions_, other.dimensions_);
     std::swap(client_buf_, other.client_buf_);
     std::swap(quant_params_, other.quant_params_);
     std::swap(qnn_tensor_, other.qnn_tensor_);
-    SetQnnTensorName(qnn_tensor_, tensor_name_.c_str());
+    SetQnnTensorName(qnn_tensor_, GetResolvedTensorName().c_str());
     SetQnnTensorDim(qnn_tensor_, dimensions_);
     SetQnnTensorClientBuf(qnn_tensor_, client_buf_);
     SetQnnTensorQParams(qnn_tensor_, quant_params_.Get());
   }
 
-  std::string tensor_name_;
+  std::string tensor_name_;           // The tensor's actual name used inside QNN graph
+  std::string tensor_name_override_;  // Optional override to original ONNX tensor name
   std::vector<uint32_t> dimensions_;
   std::vector<uint8_t> client_buf_;
   Qnn_Tensor_t qnn_tensor_ = QNN_TENSOR_INIT;

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model.cc
@@ -120,6 +120,7 @@ Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
                                    const OrtNode& fused_node,
                                    const qnn::ModelSettings& model_settings,
                                    const Ort::Logger& logger,
+                                   std::unordered_map<std::string, std::string>* tensor_name_overrides,
                                    const QnnGraph_Config_t** graph_configs,
                                    const std::string& json_qnn_graph_path) {
   ORT_CXX_LOG(logger,
@@ -143,7 +144,8 @@ Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
                                                       model_input_index_map_,
                                                       model_output_index_map_,
                                                       qnn_backend_manager_->GetQnnBackendType(),
-                                                      model_settings);
+                                                      model_settings,
+                                                      tensor_name_overrides);
 
   qnn::profile::ProfilingInfo profiling_info;
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model.h
@@ -37,6 +37,7 @@ class QnnModel {
                            const OrtNode& fused_node,
                            const qnn::ModelSettings& model_settings,
                            const Ort::Logger& logger,
+                           std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr,
                            const QnnGraph_Config_t** graph_configs = nullptr,
                            const std::string& json_qnn_graph_path = "");
 

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.cc
@@ -57,6 +57,22 @@ bool QnnModelWrapper::QnnParamExists(const std::string& param_tensor_name) const
   return model_params_map_.find(param_tensor_name) != model_params_map_.end();
 }
 
+void QnnModelWrapper::SetTensorNameOverride(const std::string& internal,
+                                            const std::string& original) const {
+  if (tensor_name_overrides_ != nullptr && !internal.empty() && !original.empty() &&
+      tensor_name_overrides_->find(internal) == tensor_name_overrides_->end()) {
+    tensor_name_overrides_->emplace(internal, original);
+  }
+}
+
+const std::string* QnnModelWrapper::GetTensorNameOverride(const std::string& internal) const {
+  if (tensor_name_overrides_ == nullptr) {
+    return nullptr;
+  }
+  auto it = tensor_name_overrides_->find(internal);
+  return it != tensor_name_overrides_->end() ? &it->second : nullptr;
+}
+
 Ort::Status QnnModelWrapper::MakeTensorWrapper(const OrtNodeUnitIODef& tensor, QnnTensorWrapper& tensor_wrapper) const {
   const std::string& tensor_name = tensor.name;
 
@@ -165,6 +181,11 @@ bool QnnModelWrapper::CreateQnnInputOutputTensors(const std::string& qnn_node_na
     // During graph partitioning, we only need to do op validation, it's not required to create Qnn graph tensor
     // We only need to create the Qnn graph tensor during Compile to create Qnn graph
     if (!do_op_validation) {
+      if (const std::string* name = model_settings_.offload_graph_io_quantization
+                                        ? GetTensorNameOverride(tensor_name)
+                                        : nullptr) {
+        it->second.SetResolvedTensorName(*name);
+      }
       std::string error_string;
       auto rt = it->second.CreateQnnGraphTensor(qnn_interface_, graph_, qnn_node_name, tensor_created_map_, error_string);
       if (!rt) {
@@ -877,6 +898,12 @@ void QnnModelWrapper::GetGraphInputOutputTensorWrapper(const std::vector<std::st
     if (it == model_tensors_map_.end()) {
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Model input or output name not exist: " + tensor_name + ". Could cause execution error.").c_str());
       break;
+    }
+
+    if (const std::string* name = model_settings_.offload_graph_io_quantization
+                                      ? GetTensorNameOverride(tensor_name)
+                                      : nullptr) {
+      it->second.SetResolvedTensorName(*name);
     }
     // It's safe to move QnnTensorWrapper out of model_tensors_map_
     // since this call happens when QnnModelWrapper end of live

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.h
@@ -50,7 +50,8 @@ class QnnModelWrapper {
                   const std::unordered_map<std::string, size_t>& input_index_map,
                   const std::unordered_map<std::string, size_t>& output_index_map,
                   QnnBackendType qnn_backend_type,
-                  const ModelSettings& model_settings)
+                  const ModelSettings& model_settings,
+                  std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr)
       : ort_graph_(ort_graph),
         logger_(logger),
         qnn_interface_(qnn_interface),
@@ -59,7 +60,8 @@ class QnnModelWrapper {
         output_index_map_(output_index_map),
         qnn_backend_type_(qnn_backend_type),
         model_settings_(model_settings),
-        api_ptrs_(ApiPtrs{api_ptrs.ort_api, api_ptrs.ep_api, api_ptrs.model_editor_api}) {
+        api_ptrs_(ApiPtrs{api_ptrs.ort_api, api_ptrs.ep_api, api_ptrs.model_editor_api}),
+        tensor_name_overrides_(tensor_name_overrides) {
   }
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QnnModelWrapper);
 
@@ -373,6 +375,9 @@ class QnnModelWrapper {
                                     /*out*/ bool& is_per_channel,
                                     /*out*/ int64_t& axis) const;
 
+  // Maps internal QNN tensor name to original ONNX name. Used by offload_graph_io_quantization.
+  void SetTensorNameOverride(const std::string& internal, const std::string& original) const;
+
  private:
   bool CreateQnnInputOutputTensors(const std::string& qnn_node_name,
                                    const std::vector<std::string>& names,
@@ -427,6 +432,8 @@ class QnnModelWrapper {
 
   bool ProcessBF16Conversions(std::vector<QnnOpProperty>& final_ops);
 
+  const std::string* GetTensorNameOverride(const std::string& internal) const;
+
   const OrtGraph& ort_graph_;
   const Ort::Logger& logger_;
   const QNN_INTERFACE_VER_TYPE& qnn_interface_;
@@ -454,6 +461,8 @@ class QnnModelWrapper {
   ModelSettings model_settings_ = {};
   utils::QnnJSONGraph json_qnn_graph_;
   const ApiPtrs api_ptrs_;
+
+  std::unordered_map<std::string, std::string>* tensor_name_overrides_ = nullptr;
 };  // QnnModelWrapper
 
 template <typename T>

--- a/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.cc
@@ -1017,7 +1017,8 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
                                                 model_input_index_map,
                                                 model_output_index_map,
                                                 qnn_backend_manager_->GetQnnBackendType(),
-                                                model_settings_);
+                                                model_settings_,
+                                                &tensor_name_overrides_);
 
   std::vector<std::unique_ptr<qnn::IQnnNodeGroup>> qnn_node_groups;
   qnn_node_groups.reserve(node_unit_size);
@@ -1715,6 +1716,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
                                              *fused_node,
                                              ep->model_settings_,
                                              ep->logger_,
+                                             &ep->tensor_name_overrides_,
                                              all_graph_configs_ptr,
                                              json_graph_filepath));
     RETURN_IF_NOT_OK(qnn_model->FinalizeGraphs(ep->logger_));

--- a/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.h
@@ -188,6 +188,9 @@ class QnnEp : public OrtEp, public ApiPtrs {
   qnn::QnnCompatibilityInfo compatibility_info_;
   // Format: <BackendId>:<SDK>:<BackendApi>:<ContextBlob>:<HtpArch>:<IsHtpUsrDrv>.
   std::string compatibility_info_string_ = "";
+
+  // Used by offload_graph_io_quantization to map internal QNN names to original ONNX names.
+  mutable std::unordered_map<std::string, std::string> tensor_name_overrides_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn-abi/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn-abi/qnn_basic_test.cc
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <thread>
+
+#include "nlohmann/json.hpp"
 
 #include "core/graph/constants.h"
 #include "core/graph/node_attr_utils.h"
@@ -1403,6 +1406,110 @@ TEST_F(QnnABIHTPBackendTests, EPOffloadsGraphIOQuantDequant) {
                                        &graph_checker);
     }
   }
+}
+
+// Test that DLC I/O tensor names match original ONNX names when offload_graph_io_quantization=1.
+TEST_F(QnnABIHTPBackendTests, OffloadGraphIoQuantizationTensorNameOverrides) {
+  ProviderOptions provider_options;
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnHtp.dll";
+#else
+  provider_options["backend_path"] = "libQnnHtp.so";
+#endif
+  provider_options["offload_graph_io_quantization"] = "1";
+
+  const std::filesystem::path dump_dir = "OffloadGraphIoQuantizationTensorNameOverrides";
+  provider_options["json_qnn_graph_dir"] = dump_dir.string();
+  provider_options["dump_json_qnn_graph"] = "1";
+
+  std::filesystem::remove_all(dump_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(dump_dir));
+
+  auto cleanup = gsl::finally([&dump_dir]() { std::filesystem::remove_all(dump_dir); });
+
+  // Build QDQ Sigmoid: x -> Q -> DQ -> Sigmoid -> Q -> DQ -> out
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 21}};
+  auto& logging_manager = DefaultLoggingManager();
+
+  onnxruntime::Model qdq_model("OffloadGraphIoQuantizationTensorNameOverrides",
+                               false,
+                               ModelMetaData(),
+                               PathString(),
+                               IOnnxRuntimeOpSchemaRegistryList(),
+                               domain_to_version,
+                               {},
+                               logging_manager.DefaultLogger());
+  ModelTestBuilder builder(qdq_model.MainGraph());
+
+  const std::string expected_input_name = "input";
+  const std::string expected_output_name = "output";
+
+  std::vector<int64_t> shape = {1, 2, 2, 2};
+  std::vector<float> data = GetFloatDataInRangeABI(0.0f, 1.0f, 8);
+  NodeArg* x = builder.MakeInput<float>(shape, data);
+
+  float scale = 1.0f / 255.0f;
+  uint8_t zero_point = 0;
+
+  NodeArg* q_out = builder.MakeIntermediate();
+  builder.AddQuantizeLinearNode<uint8_t>(x, scale, zero_point, q_out);
+
+  NodeArg* dq1_out = builder.MakeIntermediate();
+  builder.AddDequantizeLinearNode<uint8_t>(q_out, scale, zero_point, dq1_out);
+
+  NodeArg* sigmoid_out = builder.MakeIntermediate();
+  builder.AddNode("Sigmoid", {dq1_out}, {sigmoid_out});
+
+  NodeArg* q2_out = builder.MakeIntermediate();
+  builder.AddQuantizeLinearNode<uint8_t>(sigmoid_out, scale, zero_point, q2_out);
+
+  NodeArg* out = builder.MakeOutput();
+  builder.AddDequantizeLinearNode<uint8_t>(q2_out, scale, zero_point, out);
+
+  builder.SetGraphOutputs();
+  ASSERT_STATUS_OK(qdq_model.MainGraph().Resolve());
+
+  std::string model_data;
+  qdq_model.ToProto().SerializeToString(&model_data);
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  Ort::SessionOptions so;
+  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnABIExecutionProvider, provider_options);
+
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  std::filesystem::path json_file_path;
+  for (const auto& dir_entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (dir_entry.is_regular_file() && dir_entry.path().extension().string() == ".json" &&
+        dir_entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_file_path = dir_entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(json_file_path.empty()) << "No JSON graph file found in " << dump_dir;
+
+  std::set<std::string> tensor_names;
+  {
+    std::ifstream json_file(json_file_path);
+    ASSERT_TRUE(json_file.is_open()) << "Failed to open JSON file: " << json_file_path;
+
+    nlohmann::json root_json;
+    json_file >> root_json;
+
+    ASSERT_TRUE(root_json.contains("graph")) << "JSON missing 'graph' field";
+    const auto& graph_json = root_json["graph"];
+    ASSERT_TRUE(graph_json.contains("tensors")) << "JSON graph missing 'tensors' field";
+
+    for (const auto& [name, tensor] : graph_json["tensors"].items()) {
+      tensor_names.insert(name);
+    }
+  }
+
+  // Verify original ONNX names appear in DLC (not internal quantized names)
+  EXPECT_TRUE(tensor_names.count(expected_input_name))
+      << "Expected input '" << expected_input_name << "' not found.";
+  EXPECT_TRUE(tensor_names.count(expected_output_name))
+      << "Expected output '" << expected_output_name << "' not found.";
 }
 
 // TODO: Test will be re-enabled for Linux once QNN API issue is resolved


### PR DESCRIPTION
Fixed DLC I/O tensor name mismatch original ONNX model when offload_graph_io_quantization=1.

When offload_graph_io_quantization=1, Q/DQ nodes at graph boundaries are
filtered out, causing fused node I/O names to differ from original ONNX
graph I/O names. This change maps them back so DLC files use user-expected
tensor names.