### PR TITLE
Use SKIP_IF() instead of raw #ifdef for skipping tests

### DIFF
--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -384,13 +384,8 @@ TEST_F(QnnHTPBackendTests, Gemm_Broadcast_Bias_DynamicA_StaticB_StaticC) {
 // Expected val: 120.73912048339844
 // QNN QDQ val: 0 (err 120.73912048339844)
 // CPU QDQ val: 120.73889923095703 (err 0.00022125244140625)
-// Issue fixed in 2.30
-#ifdef __linux__
-// Failed on Linux with 2.31
-TEST_F(QnnHTPBackendTests, DISABLED_Gemm_Dynamic_A_Static_B_Dynamic_Bias_U16) {
-#else
 TEST_F(QnnHTPBackendTests, Gemm_Dynamic_A_Static_B_Dynamic_Bias_U16) {
-#endif
+  QNN_SKIP_TEST_ON_LINUX_X86_64("Output value mismatch with QNN SDK 2.31");
   std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
   std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
@@ -455,11 +450,8 @@ TEST_F(QnnHTPBackendTests, Gemm_Static_B_And_Bias) {
 // qdq@CPU_EP val: 29.092588424682617 (err: 0.34218788146972656, err/output_range: 1.0885642766952515%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 2.7451016902923584%
 // Test 8-bit QDQ Gemm with transposed A/B and static B and Bias inputs.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_Gemm_TransAB_Static_B_And_Bias_U8) {
-#else
 TEST_F(QnnHTPBackendTests, Gemm_TransAB_Static_B_And_Bias_U8) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
   std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
@@ -494,11 +486,8 @@ TEST_F(QnnHTPBackendTests, Gemm_TransAB_Static_B_And_Bias_U16Act_U8Weight) {
 // qdq@CPU_EP val: 29.092588424682617 (err: 0.34218788146972656, err/output_range: 1.0885642766952515%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 2.7451016902923584%
 // Test QDQ Gemm with transposed A/B and dynamic (i.e., not initializer) B and Bias inputs.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_Gemm_TransAB_Dynamic_B_And_Bias) {
-#else
 TEST_F(QnnHTPBackendTests, Gemm_TransAB_Dynamic_B_And_Bias) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
   std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -385,7 +385,7 @@ TEST_F(QnnHTPBackendTests, Gemm_Broadcast_Bias_DynamicA_StaticB_StaticC) {
 // QNN QDQ val: 0 (err 120.73912048339844)
 // CPU QDQ val: 120.73889923095703 (err 0.00022125244140625)
 TEST_F(QnnHTPBackendTests, Gemm_Dynamic_A_Static_B_Dynamic_Bias_U16) {
-  QNN_SKIP_TEST_ON_LINUX_X86_64("Output value mismatch with QNN SDK 2.31");
+  QNN_SKIP_TEST_ON_LINUX("Output value mismatch with QNN SDK 2.31");
   std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
   std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);

--- a/onnxruntime/test/providers/qnn/lrn_test.cc
+++ b/onnxruntime/test/providers/qnn/lrn_test.cc
@@ -131,11 +131,8 @@ TEST_F(QnnCPUBackendTests, LRN_size_larger_than_channel) {
 // qdq@QNN_EP val: -9.3696985244750977 (err: 0.11790370941162109, err/output_range: 0.59216529130935669%)
 // qdq@CPU_EP val: -9.5258598327636719 (err: 0.038257598876953125, err/output_range: 0.19214680790901184%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 0.40001851320266724%
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_LRNSize3) {
-#else
 TEST_F(QnnHTPBackendTests, LRNSize3) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   RunQDQLRNOpTest<uint8_t>(TestInputDef<float>({1, 128, 4, 5}, false, -10.0f, 10.0f),
                            3,  // Size
                            ExpectedEPNodeAssignment::All,
@@ -152,11 +149,8 @@ TEST_F(QnnHTPBackendTests, LRNSize3) {
 // qdq@QNN_EP val: -5.2317028045654297 (err: 0.11859703063964844, err/output_range: 0.59561461210250854%)
 // qdq@CPU_EP val: -5.3878731727600098 (err: 0.037573337554931641, err/output_range: 0.18869975209236145%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 0.40691488981246948%
-#if defined(__aarch64__)
-TEST_F(QnnHTPBackendTests, DISABLED_LRNSize5) {
-#else
 TEST_F(QnnHTPBackendTests, LRNSize5) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64_LINUX_ANDROID("QDQ accuracy below tolerance on v79 device");
   RunQDQLRNOpTest<uint8_t>(TestInputDef<float>({1, 128, 4, 5}, false, -10.0f, 10.0f),
                            5,  // Size
                            ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/lrn_test.cc
+++ b/onnxruntime/test/providers/qnn/lrn_test.cc
@@ -150,7 +150,7 @@ TEST_F(QnnHTPBackendTests, LRNSize3) {
 // qdq@CPU_EP val: -5.3878731727600098 (err: 0.037573337554931641, err/output_range: 0.18869975209236145%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 0.40691488981246948%
 TEST_F(QnnHTPBackendTests, LRNSize5) {
-  QNN_SKIP_TEST_ON_ARM64_LINUX_ANDROID("QDQ accuracy below tolerance on v79 device");
+  QNN_SKIP_TEST_ON_AARCH64("QDQ accuracy below tolerance on v79 device");
   RunQDQLRNOpTest<uint8_t>(TestInputDef<float>({1, 128, 4, 5}, false, -10.0f, 10.0f),
                            5,  // Size
                            ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -266,11 +266,8 @@ TEST_F(QnnHTPBackendTests, DISABLED_MatMulOp) {
 // qdq@QNN_EP val: 0.0099215693771839142 (err: 7.8431330621242523e-05, err/output_range: 0.78431320190429688%)
 // qdq@CPU_EP val: 0.010000000707805157 (err: 0, err/output_range: 0%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 0.78431320190429688%
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_MatMulOp_QDQ) {
-#else
 TEST_F(QnnHTPBackendTests, MatMulOp_QDQ) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   // UINT8
   // RunQDQMatMulOpTest(shape_0, shape_1, is_initializer_0, is_initializer_1, expected_ep_assignment, opset,
   // use_contrib_qdq)

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1508,6 +1508,48 @@ bool ReduceOpHasAxesInput(const std::string& op_type, int opset_version);
     }                                                                                                        \
   } while (0)
 
+// Skips the test on any ARM64 platform.
+// Matches: __aarch64__   (GCC/Clang — Linux/Android AArch64)
+//          _M_ARM64      (MSVC — Windows ARM64, native ABI)
+//          _M_ARM64EC    (MSVC — Windows ARM64EC, x64-compatible ABI on ARM64 hw)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#define QNN_SKIP_TEST_ON_ARM64(reason) \
+  do {                                 \
+    GTEST_SKIP() << (reason);          \
+  } while (0)
+#else
+#define QNN_SKIP_TEST_ON_ARM64(reason) \
+  do {                                 \
+  } while (0)
+#endif
+
+// Skips the test on Linux/Android AArch64 only (__aarch64__, GCC/Clang).
+// Does NOT match _M_ARM64 (MSVC Windows ARM64) or _M_ARM64EC (MSVC Windows ARM64EC).
+#if defined(__aarch64__)
+#define QNN_SKIP_TEST_ON_ARM64_LINUX_ANDROID(reason) \
+  do {                                               \
+    GTEST_SKIP() << (reason);                        \
+  } while (0)
+#else
+#define QNN_SKIP_TEST_ON_ARM64_LINUX_ANDROID(reason) \
+  do {                                               \
+  } while (0)
+#endif
+
+// Skips the test on Linux x86_64 only (__linux__ and NOT __aarch64__).
+// Targets the HTP simulator environment (x86_64 host running Linux).
+// Does NOT skip on Linux AArch64 (real HTP hardware) or Android.
+#if defined(__linux__) && !defined(__aarch64__)
+#define QNN_SKIP_TEST_ON_LINUX_X86_64(reason) \
+  do {                                        \
+    GTEST_SKIP() << (reason);                 \
+  } while (0)
+#else
+#define QNN_SKIP_TEST_ON_LINUX_X86_64(reason) \
+  do {                                        \
+  } while (0)
+#endif
+
 }  // namespace test
 }  // namespace onnxruntime
 

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1523,16 +1523,29 @@ bool ReduceOpHasAxesInput(const std::string& op_type, int opset_version);
   } while (0)
 #endif
 
-// Skips the test on Linux/Android AArch64 only (__aarch64__, GCC/Clang).
-// Does NOT match _M_ARM64 (MSVC Windows ARM64) or _M_ARM64EC (MSVC Windows ARM64EC).
+// Skips the test when compiled for AArch64 with GCC/Clang (__aarch64__).
+// Does NOT skip on MSVC Windows ARM64 (_M_ARM64 / _M_ARM64EC).
+// Use QNN_SKIP_TEST_ON_ARM64 instead if the test should also skip on Windows ARM64.
 #if defined(__aarch64__)
-#define QNN_SKIP_TEST_ON_ARM64_LINUX_ANDROID(reason) \
-  do {                                               \
-    GTEST_SKIP() << (reason);                        \
+#define QNN_SKIP_TEST_ON_AARCH64(reason) \
+  do {                                   \
+    GTEST_SKIP() << (reason);            \
   } while (0)
 #else
-#define QNN_SKIP_TEST_ON_ARM64_LINUX_ANDROID(reason) \
-  do {                                               \
+#define QNN_SKIP_TEST_ON_AARCH64(reason) \
+  do {                                   \
+  } while (0)
+#endif
+
+// Skips the test on any Linux platform (__linux__), including both x86_64 and AArch64.
+#if defined(__linux__)
+#define QNN_SKIP_TEST_ON_LINUX(reason) \
+  do {                                 \
+    GTEST_SKIP() << (reason);          \
+  } while (0)
+#else
+#define QNN_SKIP_TEST_ON_LINUX(reason) \
+  do {                                 \
   } while (0)
 #endif
 

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -450,11 +450,8 @@ static void RunReduceOpQDQTest(const std::string& op_type,
 //
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an input.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumU8Opset13) {
-#else
 TEST_F(QnnHTPBackendTests, ReduceSumU8Opset13) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   RunReduceOpQDQTest<uint8_t>("ReduceSum",
                               TestInputDef<float>({2, 2}, false, {-10.0f, 3.21289f, -5.9981f, 10.0f}),
                               {0, 1},  // axes
@@ -485,11 +482,8 @@ TEST_F(QnnHTPBackendTests, ReduceSumU8Opset13_LastAxis) {
 //
 // - Uses uint8 as the quantization type.
 // - Uses opset 11, which has "axes" as an attribute.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_ReduceSumU8Opset11) {
-#else
 TEST_F(QnnHTPBackendTests, ReduceSumU8Opset11) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   RunReduceOpQDQTest<uint8_t>("ReduceSum",
                               TestInputDef<float>({2, 2}, false, {-10.0f, 3.21289f, -5.9981f, 10.0f}),
                               {0, 1},  // axes
@@ -670,11 +664,8 @@ TEST_F(QnnHTPBackendTests, ReduceMinS8Opset18) {
 //
 // - Uses uint8 as the quantization type.
 // - Uses opset 18, which has "axes" as an input.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_ReduceMeanU8Opset18) {
-#else
 TEST_F(QnnHTPBackendTests, ReduceMeanU8Opset18) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   RunReduceOpQDQTest<uint8_t>("ReduceMean",
                               TestInputDef<float>({2, 2}, false, {-10.0f, 3.21289f, -5.9981f, 10.0f}),
                               {0, 1},  // axes
@@ -706,11 +697,8 @@ TEST_F(QnnHTPBackendTests, ReduceMeanU8Opset18_LastAxis) {
 //
 // - Uses uint8 as the quantization type.
 // - Uses opset 13, which has "axes" as an attribute.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_ReduceMeanU8Opset13) {
-#else
 TEST_F(QnnHTPBackendTests, ReduceMeanU8Opset13) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   RunReduceOpQDQTest<uint8_t>("ReduceMean",
                               TestInputDef<float>({2, 2}, false, {-10.0f, 3.21289f, -5.9981f, 10.0f}),
                               {0, 1},  // axes

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -763,11 +763,8 @@ TEST_F(QnnHTPBackendTests, UnaryOp_Abs_U16) {
 // qdq@CPU_EP val: -12.047059059143066 (err: 0.047059059143066406, err/output_range: 0.19607941806316376%)
 // abs(qdq@QNN_EP - qdq@CPU_EP) / output_range = 3.9215683937072754%
 // Test accuracy of QDQ Ceil op.
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-TEST_F(QnnHTPBackendTests, DISABLED_UnaryOp_Ceil) {
-#else
 TEST_F(QnnHTPBackendTests, UnaryOp_Ceil) {
-#endif
+  QNN_SKIP_TEST_ON_ARM64("QDQ accuracy below tolerance on v79 and v81 devices");
   const std::vector<float> input_data = GetFloatDataInRange(-12.0f, 12.0f, 6);
   RunQDQOpTest<uint8_t>("Ceil",
                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
@@ -990,17 +987,14 @@ TEST_F(QnnHTPBackendTests, BinaryOp_Sub4D_Broadcast) {
 }
 
 // Test accuracy of QDQ Pow
-#if defined(__linux__)
 // TODO: This fails on Linux (HTP emulation). Works on Windows ARM64.
 // Inaccuracy detected for output 'output', element 0.
 // Output quant params: scale=0.051073111593723297, zero_point=2.
 // Expected val: 0.0099999997764825821
 // QNN QDQ val: 12.921497344970703 (err 12.911497116088867)
 // CPU QDQ val: -0.10214622318744659 (err 0.11214622110128403)
-TEST_F(QnnHTPBackendTests, DISABLED_BinaryOp_Pow) {
-#else
 TEST_F(QnnHTPBackendTests, BinaryOp_Pow) {
-#endif
+  QNN_SKIP_TEST_ON_LINUX_X86_64("Output value mismatch on HTP simulator");
   std::vector<float> bases_input = {-10.0f, -8.0f, -6.0f, 1.0f, 2.0f, 3.0f, 5.5f, 10.0f};
   std::vector<float> exponents_input = {-2.0f, -1.0f, 0.0f, 0.5f, 1.0f, 2.0f, 1.5f, 0.2f};
   RunQDQOpTest<uint8_t>("Pow",

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -994,7 +994,7 @@ TEST_F(QnnHTPBackendTests, BinaryOp_Sub4D_Broadcast) {
 // QNN QDQ val: 12.921497344970703 (err 12.911497116088867)
 // CPU QDQ val: -0.10214622318744659 (err 0.11214622110128403)
 TEST_F(QnnHTPBackendTests, BinaryOp_Pow) {
-  QNN_SKIP_TEST_ON_LINUX_X86_64("Output value mismatch on HTP simulator");
+  QNN_SKIP_TEST_ON_LINUX("Output value mismatch");
   std::vector<float> bases_input = {-10.0f, -8.0f, -6.0f, 1.0f, 2.0f, 3.0f, 5.5f, 10.0f};
   std::vector<float> exponents_input = {-2.0f, -1.0f, 0.0f, 0.5f, 1.0f, 2.0f, 1.5f, 0.2f};
   RunQDQOpTest<uint8_t>("Pow",


### PR DESCRIPTION
## Motivation

Currently many tests are enabled or DISABLED based on complex `#ifdef`s. It's very hard to read, missing reasons on skipping (slightly skip) and easy-to-misuse (for example, additional skipping on more than necessary platforms)

## Changes

Defined macros that help to enforce putting a skipping reasons and narrow skipping platforms. 

Follow up will be needed to cleanup additional `DISABLE_*` tests.. Test should only be DISBALED_ when it expect to fail on all platforms. 