### PR TITLE
[ABI] Support ABI path on Makena.

### DIFF
--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -207,6 +207,16 @@ struct DeferOrtRelease {
   std::function<void(T*)> release_func_ = nullptr;
 };
 
+template <typename T>
+struct FuncDeleter {
+  using DeleteFunc = void (*)(T*);
+  DeleteFunc delete_func_;
+
+  void operator()(T* ptr) const noexcept {
+    if (ptr) delete_func_(ptr);
+  }
+};
+
 namespace QDQ {
 
 // Define NodeGroup structure similar to the one in shared/utils.h

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -12,7 +12,9 @@
 #include "core/framework/error_code_helper.h"
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/qnn_allocator.h"
+#include "core/providers/qnn/soc_utils.h"
 #include "core/session/abi_devices.h"
+#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
 
 // We allow `backend_type` (e.g., `htp`) or `backend_path` in relative path (e.g., `QnnHtp.dll`) for configurations,
 // and QnnBackendManager will later find the appropriate library and load it relative to the OnnxRuntime library.
@@ -95,34 +97,81 @@ const char* ORT_API_CALL QnnEpFactory::GetVersionImpl(const OrtEpFactory* this_p
 }
 
 // Creates and returns OrtEpDevice instances for all OrtHardwareDevices that this factory supports.
-// An EP created with this factory is expected to be able to execute a model with *all* supported
-// hardware devices at once. A single instance of QNN EP is not currently setup to partition a model among
-// multiple different QNN backends at once (e.g, npu, cpu, gpu), so currently this factory instance is set
-// to default to npu.
 OrtStatus* ORT_API_CALL QnnEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this_ptr,
                                                               const OrtHardwareDevice* const* devices,
                                                               size_t num_devices,
                                                               OrtEpDevice** ep_devices,
                                                               size_t max_ep_devices,
                                                               size_t* p_num_ep_devices) noexcept {
+  auto* factory = static_cast<QnnEpFactory*>(this_ptr);
+
   size_t& num_ep_devices = *p_num_ep_devices;
   num_ep_devices = 0;
 
-  auto* factory = static_cast<QnnEpFactory*>(this_ptr);
+  auto create_ep_device = [&factory, &ep_devices, &num_ep_devices](const OrtHardwareDevice* device) {
+    OrtEpDevice* ep_device = nullptr;
+    OrtStatus* status = factory->ep_api.CreateEpDevice(factory, device, nullptr, nullptr, &ep_device);
+    ep_devices[num_ep_devices++] = ep_device;
+    factory->ep_devices_.push_back(ep_device);
+
+    return status;
+  };
+
+  auto create_hw_device = [&factory](const OrtHardwareDeviceType device_type,
+                                     OrtHardwareDevice*& device,
+                                     const bool is_virtual = true) {
+    OrtKeyValuePairs* hw_metadata = nullptr;
+    if (is_virtual) {
+      factory->ort_api.CreateKeyValuePairs(&hw_metadata);
+      factory->ort_api.AddKeyValuePair(hw_metadata, kOrtHardwareDevice_MetadataKey_IsVirtual, "1");
+    }
+
+    OrtStatus* status = factory->ep_api.CreateHardwareDevice(device_type,
+                                                             factory->vendor_id_,
+                                                             0,
+                                                             factory->vendor_.c_str(),
+                                                             hw_metadata,
+                                                             &device);
+
+    if (hw_metadata) {
+      factory->ort_api.ReleaseKeyValuePairs(hw_metadata);
+    }
+
+    return status;
+  };
+
+  bool has_npu_hw_device = false;
 
   for (size_t idx = 0; idx < num_devices && num_ep_devices < max_ep_devices; ++idx) {
-    const OrtHardwareDevice& device = *devices[idx];
-    auto device_type = factory->ort_api.HardwareDevice_Type(&device);
-    auto vendor_id = factory->ort_api.HardwareDevice_VendorId(&device);
+    const OrtHardwareDevice* device = devices[idx];
+    auto device_type = factory->ort_api.HardwareDevice_Type(device);
+    auto vendor_id = factory->ort_api.HardwareDevice_VendorId(device);
 
-    if ((kDefaultBackends.find(device_type) != kDefaultBackends.end() && vendor_id == factory->vendor_id_) || device_type == OrtHardwareDeviceType_CPU) {
-      OrtEpDevice* ep_device = nullptr;
-      OrtKeyValuePairs* ep_options = nullptr;
-      OrtStatus* status = factory->ep_api.CreateEpDevice(factory, &device, nullptr, ep_options, &ep_device);
-      ep_devices[num_ep_devices++] = ep_device;
-      factory->ep_devices_.push_back(ep_device);
+    if ((kDefaultBackends.find(device_type) != kDefaultBackends.end() && vendor_id == factory->vendor_id_) ||
+        device_type == OrtHardwareDeviceType_CPU) {
+      RETURN_IF_NOT_NULL(create_ep_device(device));
 
-      RETURN_IF_NOT_NULL(status);
+      if (device_type == OrtHardwareDeviceType_NPU) {
+        has_npu_hw_device = true;
+      }
+    }
+  }
+
+  if (!has_npu_hw_device && num_ep_devices < max_ep_devices) {
+    if (qnn::soc::GetSocId() != 0) {
+      // If ORT Core does not detect NPU hardware but we recognize the device as WoS (through qnn::soc::GetSocId),
+      // exploit virtual hardware device to create an NPU hardware device for user to select from.
+      // Such case happens for older WoS devices (e.g., Makena) that ORT Core's device discovery logic could not detect
+      // NPU through DXCore.
+      OrtHardwareDevice* undetected_npu_hw_device = nullptr;
+      RETURN_IF_NOT_NULL(create_hw_device(OrtHardwareDeviceType_NPU, undetected_npu_hw_device, false));
+      factory->undetected_npu_hw_device_ = HardwareDeviceUniquePtr(
+          undetected_npu_hw_device,
+          FuncDeleter<OrtHardwareDevice>{factory->ep_api.ReleaseHardwareDevice});
+
+      RETURN_IF_NOT_NULL(create_ep_device(factory->undetected_npu_hw_device_.get()));
+    } else {
+      // Enable originally expected usage of virtual hardware device for cross-platform compilation if necessary.
     }
   }
 

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.h
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.h
@@ -61,6 +61,10 @@ class QnnEpFactory : public OrtEpFactory, public ApiPtrs {
 
   QnnEp* qnn_ep_ = nullptr;
   std::vector<OrtEpDevice*> ep_devices_;
+
+  using HardwareDeviceUniquePtr = std::unique_ptr<OrtHardwareDevice, FuncDeleter<OrtHardwareDevice>>;
+  // This is an actual NPU hardware but unable to be detected by ORT Core (e.g., Makena).
+  HardwareDeviceUniquePtr undetected_npu_hw_device_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/soc_utils.cc
+++ b/onnxruntime/core/providers/qnn/soc_utils.cc
@@ -1,0 +1,185 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <stdint.h>
+#include <unordered_map>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include "core/providers/qnn/soc_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace soc {
+namespace {
+
+// QNN-EP COPY START
+// Below implementations are directly copied from QNN SDK with few modifications.
+
+#ifdef _WIN32
+// Use 1-byte packing to match the original header
+#pragma pack(push, 1)
+
+//
+// Description Header structure that appears at the beginning of each ACPI table
+//
+typedef struct _DESCRIPTION_HEADER {
+  ULONG Signature;     // Signature used to identify the type of table
+  ULONG Length;        // Length of entire table including the DESCRIPTION_HEADER
+  UCHAR Revision;      // Minor version of ACPI spec to which this table conforms
+  UCHAR Checksum;      // Sum of all bytes in the entire TABLE should = 0
+  CHAR OEMID[6];       // String that uniquely ID's the OEM
+  CHAR OEMTableID[8];  // String that uniquely ID's this table
+  ULONG OEMRevision;   // OEM supplied table revision number
+  CHAR CreatorID[4];   // Vendor ID of utility which created this table
+  ULONG CreatorRev;    // Revision of utility that created the table
+} DESCRIPTION_HEADER, *PDESCRIPTION_HEADER;
+
+//
+// Processor Properties Topology Table (PPTT) structures
+//
+typedef struct _PROC_TOPOLOGY_NODE {
+  UCHAR Type;
+  UCHAR Length;
+  UCHAR Reserved[2];
+  union {
+    struct {
+      union {
+        struct {
+          ULONG PhysicalPackage : 1;
+          ULONG ACPIProcessorIdValid : 1;
+          ULONG Reserved : 30;
+        };
+        ULONG AsULONG;
+      } Flags;
+      ULONG Parent;
+      ULONG ACPIProcessorId;
+      ULONG NumberPrivateResources;
+      ULONG PrivateResources[1];  // Variable length array
+    } HeirarchyNode;
+    struct {
+      union {
+        struct {
+          ULONG SizeValid : 1;
+          ULONG SetsValid : 1;
+          ULONG AssociativityValid : 1;
+          ULONG AllocationTypeValid : 1;
+          ULONG CacheTypeValid : 1;
+          ULONG WritePolicyValid : 1;
+          ULONG LineSizeValid : 1;
+          ULONG Reserved : 25;
+        };
+        ULONG AsULONG;
+      } Flags;
+      ULONG NextLevelCacheOffset;
+      ULONG Size;
+      ULONG Sets;
+      UCHAR Associativity;
+      union {
+        struct {
+          UCHAR ReadAllocate : 1;
+          UCHAR WriteAllocate : 1;
+          UCHAR CacheType : 2;
+          UCHAR WritePolicy : 1;
+          UCHAR Reserved : 3;
+        };
+        UCHAR AsUCHAR;
+      } Attributes;
+      USHORT LineSize;
+    } CacheNode;
+    struct {
+      ULONG Vendor;
+      ULONG64 Level1;
+      ULONG64 Level2;
+      USHORT Major;
+      USHORT Minor;
+      USHORT Spin;
+    } IdNode;
+  };
+} PROC_TOPOLOGY_NODE, *PPROC_TOPOLOGY_NODE;
+
+typedef struct _PPTT {
+  DESCRIPTION_HEADER Header;
+  PROC_TOPOLOGY_NODE HierarchyNodes[1];  // Variable length array
+} PPTT, *PPPTT;
+
+// Restore default packing
+#pragma pack(pop)
+#endif
+
+#define MAX_FADT_PPTT_SIZE 65536
+#define LEVEL_ID(LV1, LV2) ((LV1 << 32) | (LV2))
+
+// Note that the table is intentionally kept compact as Makena is the only expected usage.
+// (level1_ID | level2_ID), SOC_ID
+static std::unordered_map<uint64_t, int> pptt_mappings = {
+    {LEVEL_ID(113ULL, 449ULL), 435},  // Makena
+};
+
+int getSocId() {
+#ifdef _WIN32
+  int socId = -1;
+  DWORD bufsize = 0;
+  int ret = 0;
+  PPPTT pptt;
+  BYTE* buf = NULL;
+
+  buf = (BYTE*)malloc(MAX_FADT_PPTT_SIZE);
+  if (!buf) {
+    return 0;
+  }
+
+  // start to try newer approach, level 1 ID, level 2 ID in PPTT
+  ret = GetSystemFirmwareTable('ACPI', 'TTPP', 0, 0);
+  if (!ret) {
+    free(buf);
+    return 0;
+  }
+
+  bufsize = ret;
+  ret = GetSystemFirmwareTable('ACPI', 'TTPP', buf, bufsize);
+  if (!ret) {
+    free(buf);
+    return 0;
+  }
+
+  pptt = (PPPTT)buf;
+  uint64_t key = 0;
+  for (uint32_t i = 0; i < pptt->Header.Length; i++) {
+    PPROC_TOPOLOGY_NODE ptn = (PPROC_TOPOLOGY_NODE)((BYTE*)&(pptt->HierarchyNodes[0]) + i);
+    // According to ACPI spec, type = 2 is the PPTT_ID_TABLE_TYPE
+    if (ptn->Type == 2) {
+      key = (ptn->IdNode.Level1 << 32) | (ptn->IdNode.Level2);
+      break;
+    }
+  }
+  free(buf);
+  if (key == 0) {
+    return 0;
+  }
+
+  auto it = pptt_mappings.find(key);
+  if (it != pptt_mappings.end()) {
+    socId = it->second;
+  } else {
+    socId = 0;
+  }
+
+  return socId;
+#else
+  return 0;
+#endif
+}
+
+// QNN-EP COPY END
+}  // namespace
+
+int GetSocId() {
+  static int cached_soc_id = getSocId();
+  return cached_soc_id;
+}
+
+}  // namespace soc
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/soc_utils.h
+++ b/onnxruntime/core/providers/qnn/soc_utils.h
@@ -1,0 +1,14 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace onnxruntime {
+namespace qnn {
+namespace soc {
+
+int GetSocId();
+
+}  // namespace soc
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1644,9 +1644,6 @@ TEST_F(QnnHTPBackendTests, LoadingAndUnloadingOfQnnLibrary_FixSegFault) {
 // Tests autoEP feature to automatically select an EP that supports the NPU.
 // Currently only works on Windows.
 TEST_F(QnnHTPBackendTests, AutoEp_PreferNpu) {
-  // V68 device (Makena) on win-arm64 doesn't support NPU device discovery with dxcore.dll,
-  // which is required by auto-EP.Expand commentComment on line R1471ResolvedCode has comments. Press enter to view.
-  QNN_SKIP_TEST_IF_AUTOEP_NPU_UNSUPPORTED();
   ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
                                                                      ORT_TSTR("onnxruntime_providers_qnn.dll")));
 

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1602,15 +1602,6 @@ class QnnHTPBackendTests : public ::testing::Test {
 #endif
   }
 
-  // Returns true if the test should be skipped because AutoEP is not supported on this platform.
-  static bool ShouldSkipIfAutoEpNpuUnsupported() {
-#if defined(_WIN32)  // V68 device (Makena) on win-arm64 doesn't support NPU device discovery with dxcore.dll.
-    return ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68);
-#else
-    return false;
-#endif
-  }
-
   static std::optional<QnnHTPBackendTests::QnnPlatformAttributes> cached_platform_attrs_;  // Set by the first test using this fixture.
   static BackendSupport cached_htp_support_;                                               // Set by the first test using this fixture.
   static BackendSupport cached_ir_support_;
@@ -1660,13 +1651,6 @@ bool ReduceOpHasAxesInput(const std::string& op_type, int opset_version);
     if (!QnnHTPBackendTests::HasPlatformAttributes()) {                              \
       GTEST_SKIP() << "Test requires platform attributes, which are not available."; \
     }                                                                                \
-  } while (0)
-
-#define QNN_SKIP_TEST_IF_AUTOEP_NPU_UNSUPPORTED()                                                            \
-  do {                                                                                                       \
-    if (QnnHTPBackendTests::ShouldSkipIfAutoEpNpuUnsupported()) {                                            \
-      GTEST_SKIP() << "This platform lacks dxcore.dll NPU discovery capability required by auto-EP feature"; \
-    }                                                                                                        \
   } while (0)
 
 // Skips the test on any ARM64 platform.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Current fix exploits virtual hardware device which originally designed for cross-platform compilation and create virtual NPU device if no NPU hardware device is discovered and the device is recognized as WoS device. Copy SoC utility functions from QNN SDK to check whether current device is WoS.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Makena is too old for DXCore to discover NPU device, which leads to no NPU hardware device for QNN EP to choose from and thus all execution would fail.

