### PR TITLE
[OpBuilder] Handle no-op Split.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
@@ -99,8 +99,17 @@ Ort::Status SplitOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
     }
   }
 
-  // Get the length according to axis and split it equally
   if (split_index.size() == 0) {
+    if (node_unit.Outputs().size() == 1) {
+      // This Split is essentially a no-op.
+      RETURN_IF_ERROR(qnn_model_wrapper.AddNoopReshapeNode(node_unit.Name(),
+                                                           input_names[0],
+                                                           node_unit.Outputs()[0],
+                                                           do_op_validation));
+      return Ort::Status();
+    }
+
+    // Get the length according to axis and split it equally
     std::vector<uint32_t> input_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape");
     RETURN_IF_NOT(static_cast<int32_t>(input_shape.size()) > axis_value, "axis not valid!");

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -957,6 +957,35 @@ Ort::Status QnnModelWrapper::AddTransposeNode(size_t node_index,
   return Ort::Status();
 }
 
+Ort::Status QnnModelWrapper::AddNoopReshapeNode(const std::string& node_name,
+                                                const std::string& input_name,
+                                                const OrtNodeUnitIODef& output,
+                                                bool do_op_validation) {
+  const auto tensor_wrapper_it = model_tensors_map_.find(input_name);
+  // Since no-op node is usually identified during op builder's ProcessAttributesAndOutputs, input should already
+  // processed and added.
+  RETURN_IF(tensor_wrapper_it == model_tensors_map_.end(), "Input tensor wrapper not exist for no-op node.");
+  const QnnTensorWrapper& input_tensor_wrapper = tensor_wrapper_it->second;
+
+  QnnTensorWrapper output_tensor_wrapper;
+  RETURN_IF_ERROR(MakeTensorWrapper(output, output_tensor_wrapper));
+  RETURN_IF(input_tensor_wrapper.GetTensorDims() != output_tensor_wrapper.GetTensorDims(),
+            "Expecting identical shapes for no-op input/output.");
+  std::string output_name = output_tensor_wrapper.GetName();
+  RETURN_IF_NOT(AddTensorWrapper(std::move(output_tensor_wrapper)), "Failed to add no-op output tensor.");
+
+  RETURN_IF_NOT(CreateQnnNode(utils::GetUniqueName(node_name),
+                              QNN_OP_PACKAGE_NAME_QTI_AISW,
+                              QNN_OP_RESHAPE,
+                              {input_name},
+                              {output_name},
+                              {},
+                              do_op_validation),
+                "Failed to add no-op node.");
+
+  return Ort::Status();
+}
+
 void QnnModelWrapper::GetGraphInputOutputTensorWrapper(const std::vector<std::string>& tensor_name_list,
                                                        std::vector<QnnTensorWrapper>& wrappers_list) {
   for (const auto& tensor_name : tensor_name_list) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -264,6 +264,13 @@ class QnnModelWrapper {
                                bool is_for_input = true,
                                bool is_for_output = false);
 
+  // Add Reshape node with identical input/output shapes to handle no-op node.
+  // This is a workaround for no-op nodes as there is no mechanism to reroute wrappers inside op builder currently.
+  Ort::Status AddNoopReshapeNode(const std::string& node_name,
+                                 const std::string& input_name,
+                                 const OrtNodeUnitIODef& output,
+                                 bool do_op_validation);
+
   // Transpose NCHW->HWCN for QNN weight
   Ort::Status AddNchwToHwcnTranspose(size_t node_index,
                                      const std::string& input_name,

--- a/onnxruntime/test/providers/qnn/split_test.cc
+++ b/onnxruntime/test/providers/qnn/split_test.cc
@@ -141,6 +141,16 @@ TEST_F(QnnCPUBackendTests, Split_Equal_Axis0_Opset13) {
                                ExpectedEPNodeAssignment::All);
 }
 
+// Test Split opset 13 on CPU backend: no-op
+TEST_F(QnnCPUBackendTests, Split_Noop_Opset13) {
+  RunSplitOpTestOnCPU<float>(TestInputDef<float>({1, 2}, false, {1.0f, 2.0f}),
+                             {1},  // split
+                             0,    // axis
+                             -1,   // num_outputs (not in opset 13)
+                             13,   // opset
+                             ExpectedEPNodeAssignment::All);
+}
+
 // Test Split opset 11 on CPU backend: equal split of axis 0
 TEST_F(QnnCPUBackendTests, Split_Equal_Axis0_Opset11) {
   RunSplitOpTestOnCPU<float>(TestInputDef<float>({4, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.f, 8.f}),
@@ -331,6 +341,17 @@ TEST_F(QnnHTPBackendTests, Split_Int32_Opset13) {
                                ExpectedEPNodeAssignment::All);
 }
 
+// Test that HTP can run non-QDQ Split (no-op).
+TEST_F(QnnHTPBackendTests, Split_Noop_Opset13) {
+  // Equal split.
+  RunSplitOpTestOnHTP<int32_t>(TestInputDef<int32_t>({1, 2}, false, {1, 2}),
+                               {1},  // split
+                               0,    // axis
+                               -1,   // num_outputs (not in opset 13)
+                               13,   // opset
+                               ExpectedEPNodeAssignment::All);
+}
+
 // Test 8-bit QDQ Split opset 18 on HTP backend: equal split of axis 0 via 'num_outputs' attribute
 // and 'split' input.
 TEST_F(QnnHTPBackendTests, Split_Equal_Axis0_Opset18) {
@@ -437,6 +458,16 @@ TEST_F(QnnHTPBackendTests, Split_Unequal_Axis1_Opset11) {
                                   1,       // axis
                                   -1,      // num_outputs (not in opset 11)
                                   11,      // opset
+                                  ExpectedEPNodeAssignment::All);
+}
+
+// Test QDQ Split opset 13 on HTP backend: no-op
+TEST_F(QnnHTPBackendTests, Split_QDQ_Noop_Opset13) {
+  RunQDQSplitOpTestOnHTP<uint8_t>(TestInputDef<float>({1, 2}, false, {1.0f, 2.0f}),
+                                  {1},  // split
+                                  0,    // axis
+                                  -1,   // num_outputs (not in opset 13)
+                                  13,   // opset
                                   ExpectedEPNodeAssignment::All);
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Define a utility function to add a Reshape node with identical in/out shapes to represent no-op node.
- Revise Split builder to take no-op Split into consideration.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Current Split builder failed to correctly handle cases that generate only one output (i.e., no Split perform).
Since current builder and wrapper structure are unfriendly to support reroute if facing no-op nodes, use no-op Reshape node to represent no-op instead which should be optimized in the backend.

