### PR TITLE
[OpBuilder] Partially support FP64 data type.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -102,6 +102,8 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   const auto& input = inputs[0];
 
   const auto& input_name = input.name;
+  RETURN_IF(qnn_model_wrapper.IsGraphInput(input_name) && input.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE,
+            "Unsupported FP64 data type in graph IO.");
 
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + input_name).c_str());
@@ -167,6 +169,9 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   const Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
   if (qnn_data_type == QNN_DATATYPE_INT_64 && tensor_type == QNN_TENSOR_TYPE_NATIVE) {
     qnn_data_type = QNN_DATATYPE_INT_32;
+  } else if (qnn_data_type == QNN_DATATYPE_FLOAT_64) {
+    RETURN_IF(is_graph_output, "Unsupported FP64 data type in graph IO.");
+    qnn_data_type = QNN_DATATYPE_FLOAT_32;
   }
   QnnTensorWrapper output_tensorwrapper(output_name,
                                         tensor_type,

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -232,7 +232,25 @@ class QnnTensorWrapper {
         data_type = QNN_DATATYPE_INT_32;
         client_buf_ = std::move(cast_data);
       }
+    } else if (data_type == QNN_DATATYPE_FLOAT_64) {
+      // QNN doesn't support double, so we cast to float.
+      if (tensor_type == QNN_TENSOR_TYPE_NATIVE) {
+        data_type = QNN_DATATYPE_FLOAT_32;
+      }
+      if (client_buf_.size()) {
+        const size_t num_elems = client_buf_.size() / sizeof(double);
+        std::vector<uint8_t> cast_data;
+        cast_data.resize(num_elems * sizeof(float));
+        gsl::span<double> origin_values{reinterpret_cast<double*>(client_buf_.data()), num_elems};
+        gsl::span<float> new_values(reinterpret_cast<float*>(cast_data.data()), num_elems);
+        for (size_t i = 0; i < num_elems; i++) {
+          new_values[i] = static_cast<float>(origin_values[i]);
+        }
+        data_type = QNN_DATATYPE_FLOAT_32;
+        client_buf_ = std::move(cast_data);
+      }
     }
+
     SetQnnTensorType(qnn_tensor_, tensor_type);
     SetQnnTensorName(qnn_tensor_, tensor_name_.c_str());
     SetQnnTensorDataType(qnn_tensor_, data_type);

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -34,6 +34,7 @@ size_t GetElementSizeByType(const Qnn_DataType_t& data_type) {
       {QNN_DATATYPE_UINT_64, 8},
       {QNN_DATATYPE_FLOAT_16, 2},
       {QNN_DATATYPE_FLOAT_32, 4},
+      {QNN_DATATYPE_FLOAT_64, 8},
       {QNN_DATATYPE_BFLOAT_16, 2},
       {QNN_DATATYPE_BOOL_8, 1},
       {QNN_DATATYPE_SFIXED_POINT_4, sizeof(Int4x2)},
@@ -143,6 +144,9 @@ std::ostream& operator<<(std::ostream& out, const Qnn_Scalar_t& scalar) {
     case QNN_DATATYPE_FLOAT_32:
       out << scalar.floatValue;
       break;
+    case QNN_DATATYPE_FLOAT_64:
+      out << scalar.doubleValue;
+      break;
     case QNN_DATATYPE_SFIXED_POINT_8:
     case QNN_DATATYPE_SFIXED_POINT_16:
     case QNN_DATATYPE_SFIXED_POINT_32:
@@ -191,6 +195,9 @@ std::ostream& operator<<(std::ostream& out, const Qnn_DataType_t& data_type) {
       break;
     case QNN_DATATYPE_FLOAT_32:
       out << "QNN_DATATYPE_FLOAT_32";
+      break;
+    case QNN_DATATYPE_FLOAT_64:
+      out << "QNN_DATATYPE_FLOAT_64";
       break;
     case QNN_DATATYPE_SFIXED_POINT_8:
       out << "QNN_DATATYPE_SFIXED_POINT_8";
@@ -823,6 +830,7 @@ bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64, QNN_DATATYPE_UINT_64},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, QNN_DATATYPE_FLOAT_16},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, QNN_DATATYPE_FLOAT_32},
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, QNN_DATATYPE_FLOAT_64},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL, QNN_DATATYPE_BOOL_8},
   };
 
@@ -839,6 +847,7 @@ bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64, QNN_DATATYPE_UINT_64},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16, QNN_DATATYPE_FLOAT_16},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, QNN_DATATYPE_FLOAT_32},
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE, QNN_DATATYPE_FLOAT_64},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL, QNN_DATATYPE_BOOL_8},
   };
 

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -44,6 +44,51 @@ static GetTestModelFn BuildCastTestCase(const std::vector<int64_t>& shape,
   };
 }
 
