### PR TITLE
Add cleanup task to QDC jobs

### DIFF
--- a/.github/workflows/qualcomm-internal-qdc-test.yml
+++ b/.github/workflows/qualcomm-internal-qdc-test.yml
@@ -63,6 +63,12 @@ jobs:
           create_qdc_venv
           test_ort_qdc_${{inputs.target_os}}_${{inputs.target_arch}} --only
 
+      - name: Cleanup QDC Runner tmp files
+        if: always()
+        run: |
+          echo "Cleaning $TMPDIR/QdcRunner-*"
+          rm -fr $TMPDIR/QdcRunner-*
+
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4.0.4
         if: always() # always run even if the previous step fails

--- a/qcom/scripts/all/qdc_runner.py
+++ b/qcom/scripts/all/qdc_runner.py
@@ -920,6 +920,8 @@ class RunnerCli:
         qli_archive = ORT_QLI_ARCHIVE
         windows_archive = ORT_TEST_WIN_ARM64
 
+        # If you change this temp dir's prefix, please also update the QDC CI job, which attempts to clean
+        # up after us if we're killed and don't do it outselves.
         with tempfile.TemporaryDirectory(prefix="QdcRunner-") as tmpdir:
             if android_archive.exists():
                 android_archive = self.__append_package(


### PR DESCRIPTION
* Scrub qdc_runner.py's temp files, even if the job is cancelled.