### PR TITLE
Add Tan op support

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -248,6 +248,10 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   {
     CreateGroupNormOpBuilder("GroupNormalization", *this);
   }
+
+  {
+    CreateTanOpBuilder("Tan", *this);
+  }
 }
 
 const IOpBuilder* GetOpBuilder(const std::string& onnx_op_type) {

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -145,5 +145,7 @@ void CreateIsNanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op
 
 void CreateGroupNormOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateTanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// QNN does not have a native Tan op, so it's decomposed into Sin, Cos, and Div ops
+class TanOpBuilder : public BaseOpBuilder {
+ public:
+  TanOpBuilder() : BaseOpBuilder("TanOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(TanOpBuilder);
+
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override final ORT_MUST_USE_RESULT;
+
+ protected:
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status TanOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                                        const OrtNodeUnit& node_unit,
+                                        const Ort::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  ORT_UNUSED_PARAMETER(qnn_model_wrapper);
+
+  const auto& inputs = node_unit.Inputs();
+  RETURN_IF_NOT(inputs.size() == 1, "Tan operator must have exactly 1 input.");
+
+  const auto& outputs = node_unit.Outputs();
+  RETURN_IF_NOT(outputs.size() == 1, "Tan operator must have exactly 1 output.");
+
+  RETURN_IF_NOT(inputs[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
+                    inputs[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+                "Tan operator only supports float and float16 input.");
+  RETURN_IF_NOT(outputs[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
+                    outputs[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+                "Tan operator only supports float and float16 output.");
+
+  return Ort::Status();
+}
+
+Ort::Status TanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                      const OrtNodeUnit& node_unit,
+                                                      std::vector<std::string>&& input_names,
+                                                      const Ort::Logger& logger,
+                                                      bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+
+  const auto& outputs = node_unit.Outputs();
+  const std::string& output_name = outputs[0].name;
+
+  TensorInfo input_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
+
+  TensorInfo output_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
+
+  // Create intermediate tensor for Sin output
+  std::string sin_output_name = utils::GetUniqueName(node_unit, "_sin_out");
+  QnnTensorWrapper sin_output_tensor_wrapper(sin_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
+                                             input_info.quant_param.Copy(), std::vector<uint32_t>(input_info.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sin_output_tensor_wrapper)),
+                "Failed to add Sin output tensor.");
+
+  // Create intermediate tensor for Cos output
+  std::string cos_output_name = utils::GetUniqueName(node_unit, "_cos_out");
+  QnnTensorWrapper cos_output_tensor_wrapper(cos_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
+                                             input_info.quant_param.Copy(), std::vector<uint32_t>(input_info.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cos_output_tensor_wrapper)),
+                "Failed to add Cos output tensor.");
+
+  // Create Sin node: input -> sin_out
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, "_Sin"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_ELEMENT_WISE_SIN,
+                                                {input_names[0]},
+                                                {sin_output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create Sin node.");
+
+  // Create Cos node: input -> cos_out
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, "_Cos"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_ELEMENT_WISE_COS,
+                                                {input_names[0]},
+                                                {cos_output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create Cos node.");
+
+  // Create final output tensor
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
+  Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+  QnnTensorWrapper output_tensor_wrapper(output_name, tensor_type, output_info.qnn_data_type,
+                                         output_info.quant_param.Copy(), std::move(output_info.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)),
+                "Failed to add output tensor.");
+
+  // Create Div node: sin_out / cos_out -> output
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, "_Div"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_ELEMENT_WISE_DIVIDE,
+                                                {sin_output_name, cos_output_name},
+                                                {output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create Div node.");
+
+  return Ort::Status();
+}
+
+void CreateTanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<TanOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -209,7 +209,7 @@ static void RunOpTest(const std::string& op_type,
     }
 #endif
 #if defined(__linux__) && !defined(__aarch64__)
-    provider_options["soc_model"] = soc_model.has_value() ? soc_model : std::to_string(QNN_SOC_MODEL_SM8850);
+    provider_options["soc_model"] = soc_model.has_value() ? *soc_model : std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
     provider_options["enable_htp_fp16_precision"] = "1";
   }

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -3,6 +3,7 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <optional>
 #include <string>
 #include <filesystem>
 #include <variant>
@@ -196,7 +197,8 @@ static void RunOpTest(const std::string& op_type,
                       ExpectedEPNodeAssignment expected_ep_assignment,
                       const std::string& op_domain = kOnnxDomain,
                       float fp32_abs_err = 1e-5f,
-                      bool enable_htp_fp16_precision = false) {
+                      bool enable_htp_fp16_precision = false,
+                      std::optional<std::string> soc_model = std::nullopt) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
 
@@ -207,7 +209,7 @@ static void RunOpTest(const std::string& op_type,
     }
 #endif
 #if defined(__linux__) && !defined(__aarch64__)
-    provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+    provider_options["soc_model"] = soc_model.has_value() ? soc_model : std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
     provider_options["enable_htp_fp16_precision"] = "1";
   }
@@ -331,6 +333,20 @@ TEST_F(QnnHTPBackendTests, UnaryOp_Tanh) {
                         {},
                         13,
                         ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, UnaryOp_Tan_fp) {
+  QNN_SKIP_TEST_ON_ARM64("Accuracy drop is high on ARM64/AARCH64");
+  RunOpTest<float>("Tan",
+                   {TestInputDef<float>({1, 2, 3}, false, {0.1f, 0.5f, 1.0f, -0.5f, 0.3f, -1.0f})},
+                   {},
+                   13,
+                   ExpectedEPNodeAssignment::All,
+                   kOnnxDomain,
+                   1E-05,
+                   true,
+                   std::to_string(QNN_SOC_MODEL_SM8350)  // This test fails with QNN_SOC_MODEL_SM8850 due to a known HTP issue
+  );
 }
 
 // disabled for QNN 2.28.0.241029 backendValidateOpConfig failed


### PR DESCRIPTION
### Description
This PR adds support for tan op. 



### Motivation and Context
HTP does not have a native support for tan op. This PR adds the support by decomposing it into sin, cos and divide ops. 

