### PR TITLE
Add missing check in ClipNodeGroupSelector for Clip in0 DQ presence

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -130,6 +130,7 @@ bool IsQOrDQScalePositiveConstantScalar(const OrtGraph* graph, const OrtApi& ort
   size_t num_inputs = 0;
   OrtStatus* status = nullptr;
   ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetNumInputs(q_node, &num_inputs), ort_api);
+
   if (num_inputs < 2) {
     return false;
   }
@@ -298,12 +299,7 @@ bool IsQDQPairSupported(const OrtGraph* graph, const OrtApi& ort_api, const OrtN
     ORT_RETURN_FALSE_ON_ERROR(ort_api.GetTensorTypeAndShape(q_scale_initializer, &q_tensor_info), ort_api);
 
     OrtTensorTypeAndShapeInfo* dq_tensor_info = nullptr;
-    status = ort_api.GetTensorTypeAndShape(dq_scale_initializer, &dq_tensor_info);
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      ort_api.ReleaseTensorTypeAndShapeInfo(q_tensor_info);
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.GetTensorTypeAndShape(dq_scale_initializer, &dq_tensor_info), ort_api);
 
     ONNXTensorElementDataType q_element_type, dq_element_type;
     status = ort_api.GetTensorElementType(q_tensor_info, &q_element_type);
@@ -547,7 +543,7 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const std::vector<const OrtNode*>& q_nodes) const {
   // Clip can have 1, 2, or 3 DQ inputs:
   // - 1 DQ: only data input is quantized
-  // - 2 DQ: data and min or max are quantized
+  // - 2 DQ: data or (min and max) are quantized
   // - 3 DQ: data, min, and max are all quantized
   const size_t num_dq_nodes = dq_nodes.size();
   if (num_dq_nodes < 1 || num_dq_nodes > 3) {
@@ -559,19 +555,35 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
   }
 
   // If Clip feeds a Q node, require the data input[0] to come from a DQ node.
-  // DQ -> Clip -> Q can form Clip ORT Unit, but DQ -> Op -> Clip -> Q is not allowed as Clip here is redundant.
+  // DQ -> Clip -> Q is allowed, but DQ -> Op -> Clip -> Q is not allowed.
   if (!q_nodes.empty()) {
     // 1. get num of inputs
     size_t clip_input_count = 0;
-    ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetNumInputs(node, &clip_input_count));
+    OrtStatus* status = ort_api.Node_GetNumInputs(node, &clip_input_count);
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      return false;
+    }
+
+    if (clip_input_count == 0) {
+      return false;
+    }
 
     // 2. get inputs as OrtValueInfo instances
     std::vector<const OrtValueInfo*> clip_inputs(clip_input_count);
-    ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size()));
+    status = ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size());
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      return false;
+    }
 
     // 3. get the producer/parent of the Clip first input
     const OrtNode* data_producer = nullptr;
