### PR TITLE
Add support for BN with activation in u8, scale in s8

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -466,6 +466,11 @@ void OverrideParamTypeForRequantize(Qnn_DataType_t x_dtype,
     scale_dtype = is_scale_has_negative_values ? QNN_DATATYPE_SFIXED_POINT_16 : QNN_DATATYPE_UFIXED_POINT_8;
   }
 
+  // QNN HTP with UFIXED_POINT_8 input doesn't support SFIXED_POINT_8 scale
+  if (x_dtype == QNN_DATATYPE_UFIXED_POINT_8 && scale_dtype == QNN_DATATYPE_SFIXED_POINT_8) {
+    scale_dtype = QNN_DATATYPE_UFIXED_POINT_8;
+  }
+
   // QNN HTP requires quantized bias for quantized ops
   bool is_quantized = (x_dtype == QNN_DATATYPE_UFIXED_POINT_8 || x_dtype == QNN_DATATYPE_SFIXED_POINT_8 ||
                        x_dtype == QNN_DATATYPE_UFIXED_POINT_16 || x_dtype == QNN_DATATYPE_SFIXED_POINT_16);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -466,7 +466,9 @@ void OverrideParamTypeForRequantize(Qnn_DataType_t x_dtype,
     scale_dtype = is_scale_has_negative_values ? QNN_DATATYPE_SFIXED_POINT_16 : QNN_DATATYPE_UFIXED_POINT_8;
   }
 
-  // QNN HTP with UFIXED_POINT_8 input doesn't support SFIXED_POINT_8 scale
+  // QNN HTP with UFIXED_POINT_8 input doesn't support SFIXED_POINT_8 scale and hence is updated to UFIXED_POINT_8
+  // This modification is going to be accuracy preserving because UFIXED_POINT_8's zero-point would be off by 2**(bw-1)
+  // when compared to SFIXED_POINT_8's zero-point, and scale factor being the same
   if (x_dtype == QNN_DATATYPE_UFIXED_POINT_8 && scale_dtype == QNN_DATATYPE_SFIXED_POINT_8) {
     scale_dtype = QNN_DATATYPE_UFIXED_POINT_8;
   }

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -550,6 +550,26 @@ TEST_F(QnnHTPBackendTests, BatchNorm2dQdqParams) {
                        21,
                        ExpectedEPNodeAssignment::All);
 }
+// Test BatchNorm with U8 input, S8 scale (converted to U8), float bias (converted to S32)
+TEST_F(QnnHTPBackendTests, BatchNorm2D_U8S8F32) {
+  constexpr int64_t num_channels = 2;
+  std::vector<float> input_data = {-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 1.1f, 3.3f, 8.0f,
+                                   -7.0f, -5.0f, -3.0f, -1.0f, 0.0f, 2.1f, 4.3f, 7.0f};
+
+  TestInputDef<float> input_def({2, num_channels, 2, 2}, false, input_data);
+  TestInputDef<float> scale_def({num_channels}, true, {1.0f, 2.0f});
+  TestInputDef<float> bias_def({num_channels}, true, {1.1f, 2.1f});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
+                       BuildBatchNormQdqParamsTestCase<uint8_t, int8_t>(input_def, scale_def, bias_def),
+                       provider_options,
+                       21,
+                       ExpectedEPNodeAssignment::All);
+}
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -550,6 +550,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2dQdqParams) {
                        21,
                        ExpectedEPNodeAssignment::All);
 }
+
 // Test BatchNorm with U8 input, S8 scale (converted to U8), float bias (converted to S32)
 TEST_F(QnnHTPBackendTests, BatchNorm2D_U8S8F32) {
   constexpr int64_t num_channels = 2;

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -336,7 +336,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_U8S8S32) {
   RunBatchNormQDQTest<uint8_t, int8_t>(TestInputDef<float>({2, num_channels, 2, 2}, false, input_data),  // Input data
                                        TestInputDef<float>({num_channels}, true, {1.0f, 2.0f}),          // Scale initializer
                                        TestInputDef<float>({num_channels}, true, {1.1f, 2.1f}),          // Bias initializer
-                                       ExpectedEPNodeAssignment::None);
+                                       ExpectedEPNodeAssignment::All);
 }
 
 // Check that QNN compiles DQ -> BatchNormalization -> Q as a single unit.


### PR DESCRIPTION
### Description
Updates BN op builder to support the following combination: input/output -> uint8, scale -> int8


### Motivation and Context
Several models fail compilation because of unsupported optype for batchnorm op. This PR addresses the issue with sfixed8 input for scale by converting it into ufixed8 instead. 

