### PR TITLE
[QNN EP] Resize 'mode:cubic' attribute support with Scale check

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cassert>
+#include <cmath>
 #include <unordered_map>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -12,6 +13,11 @@
 
 namespace onnxruntime {
 namespace qnn {
+
+namespace {
+constexpr const char* kNpuBF16InterpolationLimitations =
+    "QNN EP: Resize support BF16 inputs with linear mode only on the NPU.";
+}
 
 class ResizeOpBuilder : public BaseOpBuilder {
  public:
@@ -50,6 +56,7 @@ class ResizeOpBuilder : public BaseOpBuilder {
   static const OnnxAttrInfo<std::string> onnx_nearest_mode_attr;
   static const OnnxAttrInfo<int64_t> onnx_antialias_attr;
   static const OnnxAttrInfo<int64_t> onnx_exclude_outside_attr;
+  static const OnnxAttrInfo<float> onnx_cubic_coeff_a_attr;
 
   // Tables that map an ONNX attribute value (string) to the corresponding integer (enum) QNN parameter value.
   // Ex: The "half_pixel" coordinate_transformation_mode is represented as the value 0 in QNN.
@@ -61,7 +68,8 @@ class ResizeOpBuilder : public BaseOpBuilder {
 
 const std::unordered_map<std::string, uint32_t> ResizeOpBuilder::supported_modes = {
     {"nearest", QNN_OP_RESIZE_INTERPOLATION_MODE_NEAREST},
-    {"linear", QNN_OP_RESIZE_INTERPOLATION_MODE_LINEAR}};
+    {"linear", QNN_OP_RESIZE_INTERPOLATION_MODE_LINEAR},
+    {"cubic", QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC}};
 
 const std::unordered_map<std::string, uint32_t> ResizeOpBuilder::supported_coord_transf_modes = {
     {"half_pixel", QNN_OP_RESIZE_TRANSFORMATION_MODE_HALF_PIXEL},
@@ -82,6 +90,7 @@ const OnnxAttrInfo<std::string> ResizeOpBuilder::onnx_nearest_mode_attr = {"near
                                                                            "round_prefer_floor"};
 const OnnxAttrInfo<int64_t> ResizeOpBuilder::onnx_antialias_attr = {"antialias", 0};
 const OnnxAttrInfo<int64_t> ResizeOpBuilder::onnx_exclude_outside_attr = {"exclude_outside", 0};
+const OnnxAttrInfo<float> ResizeOpBuilder::onnx_cubic_coeff_a_attr = {"cubic_coeff_a", -0.75f};
 
 // Returns the QNN parameter integer value that corresponds to the given ONNX attribute mode string value.
 static Ort::Status GetQnnModeValFromOnnxString(const std::unordered_map<std::string, uint32_t>& supported_qnn_modes,
@@ -218,6 +227,53 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output_0.shape, output_shape),
                 "QNN EP: Cannot get shape for Resize output");
 
+  if (interp_mode == "cubic") {
+    const auto& inputs = node_unit.Inputs();
+    if (inputs.size() > 2) {
+      // QNN Resize only consumes input[0] (no ROI/Scales/Sizes); scales are derived internally as output/input per axis.
+      // See https://docs.qualcomm.com/doc/80-63442-10/topic/MasterOpDef.html#resize
+      // Check that if scales input is provided, it's a const initializer and its values match the QNN auto calc. scales.
+      const auto& scales_input = inputs[2];
+      if (!scales_input.name.empty()) {
+        RETURN_IF_NOT(qnn_model_wrapper.IsConstantInput(scales_input.name),
+                      "QNN EP: Resize does not support dynamic scales input for cubic mode.");
+
+        const OrtValueInfo* scales_tensor = qnn_model_wrapper.GetConstantTensor(scales_input.name);
+        if (scales_tensor != nullptr) {
+          const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
+          const std::vector<int64_t> scales_shape = utils::GetInitializerShape(scales_tensor, ort_api);
+          size_t scales_count = 1;
+          for (int64_t dim : scales_shape) {
+            scales_count *= static_cast<size_t>(dim);
+          }
+
+          if (scales_count > 0) {
+            std::vector<uint8_t> scales_raw;
+            RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scales_tensor, scales_raw));
+            RETURN_IF_NOT(scales_raw.size() == scales_count * sizeof(float),
+                          "QNN EP: Resize scales input is expected to be float.");
+            RETURN_IF_NOT(scales_count == input_shape.size(),
+                          "QNN EP: Resize scales input rank does not match input rank.");
+
+            const float* scales = reinterpret_cast<const float*>(scales_raw.data());
+            constexpr float kScaleTolerance = 1e-5f;
+            for (size_t i = 0; i < scales_count; ++i) {
+              const float expected_scale = static_cast<float>(output_shape[i]) /
+                                           static_cast<float>(input_shape[i]);
+              if (std::abs(scales[i] - expected_scale) > kScaleTolerance) {
+                return MAKE_EP_FAIL(
+                    ("QNN EP: Resize cubic mode requires scales to match output/input shape for axis [" +
+                     std::to_string(i) + "] (scales[i]=" + std::to_string(scales[i]) +
+                     ", expected=" + std::to_string(expected_scale) + ")")
+                        .c_str());
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Check that only the spatial dimensions (width, height) are resized. The batch_size (N) and channels (C) should
   // be untouched. This code runs before layout transformation, so we know that the current layout is "channel first"
   // (e.g., N, C, S1, S2, ..., SN), and that the minimum rank is 3.
@@ -229,6 +285,11 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   std::string error_msg = "QNN EP: Data type " + std::to_string(static_cast<int>(input_data_type)) +
                           " is not supported for Resize operator in CPU backend.";
   RETURN_IF_ERROR(DataTypeCheckForCpuBackend(qnn_model_wrapper, input_data_type, error_msg));
+
+  if (is_npu_backend && interp_mode != "linear" &&
+      input_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+    return MAKE_EP_FAIL(kNpuBF16InterpolationLimitations);
+  }
 
   return Ort::Status();
 }
@@ -356,6 +417,11 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     param_tensor_names.push_back(qnn_interp_mode_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_interp_mode_param));
 
+    if (is_npu_backend && qnn_interp_mode.uint32Value == QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC) {
+      const ONNXTensorElementDataType input_dtype = node_unit.Inputs()[0].type;
+      RETURN_IF(input_dtype == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16, kNpuBF16InterpolationLimitations);
+    }
+
     // Parameter 'nearest_mode'. Processed only when 'interpolation_mode' is NEAREST(0).
     if (qnn_interp_mode.uint32Value == 0) {
       Qnn_Scalar_t qnn_nearest_mode = QNN_SCALAR_INIT;
@@ -367,6 +433,16 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                              qnn_nearest_mode);
       param_tensor_names.push_back(qnn_nearest_mode_param.GetParamTensorName());
       qnn_model_wrapper.AddParamWrapper(std::move(qnn_nearest_mode_param));
+    }
+
+    if (qnn_interp_mode.uint32Value == QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC) {
+      const float cubic_coeff = GetOnnxAttr(node_helper, onnx_cubic_coeff_a_attr);
+      RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper,
+                                          node_unit.Index(),
+                                          node_unit.Name(),
+                                          cubic_coeff,
+                                          QNN_OP_RESIZE_PARAM_CUBIC_COEFF,
+                                          param_tensor_names));
     }
   }
 

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1403,6 +1403,7 @@ TEST_F(QnnHTPBackendTests, EPOffloadsGraphIOQuantDequant) {
                                     logging::Severity::kERROR,
                                     /*qnn_ctx_model_path*/ "",
                                     /*session_option_pairs*/ {},
+                                    /*graph_optimization_level*/ std::nullopt,
                                     &graph_checker);
     }
   }

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -264,9 +264,13 @@ void InferenceModelCPU(const std::string& model_data,
                        const char* log_id,
                        ExpectedEPNodeAssignment expected_ep_assignment,
                        const NameMLValMap& feeds,
-                       std::vector<OrtValue>& output_vals) {
+                       std::vector<OrtValue>& output_vals,
+                       std::optional<GraphOptimizationLevel> graph_optimization_level) {
   SessionOptions so;
   so.session_logid = log_id;
+  if (graph_optimization_level.has_value()) {
+    so.graph_optimization_level = static_cast<TransformerLevel>(*graph_optimization_level);
+  }
   RunOptions run_options;
   run_options.run_tag = so.session_logid;
 
@@ -308,10 +312,14 @@ void InferenceModel(const std::string& model_data,
                     const NameMLValMap& feeds,
                     std::vector<OrtValue>& output_vals,
                     const std::unordered_map<std::string, std::string>& session_option_pairs,
+                    std::optional<GraphOptimizationLevel> graph_optimization_level,
                     std::function<void(const Graph&)>* graph_checker) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   const std::string& registration_name = onnxruntime::kQnnExecutionProvider;
   Ort::SessionOptions session_options;
+  if (graph_optimization_level.has_value()) {
+    session_options.SetGraphOptimizationLevel(*graph_optimization_level);
+  }
   RegisterQnnEpLibrary(registered_ep_device, session_options, registration_name, provider_options);
 
   session_options.SetLogId(log_id);

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -14,6 +14,7 @@
 #include "core/framework/provider_options.h"
 #include "core/framework/tensor_shape.h"
 #include "core/common/float16.h"
+#include "core/optimizer/graph_transformer_level.h"
 #include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/util/qmath.h"
 
@@ -484,7 +485,8 @@ void InferenceModelCPU(const std::string& model_data,
                        const char* log_id,
                        ExpectedEPNodeAssignment expected_ep_assignment,
                        const NameMLValMap& feeds,
-                       std::vector<OrtValue>& output_vals);
+                       std::vector<OrtValue>& output_vals,
+                       std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt);
 
 void InferenceModel(const std::string& model_data,
                     const char* log_id,
@@ -493,6 +495,7 @@ void InferenceModel(const std::string& model_data,
                     const NameMLValMap& feeds,
                     std::vector<OrtValue>& output_vals,
                     const std::unordered_map<std::string, std::string>& session_option_pairs = {},
+                    std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt,
                     std::function<void(const Graph&)>* graph_checker = nullptr);
 
 /**
@@ -729,6 +732,7 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
                                  logging::Severity log_severity = logging::Severity::kERROR,
                                  const std::string& qnn_ctx_model_path = "",
                                  const std::unordered_map<std::string, std::string>& session_option_pairs = {},
+                                 std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt,
                                  std::function<void(const Graph&)>* qnn_ep_graph_checker = nullptr) {
   std::filesystem::path output_dir;
   if (QNNTestEnvironment::GetInstance().dump_onnx() ||
@@ -769,7 +773,7 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
   // Run f32 model on CPU EP and collect outputs.
   std::vector<OrtValue> cpu_f32_outputs;
   InferenceModelCPU(f32_model_data, "f32_model_logger", ExpectedEPNodeAssignment::All,
-                    f32_helper.feeds_, cpu_f32_outputs);
+                    f32_helper.feeds_, cpu_f32_outputs, graph_optimization_level);
   ASSERT_FALSE(cpu_f32_outputs.empty());
 
   const size_t num_outputs = cpu_f32_outputs.size();
@@ -815,7 +819,7 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
   // Run QDQ model on CPU EP and collect outputs.
   std::vector<OrtValue> cpu_qdq_outputs;
   InferenceModelCPU(qdq_model_data, "qdq_model_logger", ExpectedEPNodeAssignment::All,
-                    qdq_helper.feeds_, cpu_qdq_outputs);
+                    qdq_helper.feeds_, cpu_qdq_outputs, graph_optimization_level);
 
   TryEnableQNNSaver(qnn_options);
 
@@ -847,7 +851,8 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
                    expected_ep_assignment,
                    qdq_helper.feeds_,
                    qnn_qdq_outputs,
-                   session_option_pairs);
+                   session_option_pairs,
+                   graph_optimization_level);
   } else {
     InferenceModel(qdq_model_data,
                    "qdq_model_logger",
@@ -856,6 +861,7 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
                    qdq_helper.feeds_,
                    qnn_qdq_outputs,
                    session_option_pairs,
+                   graph_optimization_level,
                    qnn_ep_graph_checker);
   }
 

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -3,12 +3,14 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
+#include "core/optimizer/graph_transformer_level.h"
 #include "core/graph/onnx_protobuf.h"
 
 #include "gtest/gtest.h"
@@ -31,8 +33,9 @@ static GetTestModelFn GetResizeModelBuilder(const TestInputDef<float>& input_def
                                             const std::vector<int64_t>& sizes_data,
                                             const std::string& mode = "nearest",
                                             const std::string& coordinate_transformation_mode = "half_pixel",
-                                            const std::string& nearest_mode = "round_prefer_floor") {
-  return [input_def, sizes_data, mode, coordinate_transformation_mode, nearest_mode](ModelTestBuilder& builder) {
+                                            const std::string& nearest_mode = "round_prefer_floor",
+                                            std::optional<float> cubic_coeff_a = std::nullopt) {
+  return [input_def, sizes_data, mode, coordinate_transformation_mode, nearest_mode, cubic_coeff_a](ModelTestBuilder& builder) {
     NodeArg* input = MakeTestInput(builder, input_def);
     NodeArg* roi = builder.MakeInitializer<float>({0}, {});
     NodeArg* scales = builder.MakeInitializer<float>({0}, {});
@@ -46,6 +49,10 @@ static GetTestModelFn GetResizeModelBuilder(const TestInputDef<float>& input_def
     if (mode == "nearest") {
       resize_node.AddAttribute("nearest_mode", nearest_mode);
     }
+
+    if (mode == "cubic" && cubic_coeff_a.has_value()) {
+      resize_node.AddAttribute("cubic_coeff_a", *cubic_coeff_a);
+    }
   };
 }
 
@@ -53,8 +60,9 @@ static GetTestModelFn GetResizeModelBuilderWithScales(const TestInputDef<float>&
                                                       const std::vector<float>& scales_data,
                                                       const std::string& mode = "nearest",
                                                       const std::string& coordinate_transformation_mode = "half_pixel",
-                                                      const std::string& nearest_mode = "round_prefer_floor") {
-  return [input_def, scales_data, mode, coordinate_transformation_mode, nearest_mode](ModelTestBuilder& builder) {
+                                                      const std::string& nearest_mode = "round_prefer_floor",
+                                                      std::optional<float> cubic_coeff_a = std::nullopt) {
+  return [input_def, scales_data, mode, coordinate_transformation_mode, nearest_mode, cubic_coeff_a](ModelTestBuilder& builder) {
     NodeArg* input = MakeTestInput(builder, input_def);
     NodeArg* roi = builder.MakeInitializer<float>({0}, {});
     NodeArg* scales = builder.Make1DInitializer<float>(scales_data);
@@ -67,6 +75,10 @@ static GetTestModelFn GetResizeModelBuilderWithScales(const TestInputDef<float>&
     if (mode == "nearest") {
       resize_node.AddAttribute("nearest_mode", nearest_mode);
     }
+
+    if (mode == "cubic" && cubic_coeff_a.has_value()) {
+      resize_node.AddAttribute("cubic_coeff_a", *cubic_coeff_a);
+    }
   };
 }
 
@@ -75,10 +87,11 @@ static GetTestQDQModelFn<QuantType> GetQDQResizeModelBuilder(const TestInputDef<
                                                              const std::vector<int64_t>& sizes_data,
                                                              const std::string& mode = "nearest",
                                                              const std::string& coordinate_transformation_mode = "half_pixel",
-                                                             const std::string& nearest_mode = "round_prefer_floor") {
+                                                             const std::string& nearest_mode = "round_prefer_floor",
+                                                             std::optional<float> cubic_coeff_a = std::nullopt) {
   return [input_def, sizes_data, mode,
-          coordinate_transformation_mode, nearest_mode](ModelTestBuilder& builder,
-                                                        std::vector<QuantParams<QuantType>>& output_qparams) {
+          coordinate_transformation_mode, nearest_mode, cubic_coeff_a](ModelTestBuilder& builder,
+                                                                       std::vector<QuantParams<QuantType>>& output_qparams) {
     // input -> Q -> DQ ->
     NodeArg* input = MakeTestInput(builder, input_def);
     QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
@@ -95,6 +108,10 @@ static GetTestQDQModelFn<QuantType> GetQDQResizeModelBuilder(const TestInputDef<
 
     if (mode == "nearest") {
       resize_node.AddAttribute("nearest_mode", nearest_mode);
+    }
+
+    if (mode == "cubic" && cubic_coeff_a.has_value()) {
+      resize_node.AddAttribute("cubic_coeff_a", *cubic_coeff_a);
     }
 
     // Resize requires the output quantization parameters to match the input.
@@ -120,12 +137,14 @@ static void RunCPUResizeOpTest(const TestInputDef<float>& input_def, const std::
                                const std::string& mode, const std::string& coordinate_transformation_mode,
                                const std::string& nearest_mode,
                                ExpectedEPNodeAssignment expected_ep_assignment,
-                               int opset = 19) {
+                               int opset = 19,
+                               std::optional<float> cubic_coeff_a = std::nullopt) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  RunQnnModelTest(GetResizeModelBuilder(input_def, sizes_data, mode, coordinate_transformation_mode, nearest_mode),
+  RunQnnModelTest(GetResizeModelBuilder(input_def, sizes_data, mode, coordinate_transformation_mode,
+                                        nearest_mode, cubic_coeff_a),
                   provider_options,
                   opset,
                   expected_ep_assignment);
@@ -135,12 +154,14 @@ static void RunCPUResizeOpTestWithScales(const TestInputDef<float>& input_def, c
                                          const std::string& mode, const std::string& coordinate_transformation_mode,
                                          const std::string& nearest_mode,
                                          ExpectedEPNodeAssignment expected_ep_assignment,
-                                         int opset = 19) {
+                                         int opset = 19,
+                                         std::optional<float> cubic_coeff_a = std::nullopt) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  RunQnnModelTest(GetResizeModelBuilderWithScales(input_def, scales_data, mode, coordinate_transformation_mode, nearest_mode),
+  RunQnnModelTest(GetResizeModelBuilderWithScales(input_def, scales_data, mode, coordinate_transformation_mode,
+                                                  nearest_mode, cubic_coeff_a),
                   provider_options,
                   opset,
                   expected_ep_assignment);
@@ -153,18 +174,26 @@ static void RunQDQResizeOpTest(const TestInputDef<float>& input_def,
                                const std::string& nearest_mode,
                                ExpectedEPNodeAssignment expected_ep_assignment,
                                int opset = 19,
-                               QDQTolerance tolerance = QDQTolerance()) {
+                               QDQTolerance tolerance = QDQTolerance(),
+                               const std::unordered_map<std::string, std::string>& session_option_pairs = {},
+                               std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt,
+                               std::optional<float> cubic_coeff_a = std::nullopt) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  TestQDQModelAccuracy(GetResizeModelBuilder(input_def, sizes_data, mode, coordinate_transformation_mode, nearest_mode),
+  TestQDQModelAccuracy(GetResizeModelBuilder(input_def, sizes_data, mode, coordinate_transformation_mode,
+                                             nearest_mode, cubic_coeff_a),
                        GetQDQResizeModelBuilder<QuantType>(input_def, sizes_data, mode, coordinate_transformation_mode,
-                                                           nearest_mode),
+                                                           nearest_mode, cubic_coeff_a),
                        provider_options,
                        opset,
                        expected_ep_assignment,
-                       tolerance);
+                       tolerance,
+                       logging::Severity::kERROR,
+                       "",
+                       session_option_pairs,
+                       graph_optimization_level);
 }
 
 //
@@ -287,6 +316,30 @@ TEST_F(QnnCPUBackendTests, Resize2xLinearAlignCorners_scales) {
                                ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnCPUBackendTests, Resize2xCubicHalfPixel) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 60);
+  RunCPUResizeOpTest(TestInputDef<float>({1, 3, 4, 5}, false, input_data),
+                     {1, 3, 8, 10}, "cubic", "half_pixel", "",
+                     ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, Resize2xCubicHalfPixel_CustomCoeff) {
+  std::vector<float> input_data = GetFloatDataInRange(-2.0f, 4.0f, 60);
+  const float cubic_coeff_a = -0.5f;
+  RunCPUResizeOpTest(TestInputDef<float>({1, 3, 4, 5}, false, input_data),
+                     {1, 3, 8, 10}, "cubic", "half_pixel", "",
+                     ExpectedEPNodeAssignment::All,
+                     19,
+                     cubic_coeff_a);
+}
+
+TEST_F(QnnCPUBackendTests, Resize2xCubicHalfPixel_scales_inverse) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 60);
+  RunCPUResizeOpTestWithScales(TestInputDef<float>({1, 3, 4, 5}, false, input_data),
+                               {1.0f, 1.0f, 0.5f, 0.5f}, "cubic", "half_pixel", "",
+                               ExpectedEPNodeAssignment::None);
+}
+
 // Test Resize downsample with mode: "linear", coordinate_transformation_mode: "align_corners"
 TEST_F(QnnCPUBackendTests, Resize_DownSample_Linear_AlignCorners_scales) {
   std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
@@ -321,6 +374,137 @@ TEST_F(QnnHTPBackendTests, Resize_DownSample_Linear_AlignCorners) {
   RunQDQResizeOpTest<uint8_t>(TestInputDef<float>({1, 1, 2, 4}, false, input_data),
                               {1, 1, 1, 2}, "linear", "align_corners", "",
                               ExpectedEPNodeAssignment::All);
+}
+
+// Test 2x QDQ Resize mode: "cubic", coordinate_transformation_mode: "half_pixel"
+// Maps to QNN's Resize operator with cubic interpolation.
+//
+// GraphOptimizationLevel::ORT_DISABLE_ALL is set in cubic unit tests to avoid the DQ->Resize->Q folding
+// that redirects execution to the float-only CPU ResizeBiCubic implementation.
+TEST_F(QnnHTPBackendTests, ResizeU8_2xCubicHalfPixel) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunQDQResizeOpTest<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                              {1, 3, 8, 8}, "cubic", "half_pixel", "",
+                              ExpectedEPNodeAssignment::All,
+                              19,
+                              QDQTolerance(),
+                              {},
+                              GraphOptimizationLevel::ORT_DISABLE_ALL);
+}
+
+// Test 2x QDQ Resize mode: "cubic" with a custom cubic coefficient.
+TEST_F(QnnHTPBackendTests, ResizeU8_2xCubicHalfPixel_CustomCoeff) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 48);
+  const float cubic_coeff_a = -0.6f;
+  RunQDQResizeOpTest<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                              {1, 3, 8, 8}, "cubic", "half_pixel", "",
+                              ExpectedEPNodeAssignment::All,
+                              19,
+                              QDQTolerance(),
+                              {},
+                              GraphOptimizationLevel::ORT_DISABLE_ALL,
+                              cubic_coeff_a);
+}
+
+TEST_F(QnnHTPBackendTests, ResizeU8_2xCubicHalfPixelFloor_scales) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  const TestInputDef<float> input_def({1, 3, 4, 4}, false, input_data);
+  const std::vector<float> scales_data{1.0f, 1.0f, 2.0f, 2.0f};
+
+  auto float_builder = GetResizeModelBuilderWithScales(input_def, scales_data, "cubic", "half_pixel", "floor");
+
+  GetTestQDQModelFn<uint8_t> qdq_builder =
+      [input_def, scales_data](ModelTestBuilder& builder,
+                               std::vector<QuantParams<uint8_t>>& output_qparams) {
+        NodeArg* input = MakeTestInput(builder, input_def);
+        QuantParams<uint8_t> input_qparams = GetTestInputQuantParams<uint8_t>(input_def);
+        NodeArg* input_qdq = AddQDQNodePair<uint8_t>(builder, input, input_qparams.scale, input_qparams.zero_point);
+
+        NodeArg* roi = builder.MakeInitializer<float>({0}, {});
+        NodeArg* scales = builder.Make1DInitializer<float>(scales_data);
+
+        NodeArg* resize_output = builder.MakeIntermediate();
+        Node& resize_node = builder.AddNode("Resize", {input_qdq, roi, scales}, {resize_output});
+        resize_node.AddAttribute("mode", "cubic");
+        resize_node.AddAttribute("coordinate_transformation_mode", "half_pixel");
+        resize_node.AddAttribute("nearest_mode", "floor");
+
+        output_qparams[0] = input_qparams;
+        AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, resize_output,
+                                                       output_qparams[0].scale,
+                                                       output_qparams[0].zero_point);
+      };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(float_builder,
+                       qdq_builder,
+                       provider_options,
+                       19,
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(),
+                       logging::Severity::kERROR,
+                       "",
+                       {},
+                       GraphOptimizationLevel::ORT_DISABLE_ALL);
+}
+
+TEST_F(QnnHTPBackendTests, ResizeU8_2xCubicHalfPixel_scales_downsample) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  const TestInputDef<float> input_def({1, 3, 4, 4}, false, input_data);
+  const std::vector<float> scales_data{1.0f, 1.0f, 0.5f, 0.5f};
+
+  auto float_builder =
+      [input_def, scales_data](ModelTestBuilder& builder) {
+        NodeArg* input = MakeTestInput(builder, input_def);
+        NodeArg* roi = builder.MakeInitializer<float>({0}, {});
+        NodeArg* scales = builder.Make1DInitializer<float>(scales_data);
+
+        NodeArg* output = builder.MakeOutput();
+        Node& resize_node = builder.AddNode("Resize", {input, roi, scales}, {output});
+        resize_node.AddAttribute("mode", "cubic");
+        resize_node.AddAttribute("coordinate_transformation_mode", "half_pixel");
+        resize_node.AddAttribute("nearest_mode", "floor");
+      };
+
+  GetTestQDQModelFn<uint8_t> qdq_builder =
+      [input_def, scales_data](ModelTestBuilder& builder,
+                               std::vector<QuantParams<uint8_t>>& output_qparams) {
+        NodeArg* input = MakeTestInput(builder, input_def);
+        QuantParams<uint8_t> input_qparams = GetTestInputQuantParams<uint8_t>(input_def);
+        NodeArg* input_qdq = AddQDQNodePair<uint8_t>(builder, input, input_qparams.scale, input_qparams.zero_point);
+
+        NodeArg* roi = builder.MakeInitializer<float>({0}, {});
+        NodeArg* scales = builder.Make1DInitializer<float>(scales_data);
+
+        NodeArg* resize_output = builder.MakeIntermediate();
+        Node& resize_node = builder.AddNode("Resize", {input_qdq, roi, scales}, {resize_output});
+        resize_node.AddAttribute("mode", "cubic");
+        resize_node.AddAttribute("coordinate_transformation_mode", "half_pixel");
+        resize_node.AddAttribute("nearest_mode", "floor");
+
+        output_qparams[0] = input_qparams;
+        AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, resize_output,
+                                                       output_qparams[0].scale,
+                                                       output_qparams[0].zero_point);
+      };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(float_builder,
+                       qdq_builder,
+                       provider_options,
+                       19,
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(),
+                       logging::Severity::kERROR,
+                       "",
+                       {},
+                       GraphOptimizationLevel::ORT_DISABLE_ALL);
 }
 
 // Test QDQ Resize downsample with mode: "linear", coordinate_transformation_mode: "half_pixel"


### PR DESCRIPTION
### Description
Resubmission of [PR 4](https://github.com/onnxruntime/onnxruntime-qnn/pull/4) with following constraints:
If Resize op contains `scales` as input and then check if it matches QNN auto generated scales.



### Motivation and Context
https://github.com/onnxruntime/onnxruntime-qnn/pull/4 failed as QNN Resize only ingest 'input[0]' and auto-generates other inputs based on output shape. 

`onnxruntime_provider_test --gtest_filter=ResizeOpTest.ResizeOpCubicDownSampleTest`
```
https://docs.qualcomm.com/doc/80-63442-10/topic/MasterOpDef.html#resize
The QNN Resize op can only take in[0]
There is no provision to pass [ROI, Scales, Sizes].
 
QNN Scales are auto-calculated as = out[0]/in[0] for each axis.
 
For the failing test case, QNN computes Scales = [1, 1, 0.75, 0.75],
however actual Scales passed = [1, 1, 0.8, 0.8]
 
This is resulting in accuracy difference between ORT and QNN.
```