-    ORT_RETURN_FALSE_ON_ERROR(ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr));
+    status = ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr);
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      return false;
+    }
 
     // 4. check if the Clip first input producer is a DQ node
     if (data_producer == nullptr || Ort::ConstNode(data_producer).GetOperatorType() != "DequantizeLinear") {
@@ -998,6 +1010,7 @@ bool OrtDQMatMulNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& or
   const char* scale_name = nullptr;
   ORT_RETURN_FALSE_ON_ERROR(ort_api.GetValueInfoName(scale_value_info, &scale_name), ort_api);
 
+
   // Check for zero point (optional)
   const OrtValueInfo* zero_point_value_info = nullptr;
   const char* zero_point_name = nullptr;
@@ -1022,7 +1035,10 @@ bool OrtDQMatMulNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& or
   // Check tensor shapes
   OrtTensorTypeAndShapeInfo* weight_tensor_info = nullptr;
   status = ort_api.GetTensorTypeAndShape(weight_initializer, &weight_tensor_info);
-  ORT_RETURN_FALSE_ON_ERROR(status);
+  if (status != nullptr) {
+    ort_api.ReleaseStatus(status);
+    return false;
+  }
 
   OrtTensorTypeAndShapeInfo* scale_tensor_info = nullptr;
   status = ort_api.GetTensorTypeAndShape(scale_initializer, &scale_tensor_info);

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -547,7 +547,7 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const std::vector<const OrtNode*>& q_nodes) const {
   // Clip can have 1, 2, or 3 DQ inputs:
   // - 1 DQ: only data input is quantized
-  // - 2 DQ: data and min or max are quantized
+  // - 2 DQ: data or (min and max) are quantized
   // - 3 DQ: data, min, and max are all quantized
   const size_t num_dq_nodes = dq_nodes.size();
   if (num_dq_nodes < 1 || num_dq_nodes > 3) {
@@ -556,6 +556,48 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
 
   if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, static_cast<int>(num_dq_nodes))) {
     return false;
+  }
+
+  // If Clip feeds a Q node, require the data input[0] to come from a DQ node.
+  // DQ -> Clip -> Q is allowed, but DQ -> Op -> Clip -> Q is not allowed.
+  if (!q_nodes.empty()) {
+    // 1. get num of inputs
+    size_t clip_input_count = 0;
+    OrtStatus* status = ort_api.Node_GetNumInputs(node, &clip_input_count);
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      return false;
+    }
+
+    if (clip_input_count == 0) {
+      return false;
+    }
+
+    // 2. get inputs as OrtValueInfo instances
+    std::vector<const OrtValueInfo*> clip_inputs(clip_input_count);
+    status = ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size());
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      return false;
+    }
+
+    // 3. get the producer/parent of the Clip first input
+    const OrtNode* data_producer = nullptr;
+    status = ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr);
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      return false;
+    }
+
+    // 4. check if the Clip first input producer is a DQ node
+    if (data_producer == nullptr || Ort::ConstNode(data_producer).GetOperatorType() != "DequantizeLinear") {
+      return false;
+    }
+
+    // 5. check if DQ node in the same group
+    if (std::find(dq_nodes.begin(), dq_nodes.end(), data_producer) == dq_nodes.end()) {
+      return false;
+    }
   }
 
   int32_t dt_input = GetNodeIODataType(dq_nodes[0], ort_api, true, 0);

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -298,7 +298,12 @@ bool IsQDQPairSupported(const OrtGraph* graph, const OrtApi& ort_api, const OrtN
     ORT_RETURN_FALSE_ON_ERROR(ort_api.GetTensorTypeAndShape(q_scale_initializer, &q_tensor_info), ort_api);
 
     OrtTensorTypeAndShapeInfo* dq_tensor_info = nullptr;
-    ORT_RETURN_FALSE_ON_ERROR(ort_api.GetTensorTypeAndShape(dq_scale_initializer, &dq_tensor_info), ort_api);
+    status = ort_api.GetTensorTypeAndShape(dq_scale_initializer, &dq_tensor_info);
+    if (status != nullptr) {
+      ort_api.ReleaseStatus(status);
+      ort_api.ReleaseTensorTypeAndShapeInfo(q_tensor_info);
+      return false;
+    }
 
     ONNXTensorElementDataType q_element_type, dq_element_type;
     status = ort_api.GetTensorElementType(q_tensor_info, &q_element_type);

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -547,7 +547,7 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const std::vector<const OrtNode*>& q_nodes) const {
   // Clip can have 1, 2, or 3 DQ inputs:
   // - 1 DQ: only data input is quantized
-  // - 2 DQ: data or (min and max) are quantized
+  // - 2 DQ: data and min or max are quantized
   // - 3 DQ: data, min, and max are all quantized
   const size_t num_dq_nodes = dq_nodes.size();
   if (num_dq_nodes < 1 || num_dq_nodes > 3) {
@@ -559,35 +559,19 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
   }
 
   // If Clip feeds a Q node, require the data input[0] to come from a DQ node.
-  // DQ -> Clip -> Q is allowed, but DQ -> Op -> Clip -> Q is not allowed.
+  // DQ -> Clip -> Q can form Clip ORT Unit, but DQ -> Op -> Clip -> Q is not allowed as Clip here is redundant.
   if (!q_nodes.empty()) {
     // 1. get num of inputs
     size_t clip_input_count = 0;
-    OrtStatus* status = ort_api.Node_GetNumInputs(node, &clip_input_count);
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      return false;
-    }
-
-    if (clip_input_count == 0) {
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetNumInputs(node, &clip_input_count));
 
     // 2. get inputs as OrtValueInfo instances
     std::vector<const OrtValueInfo*> clip_inputs(clip_input_count);
-    status = ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size());
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size()));
 
     // 3. get the producer/parent of the Clip first input
     const OrtNode* data_producer = nullptr;
