### PR TITLE
Introduce ORT Home in CI and Build System

### DIFF
--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -58,6 +58,7 @@ from ep_build.util import (
 )
 
 DOCKER_CCACHE_ROOT_ENV_VAR = "ORT_BUILD_DOCKER_CCACHE_ROOT"
+ORT_PREBUILT_ROOT_ENV_VAR = "ORT_PREBUILT_ROOT"
 QAIRT_SDK_ROOT_ENV_VAR = "QAIRT_SDK_ROOT"
 QNN_SDK_ROOT_ENV_VAR = "QNN_SDK_ROOT"
 SNPE_ROOT_ENV_VAR = "SNPE_ROOT"
@@ -93,6 +94,9 @@ Environment variables
 
   ORT_NIGHTLY_BUILD
     If set to 1, instruct the ORT build to use a more verbose version string.
+
+  ORT_PREBUILT_ROOT
+    If specified, this will be used for the path of ORT prebuilt.
 
   QAIRT_SDK_ROOT
   QNN_SDK_ROOT
@@ -137,6 +141,11 @@ Environment variables
         help="Print the task library in DOT format and exit. Combine with --task to highlight what would run.",
     )
     parser.add_argument(
+        "--ort-prebuilt",
+        type=Path,
+        help="Path to ORT Prebuilt.",
+    )
+    parser.add_argument(
         "--qairt-sdk",
         type=Path,
         help=f"Path to QAIRT SDK. Overrides default version and {QAIRT_SDK_ROOT_ENV_VAR}, {QNN_SDK_ROOT_ENV_VAR}, and {SNPE_ROOT_ENV_VAR} environment variables.",
@@ -178,6 +187,7 @@ class TaskLibrary:
         venv_path: Path,
         config: BuildConfigT,
         target_py_version: TargetPyVersionT | None,
+        ort_prebuilt_root: Path | None,
         qairt_sdk_root: Path | None,
         docker_ccache_root: Path | None,
         build_nuget: bool,
@@ -187,6 +197,7 @@ class TaskLibrary:
         self.__config: BuildConfigT = config
         # pylance somehow cannot correctly deduce the type of self.__target_py_version
         self.__target_py_version: TargetPyVersionT | None = target_py_version
+        self.__ort_prebuilt_root = ort_prebuilt_root
         self.__qairt_sdk_root = qairt_sdk_root
         self.__docker_ccache_root = docker_ccache_root
         self.__build_nuget = build_nuget
@@ -331,6 +342,7 @@ class TaskLibrary:
                     "arm64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                 )
@@ -348,6 +360,7 @@ class TaskLibrary:
                     "arm64ec",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                 )
@@ -365,6 +378,7 @@ class TaskLibrary:
                     "arm64ec",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                     build_as_x=True,
@@ -383,6 +397,7 @@ class TaskLibrary:
                     "x86_64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                 )
@@ -494,6 +509,7 @@ class TaskLibrary:
                     "arm64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
                     False,
@@ -513,6 +529,7 @@ class TaskLibrary:
                     "arm64ec",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
                 )
@@ -533,6 +550,7 @@ class TaskLibrary:
                             "arm64",
                             self.__config,
                             None,  # Never build the arm64 slice against Python
+                            self.__ort_prebuilt_root,
                             self.__qairt_sdk_root,
                             "build",
                             build_as_x=True,
@@ -543,6 +561,7 @@ class TaskLibrary:
                             "arm64ec",
                             self.__config,
                             self.__target_py_version,
+                            self.__ort_prebuilt_root,
                             self.__qairt_sdk_root,
                             "build",
                             build_as_x=True,
@@ -575,6 +594,7 @@ class TaskLibrary:
                     "x86_64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
                 )
@@ -656,6 +676,7 @@ class TaskLibrary:
                     "x86_64",
                     "Debug",
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "generate_sln",
                 )
@@ -860,6 +881,7 @@ class TaskLibrary:
                     "arm64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "test",
                 )
@@ -909,6 +931,7 @@ class TaskLibrary:
                     "arm64ec",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "test",
                 )
@@ -990,6 +1013,7 @@ class TaskLibrary:
                     "x86_64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "test",
                 )
