### PR TITLE
[ONNX2EP] Add Roialign Op to HTP.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -253,7 +253,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
     CreateTanOpBuilder("Tan", *this);
   }
 
-  {}
+  {
     CreateRoiAlignOpBuilder("RoiAlign", *this);
   }
 }

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -252,6 +252,10 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   {
     CreateTanOpBuilder("Tan", *this);
   }
+
+  {}
+    CreateRoiAlignOpBuilder("RoiAlign", *this);
+  }
 }
 
 const IOpBuilder* GetOpBuilder(const std::string& onnx_op_type) {

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -147,5 +147,7 @@ void CreateGroupNormOpBuilder(const std::string& op_type, OpBuilderRegistrations
 
 void CreateTanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateRoiAlignOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/roialign_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/roialign_op_builder.cc
@@ -1,0 +1,130 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "QnnOpDef.h"
+
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class RoiAlignOpBuilder : public BaseOpBuilder {
+ public:
+  RoiAlignOpBuilder() : BaseOpBuilder("RoiAlignOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(RoiAlignOpBuilder);
+
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const final ORT_MUST_USE_RESULT;
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status RoiAlignOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                                             const OrtNodeUnit& node_unit,
+                                             const Ort::Logger& logger) const {
+  OrtNodeAttrHelper node_helper(node_unit);
+
+  // Sanity checks on RoiAlign onnx attrs
+  // HTP supports only align=False which corresponds to coordinate_transformation_mode="output_half_pixel"
+  std::string coordinate_transformation_mode = node_helper.Get("coordinate_transformation_mode", "half_pixel");  // ONNX default "half_pixel"
+  RETURN_IF_NOT(coordinate_transformation_mode == "output_half_pixel", "HTP only supports coordinate_transformation_mode=output_half_pixel.");
+
+  // HTP supports only average pooling
+  std::string mode = node_helper.Get("mode", "avg");  // ONNX default "avg"
+  RETURN_IF_NOT(mode == "avg", "HTP only supports avg pooling mode.");
+
+  // HTP doesn't support sampling_ratio = 0(adaptive mode)
+  int sampling_ratio = node_helper.Get("sampling_ratio", 0);
+  RETURN_IF_NOT(sampling_ratio != 0, "HTP doesn't support sampling ratio = 0.");
+
+  // Sanity check on output_width output_height
+  // Output tensor size [N, C, H, W]
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+  RETURN_IF_NOT(4 == static_cast<int>(output_info.shape.size()), "Roialign requires 4d output (num_rois, C, output_height, output_width).");
+  int output_height = node_helper.Get("output_height", 1);
+  RETURN_IF_NOT(output_height == static_cast<int>(output_info.shape[2]), "Expect output_height == output_tensor.shape[2]");
+  int output_width = node_helper.Get("output_width", 1);
+  RETURN_IF_NOT(output_width == static_cast<int>(output_info.shape[3]), "Expect output_width == output_tensor.shape[3]");
+
+  // RoiAlignOp are sensitive with data layout, requires NHWC data layout.
+  // Continue RoiAlign if NHWC format.
+  if (node_unit.Domain() == kMSInternalNHWCDomain) {
+    return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status RoiAlignOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                             const OrtNodeUnit& node_unit,
+                                             const Ort::Logger& logger,
+                                             std::vector<std::string>& input_names,
+                                             bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(do_op_validation);
+
+  const auto& inputs = node_unit.Inputs();
+  const auto input_count = GetInputCountQnnRequired(node_unit);
+  for (size_t input_i = 0; input_i < input_count; ++input_i) {
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[input_i], logger, input_names));
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status RoiAlignOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                           const OrtNodeUnit& node_unit,
+                                                           std::vector<std::string>&& input_names,
+                                                           const Ort::Logger& logger,
+                                                           bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  std::vector<std::string> param_tensor_names;
+  std::vector<uint32_t> img_size_ratio_shape{static_cast<uint32_t>(2)};
+
+  // Convert onnx::spatial_scale to htp::img_size_ratio
+  float spatial_scale = node_helper.Get("spatial_scale", 1.0f);
+  RETURN_IF(spatial_scale == 0, "Roialign got invalid spatial_scale=0");
+  std::vector<float> img_size_ratio{1 / spatial_scale, 1 / spatial_scale};
+  QnnParamWrapper roi_align_param_img_size_ratio = createQnnParamWrapper<float>(
+      node_unit.Index(),
+      node_unit.Name(),
+      QNN_OP_ROI_ALIGN_PARAM_IMG_SIZE_RATIO,
+      std::move(img_size_ratio_shape),
+      std::move(img_size_ratio));
+  param_tensor_names.push_back(roi_align_param_img_size_ratio.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(roi_align_param_img_size_ratio));
+
+  return ProcessOutputs(qnn_model_wrapper,
+                        node_unit,
+                        std::move(input_names),
+                        std::move(param_tensor_names),
+                        logger, do_op_validation, QNN_OP_ROI_ALIGN);
+}
+
+void CreateRoiAlignOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<RoiAlignOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/roialign_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/roialign_op_builder.cc
@@ -38,6 +38,12 @@ class RoiAlignOpBuilder : public BaseOpBuilder {
 Ort::Status RoiAlignOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                              const OrtNodeUnit& node_unit,
                                              const Ort::Logger& logger) const {
+  // RoiAlignOp are sensitive with data layout, requires NHWC data layout.
+  // Continue RoiAlign if NHWC format.
+  if (node_unit.Domain() == kMSInternalNHWCDomain) {
+    return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
+  }
+
   OrtNodeAttrHelper node_helper(node_unit);
 
   // Sanity checks on RoiAlign onnx attrs
@@ -62,12 +68,6 @@ Ort::Status RoiAlignOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_NOT(output_height == static_cast<int>(output_info.shape[2]), "Expect output_height == output_tensor.shape[2]");
   int output_width = node_helper.Get("output_width", 1);
   RETURN_IF_NOT(output_width == static_cast<int>(output_info.shape[3]), "Expect output_width == output_tensor.shape[3]");
-
-  // RoiAlignOp are sensitive with data layout, requires NHWC data layout.
-  // Continue RoiAlign if NHWC format.
-  if (node_unit.Domain() == kMSInternalNHWCDomain) {
-    return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
-  }
 
   return Ort::Status();
 }
@@ -94,9 +94,6 @@ Ort::Status RoiAlignOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
                                                            const Ort::Logger& logger,
                                                            bool do_op_validation) const {
   ORT_UNUSED_PARAMETER(logger);
-
-  TensorInfo input_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
 
   OrtNodeAttrHelper node_helper(node_unit);
   std::vector<std::string> param_tensor_names;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1838,6 +1838,11 @@ OrtStatus* ORT_API_CALL QnnEp::ShouldConvertDataLayoutForOpImpl(_In_ OrtEp* this
     *should_convert = 1;
   }
 
+  if (std::string(domain) == kOnnxDomain && std::string(op_type) == "RoiAlign") {
+    // RoiAlign is translated to QNN's RoiAlign, which requires the NHWC layout for processing.
+    *should_convert = 1;
+  }
+
   return nullptr;
 }
 

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -1411,6 +1411,8 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
     broken_tests->insert({"rotary_embedding_no_position_ids_rotary_dim", "unknown version"});
     broken_tests->insert({"rotary_embedding_with_interleaved_rotary_dim", "unknown version"});
     broken_tests->insert({"rotary_embedding_with_rotary_dim", "unknown version"});
+    broken_tests->insert({"roialign_aligned_false", "unknown version"});  // roialign test uses opset 22, currently supports up to 16
+
     // Fails since QNN SDK 2.17.0:
     // expected 7.70947 (40f6b3f3), got 7.84096 (40fae920), diff: 0.131491, tol=0.00870947 idx=419. 100 of 1715 differ
     broken_tests->insert({"facedetection_op8_qdq", "result differs"});

--- a/onnxruntime/test/onnx/main.cc
+++ b/onnxruntime/test/onnx/main.cc
@@ -915,7 +915,12 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
         ORT_TSTR("mod_mixed_sign_int16"),
         ORT_TSTR("mod_mixed_sign_int8"),
         ORT_TSTR("mod_uint16"),
-        ORT_TSTR("mod_uint64")};
+        ORT_TSTR("mod_uint64"),
+        // QNN only support aligned = False and op version 16.
+        // [ONNXRuntimeError] : 9 : NOT_IMPLEMENTED : Could not find an implementation for RoiAlign(22) node with name ''
+        ORT_TSTR("roialign_aligned_false"),
+        ORT_TSTR("roialign_aligned_true"),
+        ORT_TSTR("roialign_mode_max")};
 
     std::unordered_set<std::basic_string<ORTCHAR_T>> all_disabled_tests(std::begin(immutable_broken_tests), std::end(immutable_broken_tests));
 

