### PR TITLE
Update wheels for deployment

### DIFF
--- a/.github/workflows/qualcomm-internal-build-wheels-nugets-zips.yml
+++ b/.github/workflows/qualcomm-internal-build-wheels-nugets-zips.yml
@@ -136,3 +136,51 @@ jobs:
       run_tests: false  # ARM64ec unit tests are horribly broken (though model tests seem fine).
       upload_test_archive: false
       upload_wheel: true
+
+  build-windows-x86_64_311:
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: x86_64
+      target_py_vsn: "3.11"
+      upload_test_archive: false
+      upload_wheel: true
+
+  build-windows-x86_64_312:
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: x86_64
+      target_py_vsn: "3.12"
+      upload_test_archive: false
+      upload_wheel: true
+
+  build-windows-x86_64_313:
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: x86_64
+      target_py_vsn: "3.13"
+      upload_test_archive: false
+      upload_wheel: true
+
+  build-windows-x86_64_314:
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: x86_64
+      target_py_vsn: "3.14"
+      upload_test_archive: false
+      upload_wheel: true

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -54,7 +54,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ORT windows arm64ec Python 3.11 Wheel
-          path: ${{ github.workspace }}/build/dist
+          path: ${{ github.workspace }}/build/dist/arm64ec
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ORT windows x86_64 Python 3.11 Wheel
+          path: ${{ github.workspace }}/build/dist/x64
   
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -66,7 +72,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ORT windows arm64ec Python 3.12 Wheel
-          path: ${{ github.workspace }}/build/dist
+          path: ${{ github.workspace }}/build/dist/arm64ec
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ORT windows x86_64 Python 3.12 Wheel
+          path: ${{ github.workspace }}/build/dist/x64
   
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -78,7 +90,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ORT windows arm64ec Python 3.13 Wheel
-          path: ${{ github.workspace }}/build/dist
+          path: ${{ github.workspace }}/build/dist/arm64ec
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ORT windows x86_64 Python 3.13 Wheel
+          path: ${{ github.workspace }}/build/dist/x64
 
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -90,12 +108,27 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ORT windows arm64ec Python 3.14 Wheel
-          path: ${{ github.workspace }}/build/dist
+          path: ${{ github.workspace }}/build/dist/arm64ec
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ORT windows x86_64 Python 3.14 Wheel
+          path: ${{ github.workspace }}/build/dist/x64
+
+      - name: Merge AMD wheel
+        run: |
+          # Merge AMD wheels using the merge script
+          source uplevel_venv/bin/activate
+          ./qcom/scripts/upleveling/merge_wheels.sh \
+            "${{ github.workspace }}/build/dist/x64" \
+            "${{ github.workspace }}/build/dist/arm64ec" \
+            "${{ github.workspace }}/build/dist"
 
       - name: Check wheel
         run: |
           source uplevel_venv/bin/activate
