### PR TITLE
Fix the building of artifacts

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -120,7 +120,6 @@ jobs:
           "${{ inputs.target_os == 'windows' && 'python.exe' || 'python3' }}"
           qcom/build_and_test.py
           --target-py-version ${{inputs.target_py_vsn}}
-          --build-nuget
           ${{inputs.upload_test_archive == true && 'archive' || 'build'}}_ort_${{inputs.target_os}}_${{ inputs.target_arch }}
 
       - name: Test ${{inputs.target_os}} ${{ inputs.target_arch }} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -87,7 +87,6 @@ jobs:
           python.exe
           qcom/build_and_test.py
           --target-py-version 3.12
-          --build-nuget
           archive_ort_windows_arm64
           test_ort_windows_arm64
 

--- a/cmake/onnxruntime_providers_qnn_abi.cmake
+++ b/cmake/onnxruntime_providers_qnn_abi.cmake
@@ -124,6 +124,26 @@
       endforeach()
     endif()
   endif()
+
+  # Copy License to output directory
+  add_custom_command(
+    TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${REPO_ROOT}/ThirdPartyNotices.txt
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${REPO_ROOT}/docs/Privacy.md
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${REPO_ROOT}/LICENSE
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/
+  )
+  if (EXISTS "${onnxruntime_QNN_HOME}/LICENSE.pdf")
+    add_custom_command(
+      TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${onnxruntime_QNN_HOME}/LICENSE.pdf" $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/Qualcomm_LICENSE.pdf
+    )
+  endif()
   if (EXISTS "${onnxruntime_QNN_HOME}/Qualcomm AI Hub Proprietary License.pdf")
     add_custom_command(
       TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD

--- a/qcom/samples/test_qnnep.cs
+++ b/qcom/samples/test_qnnep.cs
@@ -10,11 +10,11 @@ namespace QnnEpNuGetTest
 {
     class Program
     {
-        private static string InputModelPath = "conv_autopad.onnx";
+        private static string InputModelPath = "cmake\\external\\onnx\\onnx\\backend\\test\\data\\node\\test_averagepool_2d_default\\model.onnx";
         private const int Batch = 1;
-        private const int Channel = 1;
-        private const int Height = 5;
-        private const int Width = 5;
+        private const int Channel = 3;
+        private const int Height = 32;
+        private const int Width = 32;
 
         static void Main(string[] args)
         {

--- a/qcom/samples/test_wheel.py
+++ b/qcom/samples/test_wheel.py
@@ -39,20 +39,17 @@ sess_options.add_provider_for_devices(selected_ep_devices, ep_options)
 assert sess_options.has_providers()
 
 # Create ORT session with the plugin EP
-model_path = "layout_transform_reshape.onnx"
+model_path = "cmake/external/onnx/onnx/backend/test/data/node/test_abs/model.onnx"
 sess = ort.InferenceSession(model_path, sess_options=sess_options)
 
 # Create input data for the model
-# Input "816" with shape [1, 512, 6] and dtype float32
-input_816 = np.random.randn(1, 512, 6).astype(np.float32)
-
-# Input "686" with shape [1, 4, 512] and dtype float32
-input_686 = np.random.randn(1, 4, 512).astype(np.float32)
+# Input "x" with shape [3, 4, 5] and dtype float32
+x = np.random.randn(3, 4, 5).astype(np.float32)
 
 # Run inference
 outputs = sess.run(
     None,  # Get all outputs
-    {"816": input_816, "686": input_686},
+    {"x": x},
 )
 
 print("\nInference completed successfully!")

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -261,16 +261,16 @@ else {
             }
 
             if ($DoBuild) {
+                $BuildOutputDir = (Join-Path $BuildDir $Config)
                 Assert-Success -ErrorMessage "Failed to build" {
-                    & cmake --build (Join-Path $BuildDir $Config) --config $Config
+                    & cmake --build $BuildOutputDir --config $Config
+                }
+
+                if ($CMakeGenerator -eq "Visual Studio 17 2022") {
+                    $BuildOutputDir = (Join-Path $BuildOutputDir $Config)
                 }
 
                 if ($BuildWheel) {
-                    $BuildOutputDir = (Join-Path $BuildDir $Config)
-                    if ($CMakeGenerator -eq "Visual Studio 17 2022") {
-                        $BuildOutputDir = (Join-Path $BuildOutputDir $Config)
-                    }
-
                     if ($env:ORT_NIGHTLY_BUILD) {
                         $PyNightlyArg = "--nightly_build"
                     }
@@ -290,8 +290,9 @@ else {
                 if ($BuildNuget) {
                     Use-PyVenv -PyVenv $BuildVEnv {
                         Use-WorkingDir -Path $BuildOutputDir {
+                            $BuildBatPath = (Join-Path $RepoRoot "build.bat")
                             Assert-Success -ErrorMessage "Failed to build nuget" {
-                                .\build.bat $ArchArgs $CommonArgs $QnnArgs $PlatformArgs
+                                & $BuildBatPath --skip_tests $ArchArgs $CommonArgs $QnnArgs $PlatformArgs
                             }
                         }
                     }

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ import datetime
 import logging
 import platform
 import shlex
+import shutil
 import subprocess
 import sys
+import tempfile
+import zipfile
 from glob import glob
 from os import environ, getcwd, path, remove
 from shutil import copyfile
@@ -356,3 +359,32 @@ setup(
     },
     classifiers=classifiers,
 )
+
+
+# TODO: Remove the workaround once we remove the QNN EP non-ABI build and remove the "_abi" suffix.
+# Workaround to rename the onnxruntime_providers_qnn_abi.dll to onnxruntime_providers_qnn.dll in the wheel package.
+def rename_wheel_qnn_ep_library():
+    artifact_folder = getcwd()
+    wheel_files = glob(f"{artifact_folder}/dist/*.whl")
+    for wheel_path in wheel_files:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Extract wheel
+            with zipfile.ZipFile(wheel_path, "r") as zip_ref:
+                zip_ref.extractall(tmp_dir)
+
+            # Remove the origin one
+            remove(wheel_path)
+
+            qnn_ep_libraries_need_updated = glob(f"{tmp_dir}/*/onnxruntime_providers_qnn_abi.dll")
+            for qnn_ep_library in qnn_ep_libraries_need_updated:
+                # Rename
+                shutil.move(
+                    qnn_ep_library,
+                    qnn_ep_library.replace("onnxruntime_providers_qnn_abi.dll", "onnxruntime_providers_qnn.dll"),
+                )
+
+            # Repack wheel
+            subprocess.run(f"wheel pack {tmp_dir} -d {artifact_folder}/dist", shell=True, check=True)
+
+
+rename_wheel_qnn_ep_library()

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1963,33 +1963,6 @@ def build_python_wheel(
         run_subprocess(args, cwd=cwd)
 
 
-# TODO: Remove the workaround once we remove the QNN EP non-ABI build and remove the "_abi" suffix.
-# Workaround to rename the onnxruntime_providers_qnn_abi.dll to onnxruntime_providers_qnn.dll in the wheel package.
-def rename_wheel_qnn_ep_library(build_dir, configs):
-    for config in configs:
-        artifact_folder = os.path.join(build_dir, config, config)
-        wheel_files = glob.glob(f"{artifact_folder}/dist/*.whl")
-        for wheel_path in wheel_files:
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                # Extract wheel
-                with zipfile.ZipFile(wheel_path, "r") as zip_ref:
-                    zip_ref.extractall(tmp_dir)
-
-                # Remove the origin one
-                os.remove(wheel_path)
-
-                qnn_ep_libraries_need_updated = glob.glob(f"{tmp_dir}/*/onnxruntime_providers_qnn_abi.dll")
-                for qnn_ep_library in qnn_ep_libraries_need_updated:
-                    # Rename
-                    shutil.move(
-                        qnn_ep_library,
-                        qnn_ep_library.replace("onnxruntime_providers_qnn_abi.dll", "onnxruntime_providers_qnn.dll"),
-                    )
-
-                # Repack wheel
-                subprocess.run(f"wheel pack {tmp_dir} -d {artifact_folder}/dist", shell=True, check=True)
-
-
 def build_qnn_ep_helper_assembly(source_dir, config):
     """Build the Qualcomm.ML.OnnxRuntime.QNN helper assembly"""
     helper_project_dir = os.path.join(source_dir, "csharp", "src", "Qualcomm.ML.OnnxRuntime.QNN")
@@ -2124,9 +2097,14 @@ def build_nuget_package(
 
 # TODO: Remove the workaround once we remove the QNN EP non-ABI build and remove the "_abi" suffix.
 # Workaround to rename the onnxruntime_providers_qnn_abi.dll to onnxruntime_providers_qnn.dll in the nuget package.
-def rename_qnn_ep_library(build_dir, configs):
+def rename_nuget_qnn_ep_library(build_dir, configs, use_ninja=False):
     for config in configs:
-        artifact_folder = os.path.join(build_dir, config, config)
+        # Determine working directory
+        config_build_dir = get_config_build_dir(build_dir, config)
+        if is_windows() and not use_ninja:
+            artifact_folder = os.path.join(config_build_dir, config)
+        else:
+            artifact_folder = config_build_dir
         nuget_files = glob.glob(f"{artifact_folder}/*.nupkg")
         nuget_files.extend(glob.glob(f"{artifact_folder}/nuget-local-artifacts/*.nupkg"))
         for nuget_path in nuget_files:
@@ -2608,9 +2586,6 @@ def main():
                 nightly_build=nightly_build,
                 use_ninja=(args.cmake_generator == "Ninja"),
             )
-            # TODO: Remove the workaround once we remove the QNN EP non-ABI build and remove the "_abi" suffix.
-            # Workaround to rename the onnxruntime_providers_qnn_abi.dll to onnxruntime_providers_qnn.dll in the wheel package.
-            rename_wheel_qnn_ep_library(build_dir, configs)
 
         if args.build_nuget:
             platform_arch = platform.machine()
@@ -2635,7 +2610,7 @@ def main():
             )
             # TODO: Remove the workaround once we remove the QNN EP non-ABI build and remove the "_abi" suffix.
             # Workaround to rename the onnxruntime_providers_qnn_abi.dll to onnxruntime_providers_qnn.dll in the nuget package.
-            rename_qnn_ep_library(build_dir, configs)
+            rename_nuget_qnn_ep_library(build_dir, configs, use_ninja=(args.cmake_generator == "Ninja"))
 
         if args.build_zip_asset:
             build_zip_asset(

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -155,6 +155,7 @@ def build_zip_asset(
 
         # Get list of files to include
         asset_files = get_qnn_asset_file_list()
+        asset_files.extend(["LICENSE", "Qualcomm_LICENSE.pdf", "Privacy.md", "ThirdPartyNotices.txt"])
 
         # Collect and verify files exist
         missing_files = []


### PR DESCRIPTION
### Description
- Include License in zip archive.
- Fix output folder path.
- Move the location of rename function.
- Update test files.
- Do not build nuget by default.

### Motivation and Context
There are some issues with the built artifact and the build flow.