### PR TITLE
Model test results are included in CI summary

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -129,7 +129,20 @@ jobs:
         if: ${{ always() && inputs.run_tests && inputs.build_test_same_runner }} # always run even if the previous step fails
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}-test-results
+          group_reports: false
+          include_passed: true
+          detailed_summary: true
+          verbose_summary:  false
           report_paths: |
+            ${{ github.workspace }}/build/${{inputs.target_os}}-${{inputs.target_arch}}/${{ env.BUILD_CONFIG_DIR }}/*.results.xml
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v7
+        if: ${{ always() && inputs.run_tests && inputs.build_test_same_runner }} # always run even if the previous step fails
+        with:
+          name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Test Results
+          retention-days: 7
+          path: |
             ${{ github.workspace }}/build/${{inputs.target_os}}-${{inputs.target_arch}}/${{ env.BUILD_CONFIG_DIR }}/*.results.xml
 
       - name: Setup JFrog CLI
@@ -209,10 +222,15 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}-test-results
+          group_reports: false
+          include_passed: true
+          detailed_summary: true
+          verbose_summary:  false
           report_paths: |
             ${{ github.workspace }}/build/${{inputs.target_os}}-${{inputs.target_arch}}/${{ env.BUILD_CONFIG_DIR }}/*.results.xml
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v7
         if: always() # always run even if the previous step fails
         with:
           name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Test Results

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -147,8 +147,7 @@ jobs:
           name: "android-aarch64-pyNone-tests"
           src_pattern: onnxruntime-tests-android-aarch64.zip
 
- # Intentionally not "test-android-aarch64" to avoid breaking required PR checks
-  test-android:
+  test-android-aarch64:
     if: ${{ inputs.do_all }}
     needs: [build-android-aarch64]
     uses: ./.github/workflows/qualcomm-internal-qdc-test.yml

--- a/.github/workflows/qualcomm-internal-qdc-test.yml
+++ b/.github/workflows/qualcomm-internal-qdc-test.yml
@@ -83,6 +83,10 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-pynone-test-results
+          group_reports: false
+          include_passed: true
+          detailed_summary: true
+          verbose_summary:  false
           report_paths: |
             ${{ github.workspace }}/build/qdc-${{ env.QDC_RESULTS_ARCH }}/*.results.xml
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -848,7 +848,7 @@ class TaskLibrary:
                             REPO_ROOT / "build" / "onnxruntime-tests-linux-aarch64_oe_gcc11_2.zip",
                         ),
                         QdcTestsTask(
-                            "Testing ONNX Runtime for Android in QDC",
+                            "Testing ONNX Runtime for Qualcomm Linux in QDC",
                             self.__venv_path,
                             ["qualcomm_linux"],
                             extra_args=[

--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -42,13 +42,23 @@ _QAIRT_ACCEPT_PATTERNS = [".*/aarch64-android/.*", r".*/hexagon-v.+/.*"]
 _QAIRT_ACCEPT_RE = re.compile("|".join(_QAIRT_ACCEPT_PATTERNS))
 
 
-def _add_node_models(add_file: Callable[[Path, Path], None]) -> None:
-    node_tests_root = REPO_ROOT / "cmake" / "external" / "onnx" / "onnx" / "backend" / "test" / "data" / "node"
-    logging.debug(f"Adding node model tests from ONNX submodule in {node_tests_root}")
-    for filename in node_tests_root.glob("**/*"):
+def _add_directory(add_file: Callable[[Path, Path], None], root: Path) -> None:
+    for filename in root.glob("**/*"):
         if _should_archive(filename, reject=_ORT_REJECT_RE):
             arcname = filename.relative_to(REPO_ROOT)
             add_file(filename, arcname)
