### PR TITLE
Fix negative-index shared Gather indices naming

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -72,7 +72,8 @@ Ort::Status GatherOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
 template <typename SrcType, typename DstType>
 static bool FixStaticIndices(const std::vector<uint8_t>& onnx_bytes,
                              int64_t input0_axis_dim,
-                             /*out*/ std::vector<uint8_t>& qnn_bytes) {
+                             /*out*/ std::vector<uint8_t>& qnn_bytes,
+                             /*out*/ bool* had_negative_indices) {
   const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
   gsl::span<const SrcType> onnx_indices{reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
 
@@ -84,6 +85,9 @@ static bool FixStaticIndices(const std::vector<uint8_t>& onnx_bytes,
 
     // Try to make a negative index positive by adding rank.
     if (onnx_index < 0) {
+      if (had_negative_indices != nullptr) {
+        *had_negative_indices = true;
+      }
       onnx_index += static_cast<SrcType>(input0_axis_dim);
     }
 
@@ -130,6 +134,7 @@ static Ort::Status GetInput0AxisDimValue(const QnnModelWrapper& qnn_model_wrappe
 // The HTP backend only supports dynamic int64 indices if they are a graph input.
 static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
                                        const OrtNodeUnitIODef& indices_input,
+                                       const std::string& gather_input0_name,
                                        int64_t input0_axis_dim,
                                        const Ort::Logger& logger,
                                        std::vector<std::string>& input_names,
@@ -140,6 +145,7 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
 
   std::vector<uint8_t> qnn_indices_bytes;
+  bool had_negative_indices = false;
 
   // A. Get raw bytes for static indices.
   //    If indices are int64, convert them to int32 and update indices_info.qnn_data_type.
@@ -148,11 +154,13 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor, onnx_indices_bytes));
 
     if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
-      RETURN_IF_NOT((FixStaticIndices<int64_t, int32_t>(onnx_indices_bytes, input0_axis_dim, qnn_indices_bytes)),
+      RETURN_IF_NOT((FixStaticIndices<int64_t, int32_t>(onnx_indices_bytes, input0_axis_dim, qnn_indices_bytes,
+                                                        &had_negative_indices)),
                     "QNN does not support negative index values for Gather* ops");
       indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
     } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
-      RETURN_IF_NOT((FixStaticIndices<int32_t, int32_t>(onnx_indices_bytes, input0_axis_dim, qnn_indices_bytes)),
+      RETURN_IF_NOT((FixStaticIndices<int32_t, int32_t>(onnx_indices_bytes, input0_axis_dim, qnn_indices_bytes,
+                                                        &had_negative_indices)),
                     "QNN does not support negative index values for Gather* ops");
     } else {
       qnn_indices_bytes = std::move(onnx_indices_bytes);
@@ -160,11 +168,24 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   }
 
   std::vector<uint32_t> cast_output_shape(indices_info.shape);
-  if (qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name)) {
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + indices_tensor_name).c_str());
+  std::string indices_tensor_name_to_use = indices_tensor_name;
+  // If static indices have negative values, use a deterministic neg-to-pos tensor name
+  // that is stable across graph passes and unique per Gather: input0 + axis size.
+  // Note: Using 'GetUniqueName' here causes replication of same indices across passes.
+  if (indices_info.is_initializer && had_negative_indices) {
+    indices_tensor_name_to_use = indices_tensor_name + "_neg2pos_axis" + std::to_string(input0_axis_dim) +
+                                 "_" + gather_input0_name;
+  }
+
+  if (qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name_to_use)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("Tensor already added, skip it: " + indices_tensor_name_to_use).c_str());
   } else {
-    QnnTensorWrapper input_tensorwrapper(indices_tensor_name,
-                                         qnn_model_wrapper.GetTensorType(indices_tensor_name),
+    const Qnn_TensorType_t tensor_type = indices_info.is_initializer
+                                             ? QNN_TENSOR_TYPE_STATIC
+                                             : qnn_model_wrapper.GetTensorType(indices_tensor_name_to_use);
+    QnnTensorWrapper input_tensorwrapper(indices_tensor_name_to_use,
+                                         tensor_type,
                                          indices_info.qnn_data_type, QnnQuantParamsWrapper(),
                                          std::move(indices_info.shape),
                                          std::move(qnn_indices_bytes));
@@ -172,9 +193,9 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // B. Insert QNN Cast op to convert dynamic indices from int64 to int32.
-  auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name);
+  auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name_to_use);
 
-  std::string indices_casted_name{indices_tensor_name};
+  std::string indices_casted_name{indices_tensor_name_to_use};
   // Check QNN Tensor data type.
   if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
     assert(!indices_info.is_initializer);
