### PR TITLE
 Preserve ONNX I/O order in QNN graph (DLC) serialization

### DIFF
--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_def.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 #include "QnnInterface.h"
@@ -136,6 +137,19 @@ struct OnnxTensorInfo {
   size_t index_;
   const int32_t data_type_;  // Uses TensorProto::DataType
   const std::vector<int64_t> shape_;
+};
+
+// Book-keeping for graph input or output tensors.
+struct GraphInputOutputInfo {
+  std::vector<std::string> names;
+  std::unordered_map<std::string, size_t> indices;
+  std::unordered_map<std::string, OnnxTensorInfo> tensors;
+
+  void Clear() {
+    names.clear();
+    indices.clear();
+    tensors.clear();
+  }
 };
 
 size_t memscpy(void* dst, size_t dst_size, const void* src, size_t copy_size);

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model.cc
@@ -22,6 +22,44 @@
 namespace onnxruntime {
 namespace qnn {
 
+namespace {
+
+// Resolves the correct I/O order, preferring ONNX declaration order when available.
+// When names don't match directly (e.g., with offload_graph_io_quantization), uses
+// tensor_name_overrides_reversed to translate ONNX names to internal tensor names.
+std::vector<std::string> ResolveGraphInputOutputOrder(
+    const std::vector<std::string>* onnx_names,
+    const std::unordered_set<std::string>& fused_names,
+    const std::vector<std::string>& fused_order,
+    const std::unordered_map<std::string, std::string>& tensor_name_overrides_reversed) {
+  if (!onnx_names) {
+    return fused_order;
+  }
+
+  bool names_match = std::all_of(onnx_names->begin(), onnx_names->end(),
+                                 [&](const std::string& n) { return fused_names.count(n) > 0; });
+  if (names_match) {
+    return *onnx_names;
+  }
+
+  if (!tensor_name_overrides_reversed.empty()) {
+    std::vector<std::string> mapped_order;
+    for (const auto& onnx_name : *onnx_names) {
+      auto it = tensor_name_overrides_reversed.find(onnx_name);
+      if (it != tensor_name_overrides_reversed.end() && fused_names.count(it->second)) {
+        mapped_order.push_back(it->second);
+      }
+    }
+    if (mapped_order.size() == onnx_names->size()) {
+      return mapped_order;
+    }
+  }
+
+  return fused_order;
+}
+
+}  // namespace
+
 bool QnnModel::GetGraphInfoFromModel(QnnModelWrapper& model_wrapper, const Ort::Logger& /* logger */) {
   bool rt = true;
 
@@ -34,74 +72,100 @@ bool QnnModel::GetGraphInfoFromModel(QnnModelWrapper& model_wrapper, const Ort::
   return rt;
 }
 
-Ort::Status QnnModel::SetGraphInputOutputInfo(const OrtGraph& ort_graph,
-                                              const OrtNode& fused_node,
-                                              const Ort::Logger& logger) {
-  size_t num_inputs = 0;
-  ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.Node_GetNumInputs(&fused_node, &num_inputs));
-  std::vector<const OrtValueInfo*> input_defs(num_inputs);
-  ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.Node_GetInputs(&fused_node, input_defs.data(), input_defs.size()));
-  RETURN_IF_ERROR(ParseGraphInputOrOutput(ort_graph, input_defs, input_names_, inputs_info_,
-                                          model_input_index_map_, logger, true));
+Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
+  const OrtGraph& ort_graph = context.ort_graph;
 
-  size_t num_outputs = 0;
-  ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.Node_GetNumOutputs(&fused_node, &num_outputs));
+  graph_inputs_.Clear();
+  graph_outputs_.Clear();
 
-  std::vector<const OrtValueInfo*> output_defs(num_outputs);
-  ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.Node_GetOutputs(&fused_node, output_defs.data(), output_defs.size()));
-  RETURN_IF_ERROR(ParseGraphInputOrOutput(ort_graph, output_defs, output_names_, outputs_info_,
-                                          model_output_index_map_, logger));
+  Ort::ConstNode fused_node{&context.fused_node};
+  std::vector<Ort::ConstValueInfo> input_defs = fused_node.GetInputs();
 
-  return Ort::Status();
-}
-
-Ort::Status QnnModel::ParseGraphInputOrOutput(const OrtGraph& ort_graph,
-                                              std::vector<const OrtValueInfo*> input_output_defs,
-                                              std::vector<std::string>& input_output_names,
-                                              std::unordered_map<std::string, OnnxTensorInfo>& input_output_info_table,
-                                              std::unordered_map<std::string, size_t>& input_output_index_map,
-                                              const Ort::Logger& logger,
-                                              bool is_input) {
-  for (size_t i = 0, end = input_output_defs.size(), index = 0; i < end; ++i) {
-    const OrtValueInfo* input_output_def_data = input_output_defs[i];
-    const char* input_output_def_name = nullptr;
-    ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetValueInfoName(input_output_def_data, &input_output_def_name));
-
-    const auto name = std::string(input_output_def_name);
-    if (is_input) {
-      if (IsConstantInitializer(ort_graph, name)) {
-        continue;  // exclude initializer inputs
-      }
+  // Collect non-initializer inputs
+  std::unordered_set<std::string> fused_input_names;
+  std::vector<std::string> fused_input_order;
+  for (const auto& input : input_defs) {
+    std::string name = input.GetName();
+    if (!IsConstantInitializer(ort_graph, name)) {
+      fused_input_names.insert(name);
+      fused_input_order.push_back(name);
     }
-    // Validate input/output shape
-    ORT_CXX_LOG(logger,
+  }
+
+  std::unordered_map<std::string, std::string> tensor_name_overrides_reversed;
+  if (context.tensor_name_overrides) {
+    for (const auto& [internal, onnx] : *context.tensor_name_overrides) {
+      tensor_name_overrides_reversed[onnx] = internal;
+    }
+  }
+
+  const std::vector<std::string> input_order = ResolveGraphInputOutputOrder(
+      context.onnx_input_names, fused_input_names, fused_input_order, tensor_name_overrides_reversed);
+
+  for (size_t idx = 0; idx < input_order.size(); ++idx) {
+    const auto& name = input_order[idx];
+    ORT_CXX_LOG(context.logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
-                ((is_input ? "input " : "output ") + std::to_string(i) + " " + name).c_str());
-    input_output_index_map.emplace(name, index++);
+                ("input " + std::to_string(idx) + " " + name).c_str());
+    graph_inputs_.indices.emplace(name, idx);
+    graph_inputs_.names.push_back(name);
+  }
 
-    const OrtTypeInfo* type_info = nullptr;
-    ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetValueInfoTypeInfo(input_output_def_data, &type_info));
+  for (size_t i = 0; i < input_defs.size(); ++i) {
+    const auto& value_info = input_defs[i];
+    std::string name = value_info.GetName();
+    if (IsConstantInitializer(ort_graph, name)) continue;
 
-    const OrtTensorTypeAndShapeInfo* type_shape = nullptr;
-    ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.CastTypeInfoToTensorInfo(type_info, &type_shape));
+    auto shape_info = value_info.TypeInfo().GetTensorTypeAndShapeInfo();
+    ONNXTensorElementDataType elem_type = shape_info.GetElementType();
+    std::vector<int64_t> shape = shape_info.GetShape();
 
-    ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-    ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetTensorElementType(type_shape, &elem_type));
+    for (const auto& s : shape) {
+      RETURN_IF(s < 0, ("Dynamic shape is not supported yet, for input: " + name).c_str());
+    }
 