+
+
+def _add_node_models(add_file: Callable[[Path, Path], None]) -> None:
+    node_tests_root = REPO_ROOT / "cmake" / "external" / "onnx" / "onnx" / "backend" / "test" / "data" / "node"
+    logging.debug(f"Adding node model tests from ONNX submodule in {node_tests_root}")
+    _add_directory(add_file, node_tests_root)
+
+
+def _add_qcom_scripts(add_file: Callable[[Path, Path], None]) -> None:
+    qcom_scripts_root = REPO_ROOT / "qcom" / "scripts"
+    logging.debug(f"Adding {qcom_scripts_root}")
+    _add_directory(add_file, qcom_scripts_root)
 
 
 def _should_archive(path: Path, accept: re.Pattern | None = None, reject: re.Pattern | None = None) -> bool:
@@ -84,6 +94,7 @@ def archive_android(target_platform: str, config: str, qairt_sdk_root: Path) -> 
                 archive.write(filename, arcname)
 
         _add_node_models(archive.write)
+        _add_qcom_scripts(archive.write)
 
 
 def archive_linux(target_platform: str, config: str) -> None:
@@ -101,6 +112,7 @@ def archive_linux(target_platform: str, config: str) -> None:
                 arcname = filename.relative_to(REPO_ROOT)
                 archive.add(filename, arcname)
         _add_node_models(archive.add)
+        _add_qcom_scripts(archive.add)
 
 
 def archive_windows(target_platform: str, config: str) -> None:
@@ -129,6 +141,7 @@ def archive_windows(target_platform: str, config: str) -> None:
                 arcname = str(filename.relative_to(REPO_ROOT))
                 archive.write(filename, arcname)
         _add_node_models(archive.write)
+        _add_qcom_scripts(archive.write)
 
 
 if __name__ == "__main__":

