### PR TITLE
Implement EP Assignment Verification with ORT Core Public API

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -324,6 +324,7 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions prov
   Ort::SessionOptions session_options;
 
   session_options.SetLogSeverityLevel(log_severity);
+  session_options.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
 
   TryEnableQNNSaver(provider_options);
   RegisterQnnEpLibrary(registered_ep_device, session_options, registration_name, provider_options);
@@ -415,15 +416,10 @@ void InferenceModel(const std::string& model_data,
   Ort::RunOptions ort_run_options;
   ort_run_options.SetRunTag(log_id);
 
-  std::string test_suite_name = ::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name();
-  // TODO: Implement EP assignment verification once public API for ep partition is ready
-  // This disable_cpu_ep_fallback is an workaround for ExpectedEPNodeAssignment::All
-  if (test_suite_name != "QnnCPUBackendTests" &&
-      expected_ep_assignment == ExpectedEPNodeAssignment::All) {
-    // ASSERT_EQ(ep_nodes, graph.NumberOfNodes()) << "Not all nodes were assigned to " << registration_name;
-    session_options.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
-  }
+  auto provider_type = "QNNExecutionProvider";
+  session_options.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
   Ort::Session session(*GetOrtEnv(), model_data.data(), model_data.size(), session_options);
+  ASSERT_NO_FATAL_FAILURE(VerifyEPNodeAssignment(session, provider_type, expected_ep_assignment));
 
   // TODO: Implement graph_checker once public API for ep partition is ready
   // const auto& graph = ort_session.GetGraph();

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -339,7 +339,6 @@ void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions prov
 
 void InferenceModelCPU(const std::string& model_data,
                        const char* log_id,
-                       ExpectedEPNodeAssignment expected_ep_assignment [[maybe_unused]],
                        std::unordered_map<std::string, Ort::Value>& feeds,
                        std::vector<Ort::Value>& output_vals,
                        std::optional<GraphOptimizationLevel> graph_optimization_level) {

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -552,7 +552,6 @@ void RegisterQnnEpLibrary(RegisteredEpDeviceUniquePtr& registered_ep_device,
  */
 void InferenceModelCPU(const std::string& model_data,
                        const char* log_id,
-                       ExpectedEPNodeAssignment expected_ep_assignment,
                        std::unordered_map<std::string, Ort::Value>& feeds,
                        std::vector<Ort::Value>& output_vals,
                        std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt);
@@ -845,8 +844,7 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
 
   // Run f32 model on CPU EP and collect outputs.
   std::vector<Ort::Value> cpu_f32_outputs;
-  InferenceModelCPU(f32_model_data, "f32_model_logger", ExpectedEPNodeAssignment::All,
-                    f32_helper.feeds_, cpu_f32_outputs, graph_optimization_level);
+  InferenceModelCPU(f32_model_data, "f32_model_logger", f32_helper.feeds_, cpu_f32_outputs, graph_optimization_level);
   ASSERT_FALSE(cpu_f32_outputs.empty());
 
   const size_t num_outputs = cpu_f32_outputs.size();
@@ -895,8 +893,7 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
 
   // Run QDQ model on CPU EP and collect outputs.
   std::vector<Ort::Value> cpu_qdq_outputs;
-  InferenceModelCPU(qdq_model_data, "qdq_model_logger", ExpectedEPNodeAssignment::All,
-                    qdq_helper.feeds_, cpu_qdq_outputs, graph_optimization_level);
+  InferenceModelCPU(qdq_model_data, "qdq_model_logger", qdq_helper.feeds_, cpu_qdq_outputs, graph_optimization_level);
 
   qnn_options["dump_json_qnn_graph"] = "1";
 
@@ -1097,8 +1094,7 @@ inline void TestFp16ModelAccuracy(const GetTestModelFn& f32_model_fn,
 
   // Run f32 model on CPU EP and collect outputs.
   std::vector<Ort::Value> cpu_f32_outputs;
-  InferenceModelCPU(f32_model_data, "f32_model_logger", ExpectedEPNodeAssignment::All,
-                    f32_helper.feeds_, cpu_f32_outputs);
+  InferenceModelCPU(f32_model_data, "f32_model_logger", f32_helper.feeds_, cpu_f32_outputs);
   ASSERT_FALSE(cpu_f32_outputs.empty());
 
   const size_t num_outputs = cpu_f32_outputs.size();
@@ -1142,8 +1138,7 @@ inline void TestFp16ModelAccuracy(const GetTestModelFn& f32_model_fn,
 
   // Run QDQ model on CPU EP and collect outputs.
   std::vector<Ort::Value> cpu_f16_outputs;
-  InferenceModelCPU(f16_model_data, "fp16_model_logger", ExpectedEPNodeAssignment::All,
-                    f16_helper.feeds_, cpu_f16_outputs);
+  InferenceModelCPU(f16_model_data, "fp16_model_logger", f16_helper.feeds_, cpu_f16_outputs);
 
   if (QNNTestEnvironment::GetInstance().dump_dlc()) {
     qnn_options["dump_qnn_ir_dlc"] = "1";

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -53,11 +53,12 @@ void VerifyOutput(const std::string& output_name,
                   const Ort::Value& actual_value,
                   float fp32_abs_err);
 
-// TODO: Implement the function once MS release public API about graph partition in 1.24
-// int CountAssignedNodes(const Graph& current_graph, const std::string& ep_type);
+size_t CountNodes(const Ort::Session& current_session);
+
+size_t CountAssignedNodes(const Ort::Session& current_session, const std::string& ep_type);
 
 // Verify the assignment of nodes to the EP specified by `provider_type`.
-void VerifyEPNodeAssignment(const Graph& graph, const std::string& provider_type,
+void VerifyEPNodeAssignment(const Ort::Session& current_session, const std::string& provider_type,
                             ExpectedEPNodeAssignment assignment);
 
 using ModelPathOrBytes = std::variant<std::basic_string_view<ORTCHAR_T>,
@@ -84,7 +85,7 @@ void RunWithEP(Ort::Session& ort_session,
 // Calls `check_graph` on the graph of the loaded model.
 void TestModelLoad(ModelPathOrBytes model_path_or_bytes,
                    std::unique_ptr<IExecutionProvider> execution_provider,
-                   const std::function<void(const Graph&)>& check_graph);
+                   const std::function<void(const Ort::Session&)>& check_graph);
 
 // Tests model loading only.
 // The check graph function verifies the expected EP node assignment.
@@ -92,8 +93,8 @@ inline void TestModelLoad(ModelPathOrBytes model_path_or_bytes,
                           std::unique_ptr<IExecutionProvider> execution_provider,
                           ExpectedEPNodeAssignment expected_node_assignment) {
   auto check_node_assignment =
-      [provider_type = execution_provider->Type(), expected_node_assignment](const Graph& graph) {
-        VerifyEPNodeAssignment(graph, provider_type, expected_node_assignment);
+      [provider_type = execution_provider->Type(), expected_node_assignment](const Ort::Session& current_session) {
+        VerifyEPNodeAssignment(current_session, provider_type, expected_node_assignment);
       };
   TestModelLoad(model_path_or_bytes, std::move(execution_provider), check_node_assignment);
 }

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -137,40 +137,42 @@ static void VerifyOutputs(const std::vector<std::string>& output_names,
   }
 }
 
-// TODO: Implement the CountAssignedNodes and VerifyEPNodeAssignment once public API support get ep graph partitioning info
+size_t CountNodes(const Ort::Session& current_session) {
+  size_t count = 0;
+  std::vector<Ort::ConstEpAssignedSubgraph> ep_assigned_subgraphs = current_session.GetEpGraphAssignmentInfo();
+  for (const auto& ep_assigned_subgraph : ep_assigned_subgraphs) {
+    count += ep_assigned_subgraph.GetNodes().size();
+  }
+  return count;
+}
 
-// int CountAssignedNodes(const Graph& current_graph, const std::string& ep_type) {
-//   int count = 0;
+size_t CountAssignedNodes(const Ort::Session& current_session, const std::string& ep_type) {
+  size_t count = 0;
+  std::vector<Ort::ConstEpAssignedSubgraph> ep_assigned_subgraphs = current_session.GetEpGraphAssignmentInfo();
+  for (const auto& ep_assigned_subgraph : ep_assigned_subgraphs) {
+    if (ep_assigned_subgraph.GetEpName() == ep_type) {
+      count += ep_assigned_subgraph.GetNodes().size();
+    }
+  }
 
-//   for (const auto& node : current_graph.Nodes()) {
-//     if (node.GetExecutionProviderType() == ep_type) {
-//       ++count;
-//     }
+  return count;
+}
 
-//     if (node.ContainsSubgraph()) {
-//       for (const auto& entry : node.GetSubgraphs()) {
-//         count += CountAssignedNodes(*entry, ep_type);
-//       }
-//     }
-//   }
-
-//   return count;
-// }
-
-// void VerifyEPNodeAssignment(const Graph& graph, const std::string& provider_type,
-//                             ExpectedEPNodeAssignment assignment) {
-//   const auto provider_node_count = CountAssignedNodes(graph, provider_type);
-//   if (assignment == ExpectedEPNodeAssignment::All) {
-//     // Verify the entire graph is assigned to the EP
-//     ASSERT_EQ(provider_node_count, graph.NumberOfNodes()) << "Not all nodes were assigned to " << provider_type;
-//   } else if (assignment == ExpectedEPNodeAssignment::None) {
-//     // or none of the graph
-//     ASSERT_EQ(provider_node_count, 0) << "Some nodes were assigned to " << provider_type;
-//   } else {
-//     // or some of the graph
-//     ASSERT_GT(provider_node_count, 0) << "No nodes were assigned to " << provider_type;
-//   }
-// }
+void VerifyEPNodeAssignment(const Ort::Session& current_session, const std::string& provider_type,
+                            ExpectedEPNodeAssignment assignment) {
+  size_t num_nodes = CountNodes(current_session);
+  size_t num_ep_nodes = CountAssignedNodes(current_session, provider_type);
+  if (assignment == ExpectedEPNodeAssignment::All) {
+    // Verify the entire graph is assigned to the EP
+    ASSERT_EQ(num_ep_nodes, num_nodes) << "Not all nodes were assigned to " << provider_type;
+  } else if (assignment == ExpectedEPNodeAssignment::None) {
+    // or none of the graph
+    ASSERT_EQ(num_ep_nodes, static_cast<size_t>(0)) << "Some nodes were assigned to " << provider_type;
+  } else {
+    // or some of the graph
+    ASSERT_GT(num_ep_nodes, static_cast<size_t>(0)) << "No nodes were assigned to " << provider_type;
+  }
+}
 
 static gsl::span<const std::byte> GetModelBytes(ModelPathOrBytes model_path_or_bytes,
                                                 std::vector<std::byte>& byte_buffer_out) {
@@ -234,7 +236,7 @@ void RunWithEP(Ort::Session& ort_session,
 
 void RunAndVerifyOutputsWithEP(ModelPathOrBytes model_path_or_bytes,
                                Ort::SessionOptions& ort_so,
-                               const std::string& /* provider_type */,
+                               const std::string& provider_type,
                                std::string_view log_id,
                                const std::unordered_map<std::string, Ort::Value>& feeds,
                                const EPVerificationParams& params,
@@ -268,9 +270,7 @@ void RunAndVerifyOutputsWithEP(ModelPathOrBytes model_path_or_bytes,
   // Run with EP and verify the result
   Ort::Session ort_session(*GetOrtEnv(), model_data.data(), static_cast<int>(model_data.size()), ort_so);
 
-  // TODO: VerifyEPNodeAssignment and graph_verifier require internal graph access
-  // These are commented out since we're migrating to public API
-  // ASSERT_NO_FATAL_FAILURE(VerifyEPNodeAssignment(ort_session.GetGraph(), provider_type, params.ep_node_assignment));
+  ASSERT_NO_FATAL_FAILURE(VerifyEPNodeAssignment(ort_session, provider_type, params.ep_node_assignment));
 
   Ort::RunOptions ort_run_options;
   ort_run_options.SetRunTag(log_id.data());

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -154,7 +154,6 @@ size_t CountAssignedNodes(const Ort::Session& current_session, const std::string
       count += ep_assigned_subgraph.GetNodes().size();
     }
   }
-
   return count;
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- The PR implemented the **EP Assignment Verification** in qnn test framework with the public API `Session_GetEpGraphAssignmentInfo` introduced by Microsoft in **ORT Core 1.24.1** in 
https://github.com/microsoft/onnxruntime/pull/26781.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- To avoid relying on private ORT Core headers/libraries, #23 reconstructed the QNN Test Framework using only ORT’s public headers and libraries.
- Due to the requirement on Microsoft's latest release on ORT Core, the **EP Assignment Verification** was temporarily disabled and are now being recovered with the necessary API.

