### PR TITLE
[QNN EP] Add Support for GroupNorm Operator in QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -243,6 +243,10 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   {
     CreateIsNanOpBuilder("IsNaN", *this);
   }
+
+  {
+    CreateGroupNormOpBuilder("GroupNormalization", *this);
+  }
 }
 
 const IOpBuilder* GetOpBuilder(const std::string& onnx_op_type) {

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -143,5 +143,7 @@ void CreateFusedMatMulOpBuilder(const std::string& op_type, OpBuilderRegistratio
 
 void CreateIsNanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateGroupNormOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -225,6 +225,7 @@ class BaseOpBuilder : public IOpBuilder {
         {"BatchNormalization", QNN_OP_BATCHNORM},
         {"LayerNormalization", QNN_OP_LAYER_NORM},
         {"RMSNormalization", QNN_OP_RMS_NORM},
+        {"GroupNormalization", QNN_OP_GROUP_NORM},
 
         {"LRN", QNN_OP_LRN},
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/group_norm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/group_norm_op_builder.cc
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class GroupNormOpBuilder : public BaseOpBuilder {
+ public:
+  GroupNormOpBuilder() : BaseOpBuilder("GroupNormOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GroupNormOpBuilder);
+
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override final ORT_MUST_USE_RESULT;
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status GroupNormOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                                              const OrtNodeUnit& node_unit,
+                                              const Ort::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+
+  const auto& inputs = node_unit.Inputs();
+  const auto& outputs = node_unit.Outputs();
+
+  // Check input type is float for CPU. Can't use Qnn Op validation API since it's before layout transformation
+  ONNXTensorElementDataType input_type = inputs[0].type;
+  RETURN_IF_ERROR(DataTypeCheckForCpuBackend(qnn_model_wrapper, input_type,
+                                             "QNN GroupNorm only supports float input for CPU backend."));
+
+  RETURN_IF(outputs.size() > 1, "QNN GroupNorm only support 1 output.");
+
+  TensorInfo input_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
+  const std::vector<uint32_t>& input_shape = input_info.shape;
+  const size_t input_rank = input_shape.size();
+
+  if (input_rank <= 2) {
+    return MAKE_EP_FAIL("QNN GroupNorm only supports input ranks greater than 2.");
+  }
+
+  // Handle layout transformation - check if already transformed to NHWC
+  const uint32_t num_channels = (node_unit.Domain() == kMSInternalNHWCDomain) ? input_shape.back() : input_shape[1];
+
+  TensorInfo scale_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], scale_info));
+  const std::vector<uint32_t>& scale_shape = scale_info.shape;
+  if (scale_shape.size() != 1 || scale_shape[0] != num_channels) {
+    return MAKE_EP_FAIL("QNN GroupNorm input 1 (scale) must have 1D shape [channel].");
+  }
+
+  TensorInfo bias_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
+  const std::vector<uint32_t>& bias_shape = bias_info.shape;
+  if (bias_shape.size() != 1 || bias_shape[0] != num_channels) {
+    return MAKE_EP_FAIL("QNN GroupNorm input 2 (bias) must have 1D shape [channel].");
+  }
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  const float epsilon = node_helper.Get("epsilon", 1e-05f);
+  if (epsilon <= 0.0f) {
+    return MAKE_EP_FAIL("QNN GroupNorm epsilon must be greater than 0.0");
+  }
+
+  const int64_t num_groups = node_helper.Get("num_groups", static_cast<int64_t>(1));
+  if (num_groups <= 0) {
+    return MAKE_EP_FAIL("QNN GroupNorm num_groups must be greater than 0");
+  }
+
+  if (num_channels % static_cast<uint32_t>(num_groups) != 0) {
+    return MAKE_EP_FAIL("QNN GroupNorm requires num_channels to be divisible by num_groups");
+  }
+
+  // Continue Op validation if it's NHWC transformed
+  if (node_unit.Domain() == kMSInternalNHWCDomain) {
+    return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status GroupNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                              const OrtNodeUnit& node_unit,
+                                              const Ort::Logger& logger,
+                                              std::vector<std::string>& input_names,
+                                              bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(do_op_validation);
+  const auto& inputs = node_unit.Inputs();
+
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));  // Input 0
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[1], logger, input_names));  // Scale
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));  // Bias
+
+  return Ort::Status();
+}
+
+Ort::Status GroupNormOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                            const OrtNodeUnit& node_unit,
+                                                            std::vector<std::string>&& input_names,
+                                                            const Ort::Logger& logger,
+                                                            bool do_op_validation) const {
+  OrtNodeAttrHelper node_helper(node_unit);
+  std::vector<std::string> param_tensor_names;
+
+  const float epsilon = node_helper.Get("epsilon", 1e-05f);
+  Qnn_Scalar_t epsilon_param = QNN_SCALAR_INIT;
+  epsilon_param.dataType = QNN_DATATYPE_FLOAT_32;
+  epsilon_param.floatValue = epsilon;
+  QnnParamWrapper epsilon_param_wrapper(node_unit.Index(),
+                                        node_unit.Name(),
+                                        QNN_OP_GROUP_NORM_PARAM_EPSILON,
+                                        epsilon_param);
+  param_tensor_names.push_back(epsilon_param_wrapper.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(epsilon_param_wrapper));
+
+  const int64_t num_groups = node_helper.Get("num_groups", static_cast<int64_t>(1));
+  Qnn_Scalar_t num_groups_param = QNN_SCALAR_INIT;
+  num_groups_param.dataType = QNN_DATATYPE_UINT_32;
+  num_groups_param.uint32Value = static_cast<uint32_t>(num_groups);
+  QnnParamWrapper num_groups_param_wrapper(node_unit.Index(),
+                                           node_unit.Name(),
+                                           QNN_OP_GROUP_NORM_PARAM_GROUP,
+                                           num_groups_param);
+  param_tensor_names.push_back(num_groups_param_wrapper.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(num_groups_param_wrapper));
+
+  return ProcessOutputs(qnn_model_wrapper, node_unit,
+                        std::move(input_names),
+                        std::move(param_tensor_names),
+                        logger, do_op_validation, GetQnnOpType(node_unit.OpType()));
+}
+
+void CreateGroupNormOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<GroupNormOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1822,6 +1822,11 @@ OrtStatus* ORT_API_CALL QnnEp::ShouldConvertDataLayoutForOpImpl(_In_ OrtEp* this
     *should_convert = 1;
   }
 