--- a/qcom/scripts/all/model_test_log_to_junit_xml.py
+++ b/qcom/scripts/all/model_test_log_to_junit_xml.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import argparse
+import logging
+import platform
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Literal
+
+StatusT = Literal["notrun", "run"]
+ResultT = Literal["complete", "skipped", "suppressed"]
+
+# DISABLED_ --> notrun, suppressed
+# GTEST_SKIP() --> run, skipped
+# failed test --> run, complete, has <failure message="..." type=""><![CDATA[...]]></failure> subelement
+
+
+class TestCase:
+    """The result of a single unit test instance, e.g., a model run with a specific set of inputs."""
+
+    def __init__(
+        self,
+        suite_name: str,
+        name: str,
+        file: Path,
+    ) -> None:
+        self.suite_name = suite_name
+        self.name = name
+        self.file = file
+        self.status: StatusT = "run"
+        self.result: ResultT = "complete"
+        self.failure_messages: list[str] = []
+
+    @property
+    def is_disabled(self) -> bool:
+        return self.status == "notrun"
+
+    @property
+    def is_failure(self) -> bool:
+        return len(self.failure_messages) > 0
+
+    @property
+    def is_skipped(self) -> bool:
+        return self.result == "skipped"
+
+    def to_xml(self) -> ET.Element:
+        """Get a JUnit XML representation of this test case."""
+        xml = ET.Element(
+            "testcase",
+            {
+                "name": self.name,
+                "file": str(self.file).replace("\\", "/"),
+                # line
+                "status": self.status,
+                "result": self.result,
+                "time": "0.",
+                # timestamp
+                "classname": self.suite_name.replace("\\", "/"),
+            },
+        )
+
+        if self.is_failure:
+            ET.SubElement(xml, "failure", {"message": "\n".join(self.failure_messages), "type": ""})
+        return xml
+
+
+class TestSuite:
+    """A collection of TestCases."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.cases: dict[str, TestCase] = {}
+
+    @property
+    def is_disabled(self) -> bool:
+        return any(c.is_disabled for c in self.cases.values())
+
+    @property
+    def is_failure(self) -> bool:
+        return any(c.is_failure for c in self.cases.values())
+
+    def to_xml(self) -> ET.Element:
+        """Get a JUnit XML representation of this test suite."""
+        xml = ET.Element(
+            "testsuite",
+            {
+                "name": self.name.replace("\\", "/"),
+                "tests": str(len(self.cases)),
+                "failures": str(sum(c.is_failure for c in self.cases.values())),
+                "disabled": str(sum(c.is_disabled for c in self.cases.values())),
+                "skipped": str(sum(c.is_skipped for c in self.cases.values())),
+                # errors
+                "time": "0.",
+                # timestamp
+            },
+        )
+        for case in self.cases.values():
+            xml.append(case.to_xml())
+        return xml
+
+
+def parse(log_path: Path) -> list[TestSuite]:
+    """Parse the model test runner's log into JUnit-compatible test objets."""
+    load_exp = re.compile(r"^Load Test Case: ([-\\.\w]+) in (.*)$")
+    end_of_suite_exp = re.compile(r"^result:\s*$")
+    errors_with_messages = [
+        re.compile(r".* RunImpl] ([-\\.\w]+):(.*)"),
+        re.compile(r".* operator\(\)] ([-\\.\w]+):Non-zero status code .* Status Message: (.*)"),
+    ]
+    errors_without_messages = [
+        re.compile(r"test ([-\\.\w]+) failed, please fix it"),
+    ]
+
+    log_encoding = "utf-16" if platform.uname().system == "Windows" else "utf-8"
+
+    test_suites: list[TestSuite] = []
+
+    test_suite: TestSuite | None = None
+    for line in log_path.read_text(encoding=log_encoding).splitlines():
+        if (x := load_exp.match(line)) is not None:
+            case, test_dir_str = x.groups()
+            test_dir = Path(test_dir_str)
+            suite_name = str(test_dir.parent)
+            model_path = test_dir / f"{case}.onnx"
+            if test_suite is None:
+                test_suite = TestSuite(suite_name)
+            test_suite.cases[case] = TestCase(suite_name, case, model_path)
+            continue
+        if end_of_suite_exp.match(line) is not None:
+            assert test_suite is not None, "test_suite is none"
+            test_suites.append(test_suite)
+            test_suite = None
+            continue
+        for exp in errors_with_messages:
+            if (x := exp.match(line)) is not None:
+                assert test_suite is not None, "test_suite is none"
+                test_suite.cases[x.group(1)].failure_messages.append(x.group(2))
+        for exp in errors_without_messages:
+            if (x := exp.match(line)) is not None:
+                assert test_suite is not None, "test_suite is none"
+                test_suite.cases[x.group(1)].failure_messages.append(line)
+    if test_suite is not None:
+        test_suites.append(test_suite)
+    return test_suites
+
+
+def main(log_path: Path) -> None:
+    test_suites = parse(log_path)
+    xml = ET.Element(
+        "testsuites",
+        attrib={
+            "name": f"{log_path.stem}",
+            "tests": str(len(test_suites)),
+            "failures": str(sum(ts.is_failure for ts in test_suites)),
+            "disabled": str(sum(ts.is_disabled for ts in test_suites)),
+            # errors
+            "time": "0.",
+        },
+    )
+    for test_suite in test_suites:
+        subtree = test_suite.to_xml()
+        xml.append(subtree)
+    ET.indent(xml)
+    xml_bytes: bytes = ET.tostring(xml, encoding="UTF-8", xml_declaration=True)
+    print(xml_bytes.decode())
+
+
+if __name__ == "__main__":
+    log_format = "[%(asctime)s] [model_test_log_to_junit.py] [%(levelname)s] %(message)s"
+    logging.basicConfig(level=logging.DEBUG, format=log_format, force=True)
+
+    parser = argparse.ArgumentParser(description="Convert a onnxruntime_plugin_ep_onnx_test log to JUnit XML.")
+
+    parser.add_argument("log_path", type=Path, help="Path to a onnxruntime_plugin_ep_onnx_test log.")
+
+    args = parser.parse_args()
+
+    main(args.log_path)

