### PR TITLE
[AISW-159989] Relax Pad builder check for zero pad amount.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -227,11 +227,7 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
   }
 
   bool has_negative = std::any_of(tensor_data, tensor_data + size, [](int64_t item) { return item < 0; });
-  bool has_positive = std::any_of(tensor_data, tensor_data + size, [](int64_t item) { return item > 0; });
-
-  // Zero padding value gives 3110 error on QNN on NPU.
-  const bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
-  RETURN_IF(is_npu_backend && !has_positive && !has_negative, "Got QNN invalid zero only padding value.");
+  bool has_positive = std::any_of(tensor_data, tensor_data + size, [](int64_t item) { return item >= 0; });
 
   // Onnx Pads are int64, Qnn uses uint32
   std::vector<uint32_t> pad_amount;

--- a/onnxruntime/test/providers/qnn/pad_test.cc
+++ b/onnxruntime/test/providers/qnn/pad_test.cc
@@ -459,6 +459,21 @@ TEST_F(QnnHTPBackendTests, PadNoConstantMixValue_FP32_as_FP16) {
                2e-3f);
 }
 
+TEST_F(QnnHTPBackendTests, Pad_Noop_FP32_as_FP16) {
+  bool has_constant_value_input = false;
+  bool enable_fp16_precision = true;
+  RunPadOpTest(TestInputDef<float>({3, 2}, false, {1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.6f}),
+               TestInputDef<int64_t>({4}, true, {0, 0, 0, 0}),
+               TestInputDef<float>({1}, true, {0.0f}),
+               {utils::MakeAttribute("mode", "constant")},
+               ExpectedEPNodeAssignment::All,
+               "htp",
+               has_constant_value_input,
+               18,  // opset
+               enable_fp16_precision,
+               2e-3f);
+}
+
 //
 // QDQ Pad
 TEST_F(QnnHTPBackendTests, PadNoConstantValue) {
@@ -645,6 +660,16 @@ TEST_F(QnnHTPBackendTests, Pad5d) {
                            {utils::MakeAttribute("mode", "constant")},
                            ExpectedEPNodeAssignment::All,
                            true);
+}
+
+TEST_F(QnnHTPBackendTests, Pad_Noop_QDQ) {
+  bool has_constant_value_input = false;
+  RunQDQPadOpTest<uint8_t>(TestInputDef<float>({3, 2}, false, {1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.6f}),
+                           TestInputDef<int64_t>({4}, true, {0, 0, 0, 0}),
+                           TestInputDef<float>({1}, true, {0.0f}),
+                           {utils::MakeAttribute("mode", "constant")},
+                           ExpectedEPNodeAssignment::All,
+                           has_constant_value_input);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Remove the guard of zero pad amount to allow such cases in Pad builder.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Previously zero pad amount case was rejected in Pad builder for HTP backend due to validation fail. In latest SDK, there is no such constraint anymore and thus relax the checking to allow zero pad amount case.

