### PR TITLE
[AISW-166313] Implement device compatibility API

### DIFF
--- a/onnxruntime/core/providers/qnn-abi/ort_api.h
+++ b/onnxruntime/core/providers/qnn-abi/ort_api.h
@@ -132,6 +132,10 @@ class OrtLoggingManager {
     return GetLoggerInstance();
   }
 
+  static const OrtLogger*& GetDefaultLoggerPtr() {
+    return GetLoggerPtr();
+  }
+
   static bool HasDefaultLogger() {
     return GetLoggerPtr() != nullptr;
   }

--- a/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.cc
@@ -2024,6 +2024,33 @@ OrtStatus* QnnEp::ValidateCompiledModelCompatibilityInfo(const OrtHardwareDevice
   return status.release();
 }
 
+OrtStatus* QnnEp::GetHardwareDeviceIncompatibilityDetails(const OrtHardwareDevice* /*hw*/,
+                                                          OrtDeviceEpIncompatibilityDetails* details) noexcept {
+  std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>> dummy_map;
+  Ort::Status status = qnn_backend_manager_->SetupBackend(false, false, false, false, dummy_map);
+
+  if (!status.IsOK()) {
+    uint32_t reasons = static_cast<uint32_t>(OrtDeviceEpIncompatibility_UNKNOWN);
+    const std::string error_message = status.GetErrorMessage();
+    if (error_message.find("LoadBackend") != std::string::npos) {
+      reasons = static_cast<uint32_t>(OrtDeviceEpIncompatibility_MISSING_DEPENDENCY);
+    } else if (error_message.find("InitializeBackend") != std::string::npos || error_message.find("CreateDevice") != std::string::npos) {
+      reasons = static_cast<uint32_t>(OrtDeviceEpIncompatibility_DRIVER_INCOMPATIBLE);
+    }
+
+    return ep_api.DeviceEpIncompatibilityDetails_SetDetails(
+        details,
+        reasons,
+        QNN_COMMON_ERROR_PLATFORM_NOT_SUPPORTED,
+        error_message.c_str());
+  }
+
+  // Release backend to avoid interfering later usage.
+  qnn_backend_manager_->ReleaseResources();
+
+  return status.release();
+}
+
 bool QnnEp::GetHtpPowerConfigId(uint32_t& htp_power_config_id) {
   std::lock_guard<std::mutex> lock(config_id_mutex_);
   if (!htp_power_config_id_.has_value()) {

--- a/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.h
@@ -44,6 +44,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
                                                     size_t num_devices,
                                                     const char* compatibility_info,
                                                     OrtCompiledModelCompatibility* model_compatibility) noexcept;
+  OrtStatus* GetHardwareDeviceIncompatibilityDetails(const OrtHardwareDevice* hw,
+                                                     OrtDeviceEpIncompatibilityDetails* details) noexcept;
 
  private:
   static const char* ORT_API_CALL GetNameImpl(const OrtEp* this_ptr) noexcept;

--- a/onnxruntime/core/providers/qnn-abi/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn-abi/qnn_provider_factory.cc
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <optional>
 
+#include "QnnCommon.h"
+
 #include "core/framework/error_code_helper.h"
 #include "core/providers/qnn-abi/ort_api.h"
 #include "core/providers/qnn-abi/qnn_allocator.h"
@@ -28,6 +30,12 @@ static const std::unordered_map<OrtHardwareDeviceType, std::string> kDefaultBack
 #endif
 };
 
+static const std::unordered_map<OrtHardwareDeviceType, std::string> kSupportedBackendTypes = {
+    {OrtHardwareDeviceType_CPU, "cpu"},
+    {OrtHardwareDeviceType_NPU, "htp"},
+    {OrtHardwareDeviceType_GPU, "gpu"},
+};
+
 namespace onnxruntime {
 
 // OrtEpApi infrastructure to be able to use the QNN EP as an OrtEpFactory for auto EP selection.
@@ -46,6 +54,7 @@ QnnEpFactory::QnnEpFactory(const char* ep_name,
   CreateDataTransfer = CreateDataTransferImpl;
   IsStreamAware = IsStreamAwareImpl;
   ValidateCompiledModelCompatibilityInfo = ValidateCompiledModelCompatibilityInfoImpl;
+  GetHardwareDeviceIncompatibilityDetails = GetHardwareDeviceIncompatibilityDetailsImpl;
 
   // HOST_ACCESSIBLE memory.
   OrtMemoryInfo* mem_info = nullptr;
@@ -288,6 +297,67 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
                                                                   model_compatibility);
 }
 