--- a/qcom/scripts/linux/appium/configs/android-aarch64.jsonc
+++ b/qcom/scripts/linux/appium/configs/android-aarch64.jsonc
@@ -3,7 +3,7 @@
 
 {
     // [REQUIRED] The target platform under test; corresponds to a directory under $REPO_ROOT/build/
-    "build_target": "android-aarch64"
+    "build_target": "android-aarch64",
 
     // The build configuration to test.
     // Default: Release
@@ -26,6 +26,10 @@
     // Default: "/qdc/appium"
     // "qdc_host_path": "/qdc/appium",
 
+    // Location of the "qcom/scripts" directory on the host.
+    // Default: "/qdc/appium/qcom/scripts"
+    // "host_qcom_scripts_path": "/qdc/appium/qcom/scripts",
+
     // Host directory containing model tests.
     // Sometimes it makes sense to set this in order to avoid re-uploading model tests.
     // Default: "/qdc/appium/model_tests/onnx_models"
@@ -41,5 +45,11 @@
 
     // Comma-separated list of ctest cases to skip
     // Default: null
-    // "skip_ctests": null
+    // TODO: these segfault after printing "Testing prelu_broadcast"
+    "skip_ctests": "onnxruntime_provider_test",
+
+    // Comma-separated list of model test suites cases to skip
+    // Default: null
+    // TODO: these segfault after printing "Testing prelu_broadcast"
+    "skip_model_tests": "node"
 }

--- a/qcom/scripts/linux/appium/configs/linux-aarch64_manylinux_2_34.jsonc
+++ b/qcom/scripts/linux/appium/configs/linux-aarch64_manylinux_2_34.jsonc
@@ -19,12 +19,16 @@
     //  * ssh://user@host[:port]/[?key=val[&key=val...]]
     //    * Example: ssh://root@192.168.0.115:22/?StrictHostKeychecking=no&UserKnownHostsFile=/dev/null
     // Default: adb://
-    "device_url": "ssh://user@your_device_host"
+    "device_url": "ssh://user@your_device_host",
 
     // Where the test archive is extracted on the host device.
     // In local tests, this should be left unset so that the test harness can specify a temporary directory.
     // Default: "/qdc/appium"
     // "qdc_host_path": "/qdc/appium",
+
+    // Location of the "qcom/scripts" directory on the host.
+    // Default: "/qdc/appium/qcom/scripts"
+    "host_qcom_scripts_path": "/home/USER/src/onnxruntime/qcom/scripts"
 
     // Host directory containing model tests.
     // Sometimes it makes sense to set this in order to avoid re-uploading model tests.
@@ -41,5 +45,9 @@
 
     // Comma-separated list of ctest cases to skip
     // Default: null
-    // "skip_ctests": null
+    // "skip_ctests": null,
+
+    // Comma-separated list of model test suites cases to skip
+    // Default: null
+    // "skip_model_tests": null
 }

--- a/qcom/scripts/linux/appium/configs/linux-aarch64_oe_gcc11_2.jsonc
+++ b/qcom/scripts/linux/appium/configs/linux-aarch64_oe_gcc11_2.jsonc
@@ -26,6 +26,10 @@
     // Default: "/qdc/appium"
     // "qdc_host_path": "/qdc/appium",
 
+    // Location of the "qcom/scripts" directory on the host.
+    // Default: "/qdc/appium/qcom/scripts"
+    // "host_qcom_scripts_path": "/qdc/appium/qcom/scripts",
+
     // Host directory containing model tests.
     // Sometimes it makes sense to set this in order to avoid re-uploading model tests.
     // Default: "/qdc/appium/model_tests/onnx_models"
@@ -42,5 +46,10 @@
     // Comma-separated list of ctest cases to skip
     // Default: null
     // TODO: [AISW-163150] ORT test failures on qcs6490
-    "skip_ctests": "onnxruntime_provider_test"
+    "skip_ctests": "onnxruntime_provider_test",
+
+    // Comma-separated list of model test suites cases to skip
+    // Default: null
+    // TODO: Cannot load EP plugin on Qualcomm Linux
+    "skip_model_tests": ["node", "float32", "qdq", "qdq-with-context-cache"]
 }

