### PR TITLE
Don't enable ccache in the "prebuilt" build unless it's enabled in the host build

### DIFF
--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -67,8 +67,10 @@ else()
         --use_qnn "${QNN_LIBRARY_KIND}"
         --qnn_home "${onnxruntime_QNN_HOME}"
         --no_kleidiai
-        --use_cache
     )
+    if(onnxruntime_BUILD_CACHE)
+        list(APPEND ORT_BUILD_COMMAND "--use_cache")
+    endif()
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
         list(APPEND ORT_BUILD_COMMAND --android)
         list(APPEND ORT_BUILD_COMMAND --android_sdk_path)
@@ -180,6 +182,9 @@ ExternalProject_Add(
     LOG_INSTALL ON
     LOG_OUTPUT_ON_FAILURE ON
     LOG_MERGED_STDOUTERR ON
+
+    # Don't run more than one Ninja build at a time
+    USES_TERMINAL_BUILD ON
 )
 
 # TODO: In long-term, we aim to remove the dependency of QNN-EP plugin library on ORT Core


### PR DESCRIPTION
### Description

CCache is used on demand in the ORT build: don't enable it in nested builds unless it's requested in the main build.


### Motivation and Context

When building for aarch64 manylinux, ccache is disabled by default: a sensible location for a ccache root must be specified in the environment. Otherwise, ccache will waste temporary disk space on a root that will not persist between runs. Note that CI runners are configured to use ccache via the environment variable `ORT_BUILD_DOCKER_CCACHE_ROOT`.