-    size_t num_dims = 0;
-    ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetDimensionsCount(type_shape, &num_dims));
+    graph_inputs_.tensors.emplace(std::piecewise_construct,
+                                  std::forward_as_tuple(name),
+                                  std::forward_as_tuple(i, static_cast<int32_t>(elem_type), std::move(shape)));
+  }
 
-    std::vector<int64_t> shape;
-    shape.resize(num_dims, 0);
-    ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetDimensions(type_shape, shape.data(), shape.size()));
+  std::vector<Ort::ConstValueInfo> output_defs = fused_node.GetOutputs();
+
+  std::unordered_set<std::string> fused_output_names;
+  std::vector<std::string> fused_output_order;
+  for (const auto& output : output_defs) {
+    std::string name = output.GetName();
+    fused_output_names.insert(name);
+    fused_output_order.push_back(name);
+  }
+
+  const std::vector<std::string> output_order = ResolveGraphInputOutputOrder(
+      context.onnx_output_names, fused_output_names, fused_output_order, tensor_name_overrides_reversed);
+
+  for (size_t idx = 0; idx < output_order.size(); ++idx) {
+    const auto& name = output_order[idx];
+    ORT_CXX_LOG(context.logger,
+                ORT_LOGGING_LEVEL_VERBOSE,
+                ("output " + std::to_string(idx) + " " + name).c_str());
+    graph_outputs_.indices.emplace(name, idx);
+    graph_outputs_.names.push_back(name);
+  }
+
+  for (size_t i = 0; i < output_defs.size(); ++i) {
+    const auto& value_info = output_defs[i];
+    std::string name = value_info.GetName();
+
+    auto shape_info = value_info.TypeInfo().GetTensorTypeAndShapeInfo();
+    ONNXTensorElementDataType elem_type = shape_info.GetElementType();
+    std::vector<int64_t> shape = shape_info.GetShape();
+
     for (const auto& s : shape) {
       RETURN_IF(s < 0, ("Dynamic shape is not supported yet, for output: " + name).c_str());
     }
-    // use index i so that for graph input, it has initializers included
-    input_output_info_table.emplace(std::piecewise_construct,
-                                    std::forward_as_tuple(name),
-                                    std::forward_as_tuple(i, static_cast<int32_t>(elem_type), std::move(shape)));
-    input_output_names.push_back(name);
+
+    graph_outputs_.tensors.emplace(std::piecewise_construct,
+                                   std::forward_as_tuple(name),
+                                   std::forward_as_tuple(i, static_cast<int32_t>(elem_type), std::move(shape)));
   }
 
   return Ort::Status();
@@ -116,13 +180,15 @@ const OrtNodeUnit& QnnModel::GetNodeUnit(const OrtNode* node,
   return *node_unit_it->second;
 }
 
-Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
-                                   const OrtNode& fused_node,
-                                   const qnn::ModelSettings& model_settings,
-                                   const Ort::Logger& logger,
-                                   std::unordered_map<std::string, std::string>* tensor_name_overrides,
-                                   const QnnGraph_Config_t** graph_configs,
-                                   const std::string& json_qnn_graph_path) {
+Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
+  RETURN_IF(context.onnx_input_names == nullptr, "onnx_input_names is required for ComposeGraph");
+  RETURN_IF(context.onnx_output_names == nullptr, "onnx_output_names is required for ComposeGraph");
+  RETURN_IF(context.model_settings == nullptr, "model_settings is required for ComposeGraph");
+
+  const OrtGraph& ort_graph = context.ort_graph;
+  const OrtNode& fused_node = context.fused_node;
+  const Ort::Logger& logger = context.logger;
+
   ORT_CXX_LOG(logger,
               ORT_LOGGING_LEVEL_VERBOSE,
               ("ComposeGraph Graph name: " + Ort::ConstGraph(&ort_graph).GetName()).c_str());
@@ -136,16 +202,16 @@ Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
 
   // This name must be same with the EPContext node name
   const auto& graph_name = Ort::ConstNode(&fused_node).GetName();
-  RETURN_IF_ERROR(SetGraphInputOutputInfo(ort_graph, fused_node, logger));
+  RETURN_IF_ERROR(SetGraphInputOutputInfo(context));
 
   QnnModelWrapper qnn_model_wrapper = QnnModelWrapper(ort_graph, api_ptrs_, logger,
                                                       qnn_backend_manager_->GetQnnInterface(),
                                                       qnn_backend_manager_->GetQnnBackendHandle(),
-                                                      model_input_index_map_,
-                                                      model_output_index_map_,
+                                                      graph_inputs_,
+                                                      graph_outputs_,
                                                       qnn_backend_manager_->GetQnnBackendType(),
-                                                      model_settings,
-                                                      tensor_name_overrides);
+                                                      *context.model_settings,
+                                                      context.tensor_name_overrides);
 
   qnn::profile::ProfilingInfo profiling_info;
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
@@ -155,7 +221,7 @@ Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
   }
 #endif
 
-  bool rt = qnn_model_wrapper.CreateQnnGraph(qnn_backend_manager_->GetQnnContext(), graph_name, graph_configs);
+  bool rt = qnn_model_wrapper.CreateQnnGraph(qnn_backend_manager_->GetQnnContext(), graph_name, context.graph_configs);
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   if (qnn_backend_manager_->ProfilingEnabled()) {
@@ -190,14 +256,14 @@ Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
     }
   }
 
-  const bool build_json_graph = !json_qnn_graph_path.empty();
+  const bool build_json_graph = !context.json_qnn_graph_path.empty();
   RETURN_IF_NOT(qnn_model_wrapper.ComposeQnnGraph(build_json_graph), "Failed to compose Qnn graph.");
 
-  LogTensorDetails(qnn_model_wrapper, graph_name, json_qnn_graph_path, logger);
+  LogTensorDetails(qnn_model_wrapper, graph_name, context.json_qnn_graph_path, logger);
 
   if (build_json_graph) {
     const nlohmann::json& json_graph = qnn_model_wrapper.GetQnnJSONGraph();
-    std::ofstream ofs(json_qnn_graph_path);
+    std::ofstream ofs(context.json_qnn_graph_path);
 
     if (ofs.is_open()) {
       ofs << json_graph.dump();
@@ -205,7 +271,7 @@ Ort::Status QnnModel::ComposeGraph(const OrtGraph& ort_graph,
     } else {
       ORT_CXX_LOG(logger,
                   ORT_LOGGING_LEVEL_WARNING,
-                  ("Could not open JSON graph file: " + json_qnn_graph_path).c_str());
+                  ("Could not open JSON graph file: " + context.json_qnn_graph_path).c_str());
     }
   }
 