--- a/qcom/scripts/linux/appium/tests/device/adb_device.py
+++ b/qcom/scripts/linux/appium/tests/device/adb_device.py
@@ -17,7 +17,7 @@ class AdbDevice(DeviceBase):
     def run_adb(self, adb_args: list[str], check: bool, capture_output: bool = False) -> list[str] | None:
         res = self.__run_adb(adb_args, check, capture_output=capture_output)
         if capture_output:
-            return res.stdout.decode("utf-8").split("\n")
+            return [x.strip("\r") for x in res.stdout.decode("utf-8").split("\n")]
         return None
 
     def logcat(self, regex: str | None) -> str:

--- a/qcom/scripts/linux/appium/tests/ort_test_config.py
+++ b/qcom/scripts/linux/appium/tests/ort_test_config.py
@@ -24,11 +24,14 @@ class OrtTestConfig:
 
     device_url: str = "adb://"
 
-    # this is where our zip file is extracted on the QDC host.
+    # This is where our zip file is extracted on the QDC host.
     qdc_host_path: str = DEFAULT_HOST_ROOT
 
-    # directory containing model test suites from ONNX.
+    # Directory containing model test suites from ONNX.
     host_onnx_model_test_path = f"{qdc_host_path}/model_tests/onnx_models"
+
+    # Directory containing qcom/scripts
+    host_qcom_scripts_path = f"{qdc_host_path}/qcom/scripts"
 
     # If true, remove previously uploaded builds during setup.
     clean_build: bool = True
@@ -38,6 +41,9 @@ class OrtTestConfig:
 
     # A list of test executables run by ctest to skip.
     _skip_ctests: list[str] | None = None
+
+    # A list of model test suites to skip.
+    _skip_model_tests: list[str] | None = None
 
     @property
     def build_root_relpath(self) -> str:
@@ -107,6 +113,19 @@ class OrtTestConfig:
             self._skip_ctests = []
 
     @property
+    def skip_model_tests(self) -> list[str]:
+        return [] if self._skip_model_tests is None else self._skip_model_tests
+
+    @skip_model_tests.setter
+    def skip_model_tests(self, value: Iterable[str] | str | None) -> None:
+        if isinstance(value, str):
+            value = value.split(",") if len(value) > 0 else []
+        if isinstance(value, Iterable):
+            self._skip_model_tests = list(value)
+        else:
+            self._skip_model_tests = []
+
+    @property
     def test_results_device_glob(self) -> str:
         """Glob matching test result files on the device."""
         return f"{self.device_results_root}/onnxruntime_*.results.*"
@@ -115,6 +134,18 @@ class OrtTestConfig:
     def test_results_device_log(self) -> str:
         """Path to the on-device test log; this should match the glob in test_results_device_glob."""
         return f"{self.device_results_root}/onnxruntime_test.results.txt"
+
+    @property
+    def model_test_results_filename_glob(self) -> str:
+        """Glob matching model test log filenames (not full paths)."""
+        return "onnxruntime_model_test_*.results.txt"
+
+    def model_test_device_log(self, suite: str) -> str:
+        """
+        Path to the a model tests's on-device log; should match the glob in test_results_device_glob and
+        model_test_results_filename_glob.
+        """
+        return f"{self.device_results_root}/onnxruntime_model_test_{suite}.results.txt"
 
 
 def default_test_config() -> OrtTestConfig:
@@ -142,8 +173,10 @@ def _parse_test_config_obj(config_obj: dict) -> OrtTestConfig:
         "device_home",
         "device_url",
         "host_onnx_model_test_path",
+        "host_qcom_scripts_path",
         "qdc_host_path",
         "skip_ctests",
+        "skip_model_tests",
     ]
 
     build_target = config_obj["build_target"]

--- a/qcom/scripts/linux/appium/tests/qdc_helpers.py
+++ b/qcom/scripts/linux/appium/tests/qdc_helpers.py
@@ -1,7 +1,9 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: MIT
 
-from pathlib import Path
+import subprocess
+import tempfile
+from pathlib import Path, PurePosixPath
 
 from device import DeviceBase, device_from_url
 from ort_test_config import OrtTestConfig, default_test_config
