### PR TITLE
Fix artifacts

### DIFF
--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -166,7 +166,9 @@
   if (EXISTS "${onnxruntime_QNN_HOME}/LICENSE.pdf")
     add_custom_command(
       TARGET ${onnxruntime_providers_qnn_target} POST_BUILD
+        # Copy to output directory, required for zip archive
         COMMAND ${CMAKE_COMMAND} -E copy "${onnxruntime_QNN_HOME}/LICENSE.pdf" $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>/Qualcomm_LICENSE.pdf
+        # Copy to onnxruntime_qnn directory, required for python wheel
         COMMAND ${CMAKE_COMMAND} -E copy "${onnxruntime_QNN_HOME}/LICENSE.pdf" $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>/onnxruntime_qnn/Qualcomm_LICENSE.pdf
     )
   endif()

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -137,21 +137,37 @@
       COMMENT "Copying onnxruntime_providers_qnn.dll to onnxruntime_qnn directory"
     )
   endif()
+  # Create destination directory first to ensure it exists
+  add_custom_command(
+    TARGET ${onnxruntime_providers_qnn_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>/onnxruntime_qnn
+    COMMENT "Creating QNN library destination directory"
+  )
   # Copy version & license files to output directory
   add_custom_command(
     TARGET ${onnxruntime_providers_qnn_target} POST_BUILD
+    # Copy to output directory, required for zip archive
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${REPO_ROOT}/VERSION_NUMBER
         ${REPO_ROOT}/ThirdPartyNotices.txt
         ${REPO_ROOT}/docs/Privacy.md
         ${REPO_ROOT}/LICENSE
         $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>
+    # Copy to onnxruntime_qnn directory, required for python wheel
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${REPO_ROOT}/VERSION_NUMBER
+        ${REPO_ROOT}/ThirdPartyNotices.txt
+        ${REPO_ROOT}/docs/Privacy.md
+        ${REPO_ROOT}/LICENSE
+        ${ONNXRUNTIME_ROOT}/python/__init__.py
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>/onnxruntime_qnn
     COMMENT "Copying license files"
   )
   if (EXISTS "${onnxruntime_QNN_HOME}/LICENSE.pdf")
     add_custom_command(
       TARGET ${onnxruntime_providers_qnn_target} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy "${onnxruntime_QNN_HOME}/LICENSE.pdf" $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>/Qualcomm_LICENSE.pdf
+        COMMAND ${CMAKE_COMMAND} -E copy "${onnxruntime_QNN_HOME}/LICENSE.pdf" $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_target}>/onnxruntime_qnn/Qualcomm_LICENSE.pdf
     )
   endif()
   if (EXISTS "${onnxruntime_QNN_HOME}/Qualcomm AI Hub Proprietary License.pdf")

--- a/csharp/src/Qualcomm.ML.OnnxRuntime.QNN/QnnEpHelper.cs
+++ b/csharp/src/Qualcomm.ML.OnnxRuntime.QNN/QnnEpHelper.cs
@@ -45,20 +45,28 @@ namespace Qualcomm.ML.OnnxRuntime.QNN
         public static string GetLibraryPath() => GetLibraryPathInternal(GetEpLibraryName(), "QNN EP");
 
         /// <summary>
-        /// Get the full path to the QNN HTP library (QnnHtp.dll or libQnnHtp.so)
-        /// </summary>
-        /// <returns>Full path to the QNN HTP library</returns>
-        /// <exception cref="FileNotFoundException">Thrown when QNN HTP library file is not found</exception>
-        /// <exception cref="PlatformNotSupportedException">Thrown when platform is not supported</exception>
-        public static string GetQnnHtpLibraryPath() => GetLibraryPathInternal(GetQnnHtpLibraryName(), "QNN HTP");
-
-        /// <summary>
         /// Get the full path to the QNN CPU library (QnnCpu.dll or libQnnCpu.so)
         /// </summary>
         /// <returns>Full path to the QNN CPU library</returns>
         /// <exception cref="FileNotFoundException">Thrown when QNN CPU library file is not found</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when platform is not supported</exception>
         public static string GetQnnCpuLibraryPath() => GetLibraryPathInternal(GetQnnCpuLibraryName(), "QNN CPU");
