### PR TITLE
Fix graph i/o name mapping for partition added input

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -24,9 +24,10 @@ namespace qnn {
 
 namespace {
 
-// Resolves the correct I/O order, preferring ONNX declaration order when available.
-// When names don't match directly (e.g., with offload_graph_io_quantization), uses
-// tensor_name_overrides_reversed to translate ONNX names to internal tensor names.
+// Resolves the correct I/O order for a QNN fused subgraph, preferring ONNX declaration order.
+// For each ONNX-declared name, tries `tensor_name_overrides_reversed` first (handles renames),
+// then a direct match. Fallback to fused_order if any name is unresolvable. Appends partition-
+// boundary entries not in the ONNX declaration.
 std::vector<std::string> ResolveGraphInputOutputOrder(
     const std::vector<std::string>* onnx_names,
     const std::unordered_set<std::string>& fused_names,
@@ -36,26 +37,28 @@ std::vector<std::string> ResolveGraphInputOutputOrder(
     return fused_order;
   }
 
-  bool names_match = std::all_of(onnx_names->begin(), onnx_names->end(),
-                                 [&](const std::string& n) { return fused_names.count(n) > 0; });
-  if (names_match) {
-    return *onnx_names;
-  }
+  std::vector<std::string> resolved_onnx_order;
+  resolved_onnx_order.reserve(onnx_names->size());
 
-  if (!tensor_name_overrides_reversed.empty()) {
-    std::vector<std::string> mapped_order;
-    for (const auto& onnx_name : *onnx_names) {
-      auto it = tensor_name_overrides_reversed.find(onnx_name);
-      if (it != tensor_name_overrides_reversed.end() && fused_names.count(it->second)) {
-        mapped_order.push_back(it->second);
-      }
-    }
-    if (mapped_order.size() == onnx_names->size()) {
-      return mapped_order;
+  for (const auto& onnx_name : *onnx_names) {
+    auto it = tensor_name_overrides_reversed.find(onnx_name);
+    if (it != tensor_name_overrides_reversed.end() && fused_names.count(it->second)) {
+      resolved_onnx_order.push_back(it->second);
+    } else if (fused_names.count(onnx_name)) {
+      resolved_onnx_order.push_back(onnx_name);
+    } else {
+      return fused_order;  // Unresolvable; fall back to complete fused order.
     }
   }
 
-  return fused_order;
+  // Append partition-boundary entries absent from ONNX-declared names.
+  std::unordered_set<std::string> already_added(resolved_onnx_order.begin(), resolved_onnx_order.end());
+  for (const auto& name : fused_order) {
+    if (!already_added.count(name)) {
+      resolved_onnx_order.push_back(name);
+    }
+  }
+  return resolved_onnx_order;
 }
 
 }  // namespace

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1952,6 +1952,67 @@ TEST(QnnSaverBackendTests, DISABLED_QnnSaver_OutputFiles) {
   EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "params.bin"));
 }
 
+// Reproduce bug that overlooks new input due to partition.
+TEST_F(QnnCPUBackendTests, GraphNewInputFromPartittionReproduce) {
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  auto& logging_manager = DefaultLoggingManager();
+  logging_manager.SetDefaultLoggerSeverity(logging::Severity::kVERBOSE);
+  onnxruntime::Model model("GraphInputOutputOrderMatchesOnnx", false, ModelMetaData(), PathString(),
+                           IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+                           logging_manager.DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  ONNX_NAMESPACE::TypeProto type;
+  type.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
+  auto& input = graph.GetOrCreateNodeArg("input", &type);
+
+  const std::vector<float> data = {0.0, 0.0, 0.0};
+  gsl::span<const std::byte> raw_data = ReinterpretAsSpan<const std::byte, const float>(data);
+  const std::vector<int64_t> shape = {1, 3};
+
+  ONNX_NAMESPACE::TensorProto tensor_proto;
+  tensor_proto.set_name("constant");
+  tensor_proto.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  utils::SetRawDataInTensorProto(tensor_proto, raw_data.data(), raw_data.size());
+  for (auto& dim : shape) {
+    tensor_proto.add_dims(dim);
+  }
+  graph.AddInitializedTensor(tensor_proto);
+  auto& constant = graph.GetOrCreateNodeArg("constant", nullptr);
+
+  auto& rnl_output = graph.GetOrCreateNodeArg("rnl_output", nullptr);
+  graph.AddNode("rnl", "RandomNormalLike", "", {&constant}, {&rnl_output});
+
+  auto& add_output = graph.GetOrCreateNodeArg("add_output", nullptr);
+  graph.AddNode("add", "Add", "", {&input, &rnl_output}, {&add_output});
+
+  graph.SetInputs({&input});
+  graph.SetOutputs({&add_output});
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK()) << "Graph resolve failed: " << status.ErrorMessage();
+
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  Ort::SessionOptions so;
+  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+
+  onnxruntime::ProviderOptions options;
+#if defined(_WIN32)
+  options["backend_path"] = "QnnCpu.dll";
+#else
+  options["backend_path"] = "libQnnCpu.so";
+#endif
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+}
+
 // Verifies QNN graph I/O order matches ONNX declaration order.
 TEST_F(QnnCPUBackendTests, GraphInputOutputOrderMatchesOnnx) {
   const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1952,12 +1952,12 @@ TEST(QnnSaverBackendTests, DISABLED_QnnSaver_OutputFiles) {
   EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "params.bin"));
 }
 