@@ -1010,6 +1034,22 @@ def get_docker_ccache_root(root_from_args: Path | None) -> Path | None:
     ccache_root.mkdir(parents=True, exist_ok=True)
 
     return ccache_root
+
+
+def get_ort_prebuilt_root(root_from_args: Path | None) -> Path | None:
+    ort_prebuilt: Path | None = None
+    if root_from_args is not None:
+        ort_prebuilt = root_from_args
+    elif ORT_PREBUILT_ROOT_ENV_VAR in os.environ:
+        ort_prebuilt = Path(os.environ[ORT_PREBUILT_ROOT_ENV_VAR])
+    else:
+        # Let the build fetch QAIRT
+        return None
+
+    if not ort_prebuilt.exists():
+        raise FileNotFoundError(f"ORT Prebuilt root {ort_prebuilt} does not exist.")
+
+    return ort_prebuilt
 
 
 def get_qairt_sdk_root(root_from_args: Path | None) -> Path | None:
@@ -1038,6 +1078,7 @@ def plan_from_dependencies(
     venv_path: Path,
     config: BuildConfigT,
     target_py_version: TargetPyVersionT | None,
+    ort_prebuilt_root: Path | None,
     qairt_sdk_root: Path | None,
     docker_ccache_root: Path | None,
     build_nuget: bool,
@@ -1051,6 +1092,7 @@ def plan_from_dependencies(
         venv_path,
         config,
         target_py_version,
+        ort_prebuilt_root,
         qairt_sdk_root,
         docker_ccache_root,
         build_nuget,
@@ -1102,6 +1144,7 @@ def plan_from_task_list(
     venv_path: Path,
     config: BuildConfigT,
     target_py_version: TargetPyVersionT | None,
+    ort_prebuilt_root: Path | None,
     qairt_sdk_root: Path | None,
     docker_ccache_root: Path | None,
     build_nuget: bool,
@@ -1115,6 +1158,7 @@ def plan_from_task_list(
         venv_path,
         config,
         target_py_version,
+        ort_prebuilt_root,
         qairt_sdk_root,
         docker_ccache_root,
         build_nuget,
@@ -1136,6 +1180,7 @@ def build_and_test():
     initialize_logging()
 
     args = parse_arguments()
+    ort_prebuilt_root = get_ort_prebuilt_root(args.ort_prebuilt)
     qairt_sdk_root = get_qairt_sdk_root(args.qairt_sdk)
     docker_ccache_root = get_docker_ccache_root(args.docker_ccache_root)
 
@@ -1149,6 +1194,7 @@ def build_and_test():
             args.venv_path,
             args.config,
             args.target_py_version,
+            ort_prebuilt_root,
             qairt_sdk_root,
             docker_ccache_root,
             args.build_nuget,

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -1053,7 +1053,7 @@ def get_ort_prebuilt_root(root_from_args: Path | None) -> Path | None:
     elif ORT_PREBUILT_ROOT_ENV_VAR in os.environ:
         ort_prebuilt = Path(os.environ[ORT_PREBUILT_ROOT_ENV_VAR])
     else:
-        # Let the build fetch QAIRT
+        # Let the build fetch ORT
         return None
 
     if not ort_prebuilt.exists():

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -248,6 +248,7 @@ class TaskLibrary:
                 "aarch64_manylinux_2_34",
                 self.__config,
                 self.__target_py_version,
+                self.__ort_prebuilt_root,
                 self.__qairt_sdk_root,
                 "build",
                 extra_args=extra_args,
@@ -269,6 +270,7 @@ class TaskLibrary:
                         "aarch64",
                         self.__config,
                         None,  # target-py_version
+                        self.__ort_prebuilt_root,
                         self.__qairt_sdk_root,
                         "archive",
                     )
@@ -289,6 +291,7 @@ class TaskLibrary:
                     "aarch64_manylinux_2_34",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                 )
@@ -307,6 +310,7 @@ class TaskLibrary:
                     "aarch64_oe_gcc11_2",
                     self.__config,
                     None,  # target-py_version
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                 )
@@ -325,6 +329,7 @@ class TaskLibrary:
                     "x86_64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
                 )