+  if (std::string(domain) == kOnnxDomain && std::string(op_type) == "GroupNormalization") {
+    // GroupNormalization is translated to QNN's GroupNorm, which requires the NHWC layout for processing.
+    *should_convert = 1;
+  }
+
   return nullptr;
 }
 

--- a/onnxruntime/test/providers/qnn/group_norm_op_test.cc
+++ b/onnxruntime/test/providers/qnn/group_norm_op_test.cc
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include "core/graph/graph.h"
+#include "core/graph/node_attr_utils.h"
+
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// Test GroupNormalization operator on HTP backend with default parameters
+TEST_F(QnnHTPBackendTests, GroupNorm_Float_Default) {
+  std::vector<float> input_data = {
+      0.1f, 0.3f, 0.5f, 0.7f, 0.2f, 0.4f, 0.6f, 0.8f,
+      0.15f, 0.35f, 0.55f, 0.75f, 0.25f, 0.45f, 0.65f, 0.85f,
+      0.12f, 0.32f, 0.52f, 0.72f, 0.22f, 0.42f, 0.62f, 0.82f};
+  std::vector<float> scale_data = {1.0f, 2.0f};
+  std::vector<float> bias_data = {0.1f, 0.2f};
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1, 2, 3, 4}, input_data);
+    auto* scale = builder.MakeInitializer<float>({2}, scale_data);
+    auto* bias = builder.MakeInitializer<float>({2}, bias_data);
+
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 2, 3, 4});
+    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
+    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(1));
+    group_norm_node.AddAttribute("epsilon", 1e-05f);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  ExpectedEPNodeAssignment::All,
+                  0.01f);
+}
+
+// Test GroupNormalization operator on CPU backend
+TEST_F(QnnCPUBackendTests, GroupNorm_Float_CPU) {
+  std::vector<float> input_data = {
+      0.1f, 0.3f, 0.5f, 0.7f, 0.2f, 0.4f, 0.6f, 0.8f,
+      0.15f, 0.35f, 0.55f, 0.75f, 0.25f, 0.45f, 0.65f, 0.85f,
+      0.12f, 0.32f, 0.52f, 0.72f, 0.22f, 0.42f, 0.62f, 0.82f};
+  std::vector<float> scale_data = {1.0f, 2.0f};
+  std::vector<float> bias_data = {0.1f, 0.2f};
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1, 2, 3, 4}, input_data);
+    auto* scale = builder.MakeInitializer<float>({2}, scale_data);
+    auto* bias = builder.MakeInitializer<float>({2}, bias_data);
+
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 2, 3, 4});
+    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
+    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(1));
+    group_norm_node.AddAttribute("epsilon", 1e-05f);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  ExpectedEPNodeAssignment::All,
+                  0.01f);
+}
+
+// Test GroupNormalization operator with multiple groups
+TEST_F(QnnHTPBackendTests, GroupNorm_Float_MultipleGroups) {
+  // Input with 4 channels, to be divided into 2 groups
+  std::vector<float> input_data = {
+      0.1f, 0.3f, 0.5f, 0.7f, 0.2f, 0.4f, 0.6f, 0.8f,
+      0.15f, 0.35f, 0.55f, 0.75f, 0.25f, 0.45f, 0.65f, 0.85f,
+      0.12f, 0.32f, 0.52f, 0.72f, 0.22f, 0.42f, 0.62f, 0.82f,
+      0.11f, 0.31f, 0.51f, 0.71f, 0.21f, 0.41f, 0.61f, 0.81f,
+      0.13f, 0.33f, 0.53f, 0.73f, 0.23f, 0.43f, 0.63f, 0.83f,
+      0.14f, 0.34f, 0.54f, 0.74f, 0.24f, 0.44f, 0.64f, 0.84f};
+  std::vector<float> scale_data = {1.0f, 2.0f, 0.5f, 1.5f};
+  std::vector<float> bias_data = {0.1f, 0.2f, 0.3f, 0.4f};
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1, 4, 3, 4}, input_data);
+    auto* scale = builder.MakeInitializer<float>({4}, scale_data);
+    auto* bias = builder.MakeInitializer<float>({4}, bias_data);
+
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 4, 3, 4});
+    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
+    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(2));  // 4 channels / 2 groups = 2 channels per group
+    group_norm_node.AddAttribute("epsilon", 1e-05f);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  ExpectedEPNodeAssignment::All,
+                  0.01f);
+}
+
+// Test GroupNormalization operator with different epsilon value
+TEST_F(QnnHTPBackendTests, GroupNorm_Float_LargeEpsilon) {
+  std::vector<float> input_data = {
+      0.1f, 0.3f, 0.5f, 0.7f, 0.2f, 0.4f, 0.6f, 0.8f,
+      0.15f, 0.35f, 0.55f, 0.75f, 0.25f, 0.45f, 0.65f, 0.85f,
+      0.12f, 0.32f, 0.52f, 0.72f, 0.22f, 0.42f, 0.62f, 0.82f};
+  std::vector<float> scale_data = {1.0f, 2.0f};
+  std::vector<float> bias_data = {0.1f, 0.2f};
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1, 2, 3, 4}, input_data);
+    auto* scale = builder.MakeInitializer<float>({2}, scale_data);
+    auto* bias = builder.MakeInitializer<float>({2}, bias_data);
+
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 2, 3, 4});
+    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
+    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(1));
+    group_norm_node.AddAttribute("epsilon", 0.1f);  // Larger epsilon value
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  ExpectedEPNodeAssignment::All,
+                  0.01f);
+}
+
+// Test GroupNormalization operator with 3D input
+TEST_F(QnnHTPBackendTests, GroupNorm_Float_3D) {
+  std::vector<float> input_data = {
+      0.1f, 0.3f, 0.5f, 0.7f,
+      0.2f, 0.4f, 0.6f, 0.8f,
+      0.15f, 0.35f, 0.55f, 0.75f,
+      0.25f, 0.45f, 0.65f, 0.85f};
+  std::vector<float> scale_data = {1.0f, 2.0f, 0.5f, 1.5f};
+  std::vector<float> bias_data = {0.1f, 0.2f, 0.3f, 0.4f};
+
+  auto build_test_case = [&](ModelTestBuilder& builder) {
+    auto* input = builder.MakeInput<float>({1, 4, 4}, input_data);
+    auto* scale = builder.MakeInitializer<float>({4}, scale_data);
+    auto* bias = builder.MakeInitializer<float>({4}, bias_data);
+
+    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 4, 4});
+    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
+    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(2));  // 4 channels / 2 groups = 2 channels per group
+    group_norm_node.AddAttribute("epsilon", 1e-05f);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  ExpectedEPNodeAssignment::All,
+                  0.01f);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif


### PR DESCRIPTION


### Description
- Add support for GroupNorm Op
- Add unit tests to run on HTP



### Motivation and Context
- QNN EP does not support GroupNorm Op

