### PR TITLE
Temporarily disable resize cubic downsample test

### DIFF
--- a/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
+++ b/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
@@ -725,7 +725,8 @@
     ],
     "current_failing_tests_QNN": [
         "^test_scatter_elements_with_negative_indices",
-        "^test_scatter_elements_with_duplicate_indices*"
+        "^test_scatter_elements_with_duplicate_indices*",
+        "^test_resize_downsample_scales_cubic*"
     ],
     "current_failing_tests_WEBGPU": [
         "^test_layer_normalization_2d_axis0_cpu",


### PR DESCRIPTION
### Description
CI failing due to 
resize_downsample_scales_cubic:output=Y:expected 14.5278 (41687200), got 15.3692 (4175e855), diff: 0.84139, tol=0.0145378 idx=8. 9 of 9 differ


### Motivation and Context
Values are aligning with ORT CPU inference in local test

