### PR TITLE
Modify recent op testcases with Public API and re-enable them

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -213,7 +213,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
-     "${TEST_SRC_DIR}/providers/qnn/fusedmatmul_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc"

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -215,7 +215,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/fusedmatmul_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/quickgelu_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/rmsnormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/simplifiedlayernormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc"

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -215,7 +215,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/fusedmatmul_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/rmsnormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/simplifiedlayernormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc"

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -213,7 +213,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
-     "${TEST_SRC_DIR}/providers/qnn/bf16_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/fusedmatmul_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/groupnormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -214,7 +214,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/fusedmatmul_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/groupnormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/quickgelu_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/rmsnormalization_test.cc"

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -215,7 +215,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/fusedmatmul_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/simplifiedlayernormalization_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc"

--- a/onnxruntime/test/providers/qnn/bf16_test.cc
+++ b/onnxruntime/test/providers/qnn/bf16_test.cc
@@ -18,10 +18,12 @@ namespace test {
 [[maybe_unused]] static GetTestModelFn BuildBF16AddTestCase(const TestInputDef<float>& input1_def,
                                                             const TestInputDef<float>& input2_def) {
   return [input1_def, input2_def](ModelTestBuilder& builder) {
-    NodeArg* input1 = MakeTestInput(builder, input1_def);
-    NodeArg* input2 = MakeTestInput(builder, input2_def);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Add", {input1, input2}, {output});
+    MakeTestInput<float>(builder, "input1", input1_def);
+    MakeTestInput<float>(builder, "input2", input2_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("add_node", "Add", {"input1", "input2"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -29,10 +31,12 @@ namespace test {
 [[maybe_unused]] static GetTestModelFn BuildBF16MatMulTestCase(const TestInputDef<float>& input1_def,
                                                                const TestInputDef<float>& input2_def) {
   return [input1_def, input2_def](ModelTestBuilder& builder) {
-    NodeArg* input1 = MakeTestInput(builder, input1_def);
-    NodeArg* input2 = MakeTestInput(builder, input2_def);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("MatMul", {input1, input2}, {output});
+    MakeTestInput<float>(builder, "input1", input1_def);
+    MakeTestInput<float>(builder, "input2", input2_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("matmul_node", "MatMul", {"input1", "input2"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -40,10 +44,12 @@ namespace test {
 [[maybe_unused]] static GetTestModelFn BuildBF16ConvTestCase(const TestInputDef<float>& input_def,
                                                              const TestInputDef<float>& weights_def) {
   return [input_def, weights_def](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* weights = MakeTestInput(builder, weights_def);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Conv", {input, weights}, {output});
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weights_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("conv_node", "Conv", {"input", "weights"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -160,17 +166,18 @@ static GetTestModelFn BuildBF16MultiOpTestCase() {
     std::vector<int64_t> shape = {2, 3, 4};
 
     // Create inputs
-    NodeArg* input1 = MakeTestInput(builder, TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.0f, 0.1f)));
-    NodeArg* input2 = MakeTestInput(builder, TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.1f, 0.1f)));
-    NodeArg* input3 = MakeTestInput(builder, TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.2f, 0.1f)));
+    MakeTestInput<float>(builder, "input1", TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.0f, 0.1f)));
+    MakeTestInput<float>(builder, "input2", TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.1f, 0.1f)));
+    MakeTestInput<float>(builder, "input3", TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.2f, 0.1f)));
 
     // Add1: input1 + input2
-    NodeArg* add1_output = builder.MakeIntermediate();
-    builder.AddNode("Add", {input1, input2}, {add1_output});
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes1;
+    builder.AddNode("add1_node", "Add", {"input1", "input2"}, {"add1_output"}, "", attributes1);
 
     // Add2: add1_output + input3
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Add", {add1_output, input3}, {output});
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes2;
+    builder.AddNode("add2_node", "Add", {"add1_output", "input3"}, {"output"}, "", attributes2);
+    builder.MakeOutput("output");
   };
 }
 
@@ -185,16 +192,18 @@ static GetTestModelFn BuildBF16MultiOutputTestCase() {
     std::vector<int64_t> shape = {2, 3, 4};
 
     // Create inputs
-    NodeArg* input1 = MakeTestInput(builder, TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.0f, 0.1f)));
-    NodeArg* input2 = MakeTestInput(builder, TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.1f, 0.1f)));
+    MakeTestInput<float>(builder, "input1", TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.0f, 0.1f)));
+    MakeTestInput<float>(builder, "input2", TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 0.1f, 0.1f)));
 
     // Add: input1 + input2 -> output1
-    NodeArg* output1 = builder.MakeOutput();
-    builder.AddNode("Add", {input1, input2}, {output1});
+    std::vector<ONNX_NAMESPACE::AttributeProto> add_attributes;
+    builder.AddNode("add_node", "Add", {"input1", "input2"}, {"output1"}, "", add_attributes);
+    builder.MakeOutput("output1");
 
     // Mul: input1 * input2 -> output2
-    NodeArg* output2 = builder.MakeOutput();
-    builder.AddNode("Mul", {input1, input2}, {output2});
+    std::vector<ONNX_NAMESPACE::AttributeProto> mul_attributes;
+    builder.AddNode("mul_node", "Mul", {"input1", "input2"}, {"output2"}, "", mul_attributes);
+    builder.MakeOutput("output2");
   };
 }
 