-          twine check ${{ github.workspace }}/build/dist/*
+          twine check ${{ github.workspace }}/build/dist/*.whl
 
       - name: Publish
         if: ${{ !inputs.skip_publish }}
@@ -107,7 +140,7 @@ jobs:
           twine upload -r re-artifactory-pypi-test-project \
             --cert ./qcom/scripts/upleveling/certs/artifactory-ca.pem \
             --config-file ./qcom/scripts/upleveling/.pypirc \
-            ${{ github.workspace }}/build/dist/*
+            ${{ github.workspace }}/build/dist/*.whl
 
   upload-nuget-workflow:
     name: "Upload nuget artifatcs to Artifactory"

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -23,6 +23,9 @@ on:
         type: boolean
         default: false
 
+env:
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
+
 jobs:
   build-artifacts:
     uses: ./.github/workflows/qualcomm-internal-build-wheels-nugets-zips.yml
@@ -43,78 +46,90 @@ jobs:
         run: |
           ./qcom/scripts/upleveling/create_uplevel_venv.sh
 
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        with:
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
       # Upload Python wheel to Artifactory
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows arm64 Python 3.11 Wheel
-          path: ${{ github.workspace }}/build/dist
+          name: windows-arm64-py3.11-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows arm64ec Python 3.11 Wheel
-          path: ${{ github.workspace }}/build/dist/arm64ec
+          name: windows-arm64ec-py3.11-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows x86_64 Python 3.11 Wheel
-          path: ${{ github.workspace }}/build/dist/x64
-  
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ORT windows arm64 Python 3.12 Wheel
-          path: ${{ github.workspace }}/build/dist
-  
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ORT windows arm64ec Python 3.12 Wheel
-          path: ${{ github.workspace }}/build/dist/arm64ec
+          name: windows-x86_64-py3.11-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows x86_64 Python 3.12 Wheel
-          path: ${{ github.workspace }}/build/dist/x64
-  
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ORT windows arm64 Python 3.13 Wheel
-          path: ${{ github.workspace }}/build/dist
-  
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ORT windows arm64ec Python 3.13 Wheel
-          path: ${{ github.workspace }}/build/dist/arm64ec
+          name: windows-arm64-py3.12-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows x86_64 Python 3.13 Wheel
-          path: ${{ github.workspace }}/build/dist/x64
+          name: windows-arm64ec-py3.12-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows arm64 Python 3.14 Wheel
-          path: ${{ github.workspace }}/build/dist
+          name: windows-x86_64-py3.12-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows arm64ec Python 3.14 Wheel
-          path: ${{ github.workspace }}/build/dist/arm64ec
+          name: windows-arm64-py3.13-wheels
 
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows x86_64 Python 3.14 Wheel
-          path: ${{ github.workspace }}/build/dist/x64
+          name: windows-arm64ec-py3.13-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.13-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.14-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.14-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.14-wheels
+
+      - name: Consolidate Wheels
+        run: |
+          mkdir "${{ github.workspace }}/build/dist"
+          cp "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
+
+      - name: Consolidate Wheels
+        run: |
+          mkdir "${{ github.workspace }}/build/dist/arm64ec"
+          cp "${{ github.workspace }}/build/windows-arm64ec/Release/Release/dist/"*.whl "${{ github.workspace }}/build/dist/arm64ec"
+
+      - name: Consolidate Wheels
+        run: |
+          mkdir "${{ github.workspace }}/build/dist/x64"
+          cp "${{ github.workspace }}/build/windows-x86_64/Release/dist/"*.whl "${{ github.workspace }}/build/dist/x64"
 
       - name: Merge AMD wheel
         run: |

--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -18,7 +18,7 @@ try:
 
     _lib_dir_path = setup_library_path()
     LIB_DIR_FULL_PATH = os.path.abspath(_lib_dir_path)
-except (ImportError, Exception):
+except ImportError:
     # Silently fall back to default LIB_DIR_FULL_PATH if platform loader is unavailable
     pass
 

--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -10,6 +10,18 @@ from .build_and_package_info import __version__  # noqa: F401
 
 EP_NAME = "QNNExecutionProvider"
 
+LIB_DIR_FULL_PATH = os.path.dirname(os.path.abspath(__file__))
+
+# Platform-aware library loading
+try:
+    from .platform_loader import setup_library_path
+
+    _lib_dir_path = setup_library_path()
+    LIB_DIR_FULL_PATH = os.path.abspath(_lib_dir_path)
+except (ImportError, Exception):
+    # Silently fall back to default LIB_DIR_FULL_PATH if platform loader is unavailable
+    pass
+
 
 def get_ep_names():
     return [EP_NAME]
@@ -20,16 +32,16 @@ def get_ep_name():
 
 
 def get_library_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "onnxruntime_providers_qnn.dll")
+    return os.path.join(LIB_DIR_FULL_PATH, "onnxruntime_providers_qnn.dll")
 
 
 def get_qnn_cpu_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "QnnCpu.dll")
+    return os.path.join(LIB_DIR_FULL_PATH, "QnnCpu.dll")
 
 
 def get_qnn_gpu_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "QnnGpu.dll")
+    return os.path.join(LIB_DIR_FULL_PATH, "QnnGpu.dll")
 
 
 def get_qnn_htp_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "QnnHtp.dll")
+    return os.path.join(LIB_DIR_FULL_PATH, "QnnHtp.dll")

--- a/qcom/scripts/upleveling/merge_wheels.py
+++ b/qcom/scripts/upleveling/merge_wheels.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# ==============================================================================
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# All Rights Reserved.
+# Confidential and Proprietary - Qualcomm Technologies, Inc.
+#
+# ==============================================================================
+
+"""
+Merge two architecture-specific wheels into a unified wheel package.
+
+This script takes AMD64 and ARM64EC wheels and combines them into a single
+wheel with both library sets in separate subdirectories.
+"""
+
+import argparse
+import logging
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def extract_wheel(wheel_path, extract_dir):
+    """Extract a wheel file to a directory."""
+    logging.info(f"  Extracting: {wheel_path}")
+    with zipfile.ZipFile(wheel_path, "r") as zip_ref:
+        zip_ref.extractall(extract_dir)
+    return extract_dir
+
+
+def get_package_dir(extract_dir):
+    """Find the main package directory in extracted wheel."""
+    extract_path = Path(extract_dir)
+    # Look for onnxruntime_qnn directory
+    for item in extract_path.iterdir():
+        if item.is_dir() and item.name.startswith("onnxruntime"):
+            if not item.name.endswith(".dist-info"):
+                return item
+    raise ValueError(f"Could not find package directory in {extract_dir}")
+
+
+def is_library_file(filename):
+    """Check if a file is a library file that should be moved."""
+    suffixes = {".dll", ".so", ".cat", ".pyd", ".dylib"}
+    return Path(filename).suffix.lower() in suffixes
+
+
+def merge_wheels(amd64_wheel, arm64ec_wheel, output_folder):
+    """
+    Merge two architecture-specific wheels into a unified wheel.
+
+    Args:
+        amd64_wheel: Path to AMD64 wheel file
+        arm64ec_wheel: Path to ARM64EC wheel file
+        output_folder: Output folder path for output unified wheel
+    """
+    logging.info("=" * 80)
+    logging.info("Merging Wheels into Unified Package")
+    logging.info("=" * 80)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Extract both wheels
+        logging.info("[Step 1] Extracting wheels...")
+        amd64_dir = temp_path / "amd64"
+        extract_wheel(amd64_wheel, amd64_dir)
+
+        arm64ec_dir = temp_path / "arm64ec"
+        extract_wheel(arm64ec_wheel, arm64ec_dir)
+
+        # Create unified structure
+        logging.info("[Step 2] Creating unified structure...")
+        unified_dir = temp_path / "unified"
+        unified_dir.mkdir()
+
+        # Get package directories
+        amd64_pkg = get_package_dir(amd64_dir)
+        arm64ec_pkg = get_package_dir(arm64ec_dir)
+        logging.info(f"  AMD64 package: {amd64_pkg.name}")
+        logging.info(f"  ARM64EC package: {arm64ec_pkg.name}")
+
+        # Copy AMD64 package as base
+        logging.info("[Step 3] Copying base package structure...")
+        unified_pkg = unified_dir / amd64_pkg.name
+        shutil.copytree(amd64_pkg, unified_pkg)
+        logging.info(f"  Created: {unified_pkg.name}/")
+
+        # Create libs directory structure
+        libs_dir = unified_pkg / "libs"
+        libs_dir.mkdir(exist_ok=True)
+
+        amd64_libs = libs_dir / "amd64"
+        arm64ec_libs = libs_dir / "arm64ec"
+
+        # Move AMD64 libraries to libs/amd64/
+        logging.info("[Step 4] Organizing AMD64 libraries...")
+        amd64_libs.mkdir()
+        amd64_lib_count = 0
+        for item in unified_pkg.iterdir():
+            if item.is_file() and is_library_file(item.name):
+                dest = amd64_libs / item.name
+                shutil.move(str(item), str(dest))
+                amd64_lib_count += 1
+                logging.info(f"  Moved: {item.name} -> libs/amd64/")
+
+        # Copy ARM64EC libraries to libs/arm64ec/
+        logging.info("[Step 5] Copying ARM64EC libraries...")
+        arm64ec_libs.mkdir()
+        arm64ec_lib_count = 0
+        for item in arm64ec_pkg.iterdir():
+            if item.is_file() and is_library_file(item.name):
+                dest = arm64ec_libs / item.name
+                shutil.copy2(str(item), str(dest))
+                arm64ec_lib_count += 1
+                logging.info(f"  Copied: {item.name} -> libs/arm64ec/")
+
+        # Copy platform_loader.py to package
+        logging.info("[Step 6] Adding platform_loader.py...")
+        platform_loader_src = Path(__file__).parent / "platform_loader.py"
+        if platform_loader_src.exists():
+            shutil.copy2(platform_loader_src, unified_pkg / "platform_loader.py")
+            logging.info("  Added: platform_loader.py")
+        else:
+            logging.info(f"  WARNING: platform_loader.py not found at {platform_loader_src}")
+            logging.info("  You may need to create this file manually")
+
+        # Update __init__.py to call platform loader
+        logging.info("[Step 7] Updating __init__.py...")
+        init_file = unified_pkg / "__init__.py"
+        if init_file.exists():
+            with open(init_file, encoding="utf-8") as f:
+                init_content = f.read()
+
+            # Check if platform loader is already added
+            if "platform_loader" not in init_content:
+                init_lines = init_content.splitlines(keepends=True)
+
+                # Add platform loader import at the beginning
+                loader_code = """# Platform-aware library loading
+try:
+    from .platform_loader import setup_library_path
+    _lib_dir_path = setup_library_path()
+except Exception as e:
+    import warnings
+    warnings.warn(f"Failed to setup platform-specific library path: {e}")
+"""
+                processed_lines = []
+                added = False
+                str_to_be_replaced = "os.path.dirname(os.path.abspath(__file__))"
+                for line in init_lines:
+                    if not added and not line.strip().startswith("#"):
+                        processed_lines.append("\n" + loader_code + "\n")
+                        added = True
+                    new_line = line
+                    if str_to_be_replaced in line:
+                        new_line = line.replace(str_to_be_replaced, "os.path.abspath(_lib_dir_path)")
+                    processed_lines.append(new_line)
+
+                with open(init_file, "w", encoding="utf-8") as f:
+                    f.writelines(processed_lines)
+                logging.info("  Updated: __init__.py with platform loader")
+            else:
+                logging.info("  Skipped: __init__.py already has platform loader")
+        else:
+            logging.info("  WARNING: __init__.py not found")
+
+        # Copy dist-info from AMD64 wheel
+        logging.info("[Step 8] Copying dist-info...")
+        for item in amd64_dir.iterdir():
+            if item.name.endswith(".dist-info"):
+                dest = unified_dir / item.name
+                shutil.copytree(item, dest)
+                logging.info(f"  Copied: {item.name}/")
+
+        # Create the unified wheel
+        logging.info("[Step 9] Creating unified wheel...")
+        Path(output_folder).mkdir(parents=True, exist_ok=True)
+        subprocess.run(["wheel", "pack", unified_dir, "-d", output_folder], check=True)
+
+        # Log summary
+        logging.info("=" * 80)
+        logging.info("Merge Complete!")
+        logging.info("=" * 80)
+        logging.info("Library Summary:")
+        logging.info(f"  AMD64 libraries: {amd64_lib_count}")
+        logging.info(f"  ARM64EC libraries: {arm64ec_lib_count}")
+        logging.info(f"  Total: {amd64_lib_count + arm64ec_lib_count}")
+        logging.info("Structure:")
+        logging.info(f"  {unified_pkg.name}/")
+        logging.info("    ├── libs/")
+        logging.info(f"    │   ├── amd64/     ({amd64_lib_count} files)")
+        logging.info(f"    │   └── arm64ec/    ({arm64ec_lib_count} files)")
+        logging.info("    ├── platform_loader.py")
+        logging.info("    └── __init__.py (with platform detection)")
+        logging.info("=" * 80)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge AMD64 and ARM64EC wheels into a unified package",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Example:
+  python merge_wheels.py \\
+      --amd64-wheel dist/onnxruntime_qnn-1.0.0-py3-none-win_amd64.whl \\
+      --arm64ec-wheel dist/onnxruntime_qnn-1.0.0-py3-none-win_arm64.whl \\
+      --output-folder dist
+        """,
+    )
+    parser.add_argument("--amd64-wheel", required=True, help="Path to AMD64 wheel file")
+    parser.add_argument("--arm64ec-wheel", required=True, help="Path to ARM64EC wheel file")
+    parser.add_argument("--output-folder", required=True, help="Output folder path for output unified wheel")
+
+    args = parser.parse_args()
+
+    # Validate input files exist
+    amd64_path = Path(args.amd64_wheel)
+    arm64ec_path = Path(args.arm64ec_wheel)
+
+    if not amd64_path.exists():
+        raise FileNotFoundError(f"AMD64 wheel not found: {args.amd64_wheel}")
+    if not arm64ec_path.exists():
+        raise FileNotFoundError(f"ARM64EC wheel not found: {args.arm64ec_wheel}")
+
+    # Perform merge
+    merge_wheels(args.amd64_wheel, args.arm64ec_wheel, args.output_folder)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        level=logging.INFO,
+    )
+    main()

--- a/qcom/scripts/upleveling/merge_wheels.py
+++ b/qcom/scripts/upleveling/merge_wheels.py
@@ -128,48 +128,8 @@ def merge_wheels(amd64_wheel, arm64ec_wheel, output_folder):
             logging.info(f"  WARNING: platform_loader.py not found at {platform_loader_src}")
             logging.info("  You may need to create this file manually")
 
-        # Update __init__.py to call platform loader
-        logging.info("[Step 7] Updating __init__.py...")
-        init_file = unified_pkg / "__init__.py"
-        if init_file.exists():
-            with open(init_file, encoding="utf-8") as f:
-                init_content = f.read()
-
-            # Check if platform loader is already added
-            if "platform_loader" not in init_content:
-                init_lines = init_content.splitlines(keepends=True)
-
-                # Add platform loader import at the beginning
-                loader_code = """# Platform-aware library loading
-try:
-    from .platform_loader import setup_library_path
-    _lib_dir_path = setup_library_path()
-except Exception as e:
-    import warnings
-    warnings.warn(f"Failed to setup platform-specific library path: {e}")
-"""
-                processed_lines = []
-                added = False
-                str_to_be_replaced = "os.path.dirname(os.path.abspath(__file__))"
-                for line in init_lines:
-                    if not added and not line.strip().startswith("#"):
-                        processed_lines.append("\n" + loader_code + "\n")
-                        added = True
-                    new_line = line
-                    if str_to_be_replaced in line:
-                        new_line = line.replace(str_to_be_replaced, "os.path.abspath(_lib_dir_path)")
-                    processed_lines.append(new_line)
-
-                with open(init_file, "w", encoding="utf-8") as f:
-                    f.writelines(processed_lines)
-                logging.info("  Updated: __init__.py with platform loader")
-            else:
-                logging.info("  Skipped: __init__.py already has platform loader")
-        else:
-            logging.info("  WARNING: __init__.py not found")
-
         # Copy dist-info from AMD64 wheel
-        logging.info("[Step 8] Copying dist-info...")
+        logging.info("[Step 7] Copying dist-info...")
         for item in amd64_dir.iterdir():
             if item.name.endswith(".dist-info"):
                 dest = unified_dir / item.name
@@ -177,7 +137,7 @@ except Exception as e:
                 logging.info(f"  Copied: {item.name}/")
 
         # Create the unified wheel
-        logging.info("[Step 9] Creating unified wheel...")
+        logging.info("[Step 8] Creating unified wheel...")
         Path(output_folder).mkdir(parents=True, exist_ok=True)
         subprocess.run(["wheel", "pack", unified_dir, "-d", output_folder], check=True)
 

--- a/qcom/scripts/upleveling/merge_wheels.py
+++ b/qcom/scripts/upleveling/merge_wheels.py
@@ -16,36 +16,25 @@ wheel with both library sets in separate subdirectories.
 
 import argparse
 import logging
-import shutil
 import subprocess
 import tempfile
 import zipfile
 from pathlib import Path
 
 
-def extract_wheel(wheel_path, extract_dir):
-    """Extract a wheel file to a directory."""
-    logging.info(f"  Extracting: {wheel_path}")
-    with zipfile.ZipFile(wheel_path, "r") as zip_ref:
-        zip_ref.extractall(extract_dir)
-    return extract_dir
-
-
-def get_package_dir(extract_dir):
-    """Find the main package directory in extracted wheel."""
-    extract_path = Path(extract_dir)
-    # Look for onnxruntime_qnn directory
-    for item in extract_path.iterdir():
-        if item.is_dir() and item.name.startswith("onnxruntime"):
-            if not item.name.endswith(".dist-info"):
-                return item
-    raise ValueError(f"Could not find package directory in {extract_dir}")
-
-
 def is_library_file(filename):
     """Check if a file is a library file that should be moved."""
     suffixes = {".dll", ".so", ".cat", ".pyd", ".dylib"}
     return Path(filename).suffix.lower() in suffixes
+
+
+def get_package_name_from_zip(zip_file):
+    """Find the main package directory name in a wheel zip file."""
+    for name in zip_file.namelist():
+        parts = name.split("/")
+        if len(parts) > 0 and parts[0].startswith("onnxruntime_qnn") and not parts[0].endswith(".dist-info"):
+            return parts[0]
+    raise ValueError("Could not find package directory in wheel")
 
 
 def merge_wheels(amd64_wheel, arm64ec_wheel, output_folder):
@@ -61,102 +50,100 @@ def merge_wheels(amd64_wheel, arm64ec_wheel, output_folder):
     logging.info("Merging Wheels into Unified Package")
     logging.info("=" * 80)
 
+    output_path = Path(output_folder)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Generate output filename
+    output_wheel = output_path / Path(amd64_wheel).name
+
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
+        temp_wheel = Path(temp_dir) / "temp.whl"
 
-        # Extract both wheels
-        logging.info("[Step 1] Extracting wheels...")
-        amd64_dir = temp_path / "amd64"
-        extract_wheel(amd64_wheel, amd64_dir)
+        # Open AMD64 wheel and get package name
+        logging.info("[Step 1] Opening AMD64 wheel as base...")
+        with zipfile.ZipFile(amd64_wheel, "r") as amd64_zip:
+            package_name = get_package_name_from_zip(amd64_zip)
+            logging.info(f"  Package: {package_name}")
 
-        arm64ec_dir = temp_path / "arm64ec"
-        extract_wheel(arm64ec_wheel, arm64ec_dir)
+            # Create new wheel with reorganized AMD64 files
+            logging.info("[Step 2] Reorganizing AMD64 libraries...")
+            amd64_lib_count = 0
 
-        # Create unified structure
-        logging.info("[Step 2] Creating unified structure...")
-        unified_dir = temp_path / "unified"
-        unified_dir.mkdir()
+            with zipfile.ZipFile(temp_wheel, "w", zipfile.ZIP_DEFLATED) as output_zip:
+                # Copy all files, moving libraries to libs/amd64/
+                for item in amd64_zip.infolist():
+                    data = amd64_zip.read(item.filename)
 
-        # Get package directories
-        amd64_pkg = get_package_dir(amd64_dir)
-        arm64ec_pkg = get_package_dir(arm64ec_dir)
-        logging.info(f"  AMD64 package: {amd64_pkg.name}")
-        logging.info(f"  ARM64EC package: {arm64ec_pkg.name}")
+                    # Check if this is a library file in the package root
+                    if item.filename.startswith(f"{package_name}/") and is_library_file(item.filename):
+                        parts = item.filename.split("/")
+                        if len(parts) == 2:  # package_name/filename
+                            # Move to libs/amd64/
+                            new_filename = f"{package_name}/libs/amd64/{parts[1]}"
+                            output_zip.writestr(new_filename, data)
+                            amd64_lib_count += 1
+                            logging.info(f"  Moved: {parts[1]} -> libs/amd64/")
+                            continue
 
-        # Copy AMD64 package as base
-        logging.info("[Step 3] Copying base package structure...")
-        unified_pkg = unified_dir / amd64_pkg.name
-        shutil.copytree(amd64_pkg, unified_pkg)
-        logging.info(f"  Created: {unified_pkg.name}/")
+                    # Copy file as-is
+                    output_zip.writestr(item, data)
 
-        # Create libs directory structure
-        libs_dir = unified_pkg / "libs"
-        libs_dir.mkdir(exist_ok=True)
-
-        amd64_libs = libs_dir / "amd64"
-        arm64ec_libs = libs_dir / "arm64ec"
-
-        # Move AMD64 libraries to libs/amd64/
-        logging.info("[Step 4] Organizing AMD64 libraries...")
-        amd64_libs.mkdir()
-        amd64_lib_count = 0
-        for item in unified_pkg.iterdir():
-            if item.is_file() and is_library_file(item.name):
-                dest = amd64_libs / item.name
-                shutil.move(str(item), str(dest))
-                amd64_lib_count += 1
-                logging.info(f"  Moved: {item.name} -> libs/amd64/")
-
-        # Copy ARM64EC libraries to libs/arm64ec/
-        logging.info("[Step 5] Copying ARM64EC libraries...")
-        arm64ec_libs.mkdir()
+        # Append ARM64EC libraries
+        logging.info("[Step 3] Appending ARM64EC libraries...")
         arm64ec_lib_count = 0
-        for item in arm64ec_pkg.iterdir():
-            if item.is_file() and is_library_file(item.name):
-                dest = arm64ec_libs / item.name
-                shutil.copy2(str(item), str(dest))
-                arm64ec_lib_count += 1
-                logging.info(f"  Copied: {item.name} -> libs/arm64ec/")
 
-        # Copy platform_loader.py to package
-        logging.info("[Step 6] Adding platform_loader.py...")
+        with zipfile.ZipFile(arm64ec_wheel, "r") as arm64ec_zip, zipfile.ZipFile(temp_wheel, "a") as output_zip:
+            for item in arm64ec_zip.infolist():
+                # Only add library files from package root
+                if item.filename.startswith(f"{package_name}/") and is_library_file(item.filename):
+                    parts = item.filename.split("/")
+                    if len(parts) == 2:
+                        # Add to libs/arm64ec/
+                        new_filename = f"{package_name}/libs/arm64ec/{parts[1]}"
+                        data = arm64ec_zip.read(item.filename)
+                        output_zip.writestr(new_filename, data)
+                        arm64ec_lib_count += 1
+                        logging.info(f"  Added: {parts[1]} -> libs/arm64ec/")
+
+        # Append platform_loader.py
+        logging.info("[Step 4] Appending platform_loader.py...")
         platform_loader_src = Path(__file__).parent / "platform_loader.py"
-        if platform_loader_src.exists():
-            shutil.copy2(platform_loader_src, unified_pkg / "platform_loader.py")
-            logging.info("  Added: platform_loader.py")
-        else:
-            logging.info(f"  WARNING: platform_loader.py not found at {platform_loader_src}")
-            logging.info("  You may need to create this file manually")
 
-        # Copy dist-info from AMD64 wheel
-        logging.info("[Step 7] Copying dist-info...")
-        for item in amd64_dir.iterdir():
-            if item.name.endswith(".dist-info"):
-                dest = unified_dir / item.name
-                shutil.copytree(item, dest)
-                logging.info(f"  Copied: {item.name}/")
+        with zipfile.ZipFile(temp_wheel, "a") as output_zip:
+            if platform_loader_src.exists():
+                output_zip.write(platform_loader_src, f"{package_name}/platform_loader.py")
+                logging.info("  Added: platform_loader.py")
+            else:
+                logging.warning(f"  platform_loader.py not found at {platform_loader_src}")
 
-        # Create the unified wheel
-        logging.info("[Step 8] Creating unified wheel...")
-        Path(output_folder).mkdir(parents=True, exist_ok=True)
-        subprocess.run(["wheel", "pack", unified_dir, "-d", output_folder], check=True)
+        # Extract and repack with wheel pack for proper compression
+        logging.info("[Step 5] Repacking with wheel pack for compression...")
+        extract_dir = Path(temp_dir) / "extract"
+        extract_dir.mkdir()
 
-        # Log summary
-        logging.info("=" * 80)
-        logging.info("Merge Complete!")
-        logging.info("=" * 80)
-        logging.info("Library Summary:")
-        logging.info(f"  AMD64 libraries: {amd64_lib_count}")
-        logging.info(f"  ARM64EC libraries: {arm64ec_lib_count}")
-        logging.info(f"  Total: {amd64_lib_count + arm64ec_lib_count}")
-        logging.info("Structure:")
-        logging.info(f"  {unified_pkg.name}/")
-        logging.info("    ├── libs/")
-        logging.info(f"    │   ├── amd64/     ({amd64_lib_count} files)")
-        logging.info(f"    │   └── arm64ec/    ({arm64ec_lib_count} files)")
-        logging.info("    ├── platform_loader.py")
-        logging.info("    └── __init__.py (with platform detection)")
-        logging.info("=" * 80)
+        with zipfile.ZipFile(temp_wheel, "r") as zip_ref:
+            zip_ref.extractall(extract_dir)
+
+        subprocess.run(["wheel", "pack", str(extract_dir), "-d", str(output_path)], check=True)
+        logging.info(f"  Created: {Path(amd64_wheel).name}")
+
+    # Log summary
+    logging.info("=" * 80)
+    logging.info("Merge Complete!")
+    logging.info("=" * 80)
+    logging.info("Library Summary:")
+    logging.info(f"  AMD64 libraries: {amd64_lib_count}")
+    logging.info(f"  ARM64EC libraries: {arm64ec_lib_count}")
+    logging.info(f"  Total: {amd64_lib_count + arm64ec_lib_count}")
+    logging.info("Structure:")
+    logging.info(f"  {package_name}/")
+    logging.info("    ├── libs/")
+    logging.info(f"    │   ├── amd64/     ({amd64_lib_count} files)")
+    logging.info(f"    │   └── arm64ec/    ({arm64ec_lib_count} files)")
+    logging.info("    ├── platform_loader.py")
+    logging.info("    └── __init__.py")
+    logging.info(f"Output: {output_wheel}")
+    logging.info("=" * 80)
 
 
 def main():

--- a/qcom/scripts/upleveling/merge_wheels.sh
+++ b/qcom/scripts/upleveling/merge_wheels.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+# Script to merge wheels
+# Usage: merge_wheels.sh <amd_dir> <arm64ec_dir> <output_dir>
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <amd_dir> <arm64ec_dir> <output_dir>"
+    exit 1
+fi
+
+AMD_DIR="$1"
+ARM64EC_DIR="$2"
+OUTPUT_DIR="$3"
+
+if [ ! -d "$AMD_DIR" ]; then
+    echo "Error: AMD directory '$AMD_DIR' does not exist"
+    exit 1
+fi
+
+if [ ! -d "$ARM64EC_DIR" ]; then
+    echo "Error: ARM64EC directory '$ARM64EC_DIR' does not exist"
+    exit 1
+fi
+
+# Get the repository root directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Upload files using --netrc-file
+find "$AMD_DIR" -name "*.whl" -type f -print0 | while IFS= read -r -d '' file; do
+    file_basename=$(basename "$file")
+
+    echo "Merge AMD and ARM64EC wheels with filename $file_basename..."
+    # The name of the arm64ec wheel should be the same as the name of the amd64 wheel.
+    python ./qcom/scripts/upleveling/merge_wheels.py \
+        --amd64-wheel $file \
+        --arm64ec-wheel $ARM64EC_DIR/$file_basename \
+        --output-folder $OUTPUT_DIR
+    echo "Successfully merge $file_basename"
+done
+
+echo "All AMD wheels merged successfully"

--- a/qcom/scripts/upleveling/merge_wheels.sh
+++ b/qcom/scripts/upleveling/merge_wheels.sh
@@ -33,12 +33,22 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 find "$AMD_DIR" -name "*.whl" -type f -print0 | while IFS= read -r -d '' file; do
     file_basename=$(basename "$file")
 
-    echo "Merge AMD and ARM64EC wheels with filename $file_basename..."
     # The name of the arm64ec wheel should be the same as the name of the amd64 wheel.
+    arm64ec_file_path="$ARM64EC_DIR/$file_basename"
+    if [ ! -f "$arm64ec_file_path" ]; then
+        echo "Warning: ARM64EC wheel does not exist for $file_basename, trying win_arm64..."
+        arm64ec_basename="${file_basename/win_amd64/win_arm64}"
+        arm64ec_file_path="$ARM64EC_DIR/$arm64ec_basename"
+        if [ ! -f "$arm64ec_file_path" ]; then
+            echo "Error: ARM64EC wheel does not exist"
+            exit 1
+        fi
+    fi
+    echo "Merge AMD and ARM64EC wheels with filename $file_basename..."
     python ./qcom/scripts/upleveling/merge_wheels.py \
-        --amd64-wheel $file \
-        --arm64ec-wheel $ARM64EC_DIR/$file_basename \
-        --output-folder $OUTPUT_DIR
+        --amd64-wheel "$file" \
+        --arm64ec-wheel "$arm64ec_file_path" \
+        --output-folder "$OUTPUT_DIR"
     echo "Successfully merge $file_basename"
 done
 

--- a/qcom/scripts/upleveling/platform_loader.py
+++ b/qcom/scripts/upleveling/platform_loader.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# ==============================================================================
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# All Rights Reserved.
+# Confidential and Proprietary - Qualcomm Technologies, Inc.
+#
+# ==============================================================================
+
+"""
+Platform-aware library loader for ONNX Runtime QNN
+Automatically selects the correct library path based on runtime architecture
+"""
+
+import os
+import platform
+import sys
+from pathlib import Path
+
+
+def get_runtime_architecture():
+    """
+    Detect the current runtime architecture.
+
+    Returns:
+        str: 'amd64' for native AMD64 execution
+             'arm64ec' for ARM64 device running x64 emulated code
+             'arm64' for native ARM64 execution
+
+    Raises:
+        RuntimeError: If architecture is unsupported
+    """
+    machine = platform.machine().lower()
+
+    # Check if running on ARM64
+    if machine in ("arm64", "aarch64"):
+        # Check if this is an x64 emulated process on ARM64
+        # On Windows ARM64, x64 emulated processes have PROCESSOR_ARCHITECTURE=AMD64
+        processor_arch = os.environ.get("PROCESSOR_ARCHITECTURE", "").upper()
+        if processor_arch == "AMD64":
+            return "arm64ec"  # ARM64 device running x64 emulated
+        return "arm64"  # Native ARM64
+
+    # Native AMD64 execution
+    if machine in ("amd64", "x86_64", "x64"):
+        return "amd64"
+
+    raise RuntimeError(f"Unsupported architecture: {machine}")
+
+
+def get_library_path():
+    """
+    Get the appropriate library path based on runtime architecture.
+
+    Returns:
+        Path: Path to the directory containing the correct libraries
+
+    Raises:
+        RuntimeError: If architecture is unsupported or libraries not found
+    """
+    arch = get_runtime_architecture()
+
+    # Get the package installation directory
+    package_dir = Path(__file__).parent
+    libs_dir = package_dir / "libs"
+
+    # Select the appropriate library subdirectory
+    if arch == "amd64" or arch == "arm64ec":
+        lib_path = libs_dir / arch
+    else:
+        raise RuntimeError(f"No libraries available for architecture: {arch}")
+
+    if not lib_path.exists():
+        raise RuntimeError(
+            f"Library path not found: {lib_path}\nDetected architecture: {arch}\nPackage directory: {package_dir}"
+        )
+
+    return lib_path
+
+
+def setup_library_path():
+    """
+    Setup the library search path for the current platform.
+    This should be called during package initialization.
+
+    Returns:
+        Path: The library path that was added to the search path
+    """
+    lib_path = get_library_path()
+
+    # Add to DLL search path (Windows)
+    if sys.platform == "win32":
+        # Python 3.8+ has os.add_dll_directory
+        if hasattr(os, "add_dll_directory"):
+            os.add_dll_directory(str(lib_path))
+
+        # Also add to PATH for older Python versions or as fallback
+        os.environ["PATH"] = str(lib_path) + os.pathsep + os.environ.get("PATH", "")
+
+    # Add to LD_LIBRARY_PATH (Linux)
+    elif sys.platform.startswith("linux"):
+        ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+        os.environ["LD_LIBRARY_PATH"] = str(lib_path) + os.pathsep + ld_path
+
+    return lib_path
+
+
+def get_platform_info():
+    """
+    Get detailed platform information for debugging.
+
+    Returns:
+        dict: Platform information including architecture, Python version, etc.
+    """
+    return {
+        "runtime_architecture": get_runtime_architecture(),
+        "platform_machine": platform.machine(),
+        "platform_system": platform.system(),
+        "platform_version": platform.version(),
+        "python_version": sys.version,
+        "processor_architecture": os.environ.get("PROCESSOR_ARCHITECTURE", "N/A"),
+        "library_path": str(get_library_path()),
+    }
+
+
+if __name__ == "__main__":
+    # Print platform information when run as a script
+    import json
+
+    info = get_platform_info()
+    print(json.dumps(info, indent=2))

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -264,6 +264,19 @@ class WheelUpleveler(ArtifactUpleveler):
                 with open(record_file, "w") as f:
                     f.write(record.replace(self.args.version_from, self.args.version_to))
 
+                # Update build_and_package_info.py if it exists
+                for root, _dirs, files in os.walk(tmp_dir):
+                    if "build_and_package_info.py" in files:
+                        build_info_file = os.path.join(root, "build_and_package_info.py")
+                        with open(build_info_file) as f:
+                            lines = f.readlines()
+                        with open(build_info_file, "w") as f:
+                            f.writelines(
+                                f"__version__ = '{self.args.version_to}'\n" if "__version__" in line else line
+                                for line in lines
+                            )
+                        break
+
                 # Rename dist-info directory
                 new_dist_info = dist_info_file.replace(self.args.version_from, self.args.version_to)
                 os.rename(

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -272,7 +272,7 @@ class WheelUpleveler(ArtifactUpleveler):
                             lines = f.readlines()
                         with open(build_info_file, "w") as f:
                             f.writelines(
-                                f"__version__ = '{self.args.version_to}'\n" if "__version__" in line else line
+                                f"__version__ = '{self.args.version_to}'\n" if line.startswith("__version__") else line
                                 for line in lines
                             )
                         break

--- a/setup.py
+++ b/setup.py
@@ -172,6 +172,7 @@ else:
         "QnnSaver.dll",
         "QnnSystem.dll",
         "QnnHtpPrepare.dll",
+        "HtpPrepare.dll",
         "QnnHtpV81Stub.dll",
         "libQnnHtpV81Skel.so",
         "libqnnhtpv81.cat",

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -64,6 +64,7 @@ def get_qnn_asset_file_list():
             "QnnSaver.dll",
             "QnnSystem.dll",
             "QnnHtpPrepare.dll",
+            "HtpPrepare.dll",
             "QnnHtpV81Stub.dll",
             "libQnnHtpV81Skel.so",
             "libqnnhtpv81.cat",
@@ -153,7 +154,7 @@ def build_zip_asset(
             zip_name += f"{version_suffix}"
         if zip_name_suffix:
             zip_name += f"-{zip_name_suffix}"
-        zip_name += f"-{platform_name}-{arch}-{config}.zip"
+        zip_name += f"-{platform_name}-{arch}.zip"
 
         zip_path = Path(dist_dir) / zip_name
 


### PR DESCRIPTION
### Description
Build x86_64 wheels and add a step to merge wheels related to amd.
Minor fix to the uplevel script to update the version in build_and_package_info.py.


### Motivation and Context
We want to run QNN-EP on windows x64 device, but we only have arm64ec wheel currently. It doesn't work if we install the arm64ec wheel on windows x64 device, so we need to add x64 wheel for release.
However, another problem is that the name of x64 wheel is the same as the name of arm64ec wheel, which could cause confusion and result in one wheel overwriting the other.

- x64 wheel name: onnxruntime_qnn-2.0.0-cp311-cp311-win_amd64.whl
- arm64ec wheel name: onnxruntime_qnn-2.0.0-cp311-cp311-win_amd64.whl

Therefore, this PR aims to merge the x64 and arm64ec wheels into a single wheel so that the wheel can run on both Windows-x64 and Windows-arm64 devices.