### PR TITLE
Fix BatchNorm unsigned symmetric quantization behavior and re-enable related UT

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -387,6 +387,7 @@ class BatchNormOpBuilder : public BaseOpBuilder {
         symmetric = true;
       } else if (info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) {
         data_size *= sizeof(uint16_t);
+        symmetric = true;
       }
       raw_tensor.resize(data_size);
       float scale = 0.0f;

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -936,10 +936,18 @@ Ort::Status GetQuantParams(float rmin,
 
   double scale_dbl = (rmax_dbl - rmin_dbl) / (qmax - qmin);
   double initial_zero_point = 0.0;
-  if (symmetric) {
+  if (!symmetric) {
+    // Asymmetric
+    initial_zero_point = qmin - (rmin_dbl / scale_dbl);
+  } else if ((qnn_data_type == QNN_DATATYPE_SFIXED_POINT_32 ||
+              qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16 ||
+              qnn_data_type == QNN_DATATYPE_SFIXED_POINT_8 ||
+              qnn_data_type == QNN_DATATYPE_SFIXED_POINT_4)) {
+    // Signed symmetric
     initial_zero_point = std::round(rmin_dbl + rmax_dbl) / 2;
   } else {
-    initial_zero_point = qmin - (rmin_dbl / scale_dbl);
+    // Unsigned symmetric
+    initial_zero_point = std::round(qmax + qmin) / 2;
   }
   zero_point = static_cast<int32_t>(RoundHalfToEven(static_cast<float>(Saturate(qmax, qmin, initial_zero_point))));
   zero_point = -zero_point;  // Negate to match QNN quantization definition.

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -240,10 +240,14 @@ static void RunBatchNormQDQTest(const TestInputDef<float>& input_def,
                                 const TestInputDef<float>& scale_def,
                                 const TestInputDef<float>& bias_def,
                                 ExpectedEPNodeAssignment expected_ep_assignment,
-                                QDQTolerance tolerance = QDQTolerance()) {
+                                QDQTolerance tolerance = QDQTolerance(),
+                                const std::string& soc_model = "") {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
+  if (!soc_model.empty()) {
+    provider_options["soc_model"] = soc_model;
+  }
 
   // Runs model with DQ-> InstanceNorm -> Q and compares the outputs of the CPU and QNN EPs.
   TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
@@ -380,8 +384,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_U16U8S32) {
 
 // Check that QNN compiles DQ -> BatchNormalization -> Q as a single unit.
 // Use an input of rank 4.
-// Turn on the testcase when ORT QNN-EP supports unsigned symmetric dtypes
-TEST_F(QnnHTPBackendTests, DISABLED_BatchNorm2D_U16U16S32) {
+TEST_F(QnnHTPBackendTests, BatchNorm2D_U16U16S32) {
   constexpr int64_t num_channels = 2;
   std::vector<float> input_data = {-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 1.1f, 3.3f, 8.0f,
                                    -7.0f, -5.0f, -3.0f, -1.0f, 0.0f, 2.1f, 4.3f, 7.0f};
@@ -389,7 +392,32 @@ TEST_F(QnnHTPBackendTests, DISABLED_BatchNorm2D_U16U16S32) {
   RunBatchNormQDQTest<uint16_t, uint16_t>(TestInputDef<float>({2, num_channels, 2, 2}, false, input_data),  // Input data
                                           TestInputDef<float>({num_channels}, true, {1.0f, 2.0f}),          // Scale initializer
                                           TestInputDef<float>({num_channels}, true, {1.1f, 2.1f}),          // Bias initializer
-                                          ExpectedEPNodeAssignment::All);
+                                          ExpectedEPNodeAssignment::All,
+                                          QDQTolerance(),
+#if defined(__linux__) && !defined(__aarch64__)
+                                          std::to_string(QNN_SOC_MODEL_SM8550));
+#else
+                                          "");
+#endif
+}
+
+// Check that QNN compiles DQ -> BatchNormalization -> Q as a single unit.
+// Use an input of rank 4.
+TEST_F(QnnHTPBackendTests, BatchNorm2D_U16S16S32) {
+  constexpr int64_t num_channels = 2;
+  std::vector<float> input_data = {-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 1.1f, 3.3f, 8.0f,
+                                   -7.0f, -5.0f, -3.0f, -1.0f, 0.0f, 2.1f, 4.3f, 7.0f};
+
+  RunBatchNormQDQTest<uint16_t, int16_t>(TestInputDef<float>({2, num_channels, 2, 2}, false, input_data),  // Input data
+                                         TestInputDef<float>({num_channels}, true, {1.0f, 2.0f}),          // Scale initializer
+                                         TestInputDef<float>({num_channels}, true, {1.1f, 2.1f}),          // Bias initializer
+                                         ExpectedEPNodeAssignment::All,
+                                         QDQTolerance(),
+#if defined(__linux__) && !defined(__aarch64__)
+                                         std::to_string(QNN_SOC_MODEL_SM8550));
+#else
+                                         "");
+#endif
 }
 
 // Test FP16 BatchNormalization on the HTP backend.


### PR DESCRIPTION
### Description
This PR restores the disabled BatchNorm op unit tests and introduces a correction to the BatchNorm OpBuilder logic for handling the unsigned symmetric quantization case.



### Motivation and Context
BatchNorm UTs were previously failing when the scale input used an unsigned fixed‑point data type (QNN_DATATYPE_UFIXED_POINT_16). Investigation showed that the OpBuilder did not correctly apply the QNN‑defined offset rules for unsigned symmetric quantization.