+OrtStatus* ORT_API_CALL QnnEpFactory::GetHardwareDeviceIncompatibilityDetailsImpl(
+    _In_ OrtEpFactory* this_ptr,
+    _In_ const OrtHardwareDevice* hw,
+    _Inout_ OrtDeviceEpIncompatibilityDetails* details) noexcept {
+  auto* factory = static_cast<QnnEpFactory*>(this_ptr);
+
+  // Check if the device type is supported by QNN EP
+  auto device_type = factory->ort_api.HardwareDevice_Type(hw);
+  auto vendor_id = factory->ort_api.HardwareDevice_VendorId(hw);
+
+  // QNN EP supports general CPU devices and NPU/GPU devices with Qualcomm vendor ID
+  if ((kDefaultBackends.find(device_type) != kDefaultBackends.end() && vendor_id != factory->vendor_id_) && device_type != OrtHardwareDeviceType_CPU) {
+    uint32_t reasons = static_cast<uint32_t>(OrtDeviceEpIncompatibility_DEVICE_INCOMPATIBLE);
+    return factory->ep_api.DeviceEpIncompatibilityDetails_SetDetails(
+        details,
+        reasons,
+        QNN_COMMON_ERROR_PLATFORM_NOT_SUPPORTED,
+        "QNN EP only supports general CPU devices and Qualcomm NPU and GPU devices");
+  }
+
+  // Create a temporary QNN EP and to check device compatibility
+  // Create minimal session options for backend setup
+  OrtSessionOptions* temp_session_options = nullptr;
+  RETURN_IF_NOT_NULL(factory->ort_api.CreateSessionOptions(&temp_session_options));
+
+  // Determine backend type based on device type
+  auto supported_backend_types_it = kSupportedBackendTypes.find(device_type);
+  if (supported_backend_types_it != kSupportedBackendTypes.end()) {
+    std::string backend_type = supported_backend_types_it->second;
+    RETURN_IF_NOT_NULL(factory->ort_api.AddSessionConfigEntry(temp_session_options, "backend_type", backend_type.c_str()));
+  }
+
+  // Use default logger for the compatibility check
+  // TODO: There should be a better solution.
+  const OrtLogger* logger = OrtLoggingManager::GetDefaultLoggerPtr();
+
+  // Try to create a temporary QNN EP to test backend setup
+  std::unique_ptr<QnnEp> temp_qnn_ep;
+  try {
+    temp_qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *temp_session_options, logger);
+    RETURN_IF_NOT_NULL(temp_qnn_ep->GetHardwareDeviceIncompatibilityDetails(hw, details));
+  } catch (...) {
+    uint32_t reasons = static_cast<uint32_t>(OrtDeviceEpIncompatibility_UNKNOWN);
+    return factory->ep_api.DeviceEpIncompatibilityDetails_SetDetails(
+        details,
+        reasons,
+        QNN_COMMON_ERROR_UNDEFINED,
+        "Unknown exception occurred while creating QNN EP for compatibility check");
+  }
+
+  // Clean up
+  factory->ort_api.ReleaseSessionOptions(temp_session_options);
+
+  // If we got here, the device is compatible
+  uint32_t reasons = static_cast<uint32_t>(OrtDeviceEpIncompatibility_NONE);
+  return factory->ep_api.DeviceEpIncompatibilityDetails_SetDetails(
+      details,
+      reasons,
+      QNN_SUCCESS,
+      "Device is compatible with QNN EP");
+}
 }  // namespace onnxruntime
 
 extern "C" {

--- a/onnxruntime/core/providers/qnn-abi/qnn_provider_factory.h
+++ b/onnxruntime/core/providers/qnn-abi/qnn_provider_factory.h
@@ -42,6 +42,10 @@ class QnnEpFactory : public OrtEpFactory, public ApiPtrs {
       _In_ size_t num_devices,
       _In_ const char* compatibility_info,
       _Out_ OrtCompiledModelCompatibility* model_compatibility) noexcept;
+  static OrtStatus* ORT_API_CALL GetHardwareDeviceIncompatibilityDetailsImpl(
+      _In_ OrtEpFactory* this_ptr,
+      _In_ const OrtHardwareDevice* hw,
+      _Inout_ OrtDeviceEpIncompatibilityDetails* details) noexcept;
 
   // const OrtApi& ort_api;
   const std::string ep_name_;              // EP name


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Implement `GetHardwareDeviceIncompatibilityDetails` API for QNN ABI EP

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Follow up action for https://github.com/microsoft/onnxruntime/pull/26922
- LWD: [FR115583: QNN-EP: Support Device Compatibility API - Hua-Yu Chou - Confluence](https://qualcomm-confluence.atlassian.net/wiki/spaces/~huaychou/pages/2835844805/FR115583+QNN-EP+Support+Device+Compatibility+API)
- Workflow: [ORT QNN EP Device compatibility API Workflow - Hua-Yu Chou - Confluence](https://qualcomm-confluence.atlassian.net/wiki/spaces/~huaychou/pages/2999353177/ORT+QNN+EP+Device+compatibility+API+Workflow)