@@ -54,6 +56,27 @@ class TestBase:
         self.device.shell([f"sh -c 'chmod +x {self.config().device_build_root}/*'"])
 
     def copy_logs(self):
-        self.device.shell(
-            [f"sh -c 'cp {self.config().test_results_device_glob} {self.config().qdc_log_path}'"],
+        results_glob = self.config().test_results_device_glob
+        copy_results_cmd = f'find {PurePosixPath(results_glob).parent} -path "{results_glob}" -print -exec cp "{{}}" {self.config().qdc_log_path} ";"'
+        self.device.shell([f"sh -c '{copy_results_cmd}'"])
+
+        # This is a bit convoluted, but we need to convert our model test logs to JUnit XML files and
+        # then have those included in the QDC job's artifacts. Therefore, we pull relevant logs, process
+        # them on the host, and then put them back on the device where QDC will find them.
+        device_results_log_glob = (
+            f"{self.config().device_results_root}/{self.config().model_test_results_filename_glob}"
         )
+        find_logs_cmd = f'find {PurePosixPath(device_results_log_glob).parent} -path "{device_results_log_glob}" -print'
+        log_files = self.device.shell([f"sh -c '{find_logs_cmd}'"], capture_output=True)
+        assert log_files is not None
+        log_files = [x for x in log_files if x != ""]
+        log_to_xml = Path(self.config().host_qcom_scripts_path) / "all" / "model_test_log_to_junit_xml.py"
+        with tempfile.TemporaryDirectory(prefix="ModelTestLogToXml-") as tmpdir:
+            tmppath = Path(tmpdir)
+            for log_filename in log_files:
+                host_log_path = tmppath / Path(log_filename).name
+                host_xml_path = host_log_path.with_suffix(".xml")
+                self.device.pull(Path(log_filename), host_log_path)
+                with open(host_xml_path, "w") as results_xml:
+                    subprocess.run([log_to_xml, host_log_path], stdout=results_xml, check=True)
+                self.device.push(host_xml_path, Path(self.config().qdc_log_path))

--- a/qcom/scripts/linux/appium/tests/test_ort.py
+++ b/qcom/scripts/linux/appium/tests/test_ort.py
@@ -78,8 +78,9 @@ class TestOrt(TestBase):
         self.__assert_passes(self.__get_test_cmd(test_cmd))
 
     @pytest.mark.parametrize("test_def", MODEL_TEST_DEFINITIONS, ids=MODEL_TEST_IDS)
-    @pytest.mark.skip("[AISW-167043] [ORT ABI] Build plugin for Android")
     def test_onnx_models(self, test_def: ModelTestDef) -> None:
+        if f"{test_def.name}" in CONFIG.skip_model_tests:
+            pytest.skip()
         runner_exe = Path(CONFIG.device_build_root) / "onnxruntime_plugin_ep_onnx_test"
 
         # fmt: off
@@ -87,7 +88,7 @@ class TestOrt(TestBase):
             str(runner_exe),
             "-j", "1",
             "-e", "qnn",
-            "--plugin_ep_libs", "qnn|libonnxruntime_providers_qnn.so",
+            "--plugin_ep_libs", "'qnn|libonnxruntime_providers_qnn.so'",
             "--plugin_eps", "qnn",
             "-i", f"'backend_type|{test_def.backend}'",
             *test_def.extra_args,
@@ -95,7 +96,8 @@ class TestOrt(TestBase):
         ]
         # fmt: on
 
-        self.__assert_passes(self.__get_test_cmd(test_cmd, test_def.working_dir))
+        model_test_log = Path(CONFIG.model_test_device_log(test_def.name))
+        self.__assert_passes(self.__get_test_cmd(test_cmd, test_def.working_dir, extra_log=model_test_log))
 
     def __assert_passes(self, test_cmd: str) -> None:
         self.device.shell([test_cmd])
@@ -110,17 +112,21 @@ class TestOrt(TestBase):
         self,
         test_cmd: list[str],
         working_dir: Path | None = None,
