### PR TITLE
Fix ScatterElements UT failures by aligning input encodings

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1452,19 +1452,26 @@ inline GetTestQDQModelFn<QuantType> BuildQDQOpTestCase(
     const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
     const std::string& op_domain = kOnnxDomain,
     bool use_contrib_qdq = false,
-    AllocatorPtr input_allocator = nullptr) {
+    AllocatorPtr input_allocator = nullptr,
+    bool combine_quant_inputs_qparams = false) {
   return [node_name, op_type, quant_input_defs, non_quant_input_defs, quant_input_defs_2, attrs, op_domain,
-          use_contrib_qdq, input_allocator](
+          use_contrib_qdq, input_allocator, combine_quant_inputs_qparams](
              ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
     std::vector<std::string> op_input_names;
 
     op_input_names.reserve(quant_input_defs.size() + non_quant_input_defs.size() + quant_input_defs_2.size());
 
+    std::vector<TestInputDef<float>> combined_input_defs;
+    combined_input_defs.reserve(quant_input_defs.size() + quant_input_defs_2.size());
+    combined_input_defs.insert(combined_input_defs.end(), quant_input_defs.begin(), quant_input_defs.end());
+    combined_input_defs.insert(combined_input_defs.end(), quant_input_defs_2.begin(), quant_input_defs_2.end());
+    QuantParams<QuantType> combined_input_qparams = GetTestInputsQuantParams<QuantType>(combined_input_defs);
+
     // Create QDQ inputs
     for (size_t i = 0; i < quant_input_defs.size(); i++) {
       const std::string tmp_name = "quant_input_defs_" + std::to_string(i);
       MakeTestInput<float>(builder, tmp_name, quant_input_defs[i], input_allocator);
-      QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(quant_input_defs[i]);
+      QuantParams<QuantType> input_qparams = combine_quant_inputs_qparams ? combined_input_qparams : GetTestInputQuantParams<QuantType>(quant_input_defs[i]);
 
       op_input_names.push_back(
           AddQDQNodePair<QuantType>(builder, "qdq_in" + std::to_string(i), tmp_name, input_qparams.scale,
@@ -1482,7 +1489,7 @@ inline GetTestQDQModelFn<QuantType> BuildQDQOpTestCase(
     for (size_t i = 0; i < quant_input_defs_2.size(); i++) {
       const std::string tmp_name = "quant_input_defs_2_" + std::to_string(i);
       MakeTestInput<float>(builder, tmp_name, quant_input_defs_2[i], input_allocator);
-      QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(quant_input_defs_2[i]);
+      QuantParams<QuantType> input_qparams = combine_quant_inputs_qparams ? combined_input_qparams : GetTestInputQuantParams<QuantType>(quant_input_defs_2[i]);
 
       op_input_names.push_back(
           AddQDQNodePair<QuantType>(builder, "qdq2_in" + std::to_string(i), tmp_name, input_qparams.scale,

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -175,14 +175,15 @@ static void RunQDQOpTest(const std::string& op_type,
                          ExpectedEPNodeAssignment expected_ep_assignment,
                          const std::string& op_domain = kOnnxDomain,
                          bool use_contrib_qdq = false,
-                         QDQTolerance tolerance = QDQTolerance()) {
+                         QDQTolerance tolerance = QDQTolerance(),
+                         bool combine_quant_inputs_qparams = false) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
   TestQDQModelAccuracy(BuildOpTestCase<float, InputType2>(op_type + "_node", op_type, input_defs_1, input_defs_2, input_defs_3, attrs, op_domain),
                        BuildQDQOpTestCase<InputQType, InputType2>(op_type + "_node", op_type, input_defs_1, input_defs_2, input_defs_3, attrs,
-                                                                  op_domain, use_contrib_qdq),
+                                                                  op_domain, use_contrib_qdq, nullptr, combine_quant_inputs_qparams),
                        provider_options,
                        opset_version,
                        expected_ep_assignment,
@@ -1412,8 +1413,9 @@ TEST_F(QnnHTPBackendTests, ScatterElements_Float_Reduction_None) {
 }
 
 // Test ScatterElements with default attributes on HTP
-// Disable this due to an accuracy issue with selected data range
-TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_None) {
+// HTP implicitly expects that data and updates tensors share the same encoding,
+// Therefore, we need to combine their quantization parameters.
+TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_None) {
   std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
   std::vector<int64_t> indices = {1};
   std::vector<float> updates = {10.0f};
@@ -1429,12 +1431,17 @@ TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_None) {
                                  },
                                  {},
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);  // combine_quant_inputs_qparams
 }
 
 // Test ScatterElements with reduction ADD on HTP
-// Disable this due to an accuracy issue with selected data range
-TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_Add) {
+// HTP implicitly expects that data and updates tensors share the same encoding,
+// Therefore, we need to combine their quantization parameters.
+TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_Add) {
   std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
   std::vector<int64_t> indices = {1};
   std::vector<float> updates = {10.0f};
@@ -1452,7 +1459,11 @@ TEST_F(QnnHTPBackendTests, DISABLED_ScatterElements_Int8_Reduction_Add) {
                                      test::MakeAttribute("reduction", "add"),
                                  },
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);  // combine_quant_inputs_qparams
 }
 
 // Test ScatterElements with reduction Max on HTP
@@ -1474,7 +1485,11 @@ TEST_F(QnnHTPBackendTests, ScatterElements_Int8_Reduction_Max) {
                                      test::MakeAttribute("reduction", "max"),
                                  },
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);  // combine_quant_inputs_qparams
 }
 
 // Test ScatterElements with reduction Mul on HTP
@@ -1496,7 +1511,11 @@ TEST_F(QnnHTPBackendTests, ScatterElements_int8_reduction_mul) {
                                      test::MakeAttribute("reduction", "mul"),
                                  },
                                  17,
-                                 ExpectedEPNodeAssignment::All);
+                                 ExpectedEPNodeAssignment::All,
+                                 kOnnxDomain,
+                                 false,
+                                 QDQTolerance(),
+                                 true);  // combine_quant_inputs_qparams
 }
 
 // Test 8-bit QDQ GridSample with bilinear


### PR DESCRIPTION
### Description
Fix ScatterElements unit test failures by aligning input encodings. Aggregated min/max values of both inputs (data and updates) when calculating encodings and re-enabled the previously disabled unit test.



### Motivation and Context
QNN HTP assumes that ScatterElements inputs share the same encoding. The previous UT implementation did not consider this implicit assumption, leading to failures. Combining min/max values ensures consistent encoding and resolves the issue.


