### PR TITLE
[OpBuilder] Support optional Slice axes/steps.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
@@ -148,14 +148,14 @@ class SliceOpBuilder : public BaseOpBuilder {
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
  private:
-  Ort::Status ExplictOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const;
+  Ort::Status ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const;
   void GetDataFromAttribute(const OrtNodeUnit& node_unit,
                             std::vector<int64_t>& raw_starts,
                             std::vector<int64_t>& raw_ends,
                             std::vector<int64_t>& raw_axes) const;
 };
 
-Ort::Status SliceOpBuilder::ExplictOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const {
+Ort::Status SliceOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const {
   size_t input_count = node_unit.Inputs().size();
 
   // Opset < 10: Only has 1 data input. The starts, ends, and axes values are attributes.
@@ -163,8 +163,8 @@ Ort::Status SliceOpBuilder::ExplictOpCheck(QnnModelWrapper& qnn_model_wrapper, c
   if (input_count > 1) {
     // Skip the first input. All other input need to be initializer
     for (size_t i = 1; i < input_count; i++) {
-      const auto& next_input = node_unit.Inputs()[i].name;
-      if (!qnn_model_wrapper.IsConstantInput(next_input)) {
+      const auto& next_input = node_unit.Inputs()[i];
+      if (next_input.Exists() && !qnn_model_wrapper.IsConstantInput(next_input.name)) {
         return MAKE_EP_FAIL("QNN doesn't support dynamic slice.");
       }
     }
@@ -225,7 +225,7 @@ Ort::Status SliceOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                           std::vector<std::string>& input_names,
                                           bool do_op_validation) const {
   if (do_op_validation) {
-    RETURN_IF_ERROR(ExplictOpCheck(qnn_model_wrapper, node_unit));
+    RETURN_IF_ERROR(ExplicitOpCheck(qnn_model_wrapper, node_unit));
   }
 
   // Only need to add input 0. The other inputs (if any) contain static data that is passed to QNN APIs

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -185,6 +185,8 @@ struct TestInputDef {
 
   TestInputDef() = default;
 
+  TestInputDef(bool is_optional) : is_optional_(is_optional) {};
+
   // Creates a random input definition. Specify its shape, whether it's an initializer, and
   // the min/max range.
   TestInputDef(std::vector<int64_t> shape, bool is_initializer, T rand_min, T rand_max)
@@ -311,12 +313,17 @@ struct TestInputDef {
     return per_axis_ranges;
   }
 
+  bool IsOptional() const {
+    return is_optional_;
+  }
+
  private:
   std::vector<int64_t> shape_;
   std::variant<RawData, RandomData> data_info_;
   bool is_initializer_{false};
   bool has_range_override_{false};
   std::pair<T, T> range_override_;
+  bool is_optional_{false};
 };
 
 // Convert a float input definition to a float16 input definition.
@@ -1298,9 +1305,13 @@ inline GetTestModelFn BuildOpTestCase(const std::string& node_name,
     }
 
     for (size_t i = 0; i < input_defs_2.size(); i++) {
-      const std::string tmp_name = "input_defs_2_" + std::to_string(i);
-      MakeTestInput<InputType2>(builder, tmp_name, input_defs_2[i], input_allocator);
-      op_input_names.push_back(tmp_name);
+      if (input_defs_2[i].IsOptional()) {
+        op_input_names.push_back("");
+      } else {
+        const std::string tmp_name = "input_defs_2_" + std::to_string(i);
+        MakeTestInput<InputType2>(builder, tmp_name, input_defs_2[i], input_allocator);
+        op_input_names.push_back(tmp_name);
+      }
     }
 
     builder.MakeOutput("Y");
@@ -1397,9 +1408,13 @@ inline GetTestQDQModelFn<QuantType> BuildQDQOpTestCase(
 
     // Create non-QDQ inputs
     for (size_t i = 0; i < non_quant_input_defs.size(); i++) {
-      const std::string tmp_name = "non_quant_input_defs_" + std::to_string(i);
-      MakeTestInput<OtherInputType>(builder, tmp_name, non_quant_input_defs[i], input_allocator);
-      op_input_names.push_back(tmp_name);
+      if (non_quant_input_defs[i].IsOptional()) {
+        op_input_names.push_back("");
+      } else {
+        const std::string tmp_name = "non_quant_input_defs_" + std::to_string(i);
+        MakeTestInput<OtherInputType>(builder, tmp_name, non_quant_input_defs[i], input_allocator);
+        op_input_names.push_back(tmp_name);
+      }
     }
 
     builder.AddNode(node_name, op_type,

--- a/onnxruntime/test/providers/qnn/slice_test.cc
+++ b/onnxruntime/test/providers/qnn/slice_test.cc
@@ -204,6 +204,39 @@ TEST_F(QnnHTPBackendTests, SliceU8_MultAxes_LargeEnd) {
                            TestInputDef<int64_t>({2}, true, {1, 1}),      // steps
                            ExpectedEPNodeAssignment::All);
 }
+
+// Test 8-bit QDQ Slice without axes and steps.
+TEST_F(QnnHTPBackendTests, SliceU8_NoAxesSteps) {
+  std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  RunSliceQDQTest<uint8_t>(TestInputDef<float>({2, 4}, false, input_data),
+                           TestInputDef<int64_t>({2}, true, {1, 0}),     // starts
+                           TestInputDef<int64_t>({2}, true, {2, 3}),     // ends
+                           TestInputDef<int64_t>(/*is_optional*/ true),  // axes
+                           TestInputDef<int64_t>(/*is_optional*/ true),  // steps
+                           ExpectedEPNodeAssignment::All);
+}
+
+// Test 8-bit QDQ Slice without axes.
+TEST_F(QnnHTPBackendTests, SliceU8_NoAxes) {
+  std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  RunSliceQDQTest<uint8_t>(TestInputDef<float>({2, 4}, false, input_data),
+                           TestInputDef<int64_t>({2}, true, {1, 0}),     // starts
+                           TestInputDef<int64_t>({2}, true, {2, 3}),     // ends
+                           TestInputDef<int64_t>(/*is_optional*/ true),  // axes
+                           TestInputDef<int64_t>({2}, true, {1, 1}),     // steps
+                           ExpectedEPNodeAssignment::All);
+}
+
+// Test 8-bit QDQ Slice without steps.
+TEST_F(QnnHTPBackendTests, SliceU8_NoSteps) {
+  std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+  RunSliceQDQTest<uint8_t>(TestInputDef<float>({2, 4}, false, input_data),
+                           TestInputDef<int64_t>({2}, true, {1, 0}),     // starts
+                           TestInputDef<int64_t>({2}, true, {2, 3}),     // ends
+                           TestInputDef<int64_t>({2}, true, {0, 1}),     // axes
+                           TestInputDef<int64_t>(/*is_optional*/ true),  // steps
+                           ExpectedEPNodeAssignment::All);
+}
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
The Slice builder in fact supports optional axes/steps. Fix the check by adding extra condition that input must not be optional.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
There is a bug in checking unsupported dynamic Slice that incorrectly treat optional axes/steps as dynamic inputs. 