@@ -206,9 +215,11 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_MultipleOutputs) {
 // Test BF16 handling with Relu activation
 static GetTestModelFn BuildBF16ReluTestCase(const TestInputDef<float>& input_def) {
   return [input_def](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Relu", {input}, {output});
+    MakeTestInput<float>(builder, "input", input_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("relu_node", "Relu", {"input"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -223,9 +234,11 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Relu) {
 // Test BF16 handling with Sigmoid activation
 static GetTestModelFn BuildBF16SigmoidTestCase(const TestInputDef<float>& input_def) {
   return [input_def](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Sigmoid", {input}, {output});
+    MakeTestInput<float>(builder, "input", input_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("sigmoid_node", "Sigmoid", {"input"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -240,10 +253,12 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Sigmoid) {
 // Test BF16 handling with Softmax
 static GetTestModelFn BuildBF16SoftmaxTestCase(const TestInputDef<float>& input_def, int64_t axis) {
   return [input_def, axis](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* output = builder.MakeOutput();
-    Node& node = builder.AddNode("Softmax", {input}, {output});
-    node.AddAttribute("axis", axis);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("axis", axis));
+    builder.AddNode("softmax_node", "Softmax", {"input"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -260,10 +275,12 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Softmax) {
 static GetTestModelFn BuildBF16TransposeTestCase(const TestInputDef<float>& input_def,
                                                  const std::vector<int64_t>& perm) {
   return [input_def, perm](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* output = builder.MakeOutput();
-    Node& node = builder.AddNode("Transpose", {input}, {output});
-    node.AddAttribute("perm", perm);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeIntsAttribute("perm", perm));
+    builder.AddNode("transpose_node", "Transpose", {"input"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -281,10 +298,12 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Transpose) {
 static GetTestModelFn BuildBF16ReshapeTestCase(const TestInputDef<float>& input_def,
                                                const std::vector<int64_t>& new_shape) {
   return [input_def, new_shape](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    NodeArg* shape_input = builder.MakeInitializer<int64_t>({static_cast<int64_t>(new_shape.size())}, new_shape);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Reshape", {input, shape_input}, {output});
+    MakeTestInput<float>(builder, "input", input_def);
+    builder.MakeInitializer<int64_t>("shape", {static_cast<int64_t>(new_shape.size())}, new_shape);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("reshape_node", "Reshape", {"input", "shape"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -301,13 +320,17 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Reshape) {
 // Test BF16 handling with Concat
 static GetTestModelFn BuildBF16ConcatTestCase(const std::vector<TestInputDef<float>>& input_defs, int64_t axis) {
   return [input_defs, axis](ModelTestBuilder& builder) {
-    std::vector<NodeArg*> inputs;
-    for (const auto& input_def : input_defs) {
-      inputs.push_back(MakeTestInput(builder, input_def));
+    std::vector<std::string> input_names;
+    for (size_t i = 0; i < input_defs.size(); i++) {
+      std::string input_name = "input" + std::to_string(i);
+      MakeTestInput<float>(builder, input_name, input_defs[i]);
+      input_names.push_back(input_name);
     }
-    NodeArg* output = builder.MakeOutput();
-    Node& node = builder.AddNode("Concat", inputs, {output});
-    node.AddAttribute("axis", axis);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("axis", axis));
+    builder.AddNode("concat_node", "Concat", input_names, {"output"}, "", attributes);
+    builder.MakeOutput("output");
   };
 }
 
@@ -323,13 +346,21 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Concat) {
 // Test BF16 handling with Split
 static GetTestModelFn BuildBF16SplitTestCase(const TestInputDef<float>& input_def, int64_t axis, int64_t num_outputs) {
   return [input_def, axis, num_outputs](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput(builder, input_def);
-    std::vector<NodeArg*> outputs;
+    MakeTestInput<float>(builder, "input", input_def);
+
+    std::vector<std::string> output_names;
     for (int64_t i = 0; i < num_outputs; i++) {
-      outputs.push_back(builder.MakeOutput());
+      std::string output_name = "output" + std::to_string(i);
+      output_names.push_back(output_name);
     }
-    Node& node = builder.AddNode("Split", {input}, outputs);
-    node.AddAttribute("axis", axis);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("axis", axis));
+    builder.AddNode("split_node", "Split", {"input"}, output_names, "", attributes);
+
+    for (const auto& output_name : output_names) {
+      builder.MakeOutput(output_name);
+    }
   };
 }
 

--- a/onnxruntime/test/providers/qnn/fusedmatmul_test.cc
+++ b/onnxruntime/test/providers/qnn/fusedmatmul_test.cc
@@ -40,18 +40,15 @@ static void RunFusedMatMulTest(const TestInputDef<DataType>& input_a_def,
   }
 
   auto model_builder = [input_a_def, input_b_def, transA, transB, transBatchA, transBatchB, alpha](ModelTestBuilder& builder) {
-    NodeArg* input_a = MakeTestInput<DataType>(builder, input_a_def);
-    NodeArg* input_b = MakeTestInput<DataType>(builder, input_b_def);
-    std::vector<NodeArg*> inputs = {input_a, input_b};
-
-    auto* output = builder.MakeOutput();
-
-    Node& node = builder.AddNode("FusedMatMul", inputs, {output}, kMSDomain);
-    node.AddAttribute("transA", static_cast<int64_t>(transA));
-    node.AddAttribute("transB", static_cast<int64_t>(transB));
-    node.AddAttribute("transBatchA", static_cast<int64_t>(transBatchA));
-    node.AddAttribute("transBatchB", static_cast<int64_t>(transBatchB));
-    node.AddAttribute("alpha", alpha);
+    MakeTestInput<DataType>(builder, "input_a", input_a_def);
+    MakeTestInput<DataType>(builder, "input_b", input_b_def);
+    builder.MakeOutput("output");
+    builder.AddNode("fused_matmul", "FusedMatMul", {"input_a", "input_b"}, {"output"}, kMSDomain,
+                    {builder.MakeScalarAttribute("transA", static_cast<int64_t>(transA)),
+                     builder.MakeScalarAttribute("transB", static_cast<int64_t>(transB)),
+                     builder.MakeScalarAttribute("transBatchA", static_cast<int64_t>(transBatchA)),
+                     builder.MakeScalarAttribute("transBatchB", static_cast<int64_t>(transBatchB)),
+                     builder.MakeScalarAttribute("alpha", alpha)});
   };
 
   RunQnnModelTest(model_builder,
@@ -78,47 +75,44 @@ static void RunQDQFusedMatMulTest(const TestInputDef<float>& input_a_def,
   provider_options["offload_graph_io_quantization"] = "0";
 
   GetTestModelFn model_builder_fn = [input_a_def, input_b_def, transA, transB, transBatchA, transBatchB, alpha](ModelTestBuilder& builder) {
-    NodeArg* input_a = MakeTestInput<float>(builder, input_a_def);
-    NodeArg* input_b = MakeTestInput<float>(builder, input_b_def);
-    std::vector<NodeArg*> inputs = {input_a, input_b};
-
-    auto* output = builder.MakeOutput();
-
-    Node& node = builder.AddNode("FusedMatMul", inputs, {output}, kMSDomain);
-    node.AddAttribute("transA", static_cast<int64_t>(transA));
-    node.AddAttribute("transB", static_cast<int64_t>(transB));
-    node.AddAttribute("transBatchA", static_cast<int64_t>(transBatchA));
-    node.AddAttribute("transBatchB", static_cast<int64_t>(transBatchB));
-    node.AddAttribute("alpha", alpha);
+    MakeTestInput<float>(builder, "input_a", input_a_def);
+    MakeTestInput<float>(builder, "input_b", input_b_def);
+    builder.MakeOutput("output");
+    builder.AddNode("fused_matmul", "FusedMatMul", {"input_a", "input_b"}, {"output"}, kMSDomain,
+                    {builder.MakeScalarAttribute("transA", static_cast<int64_t>(transA)),
+                     builder.MakeScalarAttribute("transB", static_cast<int64_t>(transB)),
+                     builder.MakeScalarAttribute("transBatchA", static_cast<int64_t>(transBatchA)),
+                     builder.MakeScalarAttribute("transBatchB", static_cast<int64_t>(transBatchB)),
+                     builder.MakeScalarAttribute("alpha", alpha)});
   };
 
   GetTestQDQModelFn<QType> qdq_model_builder_fn = [input_a_def, input_b_def, transA, transB, transBatchA, transBatchB, alpha, use_contrib_qdq](
                                                       ModelTestBuilder& builder, std::vector<QuantParams<QType>>& output_qparams) {
     // Process input A with QDQ
-    NodeArg* input_a = MakeTestInput<float>(builder, input_a_def);
+    MakeTestInput<float>(builder, "input_a", input_a_def);
     QuantParams<QType> input_a_qparams = GetTestInputQuantParams<QType>(input_a_def);
-    NodeArg* input_a_qdq = AddQDQNodePair<QType>(builder, input_a, input_a_qparams.scale,
-                                                 input_a_qparams.zero_point, use_contrib_qdq);
+    std::string input_a_qdq = AddQDQNodePair<QType>(builder, "qdq_input_a", "input_a",
+                                                    input_a_qparams.scale,
+                                                    input_a_qparams.zero_point, use_contrib_qdq);
 
     // Process input B with QDQ
-    NodeArg* input_b = MakeTestInput<float>(builder, input_b_def);
+    MakeTestInput<float>(builder, "input_b", input_b_def);
     QuantParams<QType> input_b_qparams = GetTestInputQuantParams<QType>(input_b_def);
-    NodeArg* input_b_qdq = AddQDQNodePair<QType>(builder, input_b, input_b_qparams.scale,
-                                                 input_b_qparams.zero_point, use_contrib_qdq);
-
-    std::vector<NodeArg*> inputs = {input_a_qdq, input_b_qdq};
+    std::string input_b_qdq = AddQDQNodePair<QType>(builder, "qdq_input_b", "input_b",
+                                                    input_b_qparams.scale,
+                                                    input_b_qparams.zero_point, use_contrib_qdq);
 
     // FusedMatMul -> op_output
-    auto* op_output = builder.MakeIntermediate();
-    Node& node = builder.AddNode("FusedMatMul", inputs, {op_output}, kMSDomain);
-    node.AddAttribute("transA", static_cast<int64_t>(transA));
-    node.AddAttribute("transB", static_cast<int64_t>(transB));
-    node.AddAttribute("transBatchA", static_cast<int64_t>(transBatchA));
-    node.AddAttribute("transBatchB", static_cast<int64_t>(transBatchB));
-    node.AddAttribute("alpha", alpha);
+    builder.AddNode("fused_matmul", "FusedMatMul", {input_a_qdq, input_b_qdq}, {"op_output"}, kMSDomain,
+                    {builder.MakeScalarAttribute("transA", static_cast<int64_t>(transA)),
+                     builder.MakeScalarAttribute("transB", static_cast<int64_t>(transB)),
+                     builder.MakeScalarAttribute("transBatchA", static_cast<int64_t>(transBatchA)),
+                     builder.MakeScalarAttribute("transBatchB", static_cast<int64_t>(transBatchB)),
+                     builder.MakeScalarAttribute("alpha", alpha)});
 
     // op_output -> Q -> DQ -> output
-    AddQDQNodePairWithOutputAsGraphOutput<QType>(builder, op_output, output_qparams[0].scale,
+    AddQDQNodePairWithOutputAsGraphOutput<QType>(builder, "qdq_output", "op_output",
+                                                 output_qparams[0].scale,
                                                  output_qparams[0].zero_point, use_contrib_qdq);
   };
 
@@ -246,7 +240,7 @@ TEST_F(QnnHTPBackendTests, FusedMatMul_Default) {
 
 // Test FusedMatMul with float16 inputs and custom alpha on HTP
 TEST_F(QnnHTPBackendTests, FusedMatMul_Float16_CustomAlpha) {
-  RunFusedMatMulTest<MLFloat16>(
+  RunFusedMatMulTest<Ort::Float16_t>(
       ConvertToFP16InputDef(TestInputDef<float>({2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6))),  // input A
       ConvertToFP16InputDef(TestInputDef<float>({3, 2}, false, GetFloatDataInRange(-1.0f, 1.0f, 6))),  // input B
       false,                                                                                           // transA
@@ -260,7 +254,7 @@ TEST_F(QnnHTPBackendTests, FusedMatMul_Float16_CustomAlpha) {
 
 // Test FusedMatMul with float16 inputs, transpose, and custom alpha on HTP
 TEST_F(QnnHTPBackendTests, FusedMatMul_Float16_TransposeA_CustomAlpha) {
-  RunFusedMatMulTest<MLFloat16>(
+  RunFusedMatMulTest<Ort::Float16_t>(
       ConvertToFP16InputDef(TestInputDef<float>({3, 2}, false, GetFloatDataInRange(-1.0f, 1.0f, 6))),   // input A
       ConvertToFP16InputDef(TestInputDef<float>({3, 4}, false, GetFloatDataInRange(-1.0f, 1.0f, 12))),  // input B
       true,                                                                                             // transA

--- a/onnxruntime/test/providers/qnn/groupnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/groupnormalization_test.cc
@@ -25,14 +25,17 @@ TEST_F(QnnHTPBackendTests, GroupNorm_Float_Default) {
   std::vector<float> bias_data = {0.1f, 0.2f};
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({1, 2, 3, 4}, input_data);
-    auto* scale = builder.MakeInitializer<float>({2}, scale_data);
-    auto* bias = builder.MakeInitializer<float>({2}, bias_data);
+    MakeTestInput<float>(builder, "X", TestInputDef<float>({1, 2, 3, 4}, false, input_data));
+    MakeTestInput<float>(builder, "scale", TestInputDef<float>({2}, true, scale_data));
+    MakeTestInput<float>(builder, "bias", TestInputDef<float>({2}, true, bias_data));
 
-    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 2, 3, 4});
-    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
-    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(1));
-    group_norm_node.AddAttribute("epsilon", 1e-05f);
+    // Create attributes
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("num_groups", static_cast<int64_t>(1)));
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 1e-05f));
+
+    builder.AddNode("group_norm", "GroupNormalization", {"X", "scale", "bias"}, {"Y"}, "", attributes);
+    builder.MakeOutput<float>("Y", std::vector<int64_t>{1, 2, 3, 4});
   };
 
   ProviderOptions provider_options;
@@ -58,14 +61,17 @@ TEST_F(QnnCPUBackendTests, GroupNorm_Float_CPU) {
   std::vector<float> bias_data = {0.1f, 0.2f};
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({1, 2, 3, 4}, input_data);
-    auto* scale = builder.MakeInitializer<float>({2}, scale_data);
-    auto* bias = builder.MakeInitializer<float>({2}, bias_data);
+    MakeTestInput<float>(builder, "X", TestInputDef<float>({1, 2, 3, 4}, false, input_data));
+    MakeTestInput<float>(builder, "scale", TestInputDef<float>({2}, true, scale_data));
+    MakeTestInput<float>(builder, "bias", TestInputDef<float>({2}, true, bias_data));
 
-    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 2, 3, 4});
-    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
-    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(1));
-    group_norm_node.AddAttribute("epsilon", 1e-05f);
+    // Create attributes
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("num_groups", static_cast<int64_t>(1)));
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 1e-05f));
+
+    builder.AddNode("group_norm", "GroupNormalization", {"X", "scale", "bias"}, {"Y"}, "", attributes);
+    builder.MakeOutput<float>("Y", std::vector<int64_t>{1, 2, 3, 4});
   };
 
   ProviderOptions provider_options;
@@ -93,14 +99,17 @@ TEST_F(QnnHTPBackendTests, GroupNorm_Float_MultipleGroups) {
   std::vector<float> bias_data = {0.1f, 0.2f, 0.3f, 0.4f};
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({1, 4, 3, 4}, input_data);
-    auto* scale = builder.MakeInitializer<float>({4}, scale_data);
-    auto* bias = builder.MakeInitializer<float>({4}, bias_data);
+    MakeTestInput<float>(builder, "X", TestInputDef<float>({1, 4, 3, 4}, false, input_data));
+    MakeTestInput<float>(builder, "scale", TestInputDef<float>({4}, true, scale_data));
+    MakeTestInput<float>(builder, "bias", TestInputDef<float>({4}, true, bias_data));
 
-    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 4, 3, 4});
-    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
-    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(2));  // 4 channels / 2 groups = 2 channels per group
-    group_norm_node.AddAttribute("epsilon", 1e-05f);
+    // Create attributes
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("num_groups", static_cast<int64_t>(2)));  // 4 channels / 2 groups = 2 channels per group
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 1e-05f));
+
+    builder.AddNode("group_norm", "GroupNormalization", {"X", "scale", "bias"}, {"Y"}, "", attributes);
+    builder.MakeOutput<float>("Y", std::vector<int64_t>{1, 4, 3, 4});
   };
 
   ProviderOptions provider_options;
@@ -126,14 +135,17 @@ TEST_F(QnnHTPBackendTests, GroupNorm_Float_LargeEpsilon) {
   std::vector<float> bias_data = {0.1f, 0.2f};
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({1, 2, 3, 4}, input_data);
-    auto* scale = builder.MakeInitializer<float>({2}, scale_data);
-    auto* bias = builder.MakeInitializer<float>({2}, bias_data);
+    MakeTestInput<float>(builder, "X", TestInputDef<float>({1, 2, 3, 4}, false, input_data));
+    MakeTestInput<float>(builder, "scale", TestInputDef<float>({2}, true, scale_data));
+    MakeTestInput<float>(builder, "bias", TestInputDef<float>({2}, true, bias_data));
 
-    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 2, 3, 4});
-    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
-    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(1));
-    group_norm_node.AddAttribute("epsilon", 0.1f);  // Larger epsilon value
+    // Create attributes
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("num_groups", static_cast<int64_t>(1)));
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 0.1f));  // Larger epsilon value
+
+    builder.AddNode("group_norm", "GroupNormalization", {"X", "scale", "bias"}, {"Y"}, "", attributes);
+    builder.MakeOutput<float>("Y", std::vector<int64_t>{1, 2, 3, 4});
   };
 
   ProviderOptions provider_options;
@@ -160,14 +172,17 @@ TEST_F(QnnHTPBackendTests, GroupNorm_Float_3D) {
   std::vector<float> bias_data = {0.1f, 0.2f, 0.3f, 0.4f};
 
   auto build_test_case = [&](ModelTestBuilder& builder) {
-    auto* input = builder.MakeInput<float>({1, 4, 4}, input_data);
-    auto* scale = builder.MakeInitializer<float>({4}, scale_data);
-    auto* bias = builder.MakeInitializer<float>({4}, bias_data);
+    MakeTestInput<float>(builder, "X", TestInputDef<float>({1, 4, 4}, false, input_data));
+    MakeTestInput<float>(builder, "scale", TestInputDef<float>({4}, true, scale_data));
+    MakeTestInput<float>(builder, "bias", TestInputDef<float>({4}, true, bias_data));
 
-    auto* output = builder.MakeOutput<float>(std::vector<int64_t>{1, 4, 4});
-    Node& group_norm_node = builder.AddNode("GroupNormalization", {input, scale, bias}, {output});
-    group_norm_node.AddAttribute("num_groups", static_cast<int64_t>(2));  // 4 channels / 2 groups = 2 channels per group
-    group_norm_node.AddAttribute("epsilon", 1e-05f);
+    // Create attributes
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("num_groups", static_cast<int64_t>(2)));  // 4 channels / 2 groups = 2 channels per group
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 1e-05f));
+
+    builder.AddNode("group_norm", "GroupNormalization", {"X", "scale", "bias"}, {"Y"}, "", attributes);
+    builder.MakeOutput<float>("Y", std::vector<int64_t>{1, 4, 4});
   };
 
   ProviderOptions provider_options;

--- a/onnxruntime/test/providers/qnn/quickgelu_test.cc
+++ b/onnxruntime/test/providers/qnn/quickgelu_test.cc
@@ -36,11 +36,13 @@ static void RunQuickGeluTest(const TestInputDef<DataType>& input_def,
   }
 
   auto model_builder = [input_def, alpha](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput<DataType>(builder, input_def);
-    auto* output = builder.MakeOutput();
+    MakeTestInput<DataType>(builder, "input", input_def);
 
-    Node& node = builder.AddNode("QuickGelu", {input}, {output}, kMSDomain);
-    node.AddAttribute("alpha", alpha);
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("alpha", alpha));
+
+    builder.AddNode("quickgelu", "QuickGelu", {"input"}, {"output"}, kMSDomain, attributes);
+    builder.MakeOutput("output");
   };
 
   RunQnnModelTest(model_builder,
@@ -62,26 +64,29 @@ static void RunQDQQuickGeluTest(const TestInputDef<float>& input_def,
   provider_options["offload_graph_io_quantization"] = "0";
 
   GetTestModelFn model_builder_fn = [input_def, alpha](ModelTestBuilder& builder) {
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
-    auto* output = builder.MakeOutput();
+    MakeTestInput<float>(builder, "input", input_def);
 
-    Node& node = builder.AddNode("QuickGelu", {input}, {output}, kMSDomain);
-    node.AddAttribute("alpha", alpha);
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("alpha", alpha));
+
+    builder.AddNode("quickgelu", "QuickGelu", {"input"}, {"output"}, kMSDomain, attributes);
+    builder.MakeOutput("output");
   };
 
   GetTestQDQModelFn<QType> qdq_model_builder_fn = [input_def, alpha, use_contrib_qdq](ModelTestBuilder& builder, std::vector<QuantParams<QType>>& output_qparams) {
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
     QuantParams<QType> input_qparams = GetTestInputQuantParams<QType>(input_def);
-    NodeArg* input_after_qdq = AddQDQNodePair<QType>(builder, input, input_qparams.scale,
-                                                     input_qparams.zero_point, use_contrib_qdq);
+    std::string input_after_qdq = AddQDQNodePair<QType>(builder, "qdq_input", "input", input_qparams.scale,
+                                                        input_qparams.zero_point, use_contrib_qdq);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("alpha", alpha));
 
     // QuickGelu -> op_output
-    auto* op_output = builder.MakeIntermediate();
-    Node& node = builder.AddNode("QuickGelu", {input_after_qdq}, {op_output}, kMSDomain);
-    node.AddAttribute("alpha", alpha);
+    builder.AddNode("quickgelu", "QuickGelu", {input_after_qdq}, {"op_output"}, kMSDomain, attributes);
 
     // op_output -> Q -> DQ -> output
-    AddQDQNodePairWithOutputAsGraphOutput<QType>(builder, op_output, output_qparams[0].scale,
+    AddQDQNodePairWithOutputAsGraphOutput<QType>(builder, "qdq_output", "op_output", output_qparams[0].scale,
                                                  output_qparams[0].zero_point, use_contrib_qdq);
   };
 
@@ -148,27 +153,27 @@ TEST_F(QnnHTPBackendTests, QuickGelu_Negative_Alpha) {
 }
 
 TEST_F(QnnHTPBackendTests, QuickGelu_Float16_Default_Alpha) {
-  RunQuickGeluTest<MLFloat16>(ConvertToFP16InputDef(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48))),
-                              1.0f,
-                              ExpectedEPNodeAssignment::All,
-                              "htp",
-                              0.01f);
+  RunQuickGeluTest<Ort::Float16_t>(ConvertToFP16InputDef(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48))),
+                                   1.0f,
+                                   ExpectedEPNodeAssignment::All,
+                                   "htp",
+                                   0.01f);
 }
 
 // Test QuickGelu with float16 inputs and custom alpha on HTP
 TEST_F(QnnHTPBackendTests, QuickGelu_Float16_Custom_Alpha) {
-  RunQuickGeluTest<MLFloat16>(ConvertToFP16InputDef(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48))),
-                              1.702f,  // alpha
-                              ExpectedEPNodeAssignment::All,
-                              "htp");
+  RunQuickGeluTest<Ort::Float16_t>(ConvertToFP16InputDef(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48))),
+                                   1.702f,  // alpha
+                                   ExpectedEPNodeAssignment::All,
+                                   "htp");
 }
 
 // Test QuickGelu with float16 inputs and negative alpha on HTP
 TEST_F(QnnHTPBackendTests, QuickGelu_Float16_Negative_Alpha) {
-  RunQuickGeluTest<MLFloat16>(ConvertToFP16InputDef(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48))),
-                              -1.702f,  // alpha
-                              ExpectedEPNodeAssignment::All,
-                              "htp");
+  RunQuickGeluTest<Ort::Float16_t>(ConvertToFP16InputDef(TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48))),
+                                   -1.702f,  // alpha
+                                   ExpectedEPNodeAssignment::All,
+                                   "htp");
 }
 
 // Test 8-bit QDQ QuickGelu with default alpha value on HTP

