### PR TITLE
Fix roialign_op_test.cc on the new qnn test infra

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -560,8 +560,8 @@ onnxruntime_fetchcontent_declare(
   URL ${DEP_URL_ort_core}
   URL_HASH SHA1=${DEP_SHA1_ort_core}
   PATCH_COMMAND
-    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_test_binaries.patch &&
-    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-Add-Roialign-Op-to-HTP.patch
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0001-cpp-model-test-runner-uses-plugin-EP.patch &&
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0002-Add-Roialign-Op-to-HTP.patch
   EXCLUDE_FROM_ALL)
 FetchContent_Populate(ort_core)
 

--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -560,7 +560,8 @@ onnxruntime_fetchcontent_declare(
   URL ${DEP_URL_ort_core}
   URL_HASH SHA1=${DEP_SHA1_ort_core}
   PATCH_COMMAND
-    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_test_binaries.patch
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_test_binaries.patch &&
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-Add-Roialign-Op-to-HTP.patch
   EXCLUDE_FROM_ALL)
 FetchContent_Populate(ort_core)
 

--- a/cmake/patches/0001-Add-Roialign-Op-to-HTP.patch
+++ b/cmake/patches/0001-Add-Roialign-Op-to-HTP.patch
@@ -1,0 +1,43 @@
+From ac65635b43b8be0cd4a239daac549110247f6e3c Mon Sep 17 00:00:00 2001
+From: qti-hungjuiw <hungjuiw@qti.qualcomm.com>
+Date: Mon, 9 Mar 2026 12:03:21 +0800
+Subject: [PATCH] Add Roialign Op to HTP
+
+---
+ onnxruntime/test/onnx/TestCase.cc | 2 ++
+ onnxruntime/test/onnx/main.cc     | 7 ++++++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/onnxruntime/test/onnx/TestCase.cc b/onnxruntime/test/onnx/TestCase.cc
+index ba733a3751..1b8ac76042 100644
+--- a/onnxruntime/test/onnx/TestCase.cc
++++ b/onnxruntime/test/onnx/TestCase.cc
+@@ -1411,6 +1411,8 @@ std::unique_ptr<std::set<BrokenTest>> GetBrokenTests(const std::string& provider
+     broken_tests->insert({"rotary_embedding_no_position_ids_rotary_dim", "unknown version"});
+     broken_tests->insert({"rotary_embedding_with_interleaved_rotary_dim", "unknown version"});
+     broken_tests->insert({"rotary_embedding_with_rotary_dim", "unknown version"});
++    broken_tests->insert({"roialign_aligned_false", "unknown version"});  // roialign test uses opset 22, currently supports up to 16
++
+     // Fails since QNN SDK 2.17.0:
+     // expected 7.70947 (40f6b3f3), got 7.84096 (40fae920), diff: 0.131491, tol=0.00870947 idx=419. 100 of 1715 differ
+     broken_tests->insert({"facedetection_op8_qdq", "result differs"});
+diff --git a/onnxruntime/test/onnx/main.cc b/onnxruntime/test/onnx/main.cc
+index 8446f88639..f08b974d60 100644
+--- a/onnxruntime/test/onnx/main.cc
++++ b/onnxruntime/test/onnx/main.cc
+@@ -915,7 +915,12 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
+         ORT_TSTR("mod_mixed_sign_int16"),
+         ORT_TSTR("mod_mixed_sign_int8"),
+         ORT_TSTR("mod_uint16"),
+-        ORT_TSTR("mod_uint64")};
++        ORT_TSTR("mod_uint64"),
++        // QNN only support aligned = False and op version 16.
++        // [ONNXRuntimeError] : 9 : NOT_IMPLEMENTED : Could not find an implementation for RoiAlign(22) node with name ''
++        ORT_TSTR("roialign_aligned_false"),
++        ORT_TSTR("roialign_aligned_true"),
++        ORT_TSTR("roialign_mode_max")};
+
+     std::unordered_set<std::basic_string<ORTCHAR_T>> all_disabled_tests(std::begin(immutable_broken_tests), std::end(immutable_broken_tests));
+
+--
+2.34.1.windows.1