--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -1,0 +1,265 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <cassert>
+#include <string>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "core/graph/node_attr_utils.h"
+
+#include "core/graph/onnx_protobuf.h"
+#include "gtest/gtest.h"
+
+#include "test/util/include/test_utils.h"
+
+#include <onnx/onnx_pb.h>
+#include <fstream>
+
+namespace onnxruntime {
+namespace test {
+
+// Returns a function that creates a graph with a single Roialign operator.
+static GetTestModelFn BuildRoialignTestCase(const TestInputDef<float>& input_def,
+                                            const TestInputDef<float>& roi_def,
+                                            const TestInputDef<int64_t>& batch_indices_def,
+                                            const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
+  return [input_def, roi_def, batch_indices_def, attrs](ModelTestBuilder& builder) {
+    NodeArg* input = MakeTestInput(builder, input_def);
+    NodeArg* roi = MakeTestInput(builder, roi_def);
+    NodeArg* batch_indices = MakeTestInput(builder, batch_indices_def);
+
+    std::vector<NodeArg*> inputs{input, roi, batch_indices};
+
+    NodeArg* output = builder.MakeOutput();
+    Node& roialign_node = builder.AddNode("RoiAlign", inputs, {output});
+
+    for (const auto& attr : attrs) {
+      roialign_node.AddAttributeProto(attr);
+    }
+  };
+}
+
+// Returns a function that creates a graph with a QDQ Roialign operator.
+template <typename QuantType>
+GetTestQDQModelFn<QuantType> BuildRoialignQDQTestCase(const TestInputDef<float>& input_def,
+                                                      const TestInputDef<float>& roi_def,
+                                                      const TestInputDef<int64_t>& batch_indices_def,
+                                                      const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
+  return [input_def, roi_def, batch_indices_def, attrs](ModelTestBuilder& builder,
+                                                        std::vector<QuantParams<QuantType>>& output_qparams) {
+    std::vector<NodeArg*> inputs;
+    // input -> Q -> DQ ->
+    NodeArg* input = MakeTestInput(builder, input_def);
+    QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+    NodeArg* input_qdq = AddQDQNodePair<QuantType>(builder, input, input_qparams.scale, input_qparams.zero_point);
+    inputs.push_back(input_qdq);
+
+    // roi -> Q -> DQ ->
+    NodeArg* roi = MakeTestInput(builder, roi_def);
+    QuantParams<QuantType> roi_qparams = GetTestInputQuantParams<QuantType>(roi_def);
+    NodeArg* roi_qdq = AddQDQNodePair<QuantType>(builder, roi, roi_qparams.scale, roi_qparams.zero_point);
+    inputs.push_back(roi_qdq);
+
+    NodeArg* batch_indices = MakeTestInput(builder, batch_indices_def);
+    inputs.push_back(batch_indices);
+
+    NodeArg* output = builder.MakeIntermediate();
+    Node& roialign_node = builder.AddNode("RoiAlign", inputs, {output});
+
+    for (const auto& attr : attrs) {
+      roialign_node.AddAttributeProto(attr);
+    }
+
+    // op_output -> Q -> DQ -> output
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, output, output_qparams[0].scale,
+                                                     output_qparams[0].zero_point);
+  };
+}
+
+// Runs an Roialign model on the QNN CPU backend. Checks the graph node assignment, and that inference
+// outputs for QNN and CPU match.
+static void RunRoiAlignOpTest(const TestInputDef<float>& input_def,
+                              const TestInputDef<float>& roi_def,
+                              const TestInputDef<int64_t>& batch_indices_def,
+                              const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                              ExpectedEPNodeAssignment expected_ep_assignment,
+                              const std::string& backend_name = "cpu",
+                              int opset = 16,
+                              float f32_abs_err = 1e-5f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["soc_model"] = "87";
+
+  RunQnnModelTest(BuildRoialignTestCase(input_def, roi_def, batch_indices_def, attrs),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment, f32_abs_err);
+}
+
+// Runs a QDQ Roialign model on the QNN HTP backend. Checks the graph node assignment, and that inference
+// outputs for QNN and CPU match.
+template <typename QuantType>
+static void RunQDQRoiAlignOpTest(const TestInputDef<float>& input_def,
+                                 const TestInputDef<float>& roi_def,
+                                 const TestInputDef<int64_t>& batch_indices_def,
+                                 const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                 ExpectedEPNodeAssignment expected_ep_assignment,
+                                 int opset = 16) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["soc_model"] = "87";
+
+  TestQDQModelAccuracy(BuildRoialignTestCase(input_def, roi_def, batch_indices_def, attrs),
+                       BuildRoialignQDQTestCase<QuantType>(input_def, roi_def, batch_indices_def, attrs),
+                       provider_options,
+                       opset,
+                       expected_ep_assignment);
+}
+
+//
+// CPU tests:
+//
+
+TEST_F(QnnCPUBackendTests, TestRoialign) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     utils::MakeAttribute("mode", "avg"),
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::All);
+}
+
+// QNN doesn't support coordinate_transformation_mode = output_half
+TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_output_half) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half"),
+                     utils::MakeAttribute("mode", "avg"),
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::None);
+}
+
+// QNN only supports pooling mode = average
+TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_mode_max) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     utils::MakeAttribute("mode", "max"),  //  mode = max will Unsupported
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::None);
+}
+
+// QNN doesn't support adaptive sampling_ratio (sampling_ratio = 0)
+TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     utils::MakeAttribute("mode", "avg"),
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(0)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::None);
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+//
+// HTP tests:
+//
+TEST_F(QnnHTPBackendTests, TestRoialign) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     utils::MakeAttribute("mode", "avg"),
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::All,
+                    "htp");
+}
+
+// QNN doesn't support coordinate_transformation_mode = output_half
+TEST_F(QnnHTPBackendTests, TestRoialign_Unsupported_output_half) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half"),
+                     utils::MakeAttribute("mode", "avg"),
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::None,
+                    "htp");
+}
+
+// QNN only supports pooling mode = average
+TEST_F(QnnHTPBackendTests, TestRoialign_Unsupported_mode_max) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     utils::MakeAttribute("mode", "max"),  //  mode = max will Unsupported
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::None,
+                    "htp");
+}
+
+// QNN doesn't support adaptive sampling_ratio (sampling_ratio = 0)
+TEST_F(QnnHTPBackendTests, TestRoialign_Unsupported_sampling_ratio) {
+  RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                    TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                    TestInputDef<int64_t>({1}, true, {0}),
+                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     utils::MakeAttribute("mode", "avg"),
+                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(0)),
+                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    ExpectedEPNodeAssignment::None,
+                    "htp");
+}
+
+//
+// QDQ Roialign
+TEST_F(QnnHTPBackendTests, TestRoialignQdq) {
+  RunQDQRoiAlignOpTest<uint8_t>(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
+                                TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
+                                TestInputDef<int64_t>({1}, true, {0}),
+                                {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                                 utils::MakeAttribute("mode", "avg"),
+                                 utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                                 utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                                 utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                                 utils::MakeAttribute("spatial_scale", 1.0f)},
+                                ExpectedEPNodeAssignment::All);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -91,7 +91,7 @@ static void RunRoiAlignOpTest(const TestInputDef<float>& input_def,
   ProviderOptions provider_options;
   provider_options["backend_type"] = backend_name;
   provider_options["offload_graph_io_quantization"] = "0";
-  provider_options["soc_model"] = "87";
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 
   RunQnnModelTest(BuildRoialignTestCase(input_def, roi_def, batch_indices_def, attrs),
                   provider_options,
@@ -157,7 +157,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_mode_max) {
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
                     {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "max"),  //  mode = max will Unsupported
+                     utils::MakeAttribute("mode", "max"),  //  mode = max is not supported
                      utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
                      utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
                      utils::MakeAttribute("output_width", static_cast<int64_t>(1)),


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add  op support for roi align.
Notice that the unit test uses hard coded model and a golden input/output to have mininal test for roi align node.
The reason is we can't use ort-cpu output as reference like other unit test, because the ort-cpu only support "aligned=Flase", while HTP only support "aligned=True".

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


