### PR TITLE
Resume inverse unit tests.

### DIFF
--- a/onnxruntime/test/providers/qnn/inverse_op_test.cc
+++ b/onnxruntime/test/providers/qnn/inverse_op_test.cc
@@ -125,7 +125,7 @@ static void RunQDQInverseOpTest(const TestInputDef<float>& input_defs,
                        tolerance);
 }
 
-TEST_F(QnnHTPBackendTests, DISABLED_Inverse_2d) {
+TEST_F(QnnHTPBackendTests, Inverse_2d) {
   RandomValueGenerator rand_gen_{optional<RandomValueGenerator::RandomSeedType>{2345}};
   const std::vector<int64_t> input_shape{2, 2};
   auto input_vector = rand_gen_.Uniform<float>(input_shape, -100.0f, 100.0f);
@@ -137,7 +137,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_Inverse_2d) {
                         "htp");
 }
 
-TEST_F(QnnHTPBackendTests, DISABLED_Inverse_3d) {
+TEST_F(QnnHTPBackendTests, Inverse_3d) {
   RandomValueGenerator rand_gen_{optional<RandomValueGenerator::RandomSeedType>{2345}};
   const std::vector<int64_t> input_shape{10, 2, 2};
   auto input_vector = rand_gen_.Uniform<float>(input_shape, -100.0f, 100.0f);
@@ -149,7 +149,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_Inverse_3d) {
                         "htp");
 }
 
-TEST_F(QnnHTPBackendTests, DISABLED_Inverse_4d) {
+TEST_F(QnnHTPBackendTests, Inverse_4d) {
   RandomValueGenerator rand_gen_{optional<RandomValueGenerator::RandomSeedType>{2345}};
   const std::vector<int64_t> input_shape{1, 10, 2, 2};
   auto input_vector = rand_gen_.Uniform<float>(input_shape, -100.0f, 100.0f);

--- a/onnxruntime/test/providers/qnn/inverse_op_test.cc
+++ b/onnxruntime/test/providers/qnn/inverse_op_test.cc
@@ -28,6 +28,7 @@ static void RunInverseTest(const std::vector<TestInputDef<DataType>>& input_defs
 
   provider_options["backend_type"] = backend_name;
   provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["soc_model"] = "30";
 
   RunQnnModelTest(BuildOpTestCase<DataType>("Inverse", input_defs, {}, attrs, kMSDomain),  // Inverse Op exist in kMSDomain
                   provider_options,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
All of them passed on my machine now without any changes required.
Looks like it's not running on the default soc_model = "30" for some reason.
I can reproduce the unit test failure with `provider_options["soc_model"] = "87";`

Need to understand why it failed on latest chip (SM8850).

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