-    status = ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr);
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr));
 
     // 4. check if the Clip first input producer is a DQ node
     if (data_producer == nullptr || Ort::ConstNode(data_producer).GetOperatorType() != "DequantizeLinear") {
@@ -1038,10 +1022,7 @@ bool OrtDQMatMulNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& or
   // Check tensor shapes
   OrtTensorTypeAndShapeInfo* weight_tensor_info = nullptr;
   status = ort_api.GetTensorTypeAndShape(weight_initializer, &weight_tensor_info);
-  if (status != nullptr) {
-    ort_api.ReleaseStatus(status);
-    return false;
-  }
+  ORT_RETURN_FALSE_ON_ERROR(status);
 
   OrtTensorTypeAndShapeInfo* scale_tensor_info = nullptr;
   status = ort_api.GetTensorTypeAndShape(scale_initializer, &scale_tensor_info);

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -130,7 +130,6 @@ bool IsQOrDQScalePositiveConstantScalar(const OrtGraph* graph, const OrtApi& ort
   size_t num_inputs = 0;
   OrtStatus* status = nullptr;
   ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetNumInputs(q_node, &num_inputs), ort_api);
-
   if (num_inputs < 2) {
     return false;
   }
@@ -543,7 +542,7 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const std::vector<const OrtNode*>& q_nodes) const {
   // Clip can have 1, 2, or 3 DQ inputs:
   // - 1 DQ: only data input is quantized
-  // - 2 DQ: data or (min and max) are quantized
+  // - 2 DQ: data and min or max are quantized
   // - 3 DQ: data, min, and max are all quantized
   const size_t num_dq_nodes = dq_nodes.size();
   if (num_dq_nodes < 1 || num_dq_nodes > 3) {
@@ -555,35 +554,19 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
   }
 
   // If Clip feeds a Q node, require the data input[0] to come from a DQ node.
-  // DQ -> Clip -> Q is allowed, but DQ -> Op -> Clip -> Q is not allowed.
+  // DQ -> Clip -> Q can form Clip ORT Unit, but DQ -> Op -> Clip -> Q is not allowed as Clip here is redundant.
   if (!q_nodes.empty()) {
     // 1. get num of inputs
     size_t clip_input_count = 0;
-    OrtStatus* status = ort_api.Node_GetNumInputs(node, &clip_input_count);
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      return false;
-    }
-
-    if (clip_input_count == 0) {
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetNumInputs(node, &clip_input_count), ort_api);
 
     // 2. get inputs as OrtValueInfo instances
     std::vector<const OrtValueInfo*> clip_inputs(clip_input_count);
-    status = ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size());
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetInputs(node, clip_inputs.data(), clip_inputs.size()), ort_api);
 
     // 3. get the producer/parent of the Clip first input
     const OrtNode* data_producer = nullptr;