+static GetTestModelFn BuildCastFP64TestCase(const std::vector<int64_t>& shape) {
+  // Wrap FP64 in between since QNN cannot handle model IO in FP64 currently.
+  return [shape](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", shape, static_cast<float>(0), static_cast<float>(20));
+
+    builder.AddNode("cast1",
+                    "Cast",
+                    {"input"},
+                    {"cast1_output"},
+                    kOnnxDomain,
+                    {builder.MakeScalarAttribute(
+                        "to",
+                        static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_DOUBLE))});
+
+    builder.AddNode("cast2",
+                    "Cast",
+                    {"cast1_output"},
+                    {"output"},
+                    kOnnxDomain,
+                    {builder.MakeScalarAttribute(
+                        "to",
+                        static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetProviderOption(const std::string& backend_name, bool enable_fp16_precision) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  if (backend_name == "htp") {
+    if (enable_fp16_precision) {
+#if defined(__linux__) && !defined(__aarch64__)
+      provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+      provider_options["enable_htp_fp16_precision"] = "1";
+    } else {
+      provider_options["enable_htp_fp16_precision"] = "0";
+    }
+  }
+
+  return provider_options;
+}
+
 /**
  * Runs a Cast model on the QNN CPU or HTP backend. Checks the graph node assignment, and that inference
  * outputs for QNN and CPU match.
@@ -58,28 +103,31 @@ static void RunCastOpTest(const std::vector<int64_t>& shape, ONNX_NAMESPACE::Ten
                           ExpectedEPNodeAssignment expected_ep_assignment,
                           const std::string& backend_name = "cpu",
                           bool enable_fp16_precision = true) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = backend_name;
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  if (backend_name == "htp") {
-    if (enable_fp16_precision) {
+  if (backend_name == "htp" && enable_fp16_precision) {
 #if defined(_WIN32)
-      if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
-        GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
-      }
-#endif
-#if defined(__linux__) && !defined(__aarch64__)
-      provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
-#endif
-      provider_options["enable_htp_fp16_precision"] = "1";
-    } else {
-      provider_options["enable_htp_fp16_precision"] = "0";
+    if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
+      GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
+#endif
   }
 
   RunQnnModelTest(BuildCastTestCase<InputType>(shape, dst_type),
-                  provider_options,
+                  GetProviderOption(backend_name, enable_fp16_precision),
+                  13,  // opset
+                  expected_ep_assignment);
+}
+
+static void RunCastFP64OpTest(const std::vector<int64_t>& shape,
+                              ExpectedEPNodeAssignment expected_ep_assignment,
+                              const std::string& backend_name = "cpu") {
+#if defined(_WIN32)
+  if (backend_name == "htp" && QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
+    GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
+  }
+#endif
+
+  RunQnnModelTest(BuildCastFP64TestCase(shape),
+                  GetProviderOption(backend_name, true),
                   13,  // opset
                   expected_ep_assignment);
 }
@@ -141,6 +189,11 @@ TEST_F(QnnCPUBackendTests, TestCastFloatToInt32) {
   RunCastOpTest<float>({2, 3}, ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_INT32, ExpectedEPNodeAssignment::All);
 }
 
+// Cast float to double on CPU
+TEST_F(QnnCPUBackendTests, TestCastFloatToDouble) {
+  RunCastFP64OpTest({2, 3}, ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:
@@ -193,6 +246,11 @@ TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
   RunCastFP16HTPTest({3, 3},
                      ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                      ExpectedEPNodeAssignment::All);
+}
+
+// Cast float to double on HTP.
+TEST_F(QnnHTPBackendTests, TestCastFloatToDoubleHTP) {
+  RunCastFP64OpTest({3, 3}, ExpectedEPNodeAssignment::All, "htp");
 }
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -962,6 +962,50 @@ TEST_F(QnnHTPBackendTests, BinaryOp_Add4D_U16) {
                          true);  // Use com.microsoft Q/DQ ops
 }
 
+// Test double Add.
+TEST_F(QnnHTPBackendTests, BinaryOp_Add4D_FP64) {
+  // Wrap FP64 in between since QNN cannot handle model IO in FP64 currently.
+  GetTestModelFn builder = [](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({1, 2, 2, 3}, false, -1.0, 1.0));
+
+    builder.AddNode("cast1",
+                    "Cast",
+                    {"input"},
+                    {"cast1_output"},
+                    kOnnxDomain,
+                    {builder.MakeScalarAttribute(
+                        "to",
+                        static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_DOUBLE))});
+
+    MakeTestInput<double>(builder, "add_const", TestInputDef<double>({3}, true, {1.0, 0.5, -0.3}));
+    builder.AddNode("add", "Add", {"cast1_output", "add_const"}, {"add_output"}, kOnnxDomain);
+
+    builder.AddNode("cast2",
+                    "Cast",
+                    {"add_output"},
+                    {"output"},
+                    kOnnxDomain,
+                    {builder.MakeScalarAttribute(
+                        "to",
+                        static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("output");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+#if defined(_WIN32)
+  if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
+    GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
+  }
+#endif
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(builder, provider_options, 17, ExpectedEPNodeAssignment::All, 1e-3);
+}
+
 // Test 8-bit QDQ Sub
 TEST_F(QnnHTPBackendTests, BinaryOp_Sub4D) {
   RunQDQOpTest<uint8_t>("Sub",


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add partial support for FP64 data type.
- In `CastOpBuilder`, replace target data type from FP64 with FP32.
- In `QnnTensorWrapper`, replace tensor data type from FP64 with FP32 and downcast data from FP64 to FP32.

Note that graph IO in FP64 is not yet supported as QNN EP cannot directly modify the graph and unlike INT64 case where QNN graph IO supports INT64.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Encounter FP64 data type unsupported error during model enablement.

