### PR TITLE
Fix pool out shape calc for rank 3

### DIFF
--- a/onnxruntime/core/providers/qnn-abi/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/opbuilder/pool_op_builder.cc
@@ -196,7 +196,6 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
       }
     }
   }
-  ReArrangePads(pad_amount);
 
   // Param: rounding_mode.
   rounding_mode = node_helper.Get("ceil_mode", rounding_mode);
@@ -351,9 +350,9 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     return Ort::Status();
   }
 
-  std::vector<uint32_t> output_shape;
   if (op_type == "MaxPool" || op_type == "AveragePool") {
     const auto& outputs = node_unit.Outputs();
+    std::vector<uint32_t> output_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(outputs[0].shape, output_shape), "Cannot get shape");
 
     RETURN_IF_ERROR(SetCommonPoolParams(node_helper,
@@ -380,10 +379,12 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                              param_tensor_names,
                              qnn_model_wrapper),
                 "Failed to add param stride.");
+  std::vector<uint32_t> pad_amount_qnn = pad_amount;
+  ReArrangePads(pad_amount_qnn);
   RETURN_IF_NOT(SetPoolParam(node_unit,
                              param_pad_amount,
                              std::move(pad_amount_dim),
-                             std::move(pad_amount),
+                             std::move(pad_amount_qnn),  // QNN expects pads in [begin, end] order.
                              param_tensor_names,
                              qnn_model_wrapper),
                 "Failed to add param pad_amount.");
@@ -424,6 +425,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                   "Failed to add param count_include_pad.");
   }
 
+  // exit for common rank-4 pool processing.
   if (!needs_reshape) {
     RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper,
                                    node_unit,
@@ -443,6 +445,9 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     onnx_in_shape = {onnx_in_shape[0], 1, onnx_in_shape[1], onnx_in_shape[2]};
   }
 
+  std::vector<uint32_t> pooled_shape;
+  RETURN_IF_ERROR(AmendOutputShapeForRank3Pool(onnx_in_shape, filter_size, stride, pad_amount, pooled_shape));
+
   const auto& outputs = node_unit.Outputs();
   const std::string real_out = outputs[0].name;
   const std::string pool_out = utils::GetUniqueName(real_out, "_reshape_after");
@@ -455,7 +460,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
       QNN_TENSOR_TYPE_NATIVE,
       reshape_input_info.qnn_data_type,
       output_info.quant_param.Copy(),
-      std::move(output_shape));
+      std::move(pooled_shape));
 
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pool_tensor)), "Failed to add tensor for pool_out");
 

--- a/onnxruntime/core/providers/qnn-abi/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn-abi/builder/opbuilder/pool_op_builder.cc
@@ -179,12 +179,11 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
   }
 
   auto auto_pad = node_helper.Get("auto_pad", std::string("NOTSET"));
+  if (output_shape.size() == 3) {
+    // Calculate rank-4 output shape for rank-3 input.
+    RETURN_IF_ERROR(AmendOutputShapeForRank3Pool(input_shape, filter_size, stride, pad_amount, output_shape));
+  }
   if (auto_pad.compare("NOTSET") != 0) {
-    if (output_shape.size() == 3) {
-      // Calculate rank-4 output shape for rank-3 input.
-      RETURN_IF_ERROR(AmendOutputShapeForRank3Pool(input_shape, filter_size, stride, pad_amount, output_shape));
-    }
-
     for (size_t axis = 0; axis < rank - 2; ++axis) {
       uint32_t total_pads = (output_shape[axis + 1] - 1) * stride[axis] +
                             (filter_size[axis] - 1) * dilations[axis] + 1 - input_shape[axis + 1];
@@ -352,9 +351,9 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     return Ort::Status();
   }
 
+  std::vector<uint32_t> output_shape;
   if (op_type == "MaxPool" || op_type == "AveragePool") {
     const auto& outputs = node_unit.Outputs();
-    std::vector<uint32_t> output_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(outputs[0].shape, output_shape), "Cannot get shape");
 
     RETURN_IF_ERROR(SetCommonPoolParams(node_helper,
@@ -443,8 +442,6 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   if (onnx_in_shape.size() == 3) {
     onnx_in_shape = {onnx_in_shape[0], 1, onnx_in_shape[1], onnx_in_shape[2]};
   }
-  std::vector<uint32_t> pooled_shape;
-  RETURN_IF_ERROR(AmendOutputShapeForRank3Pool(onnx_in_shape, filter_size, stride, pad_amount, pooled_shape));
 
   const auto& outputs = node_unit.Outputs();
   const std::string real_out = outputs[0].name;
@@ -458,7 +455,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
       QNN_TENSOR_TYPE_NATIVE,
       reshape_input_info.qnn_data_type,
       output_info.quant_param.Copy(),
-      std::move(pooled_shape));
+      std::move(output_shape));
 
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pool_tensor)), "Failed to add tensor for pool_out");
 