@@ -427,6 +432,7 @@ class TaskLibrary:
                         "aarch64",
                         self.__config,
                         None,  # target_py_version
+                        self.__ort_prebuilt_root,
                         self.__qairt_sdk_root,
                         "build",
                         extra_args=["--no-warnings-as-errors"],
@@ -462,6 +468,7 @@ class TaskLibrary:
                     "aarch64_oe_gcc11_2",
                     self.__config,
                     None,  # target-py-version
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
                 )
@@ -492,6 +499,7 @@ class TaskLibrary:
                     "x86_64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
                 )
@@ -737,6 +745,7 @@ class TaskLibrary:
                     "aarch64_manylinux_2_34",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "test",
                 )
@@ -755,6 +764,7 @@ class TaskLibrary:
                     "x86_64",
                     self.__config,
                     self.__target_py_version,
+                    self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "test",
                 )

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -106,6 +106,7 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
         target_arch: TargetArchWindowsT,
         config: BuildConfigT,
         target_py_version: TargetPyVersionT | None,
+        ort_prebuilt_root: Path | None,
         qairt_sdk_root: Path | None,
         mode: str,
         build_as_x: bool = False,
@@ -123,6 +124,8 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
 
         if venv is not None:
             cmd.extend(["-PyVEnv", str(venv).replace(" ", "` ")])
+        if ort_prebuilt_root is not None:
+            cmd.extend(["-OrtPrebuiltRoot", str(ort_prebuilt_root).replace(" ", "` ")])
         if qairt_sdk_root is not None:
             cmd.extend(["-QairtSdkRoot", str(qairt_sdk_root).replace(" ", "` ")])
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -73,6 +73,7 @@ class BuildEpLinuxTask(BashScriptsWithVenvTask):
         target_arch: TargetArchLinuxT,
         config: BuildConfigT,
         target_py_version: TargetPyVersionT | None,
+        ort_prebuilt_root: Path | None,
         qairt_sdk_root: Path | None,
         mode: str,
         extra_args: Iterable[str] | None = None,
@@ -88,6 +89,9 @@ class BuildEpLinuxTask(BashScriptsWithVenvTask):
 
         if target_py_version is not None:
             cmd.append(f"--target-py-version={target_py_version}")
+
+        if ort_prebuilt_root is not None:
+            cmd.append(f"--ort-home={ort_prebuilt_root}")
 
         if qairt_sdk_root is not None:
             cmd.append(f"--qairt-sdk-root={qairt_sdk_root}")

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -164,3 +164,11 @@ ort_prebuilt_windows_arm64:
   version: 1.23.2
   url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-arm64-{version}.zip
   content_root: onnxruntime-win-arm64-{version}
+ort_prebuilt_linux_x64:
+  version: 1.23.2
+  url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-linux-x64-{version}.tgz
+  content_root: onnxruntime-linux-x64-{version}
+ort_prebuilt_linux_aarch64:
+  version: 1.23.2
+  url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-linux-aarch64-{version}.tgz
+  content_root: onnxruntime-linux-aarch64-{version}

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -156,3 +156,11 @@ qairt:
   url: https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/{version}/v{version}.zip
   content_root: qairt/{version}
   bindir: bin
+ort_prebuilt_windows_x64:
+  version: 1.23.2
+  url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-x64-{version}.zip
+  content_root: onnxruntime-win-x64-{version}
+ort_prebuilt_windows_arm64:
+  version: 1.23.2
+  url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-arm64-{version}.zip
+  content_root: onnxruntime-win-arm64-{version}

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -32,6 +32,7 @@ function save_qairt_sdk_path() {
 
 config="Release"
 qairt_sdk_root=
+ort_prebuilt_root=
 qnn_arch_abi=
 target_py_version=
 use_cache=1
@@ -52,6 +53,10 @@ for i in "$@"; do
       ;;
     --no-warnings-as-errors)
       warnings_as_errors=
+      shift
+      ;;
+    --ort-home=*)
+      ort_prebuilt_root="${i#*=}"
       shift
       ;;
     --qairt-sdk-root=*)