-// Reproduce bug that overlooks new input due to partition.
-TEST_F(QnnCPUBackendTests, GraphNewInputFromPartittionReproduce) {
+// Verifies that a partition-added input (produced by a CPU-only op) is registered as
+// QNN_TENSOR_TYPE_APP_WRITE, not dropped from the fused subgraph's input list.
+TEST_F(QnnCPUBackendTests, PartitionAddedInputRegisteredAsGraphInput) {
   const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
   auto& logging_manager = DefaultLoggingManager();
-  logging_manager.SetDefaultLoggerSeverity(logging::Severity::kVERBOSE);
-  onnxruntime::Model model("GraphInputOutputOrderMatchesOnnx", false, ModelMetaData(), PathString(),
+  onnxruntime::Model model("PartitionAddedInputRegisteredAsGraphInput", false, ModelMetaData(), PathString(),
                            IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
                            logging_manager.DefaultLogger());
   Graph& graph = model.MainGraph();
@@ -1968,7 +1968,7 @@ TEST_F(QnnCPUBackendTests, GraphNewInputFromPartittionReproduce) {
   type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
   auto& input = graph.GetOrCreateNodeArg("input", &type);
 
-  const std::vector<float> data = {0.0, 0.0, 0.0};
+  const std::vector<float> data = {0.0f, 0.0f, 0.0f};
   gsl::span<const std::byte> raw_data = ReinterpretAsSpan<const std::byte, const float>(data);
   const std::vector<int64_t> shape = {1, 3};
 
@@ -1976,18 +1976,15 @@ TEST_F(QnnCPUBackendTests, GraphNewInputFromPartittionReproduce) {
   tensor_proto.set_name("constant");
   tensor_proto.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
   utils::SetRawDataInTensorProto(tensor_proto, raw_data.data(), raw_data.size());
-  for (auto& dim : shape) {
+  for (const auto dim : shape) {
     tensor_proto.add_dims(dim);
   }
   graph.AddInitializedTensor(tensor_proto);
   auto& constant = graph.GetOrCreateNodeArg("constant", nullptr);
-
   auto& rnl_output = graph.GetOrCreateNodeArg("rnl_output", nullptr);
   graph.AddNode("rnl", "RandomNormalLike", "", {&constant}, {&rnl_output});
-
   auto& add_output = graph.GetOrCreateNodeArg("add_output", nullptr);
   graph.AddNode("add", "Add", "", {&input, &rnl_output}, {&add_output});
-
   graph.SetInputs({&input});
   graph.SetOutputs({&add_output});
 
@@ -2007,10 +2004,189 @@ TEST_F(QnnCPUBackendTests, GraphNewInputFromPartittionReproduce) {
   options["backend_path"] = "libQnnCpu.so";
 #endif
 
+  const std::filesystem::path tmp_dir = "qnn_partition_input_test";
+  std::filesystem::remove_all(tmp_dir);
+  std::filesystem::create_directory(tmp_dir);
+  auto cleanup = gsl::finally([&tmp_dir]() { std::filesystem::remove_all(tmp_dir); });
+
+  options["json_qnn_graph_dir"] = tmp_dir.string();
+  options["dump_json_qnn_graph"] = "1";
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  std::vector<std::pair<std::string, int>> inputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+    nlohmann::json root;
+    json_file >> root;
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      if (tensor.value("type", -1) == 0) {  // QNN_TENSOR_TYPE_APP_WRITE
+        inputs_with_id.emplace_back(name, tensor.value("id", -1));
+      }
+    }
+  }
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  // ONNX-declared input first, partition-added input second.
+  ASSERT_EQ(inputs_with_id.size(), 2u);
+  EXPECT_EQ(inputs_with_id[0].first, "input");
+  EXPECT_EQ(inputs_with_id[1].first, "rnl_output");
+}
+
+// Verifies the same as PartitionAddedInputRegisteredAsGraphInput but via the
+// tensor_name_overrides code path: with offload_graph_io_quantization=1,
+// QuantizeLinear stays on CPU and causes a tensor name remap (q_input <-> input).
+TEST_F(QnnCPUBackendTests, PartitionAddedInputRegisteredAsGraphInputOffloadGraphIoQuantization) {
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  auto& logging_manager = DefaultLoggingManager();
+  onnxruntime::Model model("PartitionAddedInputRegisteredAsGraphInputOffloadGraphIoQuantization", false, ModelMetaData(),
+                           PathString(), IOnnxRuntimeOpSchemaRegistryList(), domain_to_version, {},
+                           logging_manager.DefaultLogger());
+  Graph& graph = model.MainGraph();
+
+  // Graph input: float32 [1, 3].
+  ONNX_NAMESPACE::TypeProto float_type;
+  float_type.mutable_tensor_type()->set_elem_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+  float_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(1);
+  float_type.mutable_tensor_type()->mutable_shape()->add_dim()->set_dim_value(3);
+  auto& input = graph.GetOrCreateNodeArg("input", &float_type);
+
+  // Initializer: float32 [1, 3] zeros — seed for RandomNormalLike.
+  {
+    const std::vector<float> data = {0.0f, 0.0f, 0.0f};
+    gsl::span<const std::byte> raw = ReinterpretAsSpan<const std::byte, const float>(data);
+    ONNX_NAMESPACE::TensorProto tp;
+    tp.set_name("constant");
+    tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    utils::SetRawDataInTensorProto(tp, raw.data(), raw.size());
+    tp.add_dims(1);
+    tp.add_dims(3);
+    graph.AddInitializedTensor(tp);
+  }
+
+  // Initializer: float32 scalar scale = 1/255 for QuantizeLinear / DequantizeLinear.
+  {
+    const std::vector<float> data = {1.0f / 255.0f};
+    gsl::span<const std::byte> raw = ReinterpretAsSpan<const std::byte, const float>(data);
+    ONNX_NAMESPACE::TensorProto tp;
+    tp.set_name("scale");
+    tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+    utils::SetRawDataInTensorProto(tp, raw.data(), raw.size());
+    graph.AddInitializedTensor(tp);
+  }
+
+  // Initializer: uint8 scalar zero_point = 0 for QuantizeLinear / DequantizeLinear.
+  {
+    const std::vector<uint8_t> data = {0};
+    gsl::span<const std::byte> raw = ReinterpretAsSpan<const std::byte, const uint8_t>(data);
+    ONNX_NAMESPACE::TensorProto tp;
+    tp.set_name("zero_point");
+    tp.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_UINT8);
+    utils::SetRawDataInTensorProto(tp, raw.data(), raw.size());
+    graph.AddInitializedTensor(tp);
+  }
+
+  auto& constant = graph.GetOrCreateNodeArg("constant", nullptr);
+  auto& scale = graph.GetOrCreateNodeArg("scale", nullptr);
+  auto& zero_point = graph.GetOrCreateNodeArg("zero_point", nullptr);
+
+  // QuantizeLinear: input -> q_input.
+  // With offload_graph_io_quantization=1 this stays on CPU (consumes a graph input)
+  // and records the name override: q_input -> input.
+  auto& q_input = graph.GetOrCreateNodeArg("q_input", nullptr);
+  graph.AddNode("quantize", "QuantizeLinear", "", {&input, &scale, &zero_point}, {&q_input});
+
+  // DequantizeLinear: q_input -> dq_input.
+  // This is NOT a graph-output DQ so it is accepted by QNN and goes into the fused subgraph.
+  auto& dq_input = graph.GetOrCreateNodeArg("dq_input", nullptr);
+  graph.AddNode("dequantize", "DequantizeLinear", "", {&q_input, &scale, &zero_point}, {&dq_input});
+
+  // RandomNormalLike: constant -> rnl_output.
+  // Stochastic op — not supported by QNN, stays on CPU and creates a partition-added input.
+  auto& rnl_output = graph.GetOrCreateNodeArg("rnl_output", nullptr);
+  graph.AddNode("rnl", "RandomNormalLike", "", {&constant}, {&rnl_output});
+
+  // Add: dq_input + rnl_output -> add_output.  Goes to QNN.
+  auto& add_output = graph.GetOrCreateNodeArg("add_output", nullptr);
+  graph.AddNode("add", "Add", "", {&dq_input, &rnl_output}, {&add_output});
+
+  graph.SetInputs({&input});
+  graph.SetOutputs({&add_output});
+
+  auto status = graph.Resolve();
+  ASSERT_TRUE(status.IsOK()) << "Graph resolve failed: " << status.ErrorMessage();
+
+  std::string model_data;
+  model.ToProto().SerializeToString(&model_data);
+
+  Ort::SessionOptions so;
+  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+
+  onnxruntime::ProviderOptions options;
+#if defined(_WIN32)
+  options["backend_path"] = "QnnCpu.dll";
+#else
+  options["backend_path"] = "libQnnCpu.so";
+#endif
+  options["offload_graph_io_quantization"] = "1";
+
+  const std::filesystem::path tmp_dir = "qnn_partition_input_offload_test";
+  std::filesystem::remove_all(tmp_dir);
+  std::filesystem::create_directory(tmp_dir);
+  auto cleanup = gsl::finally([&tmp_dir]() { std::filesystem::remove_all(tmp_dir); });
+
+  options["json_qnn_graph_dir"] = tmp_dir.string();
+  options["dump_json_qnn_graph"] = "1";
+
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
 
   Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  std::vector<std::pair<std::string, int>> inputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+    nlohmann::json root;
+    json_file >> root;
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      if (tensor.value("type", -1) == 0) {  // QNN_TENSOR_TYPE_APP_WRITE
+        inputs_with_id.emplace_back(name, tensor.value("id", -1));
+      }
+    }
+  }
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  // ONNX-declared input first (registered under its external name "input" via tensor_name_overrides),
+  // partition-added input second.
+  ASSERT_EQ(inputs_with_id.size(), 2u);
+  EXPECT_EQ(inputs_with_id[0].first, "input");
+  EXPECT_EQ(inputs_with_id[1].first, "rnl_output");
 }
 
 // Verifies QNN graph I/O order matches ONNX declaration order.


### PR DESCRIPTION
Fix graph i/o name mapping to correctly preserve the partition-added input.

Corner case missed now also added as tests. 

Thanks @minfhong-qti for providing the repro test!!