### PR TITLE
Fix UT failures for Gemm and Resize

### DIFF
--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -72,9 +72,8 @@ TEST_F(QnnCPUBackendTests, Gemm_2D_Bias) {
                      ExpectedEPNodeAssignment::All);  // Assigned to QNN EP.
 }
 
-// since Qnn v2.34 value pair (120.73912, 121.73912) at index #0 don't match, which is 1 from 120.739
 // Test Gemm with dynamic (i.e., not initializer) inputs (A, B, Bias).
-TEST_F(QnnCPUBackendTests, DISABLED_Gemm_Dynamic_A_B_Bias) {
+TEST_F(QnnCPUBackendTests, Gemm_Dynamic_A_B_Bias) {
   std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
   std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
@@ -110,9 +109,8 @@ TEST_F(QnnCPUBackendTests, Gemm_TransAB_Static_B_And_Bias) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// Since Qnn 2.34 value pair (29.4347763, 30.4347763) at index #0 don't match, which is 1 from 29.4348
 // Test Gemm with transposed A/B and dynamic (i.e., not initializer) B and Bias inputs.
-TEST_F(QnnCPUBackendTests, DISABLED_Gemm_TransAB_Dynamic_B_And_Bias) {
+TEST_F(QnnCPUBackendTests, Gemm_TransAB_Dynamic_B_And_Bias) {
   std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
   std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
@@ -124,8 +122,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_Gemm_TransAB_Dynamic_B_And_Bias) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// Since Qnn 2.34 value pair (11, 10) at index #0 don't match, which is -1 from 11
-TEST_F(QnnCPUBackendTests, DISABLED_Gemm_Broadcast_Bias_DynamicInputs) {
+TEST_F(QnnCPUBackendTests, Gemm_Broadcast_Bias_DynamicInputs) {
   std::vector<float> input_a_data = {1.0f, 2.0f, 3.0f, 4.0f, -1.0f, -2.0f, -3.0f, -4.0f};
   std::vector<float> input_b_data(12, 1.0f);
   std::vector<float> input_c_data = {1.0f, 2.0f, 3.0f};
@@ -141,10 +138,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_Gemm_Broadcast_Bias_DynamicInputs) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// TODO: When this is fixed, enable GemmOpTypedTests/0.TestGemmBroadcast test in cpu/math/gemm_test.cc
-// This began failing in QNN SDK 2.17 for the CPU backend.
-// Log: the value pair (11, 10) at index #0 don't match, which is -1 from 11
-TEST_F(QnnCPUBackendTests, DISABLED_Gemm_Broadcast_Bias_DynamicA_StaticB_DynamicC) {
+TEST_F(QnnCPUBackendTests, Gemm_Broadcast_Bias_DynamicA_StaticB_DynamicC) {
   std::vector<float> input_a_data = {1.0f, 2.0f, 3.0f, 4.0f, -1.0f, -2.0f, -3.0f, -4.0f};
   std::vector<float> input_b_data(12, 1.0f);
   std::vector<float> input_c_data = {1.0f, 2.0f, 3.0f};

--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -127,7 +127,7 @@ TEST_F(QnnCPUBackendTests, MaxPool_Large_Input) {
                 ExpectedEPNodeAssignment::All);
 }
 
-// Fails on QNN v2.17, QNN.graphAddNode() failed for node `MaxPool` of type `PoolMax2d` with error code 6000
+// QNN CPU doesn't support ceil rounding mode. Enable this UT when QNN CPU support this case.
 TEST_F(QnnCPUBackendTests, DISABLED_MaxPool_Ceil) {
   RunPoolOpTest("MaxPool",
                 TestInputDef<float>({1, 2, 3, 3}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
@@ -141,7 +141,7 @@ TEST_F(QnnCPUBackendTests, DISABLED_MaxPool_Ceil) {
                 ExpectedEPNodeAssignment::All);
 }
 
-// Fails on QNN v2.17, QNN.graphAddNode() failed for node `MaxPool` of type `PoolMax2d` with error code 6000
+// QNN CPU doesn't support ceil rounding mode. Enable this UT when QNN CPU support this case.
 TEST_F(QnnCPUBackendTests, DISABLED_MaxPool_Large_Input2_Ceil) {
   RunPoolOpTest("MaxPool",
                 TestInputDef<float>({1, 128, 16, 113}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -373,17 +373,13 @@ TEST_F(QnnCPUBackendTests, Resize_DownSample_Linear_AlignCorners_scales) {
                                ExpectedEPNodeAssignment::All);
 }
 
-// Test Resize downsample with mode: "linear", coordinate_transformation_mode: "half_pixel"
-// Fails on QNN v2.17, the value pair (2.66666651, 3.5) at index #0 don't match, which is 0.833333 from 2.66667
-// TODO: Enable ResizeOpTest.ResizeOpLinearDownSampleTest_4DBilinear cpu resize_op tests when fixed.
-//
-// Input f32[1,1,2,4]: 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0
-// Expected output f32[1, 1, 1, 2]: 2.6666 4.3333
-// Actual output f32[1, 1, 1, 2]: 3.5, 5.5
-TEST_F(QnnCPUBackendTests, DISABLED_Resize_DownSample_Linear_HalfPixel_scales) {
+// Note: The QNN CPU backend does not define explicit scale attributes. It derives scale values
+// implicitly from the input and output tensor shapes. Therefore, the selected parameters must
+// ensure that the product of the input dimensions and the inferred scales evaluates to an integer.
+TEST_F(QnnCPUBackendTests, Resize_DownSample_Linear_HalfPixel_scales) {
   std::vector<float> input_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
   RunCPUResizeOpTestWithScales(TestInputDef<float>({1, 1, 2, 4}, false, input_data),
-                               {1.0f, 1.0f, 0.6f, 0.6f}, "linear", "half_pixel", "",
+                               {1.0f, 1.0f, 0.5f, 0.5f}, "linear", "half_pixel", "",
                                ExpectedEPNodeAssignment::All);
 }
 


### PR DESCRIPTION
### Description
This PR re-enable/fix the following UT failures:
- Gemm_Dynamic_A_B_Bias
- Gemm_TransAB_Dynamic_B_And_Bias
- Gemm_Broadcast_Bias_DynamicInputs
- Gemm_Broadcast_Bias_DynamicA_StaticB_DynamicC
- Resize_DownSample_Linear_HalfPixel_scales

It also adds explanatory comments for MaxPool tests that must remain disabled due to QNN CPU's lack of ceil_mode support:
- DISABLED_MaxPool_Ceil
- DISABLED_MaxPool_Large_Input2_Ceil



### Motivation and Context
Several unit tests for Gemm and Resize were failing. These failures need to be resolved to ensure operator correctness and maintain test coverage. Additionally, some MaxPool tests using ceil_mode cannot be supported by QNN CPU, and the absence of clarifying comments may cause confusion for future maintainers.