@@ -89,6 +94,14 @@ qairt_sdk_file_path="${build_dir}/qairt-sdk-path-${config}.txt"
 
 if [ -z "${qairt_sdk_root}" ]; then
     qairt_sdk_root="$(get_qairt_contentdir)"
+fi
+
+if [ -z "${ort_prebuilt_root}" ]; then
+    if [ "${target_arch}" == "aarch64_oe_gcc11_2" ]; then
+        ort_prebuilt_root="$(get_ort_aarch64_prebuilt_root)"
+    else
+        ort_prebuilt_root="$(get_ort_x64_prebuilt_root)"
+    fi
 fi
 
 cmake_bindir="$(get_cmake_bindir)"
@@ -152,7 +165,7 @@ test_runner=
 
 case "${target_platform}" in
   linux)
-    qnn_args=(--use_qnn --qnn_home "${qairt_sdk_root}")
+    qnn_args=(--use_qnn --qnn_home "${qairt_sdk_root}" --ort_home "${ort_prebuilt_root}")
     platform_args=(--build_shared_lib)
 
     test_runner="${REPO_ROOT}/qcom/scripts/linux/run_tests.sh"
@@ -208,6 +221,7 @@ case "${target_platform}" in
       android_ndk_path="$(get_android_ndk_root)"
     fi
 
