### PR TITLE
Avoid CAST(FP16/32) -> Q -> DQ fusion as QNN Convert op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/cast_lone_q_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/cast_lone_q_fusion.cc
@@ -13,6 +13,22 @@ namespace qnn {
 constexpr char kOpCast[] = "Cast";
 constexpr char kOpConvert[] = "Convert";
 
+static bool IsQnnConvertInputSupported(Qnn_DataType_t data_type) {
+  switch (data_type) {
+    case QNN_DATATYPE_FLOAT_16:
+    case QNN_DATATYPE_FLOAT_32:
+    case QNN_DATATYPE_BOOL_8:
+    case QNN_DATATYPE_UINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+      return true;
+    default:
+      return false;
+  }
+}
+
 Ort::Status CreateOrValidateOnQnn(QnnModelWrapper* qnn_model_wrapper,
                                   gsl::span<const OrtNodeUnit* const> node_units,
                                   [[maybe_unused]] const Ort::Logger& logger,
@@ -87,8 +103,7 @@ std::unique_ptr<IQnnNodeGroup> CastLoneQFusion::TryFusion(
   if (!qnn_model_wrapper.GetTensorInfo(cast_node_unit.Inputs()[0], cast_input_info).IsOK()) {
     return nullptr;
   }
-  if (cast_input_info.qnn_data_type != QNN_DATATYPE_FLOAT_16 &&
-      cast_input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32) {
+  if (!IsQnnConvertInputSupported(cast_input_info.qnn_data_type)) {
     return nullptr;
   }
   std::array<const OrtNodeUnit*, 2> node_unit_array{&cast_node_unit, quantize_linear};

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/cast_lone_q_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/cast_lone_q_fusion.cc
@@ -82,6 +82,15 @@ std::unique_ptr<IQnnNodeGroup> CastLoneQFusion::TryFusion(
   if (qnn_model_wrapper.IsConstantInput(cast_node_unit.Inputs()[0].name)) {
     return nullptr;
   }
+
+  TensorInfo cast_input_info = {};
+  if (!qnn_model_wrapper.GetTensorInfo(cast_node_unit.Inputs()[0], cast_input_info).IsOK()) {
+    return nullptr;
+  }
+  if (cast_input_info.qnn_data_type != QNN_DATATYPE_FLOAT_16 &&
+      cast_input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32) {
+    return nullptr;
+  }
   std::array<const OrtNodeUnit*, 2> node_unit_array{&cast_node_unit, quantize_linear};
   auto node_units = gsl::make_span<const OrtNodeUnit*>(node_unit_array.data(), 2);
 


### PR DESCRIPTION
### Description
CAST -> Q -> DQ fusion as CONVERT op should be avoided for Float16/32 Cast outputs, 
instead CAST -> QUANTIZE should be used.



### Motivation and Context
Fixes https://github.com/qcom-ai-hub/tetracode/issues/16559 

Model has following topology:
INT32 -> Cast -> Fp32 -> Q -> DQ -> UFXP16

This was resulting in : INT32 -> Convert -> UFXP16 , but QNN Convert op don't support INT32 to UFXP16

Added check in `cast_lone_q_fusion.cc` to avoid fusion if Casting to FP16/32 type as it should be fold subsequent QDQ to Quantize op