--- a/cmake/patches/ort_core/0001-cpp-model-test-runner-uses-plugin-EP.patch
+++ b/cmake/patches/ort_core/0001-cpp-model-test-runner-uses-plugin-EP.patch
@@ -1,3 +1,44 @@
+From c72f2f3cebee9aed9db117101c85ea4f68aec107 Mon Sep 17 00:00:00 2001
+From: qti-hungjuiw <hungjuiw@qti.qualcomm.com>
+Date: Mon, 9 Mar 2026 12:01:48 +0800
+Subject: [PATCH 1/2] cpp model test runner uses plugin EP
+
+---
+ cmake/CMakeLists.txt                          |   5 +
+ cmake/onnxruntime_unittests.cmake             |  91 +-
+ onnxruntime/test/onnx/TestCase.cc             |  20 +
+ onnxruntime/test/onnx/dataitem_request.cc     |  13 +-
+ .../onnx/plugin_ep/command_args_parser.cc     | 370 ++++++++
+ .../test/onnx/plugin_ep/command_args_parser.h |  68 ++
+ onnxruntime/test/onnx/plugin_ep/main.cc       | 795 ++++++++++++++++
+ onnxruntime/test/onnx/testcase_driver.cc      |   6 +-
+ onnxruntime/test/onnx/testcase_request.cc     |  17 +-
+ onnxruntime/test/onnx/utils/macros.h          |  18 +
+ .../utils}/strings_helper.cc                  | 121 ++-
+ .../{perftest => onnx/utils}/strings_helper.h |  21 +-
+ onnxruntime/test/onnx/utils/utils.cc          |  93 ++
+ onnxruntime/test/onnx/utils/utils.h           |  24 +
+ .../test/perftest/command_args_parser.cc      |  16 +-
+ onnxruntime/test/perftest/common_utils.cc     |  83 +-
+ onnxruntime/test/perftest/main.cc             |   9 +-
+ onnxruntime/test/perftest/ort_test_session.cc |  16 +-
+ onnxruntime/test/perftest/utils.h             |  10 -
+ .../internal_api}/compare_ortvalue.cc         |   0
+ .../values/public_api/compare_ortvalue.cc     | 849 ++++++++++++++++++
+ .../util/values/public_api/compare_ortvalue.h |  35 +
+ 22 files changed, 2498 insertions(+), 182 deletions(-)
+ create mode 100644 onnxruntime/test/onnx/plugin_ep/command_args_parser.cc
+ create mode 100644 onnxruntime/test/onnx/plugin_ep/command_args_parser.h
+ create mode 100644 onnxruntime/test/onnx/plugin_ep/main.cc
+ create mode 100644 onnxruntime/test/onnx/utils/macros.h
+ rename onnxruntime/test/{perftest => onnx/utils}/strings_helper.cc (83%)
+ rename onnxruntime/test/{perftest => onnx/utils}/strings_helper.h (81%)
+ create mode 100644 onnxruntime/test/onnx/utils/utils.cc
+ create mode 100644 onnxruntime/test/onnx/utils/utils.h
+ rename onnxruntime/test/util/{ => values/internal_api}/compare_ortvalue.cc (100%)
+ create mode 100644 onnxruntime/test/util/values/public_api/compare_ortvalue.cc
+ create mode 100644 onnxruntime/test/util/values/public_api/compare_ortvalue.h
+
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
 index 6d0d39556e..00a303368f 100644
 --- a/cmake/CMakeLists.txt
@@ -21,7 +62,7 @@ index ad6f6eb790..7ba7e3c0b1 100644
 @@ -356,6 +356,14 @@ file(GLOB onnxruntime_test_utils_src CONFIGURE_DEPENDS
    "${TEST_SRC_DIR}/util/*.cc"
  )
- 
+
 +file(GLOB onnxruntime_test_utils_public_values_src CMAKE_CONFIGURE_DEPENDS
 +  "${TEST_SRC_DIR}/util/values/public_api/*.cc"
 +)