+    # TODO: Add --ort_home "${ort_prebuilt_root}" once MS release ORT prebuilt for Android
     qnn_args=(--use_qnn static_lib --qnn_home "${qairt_sdk_root}")
     platform_args=(--build_shared_lib \
                    --android_sdk_path "${android_sdk_path}" \

--- a/qcom/scripts/linux/tools.sh
+++ b/qcom/scripts/linux/tools.sh
@@ -99,6 +99,20 @@ function get_package_contentdir() {
 }
 
 #
+# Get the root of the managed ORT x64 prebuilt installation.
+#
+function get_ort_x64_prebuilt_root() {
+    get_package_contentdir ort_prebuilt_linux_x64
+}
+
+#
+# Get the root of the managed ORT aarch64 prebuilt installation.
+#
+function get_ort_aarch64_prebuilt_root() {
+    get_package_contentdir ort_prebuilt_linux_aarch64
+}
+
+#
 # Get the root of the managed QAIRT installation.
 #
 function get_qairt_contentdir() {

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -16,6 +16,10 @@ param (
     [bool]$BuildNuget = $false,
 
     [Parameter(Mandatory = $false,
+               HelpMessage = "Path to ORT Prebuilt.")]
+    [string]$OrtPrebuiltRoot,
+
+    [Parameter(Mandatory = $false,
                HelpMessage = "Path to QAIRT SDK.")]
     [string]$QairtSdkRoot,
 
@@ -71,6 +75,22 @@ if (-not (Test-Path $BuildDir)) {
 
 Enter-PyVenv $PyVEnv
 
+if ($OrtPrebuiltRoot -eq "") {
+    if ($Arch -eq "x86_64") {
+        $OrtPrebuiltRoot = (Get-OrtX64PrebuiltRoot)
+    }
+    elseif ($Arch -eq "ARM64") {
+        $OrtPrebuiltRoot = (Get-OrtARM64PrebuiltRoot)
+    }
+    else {
+        # TODO: Consider Prebuilt for other Arch
+        $OrtPrebuiltRoot = (Get-OrtARM64PrebuiltRoot)
+    }
+}
+else {
+    $OrtPrebuiltRoot = Resolve-Path -Path $OrtPrebuiltRoot
+}
+
 if ($QairtSdkRoot -eq "") {
     $QairtSdkRoot = (Get-QairtRoot)
 }
@@ -117,7 +137,7 @@ $CommonArgs = `
     "--config", $Config, `
     "--parallel"
 
-$QnnArgs = "--use_qnn", "--qnn_home", "$QairtSdkRoot"
+$QnnArgs = "--use_qnn", "--qnn_home", "$QairtSdkRoot", "--ort_home", "$OrtPrebuiltRoot"
 $GenerateBuild = $false
 $DoBuild = $false
 $BuildWheel = $false

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -79,12 +79,11 @@ if ($OrtPrebuiltRoot -eq "") {
     if ($Arch -eq "x86_64") {
         $OrtPrebuiltRoot = (Get-OrtX64PrebuiltRoot)
     }
-    elseif ($Arch -eq "ARM64") {
+    elseif ($Arch -eq "aarch64" -or $Arch -eq "arm64" -or $Arch -eq "arm64ec") {
         $OrtPrebuiltRoot = (Get-OrtARM64PrebuiltRoot)
     }
     else {
-        # TODO: Consider Prebuilt for other Arch
-        $OrtPrebuiltRoot = (Get-OrtARM64PrebuiltRoot)
+        Write-Warning "No prebuilt ORT available for architecture '$Arch'. Please provide OrtPrebuiltRoot parameter."
     }
 }
 else {

--- a/qcom/scripts/windows/tools.ps1
+++ b/qcom/scripts/windows/tools.ps1
@@ -124,6 +124,14 @@ function Get-NugetBinDir() {
     Get-PackageBinDir nuget_windows_x86_64
 }
 
+function Get-OrtX64PrebuiltRoot() {
+    Get-PackageContentDir ort_prebuilt_windows_x64
+}
+
+function Get-OrtARM64PrebuiltRoot() {
+    Get-PackageContentDir ort_prebuilt_windows_arm64
+}
+
 function Get-QairtRoot() {
     Get-PackageContentDir qairt
 }

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -357,6 +357,7 @@ def generate_build_tree(
     acl_libs,
     armnn_home,
     armnn_libs,
+    ort_home,
     qnn_home,
     snpe_root,
     cann_home,
@@ -802,6 +803,9 @@ def generate_build_tree(
             "-Donnxruntime_USE_OPENVINO_MULTI=" + ("ON" if args.use_openvino.startswith("MULTI") else "OFF"),
             "-Donnxruntime_USE_OPENVINO_AUTO=" + ("ON" if args.use_openvino.startswith("AUTO") else "OFF"),
         ]
+
+    if ort_home and os.path.exists(ort_home):
+        cmake_args += ["-Donnxruntime_ORT_HOME=" + ort_home]
 
     # VitisAI and OpenVINO providers currently only support full_protobuf option.
     if args.use_full_protobuf or args.use_openvino or args.use_vitisai or args.gen_doc or args.enable_generic_interface:
@@ -2407,6 +2411,7 @@ def main():
     qnn_home = ""
     if args.use_qnn:
         qnn_home = args.qnn_home
+    ort_home = args.ort_home
 
     # if using tensorrt, setup tensorrt paths
     tensorrt_home = ""
@@ -2555,6 +2560,7 @@ def main():
             acl_libs,
             armnn_home,
             armnn_libs,
+            ort_home,
             qnn_home,
             snpe_root,
             cann_home,

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -747,6 +747,7 @@ def add_execution_provider_args(parser: argparse.ArgumentParser) -> None:
         help="Enable QNN EP. Optionally specify 'shared_lib' (default) or 'static_lib'.",
     )
     qnn_group.add_argument("--qnn_home", help="Path to QNN SDK directory.")
+    qnn_group.add_argument("--ort_home", help="Path to ORT Prebuilt directory.")
 
     # --- SNPE ---
     snpe_group = parser.add_argument_group("SNPE Execution Provider (Qualcomm)")


### PR DESCRIPTION
### Description
**New ORT_HOME Build System Features:**
- `onnxruntime_ORT_HOME` cmake build system
- `--ort_home` parameter in `build_args.py` 
- Flexible ORT prebuilt selection mechanism
- Enhanced build configuration options across platforms

### Motivation
**Build Flexibility and Complete Decoupling**
- **Complete decoupling**: QNN EP development becomes completely independent of specific ORT versions
    - **Flexibility to build against any ORT release**: Developers can specify any ORT version using `--ort_home` parameter
    - **Flexibility to build against any QAIRT release**: Independent selection of QAIRT versions without ORT constraints
- **Version Matrix Testing**: Ability to test QNN EP against multiple ORT/QAIRT combinations

**Developer Productivity and Workflow Enhancement**
- **Rapid Prototyping**: Quickly test against different ORT versions without rebuilding entire toolchain
- **Version Compatibility Testing**: Easy validation against multiple ORT releases for compatibility assurance