+
+        /// <summary>
+        /// Get the full path to the QNN GPU library (QnnGpu.dll or libQnnGpu.so)
+        /// </summary>
+        /// <returns>Full path to the QNN GPU library</returns>
+        /// <exception cref="FileNotFoundException">Thrown when QNN GPU library file is not found</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when platform is not supported</exception>
+        public static string GetQnnGpuLibraryPath() => GetLibraryPathInternal(GetQnnGpuLibraryName(), "QNN GPU");
+
+        /// <summary>
+        /// Get the full path to the QNN HTP library (QnnHtp.dll or libQnnHtp.so)
+        /// </summary>
+        /// <returns>Full path to the QNN HTP library</returns>
+        /// <exception cref="FileNotFoundException">Thrown when QNN HTP library file is not found</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when platform is not supported</exception>
+        public static string GetQnnHtpLibraryPath() => GetLibraryPathInternal(GetQnnHtpLibraryName(), "QNN HTP");
 
         private static string GetLibraryPathInternal(string libraryName, string libraryDescription)
         {
@@ -78,9 +86,11 @@ namespace Qualcomm.ML.OnnxRuntime.QNN
 
         private static string GetEpLibraryName() => GetPlatformLibraryName("onnxruntime_providers_qnn");
 
-        private static string GetQnnHtpLibraryName() => GetPlatformLibraryName("QnnHtp");
-
         private static string GetQnnCpuLibraryName() => GetPlatformLibraryName("QnnCpu");
+
+        private static string GetQnnGpuLibraryName() => GetPlatformLibraryName("QnnGpu");
+
+        private static string GetQnnHtpLibraryName() => GetPlatformLibraryName("QnnHtp");
 
         private static string GetPlatformLibraryName(string baseName)
         {

--- a/csharp/src/Qualcomm.ML.OnnxRuntime.QNN/QnnEpHelper.cs
+++ b/csharp/src/Qualcomm.ML.OnnxRuntime.QNN/QnnEpHelper.cs
@@ -14,7 +14,7 @@ namespace Qualcomm.ML.OnnxRuntime.QNN
     /// </summary>
     public static class QnnEpHelper
     {
-        private const string EpName = "QnnExecutionProvider";
+        private const string EpName = "QNNExecutionProvider";
         private static readonly string[] EpNames = { EpName };
         
         // Cache platform-specific values to avoid repeated checks
@@ -27,7 +27,7 @@ namespace Qualcomm.ML.OnnxRuntime.QNN
         /// <summary>
         /// Get the QNN execution provider name
         /// </summary>
-        /// <returns>The EP name ("QnnExecutionProvider")</returns>
+        /// <returns>The EP name ("QNNExecutionProvider")</returns>
         public static string GetEpName() => EpName;
 
         /// <summary>

--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -24,5 +24,9 @@ def get_qnn_cpu_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "QnnCpu.dll")
 
 
+def get_qnn_gpu_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "QnnGpu.dll")
+
+
 def get_qnn_htp_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "QnnHtp.dll")

--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -5,7 +5,7 @@
 
 import os
 
-EP_NAME = "QnnExecutionProvider"
+EP_NAME = "QNNExecutionProvider"
 
 
 def get_ep_names():

--- a/qcom/samples/test_qnnep.cs
+++ b/qcom/samples/test_qnnep.cs
@@ -41,8 +41,9 @@ namespace QnnEpNuGetTest
             Console.WriteLine($"EP Name: {epName}");
 
             // Register the QNN execution provider library
+            string epRegistrationName = "QNNExecutionProvider";
             env.RegisterExecutionProviderLibrary(
-                "QnnExecutionProvider",
+                epRegistrationName,
                 epLibPath);
 
             var epDevices = env.GetEpDevices();
@@ -104,7 +105,7 @@ namespace QnnEpNuGetTest
                     }
                 }
             }
-            env.UnregisterExecutionProviderLibrary("QnnExecutionProvider");
+            env.UnregisterExecutionProviderLibrary(epRegistrationName);
         }
     }
 }

--- a/qcom/samples/test_qnnep.cs
+++ b/qcom/samples/test_qnnep.cs
@@ -24,12 +24,15 @@ namespace QnnEpNuGetTest
             // Get EP library path
             string epLibPath = QnnEpHelper.GetLibraryPath();
             Console.WriteLine($"EP Library: {epLibPath}");
-            // Get QNN HTP path
-            string htpLibPath = QnnEpHelper.GetQnnHtpLibraryPath();
-            Console.WriteLine($"HTP Library: {htpLibPath}");
             // Get QNN CPU path
             string cpuLibPath = QnnEpHelper.GetQnnCpuLibraryPath();
             Console.WriteLine($"CPU Library: {cpuLibPath}");
+            // Get QNN GPU path
+            string gpuLibPath = QnnEpHelper.GetQnnGpuLibraryPath();
+            Console.WriteLine($"GPU Library: {gpuLibPath}");
+            // Get QNN HTP path
+            string htpLibPath = QnnEpHelper.GetQnnHtpLibraryPath();
+            Console.WriteLine($"HTP Library: {htpLibPath}");
             // Get all EP names
             var epNames = QnnEpHelper.GetEpNames();
             foreach (var availableEpName in epNames)

--- a/qcom/samples/test_wheel.py
+++ b/qcom/samples/test_wheel.py
@@ -9,7 +9,7 @@ import onnxruntime as ort
 # Path to the plugin EP library
 ep_lib_path = qnn_ep.get_library_path()
 # Registration name can be anything the application chooses
-ep_registration_name = "QnnExecutionProvider"
+ep_registration_name = "QNNExecutionProvider"
 
 # Register plugin EP library with ONNX Runtime
 ort.register_execution_provider_library(ep_registration_name, ep_lib_path)


### PR DESCRIPTION
### Description
- Include necessary files in the wheel.
- Update EP name to QNNExecutionProvider.
- Add an API to get the path of GPU library.

### Motivation and Context
The `qnn_ep.get_library_path()` cannot be called after the PR https://github.com/onnxruntime/onnxruntime-qnn/pull/21 replacing all qnn-abi to qnn. The reason is that the `__init__.py` is not included in the wheel file.