-    status = ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr);
-    if (status != nullptr) {
-      ort_api.ReleaseStatus(status);
-      return false;
-    }
+    ORT_RETURN_FALSE_ON_ERROR(ort_api.ValueInfo_GetValueProducer(clip_inputs[0], &data_producer, nullptr), ort_api);
 
     // 4. check if the Clip first input producer is a DQ node
     if (data_producer == nullptr || Ort::ConstNode(data_producer).GetOperatorType() != "DequantizeLinear") {
@@ -1009,7 +992,6 @@ bool OrtDQMatMulNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& or
 
   const char* scale_name = nullptr;
   ORT_RETURN_FALSE_ON_ERROR(ort_api.GetValueInfoName(scale_value_info, &scale_name), ort_api);
-
 
   // Check for zero point (optional)
   const OrtValueInfo* zero_point_value_info = nullptr;

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -130,7 +130,7 @@ TEST_F(QnnHTPBackendTests, Clip_U8_DefaultMinMax_Rank4) {
 }
 
 // Test 16-bit QDQ Clip with default min/max.
-// NOTE: The Clip operator is *optimized* away during L1 optimizations, so QNN EP does not get a graph with a Clip op.
+// NOTE: The Clip operator is *opt with QDQ Mninimized* away during L1 optimizations, so QNN EP does not get a graph with a Clip op.
 // Instead, QNN EP will get a graph with a Q -> DQ.
 // - Original sequence: Q1 -> DQ1 -> Clip -> Q2 -> DQ2
 // - ClipQuantFusion: Fuses Clip -> QuantizeLinear resulting in Q1 -> DQ1 -> Q2' -> DQ2
@@ -159,6 +159,53 @@ TEST_F(QnnHTPBackendTests, Clip_U16_Rank4) {
                                 ExpectedEPNodeAssignment::All,
                                 13,     // opset
                                 true);  // Use com.microsoft Q/DQ ops
+}
+
+// Clip with QDQ Min/Max: DQ(data) + DQ(min) + DQ(max) -> Clip -> Q(output).
+TEST_F(QnnHTPBackendTests, Clip_U8_IndependentQDQ_MinMaxQDQ) {
+  GetTestModelFn model_fn = [](ModelTestBuilder& builder) {
+    std::vector<uint8_t> input_data(48);
+    for (size_t i = 0; i < input_data.size(); ++i) {
+      input_data[i] = static_cast<uint8_t>(i);
+    }
+
+    // input (u8) -> DQ ->
+    NodeArg* quant_input = builder.MakeInput<uint8_t>({1, 3, 4, 4}, input_data);
+    NodeArg* input_dq = builder.MakeIntermediate();
+    const float scale = 0.1f;
+    const uint8_t zp = 128;
+    builder.AddDequantizeLinearNode<uint8_t>(quant_input, scale, zp, input_dq);
+
+    // Quantized min/max -> DQ ->
+    const float min_value = -1.0f;
+    const float max_value = 1.0f;
+    const uint8_t min_q = static_cast<uint8_t>(std::round(min_value / scale) + zp);
+    const uint8_t max_q = static_cast<uint8_t>(std::round(max_value / scale) + zp);
+
+    NodeArg* min_quant = builder.MakeInitializer<uint8_t>({}, {min_q});
+    NodeArg* max_quant = builder.MakeInitializer<uint8_t>({}, {max_q});
+    NodeArg* min_dq = builder.MakeIntermediate();
+    NodeArg* max_dq = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<uint8_t>(min_quant, scale, zp, min_dq);
+    builder.AddDequantizeLinearNode<uint8_t>(max_quant, scale, zp, max_dq);
+
+    // Clip ->
+    NodeArg* clip_output = builder.MakeIntermediate();
+    builder.AddNode("Clip", {input_dq, min_dq, max_dq}, {clip_output});
+
+    // Q -> output (u8)
+    NodeArg* output = builder.MakeOutput();
+    builder.AddQuantizeLinearNode<uint8_t>(clip_output, scale, zp, output);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(model_fn,
+                  provider_options,
+                  13,  // opset
+                  ExpectedEPNodeAssignment::All);
 }
 
 // Test QDQ Clip of rank 5.

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -170,11 +170,10 @@ TEST_F(QnnHTPBackendTests, Clip_U8_IndependentQDQ_MinMaxQDQ) {
     }
 
     // input (u8) -> DQ ->
-    NodeArg* quant_input = builder.MakeInput<uint8_t>({1, 3, 4, 4}, input_data);
-    NodeArg* input_dq = builder.MakeIntermediate();
     const float scale = 0.1f;
     const uint8_t zp = 128;
-    builder.AddDequantizeLinearNode<uint8_t>(quant_input, scale, zp, input_dq);
+    builder.MakeInput<uint8_t>("quant_input", {1, 3, 4, 4}, input_data);
+    builder.AddDequantizeLinearNode<uint8_t>("input_dq", "quant_input", scale, zp, "input_dq_out");
 
     // Quantized min/max -> DQ ->
     const float min_value = -1.0f;
@@ -182,20 +181,17 @@ TEST_F(QnnHTPBackendTests, Clip_U8_IndependentQDQ_MinMaxQDQ) {
     const uint8_t min_q = static_cast<uint8_t>(std::round(min_value / scale) + zp);
     const uint8_t max_q = static_cast<uint8_t>(std::round(max_value / scale) + zp);
 
-    NodeArg* min_quant = builder.MakeInitializer<uint8_t>({}, {min_q});
-    NodeArg* max_quant = builder.MakeInitializer<uint8_t>({}, {max_q});
-    NodeArg* min_dq = builder.MakeIntermediate();
-    NodeArg* max_dq = builder.MakeIntermediate();
-    builder.AddDequantizeLinearNode<uint8_t>(min_quant, scale, zp, min_dq);
-    builder.AddDequantizeLinearNode<uint8_t>(max_quant, scale, zp, max_dq);
+    builder.MakeInitializer<uint8_t>("min_quant", {}, {min_q});
+    builder.MakeInitializer<uint8_t>("max_quant", {}, {max_q});
+    builder.AddDequantizeLinearNode<uint8_t>("min_dq", "min_quant", scale, zp, "min_dq_out");
+    builder.AddDequantizeLinearNode<uint8_t>("max_dq", "max_quant", scale, zp, "max_dq_out");
 
     // Clip ->
-    NodeArg* clip_output = builder.MakeIntermediate();
-    builder.AddNode("Clip", {input_dq, min_dq, max_dq}, {clip_output});
+    builder.AddNode("Clip", "Clip", {"input_dq_out", "min_dq_out", "max_dq_out"}, {"clip_out"});
 
     // Q -> output (u8)
-    NodeArg* output = builder.MakeOutput();
-    builder.AddQuantizeLinearNode<uint8_t>(clip_output, scale, zp, output);
+    builder.AddQuantizeLinearNode<uint8_t>("output_q", "clip_out", scale, zp, "Y");
+    builder.MakeOutput("Y");
   };
 
   ProviderOptions provider_options;

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -130,7 +130,7 @@ TEST_F(QnnHTPBackendTests, Clip_U8_DefaultMinMax_Rank4) {
 }
 
 // Test 16-bit QDQ Clip with default min/max.
-// NOTE: The Clip operator is *opt with QDQ Mninimized* away during L1 optimizations, so QNN EP does not get a graph with a Clip op.
+// NOTE: The Clip operator is *optimized* away during L1 optimizations, so QNN EP does not get a graph with a Clip op.
 // Instead, QNN EP will get a graph with a Q -> DQ.
 // - Original sequence: Q1 -> DQ1 -> Clip -> Q2 -> DQ2
 // - ClipQuantFusion: Fuses Clip -> QuantizeLinear resulting in Q1 -> DQ1 -> Q2' -> DQ2

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1351,7 +1351,7 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_ReluClipFusion) {
                                      weight_def,
                                      bias_def,
                                      {1, 1},        // Strides
-                                     {0, 0, 0, 0},  // Pads
+                                     {0, 0, 0, 0},  // Clip Pads
                                      {1, 1},        // Dilations
                                      1,             // default group
                                      "NOTSET",
@@ -1377,6 +1377,97 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_ReluClipFusion) {
                                       21,     // opset
                                       QDQTolerance(),
                                       clip_info_2);