+        extra_log: Path | None = None,
     ) -> str:
         if working_dir is None:
             working_dir = Path(CONFIG.device_build_root)
         test_str = " ".join(test_cmd)
-        return (
+        cmd = (
             f"cd {working_dir} && "
             f"echo -=-=-=-=-=-=-=-=-=-=- >> {CONFIG.test_results_device_log} && "
             f"echo Running test: {test_str} >> {CONFIG.test_results_device_log} && "
             f"(env ADSP_LIBRARY_PATH={CONFIG.device_adsp_library_path} LD_LIBRARY_PATH={CONFIG.device_ld_library_path} "
             f"{test_str}; echo $? > {self.__rc_device_path}) 2>&1 | tee -a {CONFIG.test_results_device_log}"
         )
+        if extra_log is not None:
+            cmd += f" | tee {extra_log}"
+        return cmd
 
     @property
     def __rc_device_path(self) -> Path:

--- a/qcom/scripts/linux/run_tests.sh
+++ b/qcom/scripts/linux/run_tests.sh
@@ -46,6 +46,9 @@ function run_model_test() {
     rc=$?
     set -e
 
+    "${python_exe}" "${REPO_ROOT}/qcom/scripts/all/model_test_log_to_junit_xml.py" \
+        "${build_dir}/${suite}_model_tests.log" > "${build_dir}/${suite}_model_tests.results.xml"
+
     if [ ${rc} -ne 0 ]; then
         errors=$(($errors+1))
     fi

--- a/qcom/scripts/windows/run_tests.ps1
+++ b/qcom/scripts/windows/run_tests.ps1
@@ -24,8 +24,10 @@ $CTestExe = (Join-Path $RootDir "ctest.exe")
 # of the rest of the ONNX Runtime build.
 if (Test-Path (Join-Path $RootDir "onnxruntime_plugin_ep_onnx_test.exe")) {
     $OnnxEpTestRunnerExe = (Join-Path $RootDir "onnxruntime_plugin_ep_onnx_test.exe")
+    $ResultsXmlDir = $RootDir
 } else {
     $OnnxEpTestRunnerExe = (Join-Path (Join-Path $RootDir $Config) "onnxruntime_plugin_ep_onnx_test.exe")
+    $ResultsXmlDir = (Join-Path $RootDir $Config)
 }
 
 $CTestTestFile = (Join-Path $RootDir "CTestTestfile.cmake")
@@ -138,13 +140,27 @@ $TestModelsViaEpPlugin = {
     )
 
     Write-Host "--=-=-=- Running ONNX model $Suite tests with the ABI-stable EP plugin -=--=-=-"
+
+    $ModelLog = Join-Path $ResultsXmlDir "${Suite}_model_tests.log"
+    $ModelXml = Join-Path $ResultsXmlDir "${Suite}_model_tests.results.xml"
+
+    if (Test-Path $ModelLog) { Remove-Item $ModelLog }
+    if (Test-Path $ModelXml) { Remove-Item -Force $ModelXml }
+
     & $OnnxEpTestRunnerExe `
         -j 1 `
         --plugin_ep_libs "qnn|onnxruntime_providers_qnn.dll" `
         --plugin_eps qnn `
         -i "backend_type|$Backend" `
-        $TestPath | Write-Host
-    if (-not $?) {
+        $TestPath | Tee-Object -FilePath $ModelLog | Write-Host
+    $TestResult = $?
+
+    if (Test-Path $ModelLog) {
+        py "${RepoRoot}\qcom\scripts\all\model_test_log_to_junit_xml.py" `
+            $ModelLog | Out-File -FilePath $ModelXml -Encoding utf8
+    }
+
+    if (-not $TestResult) {
         return $true
     }
     return $false


### PR DESCRIPTION
### Description

* Add script to turn `onnx_test_runner` into JUnit-format XML results files.
* Invoke it when running model tests.

### Motivation and Context

When model tests fail in CI, the test job fails, but no further information is available without inspecting logs. With this change, the failing tests will be shown in the JUnit job summaries.