@@ -224,7 +245,8 @@ Ort::Status GatherOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
   int64_t input0_axis_dim = 0;
   RETURN_IF_ERROR(GetInput0AxisDimValue(qnn_model_wrapper, node_unit, /*default_axis_value=*/0, input0_axis_dim));
-  return ProcessIndicesInput(qnn_model_wrapper, inputs[1], input0_axis_dim, logger, input_names, do_op_validation);
+  return ProcessIndicesInput(qnn_model_wrapper, inputs[1], input_names[0], input0_axis_dim,
+                             logger, input_names, do_op_validation);
 }
 
 Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -70,10 +70,10 @@ Ort::Status GatherOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
 // Makes negative indices positive and converts int64 indices to another integer type (typically int32 or uint32).
 // The input and output are both represented as byte arrays.
 template <typename SrcType, typename DstType>
-static bool FixStaticIndices(const std::vector<uint8_t>& onnx_bytes,
-                             int64_t input0_axis_dim,
-                             /*out*/ std::vector<uint8_t>& qnn_bytes,
-                             /*out*/ bool* had_negative_indices) {
+static bool MakeStaticIndicesPositiveAndValidate(const std::vector<uint8_t>& onnx_bytes,
+                                                 int64_t input0_axis_dim,
+                                                 /*out*/ std::vector<uint8_t>& qnn_bytes,
+                                                 /*out*/ bool* has_negative_indices) {
   const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
   gsl::span<const SrcType> onnx_indices{reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
 
@@ -85,8 +85,8 @@ static bool FixStaticIndices(const std::vector<uint8_t>& onnx_bytes,
 
     // Try to make a negative index positive by adding rank.
     if (onnx_index < 0) {
-      if (had_negative_indices != nullptr) {
-        *had_negative_indices = true;
+      if (has_negative_indices != nullptr) {
+        *has_negative_indices = true;
       }
       onnx_index += static_cast<SrcType>(input0_axis_dim);
     }
@@ -139,13 +139,13 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
                                        const Ort::Logger& logger,
                                        std::vector<std::string>& input_names,
                                        bool do_op_validation) {
-  const auto& indices_tensor_name = indices_input.name;
+  std::string indices_name = indices_input.name;
 
   TensorInfo indices_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
 
   std::vector<uint8_t> qnn_indices_bytes;
-  bool had_negative_indices = false;
+  bool has_negative_indices = false;
 
   // A. Get raw bytes for static indices.
   //    If indices are int64, convert them to int32 and update indices_info.qnn_data_type.
@@ -154,13 +154,15 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor, onnx_indices_bytes));
 
     if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
-      RETURN_IF_NOT((FixStaticIndices<int64_t, int32_t>(onnx_indices_bytes, input0_axis_dim, qnn_indices_bytes,
-                                                        &had_negative_indices)),
+      RETURN_IF_NOT((MakeStaticIndicesPositiveAndValidate<int64_t, int32_t>(onnx_indices_bytes, input0_axis_dim,
+                                                                            qnn_indices_bytes,
+                                                                            &has_negative_indices)),
                     "QNN does not support negative index values for Gather* ops");
       indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
     } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
-      RETURN_IF_NOT((FixStaticIndices<int32_t, int32_t>(onnx_indices_bytes, input0_axis_dim, qnn_indices_bytes,
-                                                        &had_negative_indices)),
+      RETURN_IF_NOT((MakeStaticIndicesPositiveAndValidate<int32_t, int32_t>(onnx_indices_bytes, input0_axis_dim,
+                                                                            qnn_indices_bytes,
+                                                                            &has_negative_indices)),
                     "QNN does not support negative index values for Gather* ops");
     } else {
       qnn_indices_bytes = std::move(onnx_indices_bytes);
@@ -168,23 +170,22 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   }
 
   std::vector<uint32_t> cast_output_shape(indices_info.shape);
-  std::string indices_tensor_name_to_use = indices_tensor_name;
   // If static indices have negative values, use a deterministic neg-to-pos tensor name
   // that is stable across graph passes and unique per Gather: input0 + axis size.
   // Note: Using 'GetUniqueName' here causes replication of same indices across passes.
-  if (indices_info.is_initializer && had_negative_indices) {
-    indices_tensor_name_to_use = indices_tensor_name + "_neg2pos_axis" + std::to_string(input0_axis_dim) +
-                                 "_" + gather_input0_name;
+  if (indices_info.is_initializer && has_negative_indices) {
+    indices_name = indices_name + "_neg2pos_axis" + std::to_string(input0_axis_dim) +
+                   "_" + gather_input0_name;
   }
 
-  if (qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name_to_use)) {
+  if (qnn_model_wrapper.IsQnnTensorWrapperExist(indices_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                ("Tensor already added, skip it: " + indices_tensor_name_to_use).c_str());
+                ("Tensor already added, skip it: " + indices_name).c_str());
   } else {
     const Qnn_TensorType_t tensor_type = indices_info.is_initializer
                                              ? QNN_TENSOR_TYPE_STATIC
-                                             : qnn_model_wrapper.GetTensorType(indices_tensor_name_to_use);
-    QnnTensorWrapper input_tensorwrapper(indices_tensor_name_to_use,
+                                             : qnn_model_wrapper.GetTensorType(indices_name);
+    QnnTensorWrapper input_tensorwrapper(indices_name,
                                          tensor_type,
                                          indices_info.qnn_data_type, QnnQuantParamsWrapper(),
                                          std::move(indices_info.shape),
@@ -193,15 +194,15 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // B. Insert QNN Cast op to convert dynamic indices from int64 to int32.
-  auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name_to_use);
+  auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_name);
 
-  std::string indices_casted_name{indices_tensor_name_to_use};
+  std::string indices_casted_name{indices_name};
   // Check QNN Tensor data type.
   if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
     assert(!indices_info.is_initializer);
     indices_casted_name += "_int32";
-    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::GetUniqueName(indices_tensor_name, QNN_OP_CAST),
-                                                  indices_tensor_name,
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::GetUniqueName(indices_name, QNN_OP_CAST),
+                                                  indices_name,
                                                   indices_casted_name,
                                                   QNN_TENSOR_TYPE_NATIVE,
                                                   QNN_DATATYPE_INT_32,

--- a/onnxruntime/test/providers/qnn/gather_test.cc
+++ b/onnxruntime/test/providers/qnn/gather_test.cc
@@ -80,6 +80,73 @@ GetTestQDQModelFn<QuantType> BuildQDQGatherNdTestCase(const TestInputDef<float>&
   };
 }
 
+template <typename QuantType, typename IndicesType>
+GetTestModelFn BuildTwoGatherSharedIndicesTestCase(const TestInputDef<float>& input_def0,
+                                                   const TestInputDef<float>& input_def1,
+                                                   const TestInputDef<IndicesType>& indices_def,
+                                                   const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
+  return [input_def0, input_def1, indices_def, attrs](ModelTestBuilder& builder) {
+    NodeArg* input0 = MakeTestInput(builder, input_def0);
+    NodeArg* input1 = MakeTestInput(builder, input_def1);
+    NodeArg* indices_input = MakeTestInput(builder, indices_def);
+
+    NodeArg* gather0_output = builder.MakeOutput();
+    Node& gather0_node = builder.AddNode("Gather", {input0, indices_input}, {gather0_output});
+    for (const auto& attr : attrs) {
+      gather0_node.AddAttributeProto(attr);
+    }
+
+    NodeArg* gather1_output = builder.MakeOutput();
+    Node& gather1_node = builder.AddNode("Gather", {input1, indices_input}, {gather1_output});
+    for (const auto& attr : attrs) {
+      gather1_node.AddAttributeProto(attr);
+    }
+  };
+}
+
+template <typename QuantType, typename IndicesType>
+GetTestQDQModelFn<QuantType> BuildQDQTwoGatherSharedIndicesTestCase(
+    const TestInputDef<float>& input_def0,
+    const TestInputDef<float>& input_def1,
+    const TestInputDef<IndicesType>& indices_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    bool use_contrib_qdq = false) {
+  return [input_def0, input_def1, indices_def, attrs, use_contrib_qdq](
+             ModelTestBuilder& builder,
+             std::vector<QuantParams<QuantType>>& output_qparams) {
+    NodeArg* input0 = MakeTestInput(builder, input_def0);
+    NodeArg* input1 = MakeTestInput(builder, input_def1);
+
+    QuantParams<QuantType> input0_qparams = GetTestInputQuantParams<QuantType>(input_def0);
+    QuantParams<QuantType> input1_qparams = GetTestInputQuantParams<QuantType>(input_def1);
+    NodeArg* input0_qdq = AddQDQNodePair<QuantType>(builder, input0, input0_qparams.scale,
+                                                    input0_qparams.zero_point, use_contrib_qdq);
+    NodeArg* input1_qdq = AddQDQNodePair<QuantType>(builder, input1, input1_qparams.scale,
+                                                    input1_qparams.zero_point, use_contrib_qdq);
+
+    NodeArg* indices_input = MakeTestInput(builder, indices_def);
+
+    NodeArg* gather0_output = builder.MakeIntermediate();
+    Node& gather0_node = builder.AddNode("Gather", {input0_qdq, indices_input}, {gather0_output});
+    for (const auto& attr : attrs) {
+      gather0_node.AddAttributeProto(attr);
+    }
+
+    NodeArg* gather1_output = builder.MakeIntermediate();
+    Node& gather1_node = builder.AddNode("Gather", {input1_qdq, indices_input}, {gather1_output});
+    for (const auto& attr : attrs) {
+      gather1_node.AddAttributeProto(attr);
+    }
+
+    output_qparams[0] = input0_qparams;
+    output_qparams[1] = input1_qparams;
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, gather0_output, input0_qparams.scale,
+                                                     input0_qparams.zero_point, use_contrib_qdq);
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, gather1_output, input1_qparams.scale,
+                                                     input1_qparams.zero_point, use_contrib_qdq);
+  };
+}
+
 // Test the accuracy of a QDQ Gather model on QNN EP. Checks if the QDQ model on QNN EP as accurate as the QDQ model on CPU EP
 // (compared to float32 model).
 template <typename QuantType, typename IndicesType>
@@ -96,6 +163,30 @@ static void RunQDQGatherOpTest(const TestInputDef<float>& input_def,
   auto f32_model_builder = BuildOpTestCase<float, IndicesType>("Gather", {input_def}, {indices_def}, attrs);
   auto qdq_model_builder = BuildQDQGatherTestCase<QuantType, IndicesType>(input_def, indices_def, attrs,
                                                                           use_contrib_qdq);
+
+  TestQDQModelAccuracy<QuantType>(f32_model_builder,
+                                  qdq_model_builder,
+                                  provider_options,
+                                  opset,
+                                  expected_ep_assignment);
+}
+
+template <typename QuantType, typename IndicesType>
+static void RunQDQTwoGatherSharedIndicesOpTest(const TestInputDef<float>& input_def0,
+                                               const TestInputDef<float>& input_def1,
+                                               const TestInputDef<IndicesType>& indices_def,
+                                               const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                               int opset,
+                                               ExpectedEPNodeAssignment expected_ep_assignment,
+                                               bool use_contrib_qdq = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  auto f32_model_builder = BuildTwoGatherSharedIndicesTestCase<QuantType, IndicesType>(
+      input_def0, input_def1, indices_def, attrs);
+  auto qdq_model_builder = BuildQDQTwoGatherSharedIndicesTestCase<QuantType, IndicesType>(
+      input_def0, input_def1, indices_def, attrs, use_contrib_qdq);
 
   TestQDQModelAccuracy<QuantType>(f32_model_builder,
                                   qdq_model_builder,
@@ -155,6 +246,22 @@ TEST_F(QnnHTPBackendTests, GatherOp_IndicesStaticInt32_NegativeIndices) {
                                        {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
                                        13,
                                        ExpectedEPNodeAssignment::All);
+}
+
+// Two Gather ops with shared static negative indices on axis 0 and different input sizes.
+TEST_F(QnnHTPBackendTests, GatherOp_SharedStaticNegIndices_TwoInputs_Axis0) {
+  const std::vector<int64_t> input0_shape{3, 2};
+  const std::vector<int64_t> input1_shape{4, 2};
+  const std::vector<float> input0_data = GetSequentialFloatData(input0_shape, 1.0f, 1.0f);
+  const std::vector<float> input1_data = GetSequentialFloatData(input1_shape, 10.0f, 1.0f);
+
+  RunQDQTwoGatherSharedIndicesOpTest<uint8_t, int32_t>(
+      TestInputDef<float>(input0_shape, false, input0_data),
+      TestInputDef<float>(input1_shape, false, input1_data),
+      TestInputDef<int32_t>({2, 2}, true, {-1, 0, 1, 2}),
+      {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+      13,
+      ExpectedEPNodeAssignment::All);
 }
 
 // Test creates a DQ -> Gather -> Q -> DQ graph, and checks that all


### PR DESCRIPTION
### Description
Make negative-index Gather initializers use deterministic, axis-specific tensor names so the positive converted QNN indices are not reused across different dimension sizes Gather ops.



### Motivation and Context
Fixes https://github.com/qcom-ai-hub/tetracode/issues/17329

- In the given customer model, some Gathers failed QNN validation because they shared indices initializer with -1 which was converted to Positive based on Axis Dimensions, leading to out-of-range indices.

- scenario:
- - Indices tensor with value -1 used by Gather input0 shapes (16,1,384), (8,1,384) and (4,1,384) should map to 15, 7 and 3 respectively
- - However, due to common QNN name, it generate 15, 15, 15 for all Gathers resulting in QNN validation failure ( probably due to out-of-bound )

<img width="636" height="381" alt="image" src="https://github.com/user-attachments/assets/f017f230-e44c-4cf2-a37d-f76d2590b51d" />


- The change ensures each Gather uses the correct neg-to-pos conversion while still reusing tensors across passes. 