--- a/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
@@ -4,7 +4,6 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <string>
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 
 #include "gtest/gtest.h"
@@ -24,7 +23,7 @@ static void RunRMSNormCpuTest(const TestInputDef<float>& input_def,
   provider_options["backend_type"] = "cpu";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  RunQnnModelTest(BuildOpTestCase<float>("RMSNormalization", {input_def, scale_def}, {}, attrs),
+  RunQnnModelTest(BuildOpTestCase<float>("rms_norm", "RMSNormalization", {input_def, scale_def}, {}, attrs),
                   provider_options,
                   23,
                   expected_ep_assignment);
@@ -33,28 +32,28 @@ static void RunRMSNormCpuTest(const TestInputDef<float>& input_def,
 TEST_F(QnnCPUBackendTests, RMSNorm) {
   RunRMSNormCpuTest(TestInputDef<float>({2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                     TestInputDef<float>({2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
-                    {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))},
                     ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, RMSNorm1D_Axis0) {
   RunRMSNormCpuTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                     TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
-                    {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))},
                     ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, RMSNorm2D) {
   RunRMSNormCpuTest(TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
                     TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
-                    {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))},
                     ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnCPUBackendTests, RMSNorm3D) {
   RunRMSNormCpuTest(TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
                     TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
-                    {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))},
                     ExpectedEPNodeAssignment::All);
 }
 
@@ -66,44 +65,43 @@ GetTestQDQModelFn<InputQType> BuildQDQRMSNormTestCase(const TestInputDef<float>&
   return [input_def, scale_def, attrs,
           use_contrib_qdq_ops](ModelTestBuilder& builder,
                                std::vector<QuantParams<InputQType>>& output_qparams) {
-    std::vector<NodeArg*> rms_norm_inputs;
-
-    NodeArg* input = MakeTestInput(builder, input_def);
+    // Input QDQ pair
+    MakeTestInput<float>(builder, "input", input_def);
     QuantParams<InputQType> input_qparams = GetTestInputQuantParams<InputQType>(input_def);
-    NodeArg* input_qdq = AddQDQNodePair<InputQType>(builder, input, input_qparams.scale, input_qparams.zero_point,
-                                                    use_contrib_qdq_ops);
-    rms_norm_inputs.push_back(input_qdq);
+    std::string input_qdq = AddQDQNodePair<InputQType>(builder, "qdq_input", "input",
+                                                       input_qparams.scale, input_qparams.zero_point,
+                                                       use_contrib_qdq_ops);
 
-    NodeArg* scale_qdq = nullptr;
+    // Scale QDQ pair
+    std::string scale_qdq;
     QuantParams<ScaleQType> scale_qparams = GetTestInputQuantParams<ScaleQType>(scale_def);
 
     if (scale_def.IsInitializer() && scale_def.IsRawData()) {
       std::vector<float> scale_scales = {scale_qparams.scale};
       std::vector<ScaleQType> scale_zps = {scale_qparams.zero_point};
-      TensorShape scale_shape = scale_def.GetTensorShape();
-      std::vector<ScaleQType> quantized_scales(scale_shape.Size());
+      const std::vector<int64_t>& scale_shape = scale_def.GetShape();
+      std::vector<ScaleQType> quantized_scales(SizeOfShape(scale_shape));
       QuantizeValues<float, ScaleQType>(scale_def.GetRawData(), quantized_scales, scale_shape,
                                         scale_scales, scale_zps, std::nullopt);
 
-      NodeArg* scale_initzer = builder.MakeInitializer<ScaleQType>(scale_def.GetShape(), quantized_scales);
-      scale_qdq = builder.MakeIntermediate();
-      builder.AddDequantizeLinearNode<ScaleQType>(scale_initzer, scale_scales, scale_zps, scale_qdq,
-                                                  nullptr, use_contrib_qdq_ops);
+      builder.MakeInitializer<ScaleQType>("scale_initializer", scale_shape, quantized_scales);
+      scale_qdq = "scale_dq_out";
+      builder.AddDequantizeLinearNode<ScaleQType>("scale_dq", "scale_initializer",
+                                                  scale_scales, scale_zps, scale_qdq,
+                                                  {}, use_contrib_qdq_ops);
     } else {
-      NodeArg* scale = MakeTestInput(builder, scale_def);
-      scale_qdq = AddQDQNodePair<ScaleQType>(builder, scale, scale_qparams.scale, scale_qparams.zero_point,
+      MakeTestInput<float>(builder, "scale", scale_def);
+      scale_qdq = AddQDQNodePair<ScaleQType>(builder, "qdq_scale", "scale",
+                                             scale_qparams.scale, scale_qparams.zero_point,
                                              use_contrib_qdq_ops);
     }
-    rms_norm_inputs.push_back(scale_qdq);
 
-    NodeArg* rms_norm_output = builder.MakeIntermediate();
-    Node& rms_norm_node = builder.AddNode("RMSNormalization", rms_norm_inputs, {rms_norm_output});
+    // RMSNormalization node
+    builder.AddNode("rms_norm", "RMSNormalization", {input_qdq, scale_qdq}, {"rms_norm_output"}, "", attrs);
 
-    for (const auto& attr : attrs) {
-      rms_norm_node.AddAttributeProto(attr);
-    }
-
-    AddQDQNodePairWithOutputAsGraphOutput<InputQType>(builder, rms_norm_output, output_qparams[0].scale,
+    // Output QDQ pair
+    AddQDQNodePairWithOutputAsGraphOutput<InputQType>(builder, "qdq_output", "rms_norm_output",
+                                                      output_qparams[0].scale,
                                                       output_qparams[0].zero_point, use_contrib_qdq_ops);
   };
 }
@@ -134,21 +132,21 @@ static void RunRMSNormQDQTest(const TestInputDef<float>& input_def,
 TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis) {
   RunRMSNormQDQTest<uint8_t, uint8_t>(TestInputDef<float>({1, 2, 3}, false, 0.0f, 10.0f),
                                       TestInputDef<float>({3}, true, 0.0f, 10.0f),
-                                      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                       ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis_StaticScale_AU8_WU8) {
   RunRMSNormQDQTest<uint8_t, uint8_t>(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                                       TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
-                                      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                       ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis_StaticScale_AU16_WU8) {
   RunRMSNormQDQTest<uint16_t, uint8_t>(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                                        TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
-                                       {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                       {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                        ExpectedEPNodeAssignment::All,
                                        true);
 }
@@ -156,14 +154,14 @@ TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis_StaticScale_AU16_WU8) {
 TEST_F(QnnHTPBackendTests, RMSNormU8U8_4D_LastAxis) {
   RunRMSNormQDQTest<uint8_t, uint8_t>(TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 18)),
                                       TestInputDef<float>({3}, true, GetFloatDataInRange(-2.0f, 2.0f, 3)),
-                                      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                       ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis_DynamicScale) {
   RunRMSNormQDQTest<uint8_t, uint8_t>(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                                       TestInputDef<float>({3}, false, GetFloatDataInRange(0.0f, 1.0f, 3)),
-                                      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                       ExpectedEPNodeAssignment::All);
 }
 

--- a/onnxruntime/test/providers/qnn/simplifiedlayernormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/simplifiedlayernormalization_test.cc
@@ -4,7 +4,6 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <string>
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 
 #include "gtest/gtest.h"
@@ -26,7 +25,7 @@ static void RunSimplifiedLayerNormCpuTest(const TestInputDef<float>& input_def,
   provider_options["offload_graph_io_quantization"] = "0";
 
   RunQnnModelTest(
-      BuildOpTestCase<float>("SimplifiedLayerNormalization", {input_def, scale_def}, {}, attrs),
+      BuildOpTestCase<float>("simplified_layernorm", "SimplifiedLayerNormalization", {input_def, scale_def}, {}, attrs),
       provider_options,
       17,  // opset version
       expected_ep_assignment);
@@ -42,47 +41,42 @@ GetTestQDQModelFn<InputQType> BuildQDQSimplifiedLayerNormTestCase(
   return [input_def, scale_def, attrs,
           use_contrib_qdq_ops](ModelTestBuilder& builder,
                                std::vector<QuantParams<InputQType>>& output_qparams) {
-    std::vector<NodeArg*> node_inputs;
-
     // input -> Q -> DQ
-    NodeArg* input = MakeTestInput(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
     QuantParams<InputQType> input_qparams = GetTestInputQuantParams<InputQType>(input_def);
-    NodeArg* input_qdq = AddQDQNodePair<InputQType>(builder, input, input_qparams.scale,
-                                                    input_qparams.zero_point, use_contrib_qdq_ops);
-    node_inputs.push_back(input_qdq);
+    std::string input_qdq = AddQDQNodePair<InputQType>(builder, "qdq_input", "input",
+                                                       input_qparams.scale,
+                                                       input_qparams.zero_point, use_contrib_qdq_ops);
 
     // scale: static initializer -> DQ, or dynamic -> Q -> DQ
-    NodeArg* scale_qdq = nullptr;
+    std::string scale_qdq;
     QuantParams<ScaleQType> scale_qparams = GetTestInputQuantParams<ScaleQType>(scale_def);
 
     if (scale_def.IsInitializer() && scale_def.IsRawData()) {
       std::vector<float> scale_scales = {scale_qparams.scale};
       std::vector<ScaleQType> scale_zps = {scale_qparams.zero_point};
-      TensorShape scale_shape = scale_def.GetTensorShape();
-      std::vector<ScaleQType> quantized_scales(scale_shape.Size());
+      const std::vector<int64_t>& scale_shape = scale_def.GetShape();
+      std::vector<ScaleQType> quantized_scales(SizeOfShape(scale_shape));
       QuantizeValues<float, ScaleQType>(scale_def.GetRawData(), quantized_scales, scale_shape,
                                         scale_scales, scale_zps, std::nullopt);
 
-      NodeArg* scale_initzer = builder.MakeInitializer<ScaleQType>(scale_def.GetShape(), quantized_scales);
-      scale_qdq = builder.MakeIntermediate();
-      builder.AddDequantizeLinearNode<ScaleQType>(scale_initzer, scale_scales, scale_zps, scale_qdq,
-                                                  nullptr, use_contrib_qdq_ops);
+      builder.MakeInitializer<ScaleQType>("scale_initializer", scale_shape, quantized_scales);
+      scale_qdq = "scale_qdq_output";
+      builder.AddDequantizeLinearNode<ScaleQType>("scale_dq", "scale_initializer", scale_scales, scale_zps,
+                                                  scale_qdq, {}, use_contrib_qdq_ops);
     } else {
-      NodeArg* scale = MakeTestInput(builder, scale_def);
-      scale_qdq = AddQDQNodePair<ScaleQType>(builder, scale, scale_qparams.scale,
+      MakeTestInput<float>(builder, "scale", scale_def);
+      scale_qdq = AddQDQNodePair<ScaleQType>(builder, "qdq_scale", "scale", scale_qparams.scale,
                                              scale_qparams.zero_point, use_contrib_qdq_ops);
     }
-    node_inputs.push_back(scale_qdq);
 
     // SimplifiedLayerNormalization (single output Y)
-    NodeArg* output = builder.MakeIntermediate();
-    Node& node = builder.AddNode("SimplifiedLayerNormalization", node_inputs, {output});
-    for (const auto& attr : attrs) {
-      node.AddAttributeProto(attr);
-    }
+    builder.AddNode("sln_node", "SimplifiedLayerNormalization", {input_qdq, scale_qdq},
+                    {"sln_output"}, "", attrs);
 
     // output -> Q -> DQ -> graph output
-    AddQDQNodePairWithOutputAsGraphOutput<InputQType>(builder, output, output_qparams[0].scale,
+    AddQDQNodePairWithOutputAsGraphOutput<InputQType>(builder, "qdq_output", "sln_output",
+                                                      output_qparams[0].scale,
                                                       output_qparams[0].zero_point, use_contrib_qdq_ops);
   };
 }
@@ -110,7 +104,7 @@ static void RunSimplifiedLayerNormQDQTest(const TestInputDef<float>& input_def,
   };
 
   RunQnnModelTest(model_fn, provider_options, 17, expected_ep_assignment,
-                  1e-5f, logging::Severity::kERROR, false);
+                  1e-5f, OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR, false);
 }
 
 // Basic 2D input, axis=0.
@@ -118,7 +112,7 @@ TEST_F(QnnCPUBackendTests, SimplifiedLayerNorm_2D_Axis0) {
   RunSimplifiedLayerNormCpuTest(
       TestInputDef<float>({2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(0))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -127,7 +121,7 @@ TEST_F(QnnCPUBackendTests, SimplifiedLayerNorm_3D_Axis0) {
   RunSimplifiedLayerNormCpuTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(0))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -136,7 +130,7 @@ TEST_F(QnnCPUBackendTests, SimplifiedLayerNorm_4D_Axis0) {
   RunSimplifiedLayerNormCpuTest(
       TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
       TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 18)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(0))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(0))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -146,8 +140,8 @@ TEST_F(QnnCPUBackendTests, SimplifiedLayerNorm_CustomEpsilon) {
   RunSimplifiedLayerNormCpuTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(0)),
-       utils::MakeAttribute("epsilon", 1e-3f)},
+      {test::MakeAttribute("axis", static_cast<int64_t>(0)),
+       test::MakeAttribute("epsilon", 1e-3f)},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -160,21 +154,22 @@ TEST_F(QnnCPUBackendTests, SimplifiedLayerNorm_InvStdVar_Unsupported) {
 
   // Build a model with 2 outputs: Y and inv_std_var.
   auto build_model_with_inv_std_var = [](ModelTestBuilder& builder) {
-    NodeArg* input = builder.MakeInput<float>({1, 2, 3}, 0.0f, 10.0f);
-    NodeArg* scale = builder.MakeInitializer<float>({3}, 0.0f, 1.0f);
-    NodeArg* output_y = builder.MakeOutput();
-    NodeArg* output_inv_std_var = builder.MakeOutput();
-    Node& node = builder.AddNode("SimplifiedLayerNormalization",
-                                 {input, scale},
-                                 {output_y, output_inv_std_var});
-    node.AddAttribute("axis", static_cast<int64_t>(-1));
+    builder.MakeInput<float>("input", {1, 2, 3}, 0.0f, 10.0f);
+    builder.MakeInitializer<float>("scale", {3}, 0.0f, 1.0f);
+    builder.MakeOutput("output_y");
+    builder.MakeOutput("output_inv_std_var");
+    builder.AddNode("sln_node", "SimplifiedLayerNormalization",
+                    {"input", "scale"},
+                    {"output_y", "output_inv_std_var"},
+                    "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(-1))});
   };
 
   // QNN EP should reject this node because inv_std_var is not supported.
   // The node falls back to CPU EP.
   RunQnnModelTest(build_model_with_inv_std_var, provider_options, 17,
                   ExpectedEPNodeAssignment::None,
-                  1e-5f, logging::Severity::kERROR,
+                  1e-5f, OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                   false /* verify_outputs */);
 }
 
@@ -186,11 +181,12 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_Axis0_Unsupported) {
   provider_options["offload_graph_io_quantization"] = "0";
 
   RunQnnModelTest(
-      BuildOpTestCase<float>("SimplifiedLayerNormalization",
+      BuildOpTestCase<float>("simplified_layernorm",
+                             "SimplifiedLayerNormalization",
                              {TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
                               TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6))},
                              {},
-                             {utils::MakeAttribute("axis", static_cast<int64_t>(0))}),
+                             {test::MakeAttribute("axis", static_cast<int64_t>(0))}),
       provider_options,
       17,
       ExpectedEPNodeAssignment::None);
@@ -204,11 +200,12 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_Rank5_Unsupported) {
   provider_options["offload_graph_io_quantization"] = "0";
 
   RunQnnModelTest(
-      BuildOpTestCase<float>("SimplifiedLayerNormalization",
+      BuildOpTestCase<float>("simplified_layernorm",
+                             "SimplifiedLayerNormalization",
                              {TestInputDef<float>({1, 2, 3, 3, 4}, false, GetFloatDataInRange(0.0f, 10.0f, 72)),
                               TestInputDef<float>({4}, false, GetFloatDataInRange(0.0f, 1.0f, 4))},
                              {},
-                             {utils::MakeAttribute("axis", static_cast<int64_t>(-1))}),
+                             {test::MakeAttribute("axis", static_cast<int64_t>(-1))}),
       provider_options,
       17,
       ExpectedEPNodeAssignment::None);
@@ -219,7 +216,7 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_LastAxis_StaticScale_AU8_WU8) {
   RunSimplifiedLayerNormQDQTest<uint8_t, uint8_t>(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -228,7 +225,7 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_LastAxis_StaticScale_AU16_WU8) {
   RunSimplifiedLayerNormQDQTest<uint16_t, uint8_t>(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All,
       true /* use_contrib_qdq_ops */);
 }
@@ -238,7 +235,7 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_LastAxis_DynamicScale_AU8_WU8) {
   RunSimplifiedLayerNormQDQTest<uint8_t, uint8_t>(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({3}, false, GetFloatDataInRange(0.0f, 1.0f, 3)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -247,7 +244,7 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_4D_LastAxis_AU8_WU8) {
   RunSimplifiedLayerNormQDQTest<uint8_t, uint8_t>(
       TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 18)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(-2.0f, 2.0f, 3)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -256,8 +253,8 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_LastAxis_CustomEpsilon_AU8_WU8) {
   RunSimplifiedLayerNormQDQTest<uint8_t, uint8_t>(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1)),
-       utils::MakeAttribute("epsilon", 1e-3f)},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1)),
+       test::MakeAttribute("epsilon", 1e-3f)},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -266,7 +263,7 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_2D_LastAxis_AU8_WU8) {
   RunSimplifiedLayerNormQDQTest<uint8_t, uint8_t>(
       TestInputDef<float>({4, 8}, false, GetFloatDataInRange(0.0f, 10.0f, 32)),
       TestInputDef<float>({8}, true, GetFloatDataInRange(0.0f, 1.0f, 8)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All);
 }
 
@@ -275,7 +272,7 @@ TEST_F(QnnHTPBackendTests, SimplifiedLayerNorm_4D_LastAxis_AU16_WU8) {
   RunSimplifiedLayerNormQDQTest<uint16_t, uint8_t>(
       TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 18)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(-2.0f, 2.0f, 3)),
-      {utils::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All,
       true /* use_contrib_qdq_ops */);
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- The change modifies the recent added op testcases with public API and re-enables them.
    - `bf_16.cc`
    - `groupnormalization_test.cc`
    - `quickgelu_test.cc`
    - `rmsnormalization_test.cc`
    - `simplifiedlayernormalization_test.cc`, 
    - `fusedmatmul_test.cc`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- To avoid relying on private ORT Core headers/libraries, #23 reconstructed the QNN Test Framework using only ORT’s public headers and libraries.
- The newly added op test cases required several adjustments to work with the updated QNN test infrastructure. To keep the scope of #23 manageable, those tests were temporarily disabled and are now being re‑enabled with the necessary updates.