--- a/onnxruntime/test/providers/qnn-abi/pool_op_test.cpp
+++ b/onnxruntime/test/providers/qnn-abi/pool_op_test.cpp
@@ -105,6 +105,19 @@ TEST_F(QnnABICPUBackendTests, MaxPool_Global) {
                 ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnABICPUBackendTests, MaxPool_Rank3) {
+  RunPoolOpTest("MaxPool",
+                TestInputDef<float>({1, 16, 120}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
+                {utils::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                 utils::MakeAttribute("strides", std::vector<int64_t>{1}),
+                 utils::MakeAttribute("pads", std::vector<int64_t>{1, 1}),
+                 utils::MakeAttribute("dilations", std::vector<int64_t>{1}),
+                 utils::MakeAttribute("ceil_mode", static_cast<int64_t>(0)),
+                 utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
+                 utils::MakeAttribute("auto_pad", "NOTSET")},
+                ExpectedEPNodeAssignment::All);
+}
+
 TEST_F(QnnABICPUBackendTests, MaxPool_Large_Input) {
   RunPoolOpTest("MaxPool",
                 TestInputDef<float>({1, 125, 8, 56}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
@@ -237,6 +250,23 @@ TEST_F(QnnABIHTPBackendTests, MaxPool1D_ReshapeNodesPresent) {
                      logging::Severity::kERROR,
                      true,
                      &check_num_nodes);
+}
+
+// 1-D MaxPool HTP test for rank-3 without ceil with padding 1
+TEST_F(QnnABIHTPBackendTests, MaxPool_Rank3_stride1_HTP_u8) {
+  RunQDQPoolOpTest<uint8_t>(
+      "MaxPool",
+      TestInputDef<float>({1, 3, 3}, false, -10.0f, 10.0f),
+      // A single 1-D kernel of length 3
+      {utils::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+       utils::MakeAttribute("strides", std::vector<int64_t>{1}),
+       // 1-D pad: only two values
+       utils::MakeAttribute("pads", std::vector<int64_t>{1, 1}),
+       utils::MakeAttribute("dilations", std::vector<int64_t>{1}),
+       utils::MakeAttribute("ceil_mode", static_cast<int64_t>(0)),
+       //  utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
+       utils::MakeAttribute("auto_pad", "NOTSET")},
+      ExpectedEPNodeAssignment::All);
 }
 
 // 1-D MaxPool HTP test for rank-3 without ceil

--- a/onnxruntime/test/providers/qnn-abi/pool_op_test.cpp
+++ b/onnxruntime/test/providers/qnn-abi/pool_op_test.cpp
@@ -264,7 +264,7 @@ TEST_F(QnnABIHTPBackendTests, MaxPool_Rank3_stride1_HTP_u8) {
        utils::MakeAttribute("pads", std::vector<int64_t>{1, 1}),
        utils::MakeAttribute("dilations", std::vector<int64_t>{1}),
        utils::MakeAttribute("ceil_mode", static_cast<int64_t>(0)),
-       //  utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
+       utils::MakeAttribute("storage_order", static_cast<int64_t>(0)),
        utils::MakeAttribute("auto_pad", "NOTSET")},
       ExpectedEPNodeAssignment::All);
 }


### PR DESCRIPTION
### Description
Fixes issue #17373 : [ONNX2EP] QNN EP rejects MaxPool in NHWC

`[ONNXRuntimeError] : 1 : FAIL : Node '/wrist_tcn/wrist_tcn.0/branches.2/branches.2.3/MaxPool_token_551' OpType:MaxPool with domain:com.ms.internal.nhwc was inserted using the NHWC format as requested by QNNExecutionProvider, but was not selected by that EP. `

- Moved output shape calculation logic before PAD layout change to QNN layout
- This is needed irrespective of padding type

### Motivation and Context
- The QNN MaxPool node validation for failing due to incorrect output shape
- This was due to PAD layout getting switched to QNN before shape calc. instead of ONNX 