+}
+
+// Redundant Clip between Conv and Q in a QDQ model should be accepted on HTP.
+TEST_F(QnnHTPBackendTests, ConvU8U8S32_RedundantClipQDQ) {
+  std::vector<int64_t> input_shape = {1, 2, 4, 4};
+  std::vector<int64_t> weight_shape = {3, 2, 2, 2};
+  std::vector<int64_t> bias_shape = {3};
+
+  TestInputDef<float> input_def(input_shape, false,
+                                GetFloatDataInRange(0.0f, 1.0f, TensorShape(input_shape).Size()));
+  TestInputDef<float> weight_def(weight_shape, true,
+                                 GetFloatDataInRange(-1.0f, 5.0f, TensorShape(weight_shape).Size()));
+  TestInputDef<float> bias_def(bias_shape, true,
+                               GetFloatDataInRange(-1.0f, 1.0f, TensorShape(bias_shape).Size()));
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  OutputActivationInfo clip_info = {"Clip", {-2.0f, 2.0f}};
+  auto f32_fn = BuildF32ConvTestCase("Conv",
+                                     input_def,
+                                     weight_def,
+                                     bias_def,
+                                     {1, 1},        // Strides
+                                     {0, 0, 0, 0},  // Pads
+                                     {1, 1},        // Dilations
+                                     1,             // default group
+                                     "NOTSET",
+                                     clip_info);
+
+  auto qdq_fn = [input_def, weight_def, bias_def](ModelTestBuilder& builder,
+                                                  std::vector<QuantParams<uint8_t>>& output_qparams) {
+    std::vector<NodeArg*> conv_inputs;
+
+    // input -> Q/DQ ->
+    auto* input = MakeTestInput(builder, input_def);
+    QuantParams<uint8_t> input_qparams = GetTestInputQuantParams<uint8_t>(input_def);
+    auto* input_qdq = AddQDQNodePair<uint8_t>(builder, input, input_qparams.scale, input_qparams.zero_point,
+                                              /*use_contrib_qdq=*/true);
+    conv_inputs.push_back(input_qdq);
+
+    // weights -> Q/DQ ->
+    auto* weights = MakeTestInput(builder, weight_def);
+    QuantParams<uint8_t> weights_qparams = GetTestInputQuantParams<uint8_t>(weight_def);
+    auto* weights_qdq = AddQDQNodePair<uint8_t>(builder, weights, weights_qparams.scale,
+                                                weights_qparams.zero_point, /*use_contrib_qdq=*/true);
+    conv_inputs.push_back(weights_qdq);
+
+    // bias ->
+    if (!bias_def.GetShape().empty()) {
+      const float bias_scale = input_qparams.scale * weights_qparams.scale;
+      conv_inputs.push_back(MakeTestQDQBiasInput(builder, bias_def, bias_scale, /*use_contrib_qdq=*/true));
+    }
+
+    auto* conv_output = builder.MakeIntermediate();
+    Node& conv_node = builder.AddNode("Conv", conv_inputs, {conv_output});
+    conv_node.AddAttribute("auto_pad", "NOTSET");
+    conv_node.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
+    conv_node.AddAttribute("strides", std::vector<int64_t>{1, 1});
+    conv_node.AddAttribute("dilations", std::vector<int64_t>{1, 1});
+    conv_node.AddAttribute("group", static_cast<int64_t>(1));
+
+    // Clip float min/max initializers -> Q -> DQ ->
+    NodeArg* min_f = builder.MakeScalarInitializer(-2.0f);
+    NodeArg* max_f = builder.MakeScalarInitializer(2.0f);
+    NodeArg* min_q = builder.MakeIntermediate();
+    NodeArg* max_q = builder.MakeIntermediate();
+    builder.AddQuantizeLinearNode<uint8_t>(min_f, input_qparams.scale, input_qparams.zero_point, min_q);
+    builder.AddQuantizeLinearNode<uint8_t>(max_f, input_qparams.scale, input_qparams.zero_point, max_q);
+
+    NodeArg* min_dq = builder.MakeIntermediate();
+    NodeArg* max_dq = builder.MakeIntermediate();
+    builder.AddDequantizeLinearNode<uint8_t>(min_q, input_qparams.scale, input_qparams.zero_point, min_dq);
+    builder.AddDequantizeLinearNode<uint8_t>(max_q, input_qparams.scale, input_qparams.zero_point, max_dq);
+
+    // Clip ->
+    NodeArg* clip_output = builder.MakeIntermediate();
+    builder.AddNode("Clip", {conv_output, min_dq, max_dq}, {clip_output});
+
+    // Q -> output
+    AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, clip_output, output_qparams[0].scale,
+                                                   output_qparams[0].zero_point, /*use_contrib_qdq=*/true);
+  };
+
+  TestQDQModelAccuracy<uint8_t>(f32_fn,
+                       qdq_fn,
+                       provider_options,
+                       13,  // opset
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance());
 }
 
 // Test fusion of DQs -> Conv -> Relu/Clip -> Q.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1386,11 +1386,11 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_RedundantClipQDQ) {
   std::vector<int64_t> bias_shape = {3};
 
   TestInputDef<float> input_def(input_shape, false,
-                                GetFloatDataInRange(0.0f, 1.0f, TensorShape(input_shape).Size()));
+                                GetFloatDataInRange(0.0f, 1.0f, SizeOfShape(input_shape)));
   TestInputDef<float> weight_def(weight_shape, true,
-                                 GetFloatDataInRange(-1.0f, 5.0f, TensorShape(weight_shape).Size()));
+                                 GetFloatDataInRange(-1.0f, 5.0f, SizeOfShape(weight_shape)));
   TestInputDef<float> bias_def(bias_shape, true,
-                               GetFloatDataInRange(-1.0f, 1.0f, TensorShape(bias_shape).Size()));
+                               GetFloatDataInRange(-1.0f, 1.0f, SizeOfShape(bias_shape)));
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -1410,55 +1410,56 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_RedundantClipQDQ) {
 
   auto qdq_fn = [input_def, weight_def, bias_def](ModelTestBuilder& builder,
                                                   std::vector<QuantParams<uint8_t>>& output_qparams) {
-    std::vector<NodeArg*> conv_inputs;
+    std::vector<std::string> conv_inputs;
 
     // input -> Q/DQ ->
-    auto* input = MakeTestInput(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
     QuantParams<uint8_t> input_qparams = GetTestInputQuantParams<uint8_t>(input_def);
-    auto* input_qdq = AddQDQNodePair<uint8_t>(builder, input, input_qparams.scale, input_qparams.zero_point,
-                                              /*use_contrib_qdq=*/true);
-    conv_inputs.push_back(input_qdq);
+    conv_inputs.push_back(AddQDQNodePair<uint8_t>(builder, "input_qdq", "input", input_qparams.scale,
+                                                  input_qparams.zero_point, /*use_contrib_qdq=*/true));
 
     // weights -> Q/DQ ->
-    auto* weights = MakeTestInput(builder, weight_def);
+    MakeTestInput<float>(builder, "weights", weight_def);
     QuantParams<uint8_t> weights_qparams = GetTestInputQuantParams<uint8_t>(weight_def);
-    auto* weights_qdq = AddQDQNodePair<uint8_t>(builder, weights, weights_qparams.scale,
-                                                weights_qparams.zero_point, /*use_contrib_qdq=*/true);
-    conv_inputs.push_back(weights_qdq);
+    conv_inputs.push_back(AddQDQNodePair<uint8_t>(builder, "weights_qdq", "weights", weights_qparams.scale,
+                                                  weights_qparams.zero_point, /*use_contrib_qdq=*/true));
 
     // bias ->
     if (!bias_def.GetShape().empty()) {
       const float bias_scale = input_qparams.scale * weights_qparams.scale;
-      conv_inputs.push_back(MakeTestQDQBiasInput(builder, bias_def, bias_scale, /*use_contrib_qdq=*/true));
+      conv_inputs.push_back(MakeTestQDQBiasInput(builder, "bias", bias_def, bias_scale,
+                                                 /*use_contrib_qdq=*/true));
     }
 
-    auto* conv_output = builder.MakeIntermediate();
-    Node& conv_node = builder.AddNode("Conv", conv_inputs, {conv_output});
-    conv_node.AddAttribute("auto_pad", "NOTSET");
-    conv_node.AddAttribute("pads", std::vector<int64_t>{0, 0, 0, 0});
-    conv_node.AddAttribute("strides", std::vector<int64_t>{1, 1});
-    conv_node.AddAttribute("dilations", std::vector<int64_t>{1, 1});
-    conv_node.AddAttribute("group", static_cast<int64_t>(1));
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", {0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", {1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", {1, 1}));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+
+    const std::string conv_output = "conv_output";
+    builder.AddNode("Conv", "Conv", conv_inputs, {conv_output}, "", conv_attrs);
 
     // Clip float min/max initializers -> Q -> DQ ->
-    NodeArg* min_f = builder.MakeScalarInitializer(-2.0f);
-    NodeArg* max_f = builder.MakeScalarInitializer(2.0f);
-    NodeArg* min_q = builder.MakeIntermediate();
-    NodeArg* max_q = builder.MakeIntermediate();
-    builder.AddQuantizeLinearNode<uint8_t>(min_f, input_qparams.scale, input_qparams.zero_point, min_q);
-    builder.AddQuantizeLinearNode<uint8_t>(max_f, input_qparams.scale, input_qparams.zero_point, max_q);
+    builder.MakeScalarInitializer<float>("clip_min_f", -2.0f);
+    builder.MakeScalarInitializer<float>("clip_max_f", 2.0f);
+    builder.AddQuantizeLinearNode<uint8_t>("clip_min_q", "clip_min_f", input_qparams.scale,
+                                           input_qparams.zero_point, "clip_min_q_out");
+    builder.AddQuantizeLinearNode<uint8_t>("clip_max_q", "clip_max_f", input_qparams.scale,
+                                           input_qparams.zero_point, "clip_max_q_out");
 
-    NodeArg* min_dq = builder.MakeIntermediate();
-    NodeArg* max_dq = builder.MakeIntermediate();
-    builder.AddDequantizeLinearNode<uint8_t>(min_q, input_qparams.scale, input_qparams.zero_point, min_dq);
-    builder.AddDequantizeLinearNode<uint8_t>(max_q, input_qparams.scale, input_qparams.zero_point, max_dq);
+    builder.AddDequantizeLinearNode<uint8_t>("clip_min_dq", "clip_min_q_out", input_qparams.scale,
+                                             input_qparams.zero_point, "clip_min_dq_out");
+    builder.AddDequantizeLinearNode<uint8_t>("clip_max_dq", "clip_max_q_out", input_qparams.scale,
+                                             input_qparams.zero_point, "clip_max_dq_out");
 
     // Clip ->
-    NodeArg* clip_output = builder.MakeIntermediate();
-    builder.AddNode("Clip", {conv_output, min_dq, max_dq}, {clip_output});
+    const std::string clip_output = "clip_output";
+    builder.AddNode("Clip", "Clip", {conv_output, "clip_min_dq_out", "clip_max_dq_out"}, {clip_output});
 
     // Q -> output
-    AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, clip_output, output_qparams[0].scale,
+    AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, "output_qdq", clip_output, output_qparams[0].scale,
                                                    output_qparams[0].zero_point, /*use_contrib_qdq=*/true);
   };
 

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1351,7 +1351,7 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_ReluClipFusion) {
                                      weight_def,
                                      bias_def,
                                      {1, 1},        // Strides
-                                     {0, 0, 0, 0},  // Clip Pads
+                                     {0, 0, 0, 0},  // Pads
                                      {1, 1},        // Dilations
                                      1,             // default group
                                      "NOTSET",
@@ -1463,11 +1463,11 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_RedundantClipQDQ) {
   };
 
   TestQDQModelAccuracy<uint8_t>(f32_fn,
-                       qdq_fn,
-                       provider_options,
-                       13,  // opset
-                       ExpectedEPNodeAssignment::All,
-                       QDQTolerance());
+                                qdq_fn,
+                                provider_options,
+                                13,  // opset
+                                ExpectedEPNodeAssignment::All,
+                                QDQTolerance());
 }
 
 // Test fusion of DQs -> Conv -> Relu/Clip -> Q.


### PR DESCRIPTION
### Description
Added check in ClipNodeGroupSelector to validate DQ presence at input[0] if there is Q at output[0].


### Motivation and Context
Fixes https://github.com/qcom-ai-hub/tetracode/issues/16543 

Given model has **redundant clip node** as part of "Conv -> Clip" supergroup, which is represented by **Conv** ORTUnit.
<img width="591" height="718" alt="image" src="https://github.com/user-attachments/assets/58af37c8-240b-4aa6-9521-8771d7440650" />

However, due to Clip input[1] and input[2] QDQ nodes, it was also forming **Clip** ORT Node Unit, with FP32 input and UINT8 output (as DQ was missing at input[0]) causing QNN validation failure. 