@@ -489,8 +555,7 @@ Ort::Status QnnModel::SetupTensors(std::vector<QnnTensorInfo>& qnn_tensor_infos,
   size_t tensor_count = tensor_wrappers.size();
   RETURN_IF(0 == tensor_count, "Zero tensor size!");
   if (is_input) {
-    // Resize qnn_tensor_infos according to the number of graph inputs.
-    auto input_count = GetGraphInputCount();
+    auto input_count = graph_inputs_.indices.size();
     RETURN_IF(input_count < tensor_count, "The count of graph inputs should be at least the count of tensor_wrapper!");
     qnn_tensor_infos.resize(input_count);
   } else {

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model.cc
@@ -24,37 +24,41 @@ namespace qnn {
 
 namespace {
 
-// Resolves the correct I/O order, preferring ONNX declaration order when available.
-// When names don't match directly (e.g., with offload_graph_io_quantization), uses
-// tensor_name_overrides_reversed to translate ONNX names to internal tensor names.
+// Resolves I/O tensor ordering for QNN subgraph.
+//
+// Tries to return tensor names in the original ONNX declaration order. When that's not possible
+// (e.g., onnx_names unavailable, fused node uses tokenized internal names, or partial graph
+// partitioning), falls back to the fused node's original ordering.
 std::vector<std::string> ResolveGraphInputOutputOrder(
     const std::vector<std::string>* onnx_names,
     const std::unordered_set<std::string>& fused_names,
     const std::vector<std::string>& fused_order,
     const std::unordered_map<std::string, std::string>& tensor_name_overrides_reversed) {
-  if (!onnx_names) {
-    return fused_order;
-  }
+  if (onnx_names) {
+    // ONNX names match fused names directly.
+    if (std::all_of(onnx_names->begin(), onnx_names->end(),
+                    [&](const std::string& n) { return fused_names.count(n) > 0; })) {
+      return *onnx_names;
+    }
 
-  bool names_match = std::all_of(onnx_names->begin(), onnx_names->end(),
-                                 [&](const std::string& n) { return fused_names.count(n) > 0; });
-  if (names_match) {
-    return *onnx_names;
-  }
-
-  if (!tensor_name_overrides_reversed.empty()) {
-    std::vector<std::string> mapped_order;
-    for (const auto& onnx_name : *onnx_names) {
-      auto it = tensor_name_overrides_reversed.find(onnx_name);
-      if (it != tensor_name_overrides_reversed.end() && fused_names.count(it->second)) {
-        mapped_order.push_back(it->second);
+    // Translate ONNX names through overrides (onnx_name -> internal_name).
+    if (!tensor_name_overrides_reversed.empty()) {
+      std::vector<std::string> mapped_order;
+      for (const auto& onnx_name : *onnx_names) {
+        auto it = tensor_name_overrides_reversed.find(onnx_name);
+        if (it != tensor_name_overrides_reversed.end() && fused_names.count(it->second)) {
+          mapped_order.push_back(it->second);
+        }
+      }
+      if (mapped_order.size() == onnx_names->size()) {
+        return mapped_order;
       }
     }
-    if (mapped_order.size() == onnx_names->size()) {
-      return mapped_order;
-    }
   }
 
+  // Fallback: use fused node's own ordering. Reached when onnx_names is null (context cache
+  // loading) or when names can't be resolved (fused node uses tokenized internal names that
+  // have no relationship to ONNX names).
   return fused_order;
 }
 

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model.h
@@ -21,6 +21,24 @@ struct QnnTensorInfo {
   size_t ort_index = 0;
 };
 
+// Configuration for QnnModel::ComposeGraph and QnnModel::SetGraphInputOutputInfo.
+struct QnnModelContext {
+  const OrtGraph& ort_graph;
+  const OrtNode& fused_node;
+  const Ort::Logger& logger;
+
+  // Names in ONNX declaration order, absent when loading from cached context.
+  const std::vector<std::string>* onnx_input_names = nullptr;
+  const std::vector<std::string>* onnx_output_names = nullptr;
+
+  const ModelSettings* model_settings = nullptr;
+  const QnnGraph_Config_t** graph_configs = nullptr;
+
+  // Used by offload_graph_io_quantization to map internal QNN names to ONNX names.
+  std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr;
+  std::string json_qnn_graph_path;
+};
+
 class QnnModel {
  public:
   QnnModel(QnnBackendManager* qnn_backend_manager,
@@ -33,13 +51,7 @@ class QnnModel {
   ~QnnModel() = default;
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QnnModel);
 
-  Ort::Status ComposeGraph(const OrtGraph& ort_graph,
-                           const OrtNode& fused_node,
-                           const qnn::ModelSettings& model_settings,
-                           const Ort::Logger& logger,
-                           std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr,
-                           const QnnGraph_Config_t** graph_configs = nullptr,
-                           const std::string& json_qnn_graph_path = "");
+  Ort::Status ComposeGraph(const QnnModelContext& context);
 
   Ort::Status FinalizeGraphs(const Ort::Logger& logger);
 
@@ -48,45 +60,31 @@ class QnnModel {
   Ort::Status ExecuteGraph(OrtKernelContext* context, const Ort::Logger& logger);
 
   const OnnxTensorInfo* GetOutputInfo(const std::string& name) const {
-    auto it = outputs_info_.find(name);
-    if (it == outputs_info_.end()) {
+    auto it = graph_outputs_.tensors.find(name);
+    if (it == graph_outputs_.tensors.end()) {
       return nullptr;
     }
     return &(it->second);
   }
 
-  Ort::Status SetGraphInputOutputInfo(const OrtGraph& ort_graph,
-                                      const OrtNode& fused_node,
-                                      const Ort::Logger& logger);
-  Ort::Status ParseGraphInputOrOutput(const OrtGraph& ort_graph,
-                                      std::vector<const OrtValueInfo*> input_output_defs,
-                                      std::vector<std::string>& input_output_names,
-                                      std::unordered_map<std::string, OnnxTensorInfo>& input_output_info_table,
-                                      std::unordered_map<std::string, size_t>& input_output_index,
-                                      const Ort::Logger& logger,
-                                      bool is_input = false);
+  Ort::Status SetGraphInputOutputInfo(const QnnModelContext& context);
 
-  // Return the input index within Ort graph which has initializers included
+  // Input index within ORT graph (includes initializers in count)
   size_t GetOrtInputIndex(const std::string& name) const {
-    return GetInputOutputIndex(name, inputs_info_);
+    return GetInputOutputIndex(name, graph_inputs_.tensors);
   }
 
-  // Return the pure input index which doesn't cover initializers
+  // Input index excluding initializers
   size_t GetGraphInputIndex(const std::string& name) const {
-    auto it = model_input_index_map_.find(name);
-    if (it == model_input_index_map_.end()) {
+    auto it = graph_inputs_.indices.find(name);
+    if (it == graph_inputs_.indices.end()) {
       ORT_CXX_API_THROW("Input name not found.", ORT_EP_FAIL);
     }
     return it->second;
   }
 
-  // Return the number of graph inputs
-  size_t GetGraphInputCount() const {
-    return model_input_index_map_.size();
-  }
-
   size_t GetOutputIndex(const std::string& name) const {
-    return GetInputOutputIndex(name, outputs_info_);
+    return GetInputOutputIndex(name, graph_outputs_.tensors);
   }
 
   Ort::Status DeserializeGraphInfoFromBinaryInfo(const QnnSystemContext_GraphInfo_t& qnn_sys_ctx_graph_info,
@@ -126,19 +124,19 @@ class QnnModel {
   }
 
   const std::vector<std::string>& GetInputNames() const {
-    return input_names_;
+    return graph_inputs_.names;
   }
 
   const std::vector<std::string>& GetOutputNames() const {
-    return output_names_;
+    return graph_outputs_.names;
   }
 
   const std::unordered_map<std::string, OnnxTensorInfo>& GetInputsInfo() const {
-    return inputs_info_;
+    return graph_inputs_.tensors;
   }
 
   const std::unordered_map<std::string, OnnxTensorInfo>& GetOutputsInfo() const {
-    return outputs_info_;
+    return graph_outputs_.tensors;
   }
 
   const std::string& Name() const { return graph_info_->Name(); }
@@ -161,7 +159,7 @@ class QnnModel {
   size_t GetInputOutputIndex(const std::string& name, const std::unordered_map<std::string, OnnxTensorInfo>& io_info) const {
     auto it = io_info.find(name);
     if (it == io_info.end()) {
-      ORT_CXX_API_THROW("Input/Output name not found.", ORT_EP_FAIL);
+      ORT_CXX_API_THROW("Tensor name not found.", ORT_EP_FAIL);
     }
     return it->second.index_;
   }
@@ -169,13 +167,8 @@ class QnnModel {
  private:
   std::unique_ptr<GraphInfo> graph_info_;
   QnnBackendManager* qnn_backend_manager_ = nullptr;
-  // <input_name, input_index>, initializer inputs are excluded, keep the input index here
-  std::unordered_map<std::string, size_t> model_input_index_map_;
-  std::unordered_map<std::string, size_t> model_output_index_map_;
-  std::vector<std::string> input_names_;
-  std::vector<std::string> output_names_;
-  std::unordered_map<std::string, OnnxTensorInfo> inputs_info_;
-  std::unordered_map<std::string, OnnxTensorInfo> outputs_info_;
+  GraphInputOutputInfo graph_inputs_;
+  GraphInputOutputInfo graph_outputs_;
   std::vector<QnnTensorInfo> qnn_input_infos_;
   std::vector<QnnTensorInfo> qnn_output_infos_;
   QnnBackendType qnn_backend_type_ = QnnBackendType::CPU;

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.cc
@@ -125,17 +125,7 @@ bool QnnModelWrapper::AddTensorWrapper(QnnTensorWrapper&& tensor_wrapper) {
     return true;
   }
 
-  const Qnn_TensorType_t& qnn_tensor_type = tensor_wrapper.GetTensorType();
-  // save created tensors for later lookup to populate graph node construction
   model_tensors_map_.emplace(tensor_name, std::move(tensor_wrapper));
-
-  // save network input/outputs tensors to use for setting the Qnn graph's
-  // input and output tensors for populating GraphInfo for caller
-  if (qnn_tensor_type == QNN_TENSOR_TYPE_APP_WRITE) {
-    model_input_names_.push_back(tensor_name);
-  } else if (qnn_tensor_type == QNN_TENSOR_TYPE_APP_READ) {
-    model_output_names_.push_back(tensor_name);
-  }
 
   return true;
 }
@@ -584,9 +574,52 @@ bool QnnModelWrapper::ProcessBF16Conversions(std::vector<QnnOpProperty>& final_o
   return true;
 }
 
+// Register graph inputs/outputs in ONNX declaration order. This ensures DLC
+// serialization preserves the original input/output ordering. Must be called
+// before processing ops, tensorCreateGraphTensor() order determines ordering
+bool QnnModelWrapper::RegisterGraphInputOutputInOrder() {
+  auto run = [this](const std::vector<std::string>& sorted_names,
+                    Qnn_TensorType_t expected_type,
+                    const char* io_type) -> bool {
+    for (const auto& name : sorted_names) {
+      auto it = model_tensors_map_.find(name);
+      if (it == model_tensors_map_.end()) {
+        continue;
+      }
+      if (it->second.GetTensorType() != expected_type) {
+        continue;
+      }
+      if (tensor_created_map_.count(name)) {
+        continue;
+      }
+
+      if (model_settings_.offload_graph_io_quantization) {
+        if (const auto* override_name = GetTensorNameOverride(name)) {
+          it->second.SetResolvedTensorName(*override_name);
+        }
+      }
+
+      std::string error;
+      if (!it->second.CreateQnnGraphTensor(qnn_interface_, graph_, io_type, tensor_created_map_, error)) {
+        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR,
+                    (std::string("Failed to pre-register ") + io_type + ": " + name + ". " + error).c_str());
+        return false;
+      }
+    }
+    return true;
+  };
+
+  return run(graph_inputs_.names, QNN_TENSOR_TYPE_APP_WRITE, "input") &&
+         run(graph_outputs_.names, QNN_TENSOR_TYPE_APP_READ, "output");
+}
+
 bool QnnModelWrapper::ComposeQnnGraph(bool build_json_qnn_graph) {
   ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Compose Qnn Graph.");
   if (qnn_op_property_list_.empty()) {
+    return false;
+  }
+
+  if (!RegisterGraphInputOutputInOrder()) {
     return false;
   }
 

--- a/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn-abi/builder/qnn_model_wrapper.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "nlohmann/json.hpp"
@@ -47,8 +48,8 @@ class QnnModelWrapper {
                   const Ort::Logger& logger,
                   const QNN_INTERFACE_VER_TYPE& qnn_interface,
                   const Qnn_BackendHandle_t& backend_handle,
-                  const std::unordered_map<std::string, size_t>& input_index_map,
-                  const std::unordered_map<std::string, size_t>& output_index_map,
+                  const GraphInputOutputInfo& graph_inputs,
+                  const GraphInputOutputInfo& graph_outputs,
                   QnnBackendType qnn_backend_type,
                   const ModelSettings& model_settings,
                   std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr)
@@ -56,8 +57,8 @@ class QnnModelWrapper {
         logger_(logger),
         qnn_interface_(qnn_interface),
         backend_handle_(backend_handle),
-        input_index_map_(input_index_map),
-        output_index_map_(output_index_map),
+        graph_inputs_(graph_inputs),
+        graph_outputs_(graph_outputs),
         qnn_backend_type_(qnn_backend_type),
         model_settings_(model_settings),
         api_ptrs_(ApiPtrs{api_ptrs.ort_api, api_ptrs.ep_api, api_ptrs.model_editor_api}),
@@ -111,15 +112,13 @@ class QnnModelWrapper {
 
   Qnn_ContextHandle_t GetQnnGraphContext() const { return graph_context_; }
 
-  // Move input tensor wrappers to GraphInfo, QnnModelWrapper end of live
   std::vector<QnnTensorWrapper>&& GetGraphInputTensorWrappers() {
-    GetGraphInputOutputTensorWrapper(model_input_names_, model_input_tensor_wrappers_);
+    GetGraphInputOutputTensorWrapper(graph_inputs_.names, model_input_tensor_wrappers_);
     return std::move(model_input_tensor_wrappers_);
   }
 
-  // Move output tensor wrappers to GraphInfo, QnnModelWrapper end of live
   std::vector<QnnTensorWrapper>&& GetGraphOutputTensorWrappers() {
-    GetGraphInputOutputTensorWrapper(model_output_names_, model_output_tensor_wrappers_);
+    GetGraphInputOutputTensorWrapper(graph_outputs_.names, model_output_tensor_wrappers_);
     return std::move(model_output_tensor_wrappers_);
   }
 
@@ -198,11 +197,11 @@ class QnnModelWrapper {
   bool IsQnnTensorWrapperExist(const std::string& tensor_name) const;
 
   bool IsGraphOutput(const std::string& tensor_name) const {
-    return output_index_map_.find(tensor_name) != output_index_map_.end();
+    return graph_outputs_.indices.find(tensor_name) != graph_outputs_.indices.end();
   }
 
   bool IsGraphInput(const std::string& tensor_name) const {
-    return input_index_map_.find(tensor_name) != input_index_map_.end();
+    return graph_inputs_.indices.find(tensor_name) != graph_inputs_.indices.end();
   }
 
   const nlohmann::json& GetQnnJSONGraph() {
@@ -402,6 +401,10 @@ class QnnModelWrapper {
   void GetGraphInputOutputTensorWrapper(const std::vector<std::string>& names,
                                         std::vector<QnnTensorWrapper>& wrappers_list);
 
+  // Register graph inputs and outputs in ONNX declaration order. Must be called before
+  // processing ops, as tensorCreateGraphTensor() order determines tensor IDs in DLC.
+  bool RegisterGraphInputOutputInOrder();
+
   // BF16 conversion helper methods
   bool IsBF16ConversionEnabled() const {
     return model_settings_.htp_bf16_enable &&
@@ -443,8 +446,6 @@ class QnnModelWrapper {
   // QNN context that holds the QNN graph referenced by `graph_`
   Qnn_ContextHandle_t graph_context_ = nullptr;
 
-  std::vector<std::string> model_input_names_;
-  std::vector<std::string> model_output_names_;
   std::vector<QnnTensorWrapper> model_input_tensor_wrappers_;
   std::vector<QnnTensorWrapper> model_output_tensor_wrappers_;
   // All QnnTensorWrapper for the graph
@@ -455,8 +456,8 @@ class QnnModelWrapper {
   // <tensor_name, qnn_tensor_created> -- true means qnn tensor created in qnn graph
   // it includs normal qnn_tensors and qnn_tensors inside param_tensors
   std::unordered_map<std::string, bool> tensor_created_map_;
-  const std::unordered_map<std::string, size_t>& input_index_map_;
-  const std::unordered_map<std::string, size_t>& output_index_map_;
+  const GraphInputOutputInfo& graph_inputs_;
+  const GraphInputOutputInfo& graph_outputs_;
   QnnBackendType qnn_backend_type_ = QnnBackendType::CPU;
   ModelSettings model_settings_ = {};
   utils::QnnJSONGraph json_qnn_graph_;

--- a/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.cc
@@ -982,40 +982,39 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
   RETURN_IF_NOT_NULL(ort_api.Graph_GetInputs(graph, graph_inputs.data(), graph_inputs.size()));
   RETURN_IF_NOT_NULL(ort_api.Graph_GetOutputs(graph, graph_outputs.data(), graph_outputs.size()));
 
-  // Util function that initializes a table that maps a graph input or output name to its index.
-  auto init_input_output_index_map = [&](std::unordered_map<std::string, size_t>& index_map,
-                                         std::vector<const OrtValueInfo*> inouts) {
-    size_t num_elements = inouts.size();
-    for (size_t idx = 0; idx < num_elements; ++idx) {
-      const OrtValueInfo* inout = inouts[idx];
+  // Util function that initializes name vector and index map for graph inputs/outputs.
+  auto init_input_output_info = [&](std::vector<std::string>& names,
+                                    std::unordered_map<std::string, size_t>& index_map,
+                                    const std::vector<const OrtValueInfo*>& inouts) {
+    for (size_t idx = 0; idx < inouts.size(); ++idx) {
       const char* name = nullptr;
-      auto lambda_status = ort_api.GetValueInfoName(inout, &name);
+      auto lambda_status = ort_api.GetValueInfoName(inouts[idx], &name);
       if (lambda_status != nullptr) {
         ort_api.ReleaseStatus(lambda_status);
-        return;  // Skip this input/output on error
+        return;  // Skip on error
       }
-
+      names.push_back(name);
       index_map.emplace(name, idx);
     }
   };
 
-  std::unordered_map<std::string, size_t> model_input_index_map;
   // Note that ort_api.GraphGetInputs includes initializers that are included in the list of graph inputs but
   // in previous non-ABI, graph_viewer.GetInputs does not include them. Fortunately, this index map is only used in
   // QnnModelWrapper::GetTensorType to determine APP_WRITE tensor type. Since STATIC tensor type is checked before
   // APP_WRITE in current implementation, there should be no impact including initializers here.
-  init_input_output_index_map(model_input_index_map, graph_inputs);
+  qnn::GraphInputOutputInfo model_inputs;
+  init_input_output_info(model_inputs.names, model_inputs.indices, graph_inputs);
 
-  std::unordered_map<std::string, size_t> model_output_index_map;
-  init_input_output_index_map(model_output_index_map, graph_outputs);
+  qnn::GraphInputOutputInfo model_outputs;
+  init_input_output_info(model_outputs.names, model_outputs.indices, graph_outputs);
 
   auto qnn_model_wrapper = qnn::QnnModelWrapper(*graph,
                                                 ApiPtrs{ort_api, ep_api, model_editor_api},
                                                 logger_,
                                                 qnn_backend_manager_->GetQnnInterface(),
                                                 qnn_backend_manager_->GetQnnBackendHandle(),
-                                                model_input_index_map,
-                                                model_output_index_map,
+                                                model_inputs,
+                                                model_outputs,
                                                 qnn_backend_manager_->GetQnnBackendType(),
                                                 model_settings_,
                                                 &tensor_name_overrides_);
@@ -1340,6 +1339,29 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     return nullptr;
   }
 
+  // Store original graph I/O order for use in Compile.
+  // The partitioning process may reorder inputs, so we capture the original order here.
+  {
+    Ort::ConstGraph ort_graph{graph};
+
+    std::vector<std::string> input_order;
+    for (const auto& input : ort_graph.GetInputs()) {
+      // Skip initializers - only track true model inputs
+      if (!input.IsConstantInitializer()) {
+        input_order.push_back(input.GetName());
+      }
+    }
+
+    std::vector<std::string> output_order;
+    for (const auto& output : ort_graph.GetOutputs()) {
+      output_order.push_back(output.GetName());
+    }
+
+    if (!ep->onnx_graph_io_names_.has_value()) {
+      ep->onnx_graph_io_names_.emplace(std::move(input_order), std::move(output_order));
+    }
+  }
+
   // Get node units for the ABI layer
   std::vector<std::unique_ptr<OrtNodeUnit>> node_unit_holder;
   std::unordered_map<const OrtNode*, const OrtNodeUnit*> node_unit_map;
@@ -1487,9 +1509,17 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
                                           .c_str());
         }
 
-        RETURN_IF_NOT_OK(qnn_model_shared->SetGraphInputOutputInfo(*graphs[graph_idx],
-                                                                   *fused_nodes[graph_idx],
-                                                                   logger_));
+        qnn::QnnModelContext context{
+            /*ort_graph=*/*graphs[graph_idx],
+            /*fused_node=*/*fused_nodes[graph_idx],
+            /*logger=*/logger_,
+            /*onnx_input_names=*/nullptr,
+            /*onnx_output_names=*/nullptr,
+            /*model_settings=*/nullptr,
+            /*graph_configs=*/nullptr,
+            /*tensor_name_overrides=*/nullptr,
+            /*json_qnn_graph_path=*/{}};
+        RETURN_IF_NOT_OK(qnn_model_shared->SetGraphInputOutputInfo(context));
         RETURN_IF_NOT_OK(qnn_model_shared->SetupQnnInputOutput(logger_));
         qnn_models_.emplace(names[graph_idx].first, std::move(qnn_model_shared));
 
@@ -1557,7 +1587,17 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
     }
 
     auto qnn_model = std::move(qnn_model_it->second);
-    RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(*graphs[graph_idx], *fused_nodes[graph_idx], logger_));
+    qnn::QnnModelContext context{
+        /*ort_graph=*/*graphs[graph_idx],
+        /*fused_node=*/*fused_nodes[graph_idx],
+        /*logger=*/logger_,
+        /*onnx_input_names=*/nullptr,
+        /*onnx_output_names=*/nullptr,
+        /*model_settings=*/nullptr,
+        /*graph_configs=*/nullptr,
+        /*tensor_name_overrides=*/nullptr,
+        /*json_qnn_graph_path=*/{}};
+    RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(context));
     RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(logger_));
 
     // fused node name is QNNExecutionProvider_QNN_[hash_id]_[id]
@@ -1704,21 +1744,33 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
       all_graph_configs_ptr = all_graph_configs.data();
     }
 
-    std::string json_graph_filepath;
+    // Get original input/output order captured in GetCapability
+    if (!ep->onnx_graph_io_names_.has_value()) {
+      return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                      "ONNX I/O names not found. GetCapability must be called before Compile.");
+    }
+    const auto& onnx_input_names = ep->onnx_graph_io_names_->first;
+    const auto& onnx_output_names = ep->onnx_graph_io_names_->second;
+
+    // Build context for graph composition
+    qnn::QnnModelContext context{
+        /*ort_graph=*/*graph,
+        /*fused_node=*/*fused_node,
+        /*logger=*/ep->logger_,
+        /*onnx_input_names=*/&onnx_input_names,
+        /*onnx_output_names=*/&onnx_output_names,
+        /*model_settings=*/&ep->model_settings_,
+        /*graph_configs=*/all_graph_configs_ptr,
+        /*tensor_name_overrides=*/&ep->tensor_name_overrides_,
+        /*json_qnn_graph_path=*/std::string{}};
 
     if (ep->dump_json_qnn_graph_) {
       namespace fs = std::filesystem;
-      fs::path path = fs::path(ep->json_qnn_graph_dir_) / fs::path(fused_node_name + ".json");
-      json_graph_filepath = path.string();
+      context.json_qnn_graph_path =
+          (fs::path(ep->json_qnn_graph_dir_) / fs::path(fused_node_name + ".json")).string();
     }
 
-    RETURN_IF_NOT_OK(qnn_model->ComposeGraph(*graph,
-                                             *fused_node,
-                                             ep->model_settings_,
-                                             ep->logger_,
-                                             &ep->tensor_name_overrides_,
-                                             all_graph_configs_ptr,
-                                             json_graph_filepath));
+    RETURN_IF_NOT_OK(qnn_model->ComposeGraph(context));
     RETURN_IF_NOT_OK(qnn_model->FinalizeGraphs(ep->logger_));
     RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(ep->logger_));
 
@@ -1727,6 +1779,10 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
     auto node_compute_info = std::make_unique<QnnNodeComputeInfo>(*ep);
     node_compute_infos[graph_idx] = node_compute_info.release();
   }
+
+  // Clean up transient GetCapability→Compile state.
+  ep->onnx_graph_io_names_.reset();
+  ep->tensor_name_overrides_.clear();
 
   if (ep->context_cache_enabled_) {
     RETURN_IF_NOT_NULL(ep->CreateEPContextNodes(graphs[0], fused_nodes, count, ep_context_nodes));

--- a/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn-abi/qnn_execution_provider.h
@@ -189,8 +189,11 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // Format: <BackendId>:<SDK>:<BackendApi>:<ContextBlob>:<HtpArch>:<IsHtpUsrDrv>.
   std::string compatibility_info_string_ = "";
 
-  // Used by offload_graph_io_quantization to map internal QNN names to original ONNX names.
+  // Transient state captured in GetCapability() and consumed in Compile().
+  // Only one model is ever in-flight per EP instance (one EP per session).
   mutable std::unordered_map<std::string, std::string> tensor_name_overrides_;
+  // ONNX graph I/O names in declaration order: {input_names, output_names}.
+  mutable std::optional<std::pair<std::vector<std::string>, std::vector<std::string>>> onnx_graph_io_names_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn-abi/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn-abi/qnn_basic_test.cc
@@ -1919,6 +1919,327 @@ TEST(QnnABISaverBackendTests, DISABLED_QnnSaver_OutputFiles) {
   EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "params.bin"));
 }
 
+// Verifies QNN graph I/O order matches ONNX declaration order.
+TEST_F(QnnABICPUBackendTests, GraphInputOutputOrderMatchesOnnx) {
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  auto& logging_manager = DefaultLoggingManager();
+  onnxruntime::Model model("GraphInputOutputOrderMatchesOnnx", false, ModelMetaData(), PathString(),
+                           IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+                           logging_manager.DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto type1;
+  type1.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  type1.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  type1.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
+  auto& i1 = graph.GetOrCreateNodeArg("i1", &type1);
+
+  ONNX_NAMESPACE::TypeProto type2;
+  type2.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  type2.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  type2.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(5);
+  auto& i2 = graph.GetOrCreateNodeArg("i2", &type2);
+
+  ONNX_NAMESPACE::TypeProto type3;
+  type3.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  type3.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  type3.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(7);
+  auto& i3 = graph.GetOrCreateNodeArg("i3", &type3);
+
+  auto& o1 = graph.GetOrCreateNodeArg("o1", &type1);
+  graph.AddNode("relu1", "Relu", "", {&i1}, {&o1});
+
+  auto& o3 = graph.GetOrCreateNodeArg("o3", &type3);
+  graph.AddNode("relu3", "Relu", "", {&i3}, {&o3});
+
+  auto& o2 = graph.GetOrCreateNodeArg("o2", &type2);
+  graph.AddNode("relu2", "Relu", "", {&i2}, {&o2});
+
+  graph.SetInputs({&i2, &i1, &i3});
+  graph.SetOutputs({&o2, &o1, &o3});
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK()) << "Graph resolve failed: " << status.ErrorMessage();
+
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  const std::filesystem::path tmp_dir = "qnn_io_order_test";
+  std::filesystem::remove_all(tmp_dir);
+  std::filesystem::create_directory(tmp_dir);
+
+  auto cleanup = gsl::finally([&tmp_dir]() { std::filesystem::remove_all(tmp_dir); });
+
+  Ort::SessionOptions so;
+  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+
+  onnxruntime::ProviderOptions options;
+#if defined(_WIN32)
+  options["backend_path"] = "QnnCpu.dll";
+#else
+  options["backend_path"] = "libQnnCpu.so";
+#endif
+  options["json_qnn_graph_dir"] = tmp_dir.string();
+  options["dump_json_qnn_graph"] = "1";
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnABIExecutionProvider, options);
+
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  std::vector<std::pair<std::string, int>> inputs_with_id, outputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+
+    nlohmann::json root;
+    json_file >> root;
+
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      int type = tensor.value("type", -1);
+      int id = tensor.value("id", -1);
+      if (type == 0) {
+        inputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_WRITE
+      } else if (type == 1) {
+        outputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_READ
+      }
+    }
+  }
+
+  // Sort by tensor ID to recover registration order.
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+  std::sort(outputs_with_id.begin(), outputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  std::vector<std::string> input_names, output_names;
+  for (const auto& [name, id] : inputs_with_id) {
+    input_names.push_back(name);
+  }
+  for (const auto& [name, id] : outputs_with_id) {
+    output_names.push_back(name);
+  }
+
+  // Verify correct count.
+  ASSERT_EQ(input_names.size(), 3u) << "Expected 3 inputs";
+  ASSERT_EQ(output_names.size(), 3u) << "Expected 3 outputs";
+
+  // Verify ordering matches ONNX declaration: {i2, i1, i3} and {o2, o1, o3}.
+  EXPECT_EQ(input_names[0], "i2");
+  EXPECT_EQ(input_names[1], "i1");
+  EXPECT_EQ(input_names[2], "i3");
+
+  EXPECT_EQ(output_names[0], "o2");
+  EXPECT_EQ(output_names[1], "o1");
+  EXPECT_EQ(output_names[2], "o3");
+}
+
+// Verifies QNN graph I/O order matches ONNX declaration order with offload_graph_io_quantization=1.
+TEST_F(QnnABICPUBackendTests, GraphInputOutputOrderMatchesOnnxOffloadGraphIoQuantization) {
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 21}, {kMSDomain, 1}};
+  auto& logging_manager = DefaultLoggingManager();
+  onnxruntime::Model model("GraphInputOutputOrderMatchesOnnxOffloadGraphIoQuantization",
+                           false, ModelMetaData(), PathString(),
+                           IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+                           logging_manager.DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto float_type1;
+  float_type1.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_type1.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  float_type1.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
+  auto& i1 = graph.GetOrCreateNodeArg("i1", &float_type1);
+
+  ONNX_NAMESPACE::TypeProto float_type2;
+  float_type2.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_type2.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  float_type2.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(5);
+  auto& i2 = graph.GetOrCreateNodeArg("i2", &float_type2);
+
+  ONNX_NAMESPACE::TypeProto float_type3;
+  float_type3.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_type3.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  float_type3.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(7);
+  auto& i3 = graph.GetOrCreateNodeArg("i3", &float_type3);
+
+  ONNX_NAMESPACE::TypeProto scale_type;
+  scale_type.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  scale_type.mutable_tensor_type()->mutable_shape();  // scalar
+
+  ONNX_NAMESPACE::TypeProto zp_type;
+  zp_type.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  zp_type.mutable_tensor_type()->mutable_shape();  // scalar
+
+  ONNX_NAMESPACE::TypeProto uint8_type1;
+  uint8_type1.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  uint8_type1.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  uint8_type1.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
+
+  ONNX_NAMESPACE::TypeProto uint8_type2;
+  uint8_type2.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  uint8_type2.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  uint8_type2.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(5);
+
+  ONNX_NAMESPACE::TypeProto uint8_type3;
+  uint8_type3.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  uint8_type3.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  uint8_type3.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(7);
+
+  float scale_val = 1.0f / 255.0f;
+  uint8_t zp_val = 128;
+
+  ONNX_NAMESPACE::TensorProto scale_tensor;
+  scale_tensor.set_name("scale");
+  scale_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  scale_tensor.add_float_data(scale_val);
+  graph.AddInitializedTensor(scale_tensor);
+  auto& scale_arg = graph.GetOrCreateNodeArg("scale", &scale_type);
+
+  ONNX_NAMESPACE::TensorProto zp_tensor;
+  zp_tensor.set_name("zero_point");
+  zp_tensor.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+  zp_tensor.add_int32_data(zp_val);
+  graph.AddInitializedTensor(zp_tensor);
+  auto& zp_arg = graph.GetOrCreateNodeArg("zero_point", &zp_type);
+
+  auto& q1_out = graph.GetOrCreateNodeArg("q1_out", &uint8_type1);
+  graph.AddNode("q1", "QuantizeLinear", "", {&i1, &scale_arg, &zp_arg}, {&q1_out});
+  auto& dq1_out = graph.GetOrCreateNodeArg("dq1_out", &float_type1);
+  graph.AddNode("dq1", "DequantizeLinear", "", {&q1_out, &scale_arg, &zp_arg}, {&dq1_out});
+  auto& sigmoid1_out = graph.GetOrCreateNodeArg("sigmoid1_out", &float_type1);
+  graph.AddNode("sigmoid1", "Sigmoid", "", {&dq1_out}, {&sigmoid1_out});
+  auto& q1_out2 = graph.GetOrCreateNodeArg("q1_out2", &uint8_type1);
+  graph.AddNode("q1_2", "QuantizeLinear", "", {&sigmoid1_out, &scale_arg, &zp_arg}, {&q1_out2});
+  auto& o1 = graph.GetOrCreateNodeArg("o1", &float_type1);
+  graph.AddNode("dq1_2", "DequantizeLinear", "", {&q1_out2, &scale_arg, &zp_arg}, {&o1});
+
+  auto& q3_out = graph.GetOrCreateNodeArg("q3_out", &uint8_type3);
+  graph.AddNode("q3", "QuantizeLinear", "", {&i3, &scale_arg, &zp_arg}, {&q3_out});
+  auto& dq3_out = graph.GetOrCreateNodeArg("dq3_out", &float_type3);
+  graph.AddNode("dq3", "DequantizeLinear", "", {&q3_out, &scale_arg, &zp_arg}, {&dq3_out});
+  auto& sigmoid3_out = graph.GetOrCreateNodeArg("sigmoid3_out", &float_type3);
+  graph.AddNode("sigmoid3", "Sigmoid", "", {&dq3_out}, {&sigmoid3_out});
+  auto& q3_out2 = graph.GetOrCreateNodeArg("q3_out2", &uint8_type3);
+  graph.AddNode("q3_2", "QuantizeLinear", "", {&sigmoid3_out, &scale_arg, &zp_arg}, {&q3_out2});
+  auto& o3 = graph.GetOrCreateNodeArg("o3", &float_type3);
+  graph.AddNode("dq3_2", "DequantizeLinear", "", {&q3_out2, &scale_arg, &zp_arg}, {&o3});
+
+  auto& q2_out = graph.GetOrCreateNodeArg("q2_out", &uint8_type2);
+  graph.AddNode("q2", "QuantizeLinear", "", {&i2, &scale_arg, &zp_arg}, {&q2_out});
+  auto& dq2_out = graph.GetOrCreateNodeArg("dq2_out", &float_type2);
+  graph.AddNode("dq2", "DequantizeLinear", "", {&q2_out, &scale_arg, &zp_arg}, {&dq2_out});
+  auto& sigmoid2_out = graph.GetOrCreateNodeArg("sigmoid2_out", &float_type2);
+  graph.AddNode("sigmoid2", "Sigmoid", "", {&dq2_out}, {&sigmoid2_out});
+  auto& q2_out2 = graph.GetOrCreateNodeArg("q2_out2", &uint8_type2);
+  graph.AddNode("q2_2", "QuantizeLinear", "", {&sigmoid2_out, &scale_arg, &zp_arg}, {&q2_out2});
+  auto& o2 = graph.GetOrCreateNodeArg("o2", &float_type2);
+  graph.AddNode("dq2_2", "DequantizeLinear", "", {&q2_out2, &scale_arg, &zp_arg}, {&o2});
+
+  graph.SetInputs({&i2, &i1, &i3});
+  graph.SetOutputs({&o2, &o1, &o3});
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK()) << "Graph resolve failed: " << status.ErrorMessage();
+
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  const std::filesystem::path tmp_dir = "qnn_io_order_qdq_test";
+  std::filesystem::remove_all(tmp_dir);
+  std::filesystem::create_directory(tmp_dir);
+
+  auto cleanup = gsl::finally([&tmp_dir]() { std::filesystem::remove_all(tmp_dir); });
+
+  Ort::SessionOptions so;
+  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+
+  onnxruntime::ProviderOptions options;
+#if defined(_WIN32)
+  options["backend_path"] = "QnnCpu.dll";
+#else
+  options["backend_path"] = "libQnnCpu.so";
+#endif
+  options["offload_graph_io_quantization"] = "1";
+  options["json_qnn_graph_dir"] = tmp_dir.string();
+  options["dump_json_qnn_graph"] = "1";
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnABIExecutionProvider, options);
+
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  std::vector<std::pair<std::string, int>> inputs_with_id, outputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+
+    nlohmann::json root;
+    json_file >> root;
+
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      int type = tensor.value("type", -1);
+      int id = tensor.value("id", -1);
+      if (type == 0) {
+        inputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_WRITE
+      } else if (type == 1) {
+        outputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_READ
+      }
+    }
+  }
+
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+  std::sort(outputs_with_id.begin(), outputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  std::vector<std::string> input_names, output_names;
+  for (const auto& [name, id] : inputs_with_id) {
+    input_names.push_back(name);
+  }
+  for (const auto& [name, id] : outputs_with_id) {
+    output_names.push_back(name);
+  }
+
+  ASSERT_EQ(input_names.size(), 3u) << "Expected 3 inputs";
+  ASSERT_EQ(output_names.size(), 3u) << "Expected 3 outputs";
+
+  std::set<std::string> expected_input_set = {"i1", "i2", "i3"};
+  std::set<std::string> actual_input_set(input_names.begin(), input_names.end());
+  EXPECT_EQ(actual_input_set, expected_input_set);
+
+  std::set<std::string> expected_output_set = {"o1", "o2", "o3"};
+  std::set<std::string> actual_output_set(output_names.begin(), output_names.end());
+  EXPECT_EQ(actual_output_set, expected_output_set);
+
+  EXPECT_EQ(input_names[0], "i2");
+  EXPECT_EQ(input_names[1], "i1");
+  EXPECT_EQ(input_names[2], "i3");
+
+  EXPECT_EQ(output_names[0], "o2");
+  EXPECT_EQ(output_names[1], "o1");
+  EXPECT_EQ(output_names[2], "o3");
+}
+
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace test


### PR DESCRIPTION
Fix QNN graph input/output ordering to match ONNX declaration order.

Problem: When ONNX Runtime partitions a graph and creates a fused node for the QNN EP, the partitioning process can **reorder the inputs and outputs** relative to the original ONNX model declaration order. The QNN backend (specifically DLC serialization) determines tensor ordering by the order in which `tensorCreateGraphTensor()` is called. If the fused node's I/O order differs from the original ONNX model, the compiled QNN graph will have mismatched I/O positions — leading to **silent data corruption** at inference time (wrong tensors bound to wrong positions).

Solution:
- Capture ONNX I/O order in GetCapability (before graph partitioning)
- Pass order to ComposeGraph via ComposeGraphContext
- Register graph I/O with QNN in ONNX order before processing ops
- Add RegisterGraphInputOutputInOrder() to pre-register tensors