### PR TITLE
[QNN-EP] Fix use-after-free of logger object

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1328,6 +1328,8 @@ Ort::Status QnnBackendManager::SetupBackend(
     bool enable_vtcm_backup_buffer_sharing,
     std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map) {
   std::lock_guard<std::recursive_mutex> lock(logger_recursive_mutex_);
+  if (logger_ != &logger)
+    logger_ = &logger;
   if (backend_setup_completed_) {
     ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Backend setup already!");
 


### PR DESCRIPTION
### Description
Update logger object in QnnBackendManager::SetupBackend.



### Motivation and Context
While generating weight sharing context binary, Inference Session is created once for each graph. Inference session creates logger object and passes it to QnnBackendManager. QnnBackendManager stores this pointer in logger_ pointer and holds it long after Inference Session is destroys Logger. On next Inference Session, another Logger object is created but QnnBackendManager do not use this as backend_setup_completed_ is already set.