@@ -34,17 +75,17 @@ index ad6f6eb790..7ba7e3c0b1 100644
    "${TEST_SRC_DIR}/common/*.cc"
    "${TEST_SRC_DIR}/common/*.h"
 @@ -620,6 +628,7 @@ set (onnxruntime_webgpu_delay_load_test_SRC
- 
+
  set(onnxruntime_test_common_libs
    onnxruntime_unittest_utils
 +  onnxruntime_test_utils_internal_values
    onnxruntime_common
  )
- 
+
 @@ -842,6 +851,21 @@ target_include_directories(onnxruntime_test_utils PUBLIC "${TEST_SRC_DIR}/util/i
  set_target_properties(onnxruntime_test_utils PROPERTIES FOLDER "ONNXRuntimeTest")
  source_group(TREE ${TEST_SRC_DIR} FILES ${onnxruntime_test_utils_src})
- 
+
 +# This utility library uses onnxruntime c/c++ apis to provide capability of comparing two OrtValues with all supported data type.
 +onnxruntime_add_static_library(onnxruntime_test_utils_public_values ${onnxruntime_test_utils_public_values_src})
 +onnxruntime_add_include_to_target(onnxruntime_test_utils_public_values onnxruntime_common onnx onnx_proto Eigen3::Eigen)
@@ -71,10 +112,10 @@ index ad6f6eb790..7ba7e3c0b1 100644
 +        ${onnx_test_runner_src_dir}/*.cc
 +        ${onnx_test_runner_src_dir}/utils/*.h
 +        ${onnx_test_runner_src_dir}/utils/*.cc)
- 
+
 -    list(REMOVE_ITEM onnx_test_runner_common_srcs ${onnx_test_runner_src_dir}/main.cc)
 +        list(REMOVE_ITEM onnx_test_runner_common_srcs ${onnx_test_runner_src_dir}/main.cc)
- 
+
      onnxruntime_add_static_library(onnx_test_runner_common ${onnx_test_runner_common_srcs})
      if(MSVC)
 @@ -951,7 +977,7 @@ if (onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS)
@@ -89,8 +130,8 @@ index ad6f6eb790..7ba7e3c0b1 100644
 @@ -1233,7 +1259,7 @@ block()
      DEPENDS ${onnxruntime_provider_test_deps}
    )
- 
--  # Expose QNN SDK headers to unit tests via an interface target 
+
+-  # Expose QNN SDK headers to unit tests via an interface target
 +  # Expose QNN SDK headers to unit tests via an interface target
    if(onnxruntime_USE_QNN)
      add_library(qnn_sdk_headers_include INTERFACE)
@@ -99,13 +140,13 @@ index ad6f6eb790..7ba7e3c0b1 100644
        ${onnxruntime_QNN_HOME}/include/QNN)
      target_link_libraries(onnxruntime_provider_test PRIVATE qnn_sdk_headers_include)
    endif()
--  
+-
 +
    if (UNIX AND (onnxruntime_USE_TENSORRT OR onnxruntime_USE_NV))
      # The test_main.cc includes NvInfer.h where it has many deprecated declarations
      # simply ignore them for TensorRT EP build
 @@ -1298,6 +1324,7 @@ endif()
- 
+
  set(onnx_test_libs
    onnxruntime_test_utils
 +  onnxruntime_test_utils_internal_values
@@ -115,7 +156,7 @@ index ad6f6eb790..7ba7e3c0b1 100644
 @@ -1331,6 +1358,60 @@ if (NOT IOS)
              RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
  endif()
- 
+
 +if (NOT IOS)
 +    onnxruntime_add_executable(onnxruntime_plugin_ep_onnx_test
 +                               ${onnx_test_runner_src_dir}/plugin_ep/main.cc
@@ -202,7 +243,7 @@ index fbb9fb2797..ba733a3751 100644
 +    broken_tests->insert({"stft", "expected 0 (0), got 8.39259e-05 (38b0015b), diff: 8.39259e-05, tol=1e-05 idx=269. 14 of 270 differ"});
 +    broken_tests->insert({"stft_with_window", "expected 0 (0), got 4.19629e-05 (3830015b), diff: 4.19629e-05, tol=1e-05 idx=269. 12 of 270 differ"});
    }
- 
+
  #ifdef DISABLE_CONTRIB_OPS
 diff --git a/onnxruntime/test/onnx/dataitem_request.cc b/onnxruntime/test/onnx/dataitem_request.cc
 index e391f8847c..769e972064 100644
@@ -213,7 +254,7 @@ index e391f8847c..769e972064 100644
  #include "TestCase.h"
  #include "test/compare_ortvalue.h"
 +#include "utils/macros.h"
- 
+
  #include "core/common/logging/logging.h"
  #include "core/common/common.h"
 @@ -29,7 +30,7 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::Run(const ITestCase
@@ -233,7 +274,7 @@ index e391f8847c..769e972064 100644
 +      TEST_LOG_ERROR(test_case_.GetTestCaseName() + ":" + ex.what());
      });
    }
- 
+
 @@ -145,7 +146,7 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
      auto iter = name_fetch_output_map.find(output_name);
      if (iter == name_fetch_output_map.end()) {
@@ -263,7 +304,7 @@ index e391f8847c..769e972064 100644
              "Expected None output but received an OrtValue that is not None"};
 @@ -213,7 +214,7 @@ std::pair<EXECUTE_RESULT, TIME_SPEC> DataTaskRequestContext::RunImpl() {
      }
- 
+
      if (compare_result != COMPARE_RESULT::SUCCESS && !ret.second.empty()) {
 -      LOGS_DEFAULT(ERROR) << test_case_.GetTestCaseName() << ":output=" << output_name << ":" << ret.second;
 +      TEST_LOG_ERROR(test_case_.GetTestCaseName() + ":output=" + output_name + ":" + ret.second);
@@ -1530,10 +1571,10 @@ index 0e14a0dcb6..06b2872ccc 100644
  #include "testcase_request.h"
  #include "testenv.h"
 +#include "utils/macros.h"
- 
+
  #include <core/common/logging/logging.h>
 +#include <sstream>
- 
+
  namespace onnxruntime {
  namespace test {
 @@ -37,7 +39,7 @@ std::vector<std::shared_ptr<TestCaseResult>> TestCaseDriver::RunParallel(const T
@@ -1552,7 +1593,7 @@ index 0e14a0dcb6..06b2872ccc 100644
 -  LOGF_DEFAULT(ERROR, "Running tests finished. Generating report");
 +  TEST_LOG_VERBOSE("Running tests finished. Generating report");
  }
- 
+
  void TestCaseDriver::OnTestCaseComplete(size_t test_case_id, std::shared_ptr<TestCaseResult> result) {
 diff --git a/onnxruntime/test/onnx/testcase_request.cc b/onnxruntime/test/onnx/testcase_request.cc
 index 95c7c89056..3814be0637 100644
@@ -1563,13 +1604,13 @@ index 95c7c89056..3814be0637 100644
  #include "dataitem_request.h"
  #include "TestCase.h"
 +#include "utils/macros.h"
- 
+
  #include "core/common/logging/logging.h"
  #include "core/common/logging/macros.h"
- 
+
 +#include <iostream>
  #include <utility>
- 
+
  namespace onnxruntime {
 @@ -39,12 +41,13 @@ bool TestCaseRequestContext::SetupSession() {
      session_opts_.SetLogId(test_case_name);
@@ -1645,7 +1686,7 @@ index d9fd2a2a55..951f138890 100644
 +++ b/onnxruntime/test/onnx/utils/strings_helper.cc
 @@ -12,49 +12,8 @@
  #include "core/common/string_utils.h"
- 
+
  namespace onnxruntime {
 -namespace perftest {
 -
@@ -1692,13 +1733,13 @@ index d9fd2a2a55..951f138890 100644
 -}
 +namespace test {
 +namespace utils {
- 
+
  bool ParseDimensionOverride(const std::string& input, std::map<std::string, int64_t>& free_dim_override_map) {
    std::stringstream ss(input);
 @@ -103,13 +62,55 @@ bool ParseDimensionOverrideFromArgv(int argc, std::vector<std::string>& argv, st
    return true;
  }
- 
+
 +void ParseSessionConfigs(const std::string& configs_string,
 +                         std::unordered_map<std::string, std::string>& session_configs,
 +                         const std::unordered_set<std::string>& available_keys) {
@@ -1744,7 +1785,7 @@ index d9fd2a2a55..951f138890 100644
  void ParseEpOptions(const std::string& input, std::vector<std::unordered_map<std::string, std::string>>& result) {
 -  auto tokens = utils::SplitString(input, ";", true);
 +  auto tokens = onnxruntime::utils::SplitString(input, ";", true);
- 
+
    for (const auto& token : tokens) {
      result.emplace_back();  // Adds a new empty map
      if (!token.empty()) {
@@ -1806,7 +1847,7 @@ index d6c6f6112a..eea7474f22 100644
  #include <unordered_map>
 @@ -9,16 +11,17 @@
  #include <vector>
- 
+
  namespace onnxruntime {
 -namespace perftest {
 -
@@ -1815,21 +1856,21 @@ index d6c6f6112a..eea7474f22 100644
 -                         const std::unordered_set<std::string>& available_keys = {});
 +namespace test {
 +namespace utils {
- 
+
  bool ParseDimensionOverride(const std::string& input, std::map<std::string, int64_t>& free_dim_override_map);
- 
+
  bool ParseDimensionOverrideFromArgv(int argc, std::vector<std::string>& argv, std::string& option, std::map<std::string, int64_t>& free_dim_override_map);
- 
+
 +void ParseSessionConfigs(const std::string& configs_string,
 +                         std::unordered_map<std::string, std::string>& session_configs,
 +                         const std::unordered_set<std::string>& available_keys = {});
 +
  void ParseEpList(const std::string& input, std::vector<std::string>& result);
- 
+
  void ParseEpOptions(const std::string& input, std::vector<std::unordered_map<std::string, std::string>>& result);
 @@ -26,5 +29,11 @@ void ParseEpOptions(const std::string& input, std::vector<std::unordered_map<std
  void ParseEpDeviceIndexList(const std::string& input, std::vector<int>& result);
- 
+
  void ParseEpDeviceFilterKeyValuePairs(const std::string& input, std::vector<std::pair<std::string, std::string>>& result);
 -}  // namespace perftest
 +
@@ -1975,23 +2016,23 @@ index e21120e62e..cb583812e1 100644
 +++ b/onnxruntime/test/perftest/command_args_parser.cc
 @@ -19,7 +19,7 @@
  #include <core/session/onnxruntime_run_options_config_keys.h>
- 
+
  #include "test_configuration.h"
 -#include "strings_helper.h"
 +#include "test/onnx/utils/strings_helper.h"
- 
+
  #ifdef _MSC_VER
  #pragma warning(push)
 @@ -233,8 +233,8 @@ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int a
    absl::SetFlagsUsageConfig(config);
    absl::SetProgramUsageMessage(CustomUsageMessage());
- 
+
 -  auto utf8_argv_strings = utils::ConvertArgvToUtf8Strings(argc, argv);
 -  auto utf8_argv = utils::CStringsFromStrings(utf8_argv_strings);
 +  auto utf8_argv_strings = test::utils::ConvertArgvToUtf8Strings(argc, argv);
 +  auto utf8_argv = test::utils::CStringsFromStrings(utf8_argv_strings);
    auto positional = absl::ParseCommandLine(static_cast<int>(utf8_argv.size()), utf8_argv.data());
- 
+
    // -f
 @@ -245,7 +245,7 @@ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int a
        // To preserve the previous usage of '-f', where users may specify it multiple times to override different dimension names,
@@ -2027,7 +2068,7 @@ index e21120e62e..cb583812e1 100644
 -    if (!plugin_eps.empty()) ParseEpList(plugin_eps, test_config.machine_config.plugin_provider_type_list);
 +    if (!plugin_eps.empty()) test::utils::ParseEpList(plugin_eps, test_config.machine_config.plugin_provider_type_list);
    }
- 
+
    // --plugin_ep_options
 @@ -563,7 +563,7 @@ bool CommandLineParser::ParseArguments(PerformanceTestConfig& test_config, int a
      const auto& filter_ep_devices = absl::GetFlag(FLAGS_filter_ep_devices);
@@ -2044,17 +2085,17 @@ index 63882c64c2..8b4ce43356 100644
 +++ b/onnxruntime/test/perftest/common_utils.cc
 @@ -2,7 +2,7 @@
  // Licensed under the MIT License.
- 
+
  #include "test/perftest/utils.h"
 -#include "test/perftest/strings_helper.h"
 +#include "test/onnx/utils/strings_helper.h"
  #include <core/platform/path_lib.h>
- 
+
  #include <cstdint>
 @@ -13,83 +13,6 @@ namespace onnxruntime {
  namespace perftest {
  namespace utils {
- 
+
 -void ListEpDevices(const Ort::Env& env) {
 -  std::vector<Ort::ConstEpDevice> ep_devices = env.GetEpDevices();
 -
@@ -2145,12 +2186,12 @@ index 63882c64c2..8b4ce43356 100644
        if (static_cast<size_t>(index) > (ep_devices.size() - 1)) {
          fprintf(stderr, "%s", "The device index provided is not correct. Will skip this device id.");
 @@ -175,7 +98,7 @@ void AppendPluginExecutionProviders(Ort::Env& env,
- 
+
    // EP's associated provider option lists
    std::vector<std::unordered_map<std::string, std::string>> ep_options_list;
 -  ParseEpOptions(ep_option_string, ep_options_list);
 +  test::utils::ParseEpOptions(ep_option_string, ep_options_list);
- 
+
    // If user only provide the EPs' provider option lists for the first several EPs,
    // add empty provider option lists for the rest EPs.
 diff --git a/onnxruntime/test/perftest/main.cc b/onnxruntime/test/perftest/main.cc
@@ -2166,16 +2207,16 @@ index 512f217a77..c1fd4663be 100644
  #include "utils.h"
 -#include "strings_helper.h"
  #include <google/protobuf/stubs/common.h>
- 
+
  using namespace onnxruntime;
 @@ -48,7 +49,7 @@ int real_main(int argc, char* argv[]) {
    }
- 
+
    if (!test_config.plugin_ep_names_and_libs.empty()) {
 -    perftest::utils::RegisterExecutionProviderLibrary(env, test_config);
 +    test::utils::RegisterExecutionProviderLibrary(env, test_config.plugin_ep_names_and_libs, test_config.registered_plugin_eps);
    }
- 
+
    // Unregister all registered plugin EP libraries before program exits.
 @@ -58,12 +59,12 @@ int real_main(int argc, char* argv[]) {
    // See "ep_device.ep_factory->ReleaseAllocator" in Environment::CreateSharedAllocatorImpl.
@@ -2185,7 +2226,7 @@ index 512f217a77..c1fd4663be 100644
 +      test::utils::UnregisterExecutionProviderLibrary(env, test_config.registered_plugin_eps);  // this won't throw
      }
    });
- 
+
    if (test_config.list_available_ep_devices) {
 -    perftest::utils::ListEpDevices(env);
 +    test::utils::ListEpDevices(env);
@@ -2203,7 +2244,7 @@ index 71f9050730..1e879bf5df 100644
 -#include "strings_helper.h"
  #include "utils.h"
 +#include "test/onnx/utils/strings_helper.h"
- 
+
  #ifdef USE_OPENVINO
  #include "nlohmann/json.hpp"
 @@ -252,13 +252,13 @@ OnnxRuntimeTestSession::OnnxRuntimeTestSession(Ort::Env& env, std::random_device
@@ -2232,7 +2273,7 @@ index 71f9050730..1e879bf5df 100644
                                                                     kCoremlProviderOption_ModelCacheDirectory};
 -    ParseSessionConfigs(ov_string, provider_options, available_keys);
 +    test::utils::ParseSessionConfigs(ov_string, provider_options, available_keys);
- 
+
      std::unordered_map<std::string, std::string> available_options = {
          {"CPUAndNeuralEngine", "1"},
 diff --git a/onnxruntime/test/perftest/utils.h b/onnxruntime/test/perftest/utils.h
@@ -2240,9 +2281,9 @@ index c008273a3d..e630d1b098 100644
 --- a/onnxruntime/test/perftest/utils.h
 +++ b/onnxruntime/test/perftest/utils.h
 @@ -23,16 +23,6 @@ class ICPUUsage {
- 
+
  std::unique_ptr<ICPUUsage> CreateICPUUsage();
- 
+
 -std::vector<std::string> ConvertArgvToUtf8Strings(int argc, ORTCHAR_T* argv[]);
 -
 -std::vector<char*> CStringsFromStrings(std::vector<std::string>& utf8_args);
@@ -3156,3 +3197,5 @@ index 0000000000..c85630b5b2
 +std::pair<COMPARE_RESULT, std::string> VerifyValueInfo(const ONNX_NAMESPACE::ValueInfoProto& expected,
 +                                                       const OrtValue* value);
 +}  // namespace onnxruntime
+--
+2.34.1.windows.1

--- a/cmake/patches/ort_core/0002-Add-Roialign-Op-to-HTP.patch
+++ b/cmake/patches/ort_core/0002-Add-Roialign-Op-to-HTP.patch
@@ -1,7 +1,7 @@
-From ac65635b43b8be0cd4a239daac549110247f6e3c Mon Sep 17 00:00:00 2001
+From cf0d097d6864e8f5f1393c20dcbc96e2fe2efc9e Mon Sep 17 00:00:00 2001
 From: qti-hungjuiw <hungjuiw@qti.qualcomm.com>
 Date: Mon, 9 Mar 2026 12:03:21 +0800
-Subject: [PATCH] Add Roialign Op to HTP
+Subject: [PATCH 2/2] Add Roialign Op to HTP
 
 ---
  onnxruntime/test/onnx/TestCase.cc | 2 ++

--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -26,18 +26,19 @@ static GetTestModelFn BuildRoialignTestCase(const TestInputDef<float>& input_def
                                             const TestInputDef<int64_t>& batch_indices_def,
                                             const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
   return [input_def, roi_def, batch_indices_def, attrs](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* roi = MakeTestInput(builder, roi_def);
-    NodeArg* batch_indices = MakeTestInput(builder, batch_indices_def);
+    MakeTestInput<float>(builder, "X", input_def);
+    MakeTestInput<float>(builder, "rois", roi_def);
+    MakeTestInput<int64_t>(builder, "batch_indices", batch_indices_def);
 
-    std::vector<NodeArg*> inputs{input, roi, batch_indices};
+    builder.AddNode(
+        "roialign_node",
+        "RoiAlign",
+        {"X", "rois", "batch_indices"},
+        {"Y"},
+        "",
+        attrs);
 
-    NodeArg* output = builder.MakeOutput();
-    Node& roialign_node = builder.AddNode("RoiAlign", inputs, {output});
-
-    for (const auto& attr : attrs) {
-      roialign_node.AddAttributeProto(attr);
-    }
+    builder.MakeOutput("Y");
   };
 }
 
@@ -49,32 +50,30 @@ GetTestQDQModelFn<QuantType> BuildRoialignQDQTestCase(const TestInputDef<float>&
                                                       const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
   return [input_def, roi_def, batch_indices_def, attrs](ModelTestBuilder& builder,
                                                         std::vector<QuantParams<QuantType>>& output_qparams) {
-    std::vector<NodeArg*> inputs;
     // input -> Q -> DQ ->
-    NodeArg* input = MakeTestInput(builder, input_def);
+    MakeTestInput<float>(builder, "X", input_def);
     QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
-    NodeArg* input_qdq = AddQDQNodePair<QuantType>(builder, input, input_qparams.scale, input_qparams.zero_point);
-    inputs.push_back(input_qdq);
+    std::string input_qdq = AddQDQNodePair<QuantType>(builder, "qdq1", "X", input_qparams.scale, input_qparams.zero_point);
 
     // roi -> Q -> DQ ->
-    NodeArg* roi = MakeTestInput(builder, roi_def);
+    MakeTestInput<float>(builder, "rois", roi_def);
     QuantParams<QuantType> roi_qparams = GetTestInputQuantParams<QuantType>(roi_def);
-    NodeArg* roi_qdq = AddQDQNodePair<QuantType>(builder, roi, roi_qparams.scale, roi_qparams.zero_point);
-    inputs.push_back(roi_qdq);
+    std::string roi_qdq = AddQDQNodePair<QuantType>(builder, "qdq2", "rois", roi_qparams.scale, roi_qparams.zero_point);
 
-    NodeArg* batch_indices = MakeTestInput(builder, batch_indices_def);
-    inputs.push_back(batch_indices);
+    MakeTestInput<int64_t>(builder, "batch_indices", batch_indices_def);
 
-    NodeArg* output = builder.MakeIntermediate();
-    Node& roialign_node = builder.AddNode("RoiAlign", inputs, {output});
-
-    for (const auto& attr : attrs) {
-      roialign_node.AddAttributeProto(attr);
-    }
+    builder.AddNode(
+        "roialign_node",
+        "RoiAlign",
+        {input_qdq, roi_qdq, "batch_indices"},
+        {"roialign_output"},
+        "",
+        attrs);
 
     // op_output -> Q -> DQ -> output
-    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, output, output_qparams[0].scale,
-                                                     output_qparams[0].zero_point);
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(
+        builder, "qdq_out", "roialign_output",
+        output_qparams[0].scale, output_qparams[0].zero_point);
   };
 }
 
@@ -128,12 +127,12 @@ TEST_F(QnnCPUBackendTests, TestRoialign) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "avg"),
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     test::MakeAttribute("mode", "avg"),
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::All);
 }
 
@@ -142,12 +141,12 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_output_half) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half"),
-                     utils::MakeAttribute("mode", "avg"),
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half"),
+                     test::MakeAttribute("mode", "avg"),
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
 
@@ -156,12 +155,12 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_mode_max) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "max"),  //  mode = max is not supported
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     test::MakeAttribute("mode", "max"),  //  mode = max is not supported
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
 
@@ -170,12 +169,12 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "avg"),
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(0)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     test::MakeAttribute("mode", "avg"),
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(0)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
 
@@ -188,12 +187,12 @@ TEST_F(QnnHTPBackendTests, TestRoialign) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "avg"),
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     test::MakeAttribute("mode", "avg"),
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::All,
                     "htp");
 }
@@ -203,12 +202,12 @@ TEST_F(QnnHTPBackendTests, TestRoialign_Unsupported_output_half) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half"),
-                     utils::MakeAttribute("mode", "avg"),
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half"),
+                     test::MakeAttribute("mode", "avg"),
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None,
                     "htp");
 }
@@ -218,12 +217,12 @@ TEST_F(QnnHTPBackendTests, TestRoialign_Unsupported_mode_max) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "max"),  //  mode = max will Unsupported
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     test::MakeAttribute("mode", "max"),  //  mode = max will Unsupported
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None,
                     "htp");
 }
@@ -233,12 +232,12 @@ TEST_F(QnnHTPBackendTests, TestRoialign_Unsupported_sampling_ratio) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
-                    {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                     utils::MakeAttribute("mode", "avg"),
-                     utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(0)),
-                     utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                     utils::MakeAttribute("spatial_scale", 1.0f)},
+                    {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                     test::MakeAttribute("mode", "avg"),
+                     test::MakeAttribute("sampling_ratio", static_cast<int64_t>(0)),
+                     test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                     test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                     test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None,
                     "htp");
 }
@@ -249,12 +248,12 @@ TEST_F(QnnHTPBackendTests, TestRoialignQdq) {
   RunQDQRoiAlignOpTest<uint8_t>(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                                 TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                                 TestInputDef<int64_t>({1}, true, {0}),
-                                {utils::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
-                                 utils::MakeAttribute("mode", "avg"),
-                                 utils::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
-                                 utils::MakeAttribute("output_height", static_cast<int64_t>(1)),
-                                 utils::MakeAttribute("output_width", static_cast<int64_t>(1)),
-                                 utils::MakeAttribute("spatial_scale", 1.0f)},
+                                {test::MakeAttribute("coordinate_transformation_mode", "output_half_pixel"),
+                                 test::MakeAttribute("mode", "avg"),
+                                 test::MakeAttribute("sampling_ratio", static_cast<int64_t>(1)),
+                                 test::MakeAttribute("output_height", static_cast<int64_t>(1)),
+                                 test::MakeAttribute("output_width", static_cast<int64_t>(1)),
+                                 test::MakeAttribute("spatial_scale", 1.0f)},
                                 ExpectedEPNodeAssignment::All);
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Updated roialign_op_test.cc to run correctly on the latest test infrastructure introduced in #23.
- Added a patch to disable related test cases in `onnxruntime_plugin_ep_onnx_test`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

- The pull request for roialign_op_test.cc (#89) was merged before being validated against the latest main branch.
- This change addresses the resulting CI failures and ensures the tests run properly on the updated infrastructure.
