### PR TITLE
Modify recent fusion tests with Public API and re-enable them

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -217,7 +217,6 @@ list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/gather_transpose_reshape_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/optimizer/transpose_optimizer_test.cc")
 
 #This is a small wrapper library that shouldn't use any onnxruntime internal symbols(except onnxruntime_common).

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -213,8 +213,7 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
-     "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"g
-     "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc"
+     "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/optimizer/transpose_optimizer_test.cc")
 
 #This is a small wrapper library that shouldn't use any onnxruntime internal symbols(except onnxruntime_common).

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -213,8 +213,7 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
-     "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc"
+     "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"g
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/optimizer/transpose_optimizer_test.cc")
 

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -214,7 +214,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc"

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -214,7 +214,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/optimizer/transpose_optimizer_test.cc")

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -214,7 +214,6 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 # TODO: Re-enable the recent op testcases
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/matmulnbits_test.cc"
-     "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc"
      "${TEST_SRC_DIR}/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/channel_shuffle_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/channel_shuffle_fusion_test.cc
@@ -5,9 +5,6 @@
 
 #include <filesystem>
 
-#include "core/graph/graph.h"
-#include "core/graph/node_attr_utils.h"
-
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gather_transpose_reshape_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gather_transpose_reshape_fusion_test.cc
@@ -8,7 +8,6 @@
 #include <vector>
 #include <numeric>
 
-#include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "gtest/gtest.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gather_transpose_reshape_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gather_transpose_reshape_fusion_test.cc
@@ -8,7 +8,6 @@
 #include <vector>
 #include <numeric>
 
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
@@ -56,30 +55,26 @@ GetTestModelFn BuildGatherTransposeReshapeTestCase(
     const std::vector<int64_t>& final_reshape_shape) {
   return [input_def, indices_shape, indices_data, transpose_perm, final_reshape_shape](ModelTestBuilder& builder) {
     // Input: rank-5 [d0, d1, d2, d3, d4]
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
 
     // Constant Indices: rank-2 [idx0, idx1]
-    NodeArg* indices = builder.MakeInitializer<int64_t>(indices_shape, indices_data);
+    builder.MakeInitializer<int64_t>("indices", indices_shape, indices_data);
 
     // Gather(axis=4)
     // Output shape: [d0, d1, d2, d3, idx0, idx1] (Rank 6)
-    NodeArg* gather_out = builder.MakeIntermediate();
-    NodeAttributes gather_attrs;
-    gather_attrs["axis"] = utils::MakeAttribute("axis", int64_t(4));
-    builder.AddNode("Gather", {input, indices}, {gather_out}, "", &gather_attrs);
+    builder.AddNode("gather", "Gather", {"input", "indices"}, {"gather_out"}, "",
+                    {test::MakeAttribute("axis", int64_t(4))});
 
     // Transpose
     // Output shape: Rank 6 (permuted)
-    NodeArg* transpose_out = builder.MakeIntermediate();
-    NodeAttributes transpose_attrs;
-    transpose_attrs["perm"] = utils::MakeAttribute("perm", transpose_perm);
-    builder.AddNode("Transpose", {gather_out}, {transpose_out}, "", &transpose_attrs);
+    builder.AddNode("transpose", "Transpose", {"gather_out"}, {"transpose_out"}, "",
+                    {test::MakeAttribute("perm", transpose_perm)});
 
     // Reshape -> Final Output
     // Output shape: final_reshape_shape (Rank < 6)
-    NodeArg* shape_const = builder.Make1DInitializer<int64_t>(final_reshape_shape);
-    NodeArg* output = builder.MakeOutput();
-    builder.AddNode("Reshape", {transpose_out, shape_const}, {output});
+    builder.Make1DInitializer<int64_t>("shape_const", final_reshape_shape);
+    builder.MakeOutput("output");
+    builder.AddNode("reshape", "Reshape", {"transpose_out", "shape_const"}, {"output"});
   };
 }
 

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -7,8 +7,6 @@
 #include <string>
 #include <vector>
 
-#include "core/graph/graph.h"
-#include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
@@ -35,31 +34,35 @@ GetQDQTestCaseFn BuildLPBQGemmTestCase() {
     const int64_t blocks_per_axis = 4;
     const std::vector<int64_t> input_shape{1, input_channels};
     auto input_def = TestInputDef<float>(input_shape, false, -0.5f, 0.5f);
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
 
     // QuantizeLinear for Activation
-    NodeArg* act_ql_output = builder.MakeIntermediate();
-    NodeArg* act_ql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("QuantizeLinear", {input, act_ql_scale, act_ql_zero_point}, {act_ql_output});
+    builder.MakeScalarInitializer<float>("act_ql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_ql", "QuantizeLinear",
+                    {"input", "act_ql_scale", "act_ql_zero_point"},
+                    {"act_ql_output"});
 
     // DequantizeLinear for Activation
-    NodeArg* act_dql_output = builder.MakeIntermediate();
-    NodeArg* act_dql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("DequantizeLinear", {act_ql_output, act_dql_scale, act_dql_zero_point}, {act_dql_output});
+    builder.MakeScalarInitializer<float>("act_dql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_dql", "DequantizeLinear",
+                    {"act_ql_output", "act_dql_scale", "act_dql_zero_point"},
+                    {"act_dql_output"});
 
     // DequantizeLinear for Scale
-    NodeArg* scale_dql_input = builder.MakeInitializer<uint8_t>({blocks_per_axis, output_channels}, 1, 15);
-    NodeArg* scale_dql_scale = builder.MakeInitializer<float>({output_channels}, 0.01f, 0.02f);
+    builder.MakeInitializer<uint8_t>("scale_dql_input", {blocks_per_axis, output_channels},
+                                     static_cast<uint8_t>(1), static_cast<uint8_t>(15));
+    builder.MakeInitializer<float>("scale_dql_scale", {output_channels}, 0.01f, 0.02f);
     std::vector<uint8_t> dql_zero_points_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    NodeArg* scale_dql_zero_point = builder.Make1DInitializer<uint8_t>(dql_zero_points_data);
-    NodeArg* scale_dql_output = builder.MakeIntermediate();
-    Node& scale_dql = builder.AddNode("DequantizeLinear", {scale_dql_input, scale_dql_scale, scale_dql_zero_point}, {scale_dql_output});
-    scale_dql.AddAttribute("axis", static_cast<int64_t>(1));
+    builder.Make1DInitializer<uint8_t>("scale_dql_zero_point", dql_zero_points_data);
+    builder.AddNode("scale_dql", "DequantizeLinear",
+                    {"scale_dql_input", "scale_dql_scale", "scale_dql_zero_point"},
+                    {"scale_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(1))});
 
     // QuantizeLinear for Weight
-    NodeArg* w_ql_input = builder.MakeInitializer<float>({input_channels, output_channels}, -1.0f, 1.0f);
+    builder.MakeInitializer<float>("w_ql_input", {input_channels, output_channels}, -1.0f, 1.0f);
     std::vector<Int4x2> zero_points_data;
     size_t num_storage_elems = blocks_per_axis * output_channels;
     zero_points_data.resize(Int4x2::CalcNumInt4Pairs(num_storage_elems));
@@ -68,35 +71,41 @@ GetQDQTestCaseFn BuildLPBQGemmTestCase() {
       size_t c = i & 0x1;
       zero_points_data[r].SetElem(c, 0);
     }
-    NodeArg* w_ql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
-    NodeArg* w_ql_output = builder.MakeIntermediate();
-    Node& w_ql = builder.AddNode("QuantizeLinear", {w_ql_input, scale_dql_output, w_ql_zero_point}, {w_ql_output});
-    w_ql.AddAttribute("axis", static_cast<int64_t>(0));
-    w_ql.AddAttribute("block_size", static_cast<int64_t>(4));
+    builder.MakeInitializer<Int4x2>("w_ql_zero_point", {blocks_per_axis, output_channels}, zero_points_data);
+    builder.AddNode("w_ql", "QuantizeLinear",
+                    {"w_ql_input", "scale_dql_output", "w_ql_zero_point"},
+                    {"w_ql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", static_cast<int64_t>(4))});
 
     // DequantizeLinear for Weight
-    NodeArg* w_dql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
-    NodeArg* w_dql_output = builder.MakeIntermediate();
-    Node& w_dql = builder.AddNode("DequantizeLinear", {w_ql_output, scale_dql_output, w_dql_zero_point}, {w_dql_output});
-    w_dql.AddAttribute("axis", static_cast<int64_t>(0));
-    w_dql.AddAttribute("block_size", static_cast<int64_t>(4));
+    builder.MakeInitializer<Int4x2>("w_dql_zero_point", {blocks_per_axis, output_channels}, zero_points_data);
+    builder.AddNode("w_dql", "DequantizeLinear",
+                    {"w_ql_output", "scale_dql_output", "w_dql_zero_point"},
+                    {"w_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", static_cast<int64_t>(4))});
 
     // Gemm
-    NodeArg* gemm_bias = builder.MakeInitializer<float>({output_channels}, -1.0f, 1.0f);
-    NodeArg* gemm_output = builder.MakeIntermediate();
-    builder.AddNode("Gemm", {act_dql_output, w_dql_output, gemm_bias}, {gemm_output});
+    builder.MakeInitializer<float>("gemm_bias", {output_channels}, -1.0f, 1.0f);
+    builder.AddNode("gemm", "Gemm",
+                    {"act_dql_output", "w_dql_output", "gemm_bias"},
+                    {"gemm_output"});
 
     // QuantizeLinear for Output
-    NodeArg* output_ql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_ql_output = builder.MakeIntermediate();
-    builder.AddNode("QuantizeLinear", {gemm_output, output_ql_scale, output_ql_zero_point}, {output_ql_output});
+    builder.MakeScalarInitializer<float>("output_ql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_ql_zero_point", static_cast<uint16_t>(31693));
+    builder.AddNode("output_ql", "QuantizeLinear",
+                    {"gemm_output", "output_ql_scale", "output_ql_zero_point"},
+                    {"output_ql_output"});
 
     // DequantizeLinear for Output
-    NodeArg* output_dql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_dql_output = builder.MakeOutput();
-    builder.AddNode("DequantizeLinear", {output_ql_output, output_dql_scale, output_dql_zero_point}, {output_dql_output});
+    builder.MakeScalarInitializer<float>("output_dql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_dql_zero_point", static_cast<uint16_t>(31693));
+    builder.MakeOutput("output_dql_output");
+    builder.AddNode("output_dql", "DequantizeLinear",
+                    {"output_ql_output", "output_dql_scale", "output_dql_zero_point"},
+                    {"output_dql_output"});
   };
 }
 
@@ -128,7 +137,7 @@ TEST_F(QnnHTPBackendTests, LPBQGemmFusion) {
                   /*opset_version=*/21,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
                   /*fp32_abs_err=*/1e-2f,
-                  /*log_severity =*/logging::Severity::kERROR,
+                  /*log_severity =*/OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                   /*verify_outputs=*/false);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected");

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/unittest_util/qdq_test_utils.h"
@@ -35,28 +34,30 @@ GetQDQTestCaseFn BuildLPBQGemmWithoutQLTestCase() {
     const int64_t blocks_per_axis = 4;
     const std::vector<int64_t> input_shape{1, input_channels};
     auto input_def = TestInputDef<float>(input_shape, false, -0.5f, 0.5f);
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
 
     // QuantizeLinear for Activation
-    NodeArg* act_ql_output = builder.MakeIntermediate();
-    NodeArg* act_ql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("QuantizeLinear", {input, act_ql_scale, act_ql_zero_point}, {act_ql_output});
+    builder.MakeScalarInitializer<float>("act_ql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_ql", "QuantizeLinear",
+                    {"input", "act_ql_scale", "act_ql_zero_point"}, {"act_ql_output"});
 
     // DequantizeLinear for Activation
-    NodeArg* act_dql_output = builder.MakeIntermediate();
-    NodeArg* act_dql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("DequantizeLinear", {act_ql_output, act_dql_scale, act_dql_zero_point}, {act_dql_output});
+    builder.MakeScalarInitializer<float>("act_dql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_dql", "DequantizeLinear",
+                    {"act_ql_output", "act_dql_scale", "act_dql_zero_point"}, {"act_dql_output"});
 
     // DequantizeLinear for Scale
-    NodeArg* scale_dql_input = builder.MakeInitializer<uint8_t>({blocks_per_axis, output_channels}, 1, 15);
-    NodeArg* scale_dql_scale = builder.MakeInitializer<float>({output_channels}, 0.01f, 0.02f);
+    builder.MakeInitializer<uint8_t>("scale_dql_input", {blocks_per_axis, output_channels},
+                                     static_cast<uint8_t>(1), static_cast<uint8_t>(15));
+    builder.MakeInitializer<float>("scale_dql_scale", {output_channels}, 0.01f, 0.02f);
     std::vector<uint8_t> dql_zero_points_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    NodeArg* scale_dql_zero_point = builder.Make1DInitializer<uint8_t>(dql_zero_points_data);
-    NodeArg* scale_dql_output = builder.MakeIntermediate();
-    Node& scale_dql = builder.AddNode("DequantizeLinear", {scale_dql_input, scale_dql_scale, scale_dql_zero_point}, {scale_dql_output});
-    scale_dql.AddAttribute("axis", static_cast<int64_t>(1));
+    builder.Make1DInitializer<uint8_t>("scale_dql_zero_point", dql_zero_points_data);
+    builder.AddNode("scale_dql", "DequantizeLinear",
+                    {"scale_dql_input", "scale_dql_scale", "scale_dql_zero_point"},
+                    {"scale_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(1))});
 
     // Create quantized weight directly (skip QuantizeLinear)
     // We're creating a pre-quantized weight tensor that would normally be the output of QuantizeLinear
@@ -68,7 +69,7 @@ GetQDQTestCaseFn BuildLPBQGemmWithoutQLTestCase() {
       quantized_weight_data[i].SetElem(0, i % 16);
       quantized_weight_data[i].SetElem(1, (i + 8) % 16);
     }
-    NodeArg* w_quantized = builder.MakeInitializer<Int4x2>({input_channels, output_channels}, quantized_weight_data);
+    builder.MakeInitializer<Int4x2>("w_quantized", {input_channels, output_channels}, quantized_weight_data);
 
     // DequantizeLinear for Weight (directly using the quantized weight)
     std::vector<Int4x2> zero_points_data;
@@ -79,28 +80,31 @@ GetQDQTestCaseFn BuildLPBQGemmWithoutQLTestCase() {
       size_t c = i & 0x1;
       zero_points_data[r].SetElem(c, 0);
     }
-    NodeArg* w_dql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
-    NodeArg* w_dql_output = builder.MakeIntermediate();
-    Node& w_dql = builder.AddNode("DequantizeLinear", {w_quantized, scale_dql_output, w_dql_zero_point}, {w_dql_output});
-    w_dql.AddAttribute("axis", static_cast<int64_t>(0));
-    w_dql.AddAttribute("block_size", static_cast<int64_t>(4));
+    builder.MakeInitializer<Int4x2>("w_dql_zero_point", {blocks_per_axis, output_channels}, zero_points_data);
+    builder.AddNode("w_dql", "DequantizeLinear",
+                    {"w_quantized", "scale_dql_output", "w_dql_zero_point"},
+                    {"w_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", static_cast<int64_t>(4))});
 
     // Gemm
-    NodeArg* gemm_bias = builder.MakeInitializer<float>({output_channels}, -1.0f, 1.0f);
-    NodeArg* gemm_output = builder.MakeIntermediate();
-    builder.AddNode("Gemm", {act_dql_output, w_dql_output, gemm_bias}, {gemm_output});
+    builder.MakeInitializer<float>("gemm_bias", {output_channels}, -1.0f, 1.0f);
+    builder.AddNode("gemm", "Gemm", {"act_dql_output", "w_dql_output", "gemm_bias"}, {"gemm_output"});
 
     // QuantizeLinear for Output
-    NodeArg* output_ql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_ql_output = builder.MakeIntermediate();
-    builder.AddNode("QuantizeLinear", {gemm_output, output_ql_scale, output_ql_zero_point}, {output_ql_output});
+    builder.MakeScalarInitializer<float>("output_ql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_ql_zero_point", static_cast<uint16_t>(31693));
+    builder.AddNode("output_ql", "QuantizeLinear",
+                    {"gemm_output", "output_ql_scale", "output_ql_zero_point"},
+                    {"output_ql_output"});
 
     // DequantizeLinear for Output
-    NodeArg* output_dql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_dql_output = builder.MakeOutput();
-    builder.AddNode("DequantizeLinear", {output_ql_output, output_dql_scale, output_dql_zero_point}, {output_dql_output});
+    builder.MakeScalarInitializer<float>("output_dql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_dql_zero_point", static_cast<uint16_t>(31693));
+    builder.MakeOutput("output_dql_output");
+    builder.AddNode("output_dql", "DequantizeLinear",
+                    {"output_ql_output", "output_dql_scale", "output_dql_zero_point"},
+                    {"output_dql_output"});
   };
 }
 
@@ -132,7 +136,7 @@ TEST_F(QnnHTPBackendTests, LPBQGemmFusionWithoutQL) {
                   /*opset_version=*/21,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
                   /*fp32_abs_err=*/1e-2f,
-                  /*log_severity =*/logging::Severity::kERROR,
+                  /*log_severity =*/OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                   /*verify_outputs=*/false);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected");

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqgemm_fusion_without_ql_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/unittest_util/qdq_test_utils.h"
 #include "test/providers/qnn/qnn_test_utils.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
@@ -35,31 +34,33 @@ GetQDQTestCaseFn BuildLPBQMatMulTestCase() {
     const int64_t blocks_per_axis = 4;
     const std::vector<int64_t> input_shape{1, input_channels};
     auto input_def = TestInputDef<float>(input_shape, false, -0.5f, 0.5f);
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
 
     // QuantizeLinear for Activation
-    NodeArg* act_ql_output = builder.MakeIntermediate();
-    NodeArg* act_ql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("QuantizeLinear", {input, act_ql_scale, act_ql_zero_point}, {act_ql_output});
+    builder.MakeScalarInitializer<float>("act_ql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_ql", "QuantizeLinear",
+                    {"input", "act_ql_scale", "act_ql_zero_point"}, {"act_ql_output"});
 
     // DequantizeLinear for Activation
-    NodeArg* act_dql_output = builder.MakeIntermediate();
-    NodeArg* act_dql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("DequantizeLinear", {act_ql_output, act_dql_scale, act_dql_zero_point}, {act_dql_output});
+    builder.MakeScalarInitializer<float>("act_dql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_dql", "DequantizeLinear",
+                    {"act_ql_output", "act_dql_scale", "act_dql_zero_point"}, {"act_dql_output"});
 
     // DequantizeLinear for Scale
-    NodeArg* scale_dql_input = builder.MakeInitializer<uint8_t>({blocks_per_axis, output_channels}, 1, 16);
-    NodeArg* scale_dql_scale = builder.MakeInitializer<float>({output_channels}, 0.01f, 0.02f);
+    builder.MakeInitializer<uint8_t>("scale_dql_input", {blocks_per_axis, output_channels},
+                                     static_cast<uint8_t>(1), static_cast<uint8_t>(16));
+    builder.MakeInitializer<float>("scale_dql_scale", {output_channels}, 0.01f, 0.02f);
     std::vector<uint8_t> dql_zero_points_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    NodeArg* scale_dql_zero_point = builder.Make1DInitializer<uint8_t>(dql_zero_points_data);
-    NodeArg* scale_dql_output = builder.MakeIntermediate();
-    Node& scale_dql = builder.AddNode("DequantizeLinear", {scale_dql_input, scale_dql_scale, scale_dql_zero_point}, {scale_dql_output});
-    scale_dql.AddAttribute("axis", static_cast<int64_t>(1));
+    builder.Make1DInitializer<uint8_t>("scale_dql_zero_point", dql_zero_points_data);
+    builder.AddNode("scale_dql", "DequantizeLinear",
+                    {"scale_dql_input", "scale_dql_scale", "scale_dql_zero_point"},
+                    {"scale_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(1))});
 
     // QuantizeLinear for Weight
-    NodeArg* w_ql_input = builder.MakeInitializer<float>({input_channels, output_channels}, -2.0f, 2.0f);
+    builder.MakeInitializer<float>("w_ql_input", {input_channels, output_channels}, -2.0f, 2.0f);
     std::vector<Int4x2> zero_points_data;
     size_t num_storage_elems = blocks_per_axis * output_channels;
     zero_points_data.resize(Int4x2::CalcNumInt4Pairs(num_storage_elems));
@@ -68,34 +69,38 @@ GetQDQTestCaseFn BuildLPBQMatMulTestCase() {
       size_t c = i & 0x1;
       zero_points_data[r].SetElem(c, 0);
     }
-    NodeArg* w_ql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
-    NodeArg* w_ql_output = builder.MakeIntermediate();
-    Node& w_ql = builder.AddNode("QuantizeLinear", {w_ql_input, scale_dql_output, w_ql_zero_point}, {w_ql_output});
-    w_ql.AddAttribute("axis", static_cast<int64_t>(0));
-    w_ql.AddAttribute("block_size", static_cast<int64_t>(4));
+    builder.MakeInitializer<Int4x2>("w_ql_zero_point", {blocks_per_axis, output_channels}, zero_points_data);
+    builder.AddNode("w_ql", "QuantizeLinear",
+                    {"w_ql_input", "scale_dql_output", "w_ql_zero_point"},
+                    {"w_ql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", static_cast<int64_t>(4))});
 
     // DequantizeLinear for Weight
-    NodeArg* w_dql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
-    NodeArg* w_dql_output = builder.MakeIntermediate();
-    Node& w_dql = builder.AddNode("DequantizeLinear", {w_ql_output, scale_dql_output, w_dql_zero_point}, {w_dql_output});
-    w_dql.AddAttribute("axis", static_cast<int64_t>(0));
-    w_dql.AddAttribute("block_size", static_cast<int64_t>(4));
+    builder.MakeInitializer<Int4x2>("w_dql_zero_point", {blocks_per_axis, output_channels}, zero_points_data);
+    builder.AddNode("w_dql", "DequantizeLinear",
+                    {"w_ql_output", "scale_dql_output", "w_dql_zero_point"},
+                    {"w_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", static_cast<int64_t>(4))});
 
     // MatMul
-    NodeArg* matmul_output = builder.MakeIntermediate();
-    builder.AddNode("MatMul", {act_dql_output, w_dql_output}, {matmul_output});
+    builder.AddNode("matmul", "MatMul", {"act_dql_output", "w_dql_output"}, {"matmul_output"});
 
     // QuantizeLinear for Output
-    NodeArg* output_ql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_ql_output = builder.MakeIntermediate();
-    builder.AddNode("QuantizeLinear", {matmul_output, output_ql_scale, output_ql_zero_point}, {output_ql_output});
+    builder.MakeScalarInitializer<float>("output_ql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_ql_zero_point", static_cast<uint16_t>(31693));
+    builder.AddNode("output_ql", "QuantizeLinear",
+                    {"matmul_output", "output_ql_scale", "output_ql_zero_point"},
+                    {"output_ql_output"});
 
     // DequantizeLinear for Output
-    NodeArg* output_dql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_dql_output = builder.MakeOutput();
-    builder.AddNode("DequantizeLinear", {output_ql_output, output_dql_scale, output_dql_zero_point}, {output_dql_output});
+    builder.MakeScalarInitializer<float>("output_dql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_dql_zero_point", static_cast<uint16_t>(31693));
+    builder.MakeOutput("output_dql_output");
+    builder.AddNode("output_dql", "DequantizeLinear",
+                    {"output_ql_output", "output_dql_scale", "output_dql_zero_point"},
+                    {"output_dql_output"});
   };
 }
 
@@ -127,7 +132,7 @@ TEST_F(QnnHTPBackendTests, LPBQMatMulFusion) {
                   /*opset_version=*/21,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
                   /*fp32_abs_err=*/1e-2f,
-                  /*log_severity =*/logging::Severity::kERROR,
+                  /*log_severity =*/OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                   /*verify_outputs=*/false);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "MatMul");

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/unittest_util/qdq_test_utils.h"
@@ -35,28 +34,30 @@ GetQDQTestCaseFn BuildLPBQMatMulWithoutQLTestCase() {
     const int64_t blocks_per_axis = 4;
     const std::vector<int64_t> input_shape{1, input_channels};
     auto input_def = TestInputDef<float>(input_shape, false, -0.5f, 0.5f);
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
+    MakeTestInput<float>(builder, "input", input_def);
 
     // QuantizeLinear for Activation
-    NodeArg* act_ql_output = builder.MakeIntermediate();
-    NodeArg* act_ql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("QuantizeLinear", {input, act_ql_scale, act_ql_zero_point}, {act_ql_output});
+    builder.MakeScalarInitializer<float>("act_ql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_ql", "QuantizeLinear",
+                    {"input", "act_ql_scale", "act_ql_zero_point"}, {"act_ql_output"});
 
     // DequantizeLinear for Activation
-    NodeArg* act_dql_output = builder.MakeIntermediate();
-    NodeArg* act_dql_scale = builder.MakeScalarInitializer<float>(0.00005509183756657876f);
-    NodeArg* act_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(23715);
-    builder.AddNode("DequantizeLinear", {act_ql_output, act_dql_scale, act_dql_zero_point}, {act_dql_output});
+    builder.MakeScalarInitializer<float>("act_dql_scale", 0.00005509183756657876f);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zero_point", static_cast<uint16_t>(23715));
+    builder.AddNode("act_dql", "DequantizeLinear",
+                    {"act_ql_output", "act_dql_scale", "act_dql_zero_point"}, {"act_dql_output"});
 
     // DequantizeLinear for Scale
-    NodeArg* scale_dql_input = builder.MakeInitializer<uint8_t>({blocks_per_axis, output_channels}, 1, 15);
-    NodeArg* scale_dql_scale = builder.MakeInitializer<float>({output_channels}, 0.01f, 0.02f);
+    builder.MakeInitializer<uint8_t>("scale_dql_input", {blocks_per_axis, output_channels},
+                                     static_cast<uint8_t>(1), static_cast<uint8_t>(15));
+    builder.MakeInitializer<float>("scale_dql_scale", {output_channels}, 0.01f, 0.02f);
     std::vector<uint8_t> dql_zero_points_data = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    NodeArg* scale_dql_zero_point = builder.Make1DInitializer<uint8_t>(dql_zero_points_data);
-    NodeArg* scale_dql_output = builder.MakeIntermediate();
-    Node& scale_dql = builder.AddNode("DequantizeLinear", {scale_dql_input, scale_dql_scale, scale_dql_zero_point}, {scale_dql_output});
-    scale_dql.AddAttribute("axis", static_cast<int64_t>(1));
+    builder.Make1DInitializer<uint8_t>("scale_dql_zero_point", dql_zero_points_data);
+    builder.AddNode("scale_dql", "DequantizeLinear",
+                    {"scale_dql_input", "scale_dql_scale", "scale_dql_zero_point"},
+                    {"scale_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(1))});
 
     // Create quantized weight directly (skip QuantizeLinear)
     // We're creating a pre-quantized weight tensor that would normally be the output of QuantizeLinear
@@ -68,7 +69,7 @@ GetQDQTestCaseFn BuildLPBQMatMulWithoutQLTestCase() {
       quantized_weight_data[i].SetElem(0, i % 16);
       quantized_weight_data[i].SetElem(1, (i + 8) % 16);
     }
-    NodeArg* w_quantized = builder.MakeInitializer<Int4x2>({input_channels, output_channels}, quantized_weight_data);
+    builder.MakeInitializer<Int4x2>("w_quantized", {input_channels, output_channels}, quantized_weight_data);
 
     // DequantizeLinear for Weight
     std::vector<Int4x2> zero_points_data;
@@ -79,27 +80,30 @@ GetQDQTestCaseFn BuildLPBQMatMulWithoutQLTestCase() {
       size_t c = i & 0x1;
       zero_points_data[r].SetElem(c, 0);
     }
-    NodeArg* w_dql_zero_point = builder.MakeInitializer<Int4x2>({blocks_per_axis, output_channels}, zero_points_data);
-    NodeArg* w_dql_output = builder.MakeIntermediate();
-    Node& w_dql = builder.AddNode("DequantizeLinear", {w_quantized, scale_dql_output, w_dql_zero_point}, {w_dql_output});
-    w_dql.AddAttribute("axis", static_cast<int64_t>(0));
-    w_dql.AddAttribute("block_size", static_cast<int64_t>(4));
+    builder.MakeInitializer<Int4x2>("w_dql_zero_point", {blocks_per_axis, output_channels}, zero_points_data);
+    builder.AddNode("w_dql", "DequantizeLinear",
+                    {"w_quantized", "scale_dql_output", "w_dql_zero_point"},
+                    {"w_dql_output"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", static_cast<int64_t>(4))});
 
     // MatMul
-    NodeArg* matmul_output = builder.MakeIntermediate();
-    builder.AddNode("MatMul", {act_dql_output, w_dql_output}, {matmul_output});
+    builder.AddNode("matmul", "MatMul", {"act_dql_output", "w_dql_output"}, {"matmul_output"});
 
     // QuantizeLinear for Output
-    NodeArg* output_ql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_ql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_ql_output = builder.MakeIntermediate();
-    builder.AddNode("QuantizeLinear", {matmul_output, output_ql_scale, output_ql_zero_point}, {output_ql_output});
+    builder.MakeScalarInitializer<float>("output_ql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_ql_zero_point", static_cast<uint16_t>(31693));
+    builder.AddNode("output_ql", "QuantizeLinear",
+                    {"matmul_output", "output_ql_scale", "output_ql_zero_point"},
+                    {"output_ql_output"});
 
     // DequantizeLinear for Output
-    NodeArg* output_dql_scale = builder.MakeScalarInitializer<float>(0.00019595865160226822f);
-    NodeArg* output_dql_zero_point = builder.MakeScalarInitializer<uint16_t>(31693);
-    NodeArg* output_dql_output = builder.MakeOutput();
-    builder.AddNode("DequantizeLinear", {output_ql_output, output_dql_scale, output_dql_zero_point}, {output_dql_output});
+    builder.MakeScalarInitializer<float>("output_dql_scale", 0.00019595865160226822f);
+    builder.MakeScalarInitializer<uint16_t>("output_dql_zero_point", static_cast<uint16_t>(31693));
+    builder.MakeOutput("output_dql_output");
+    builder.AddNode("output_dql", "DequantizeLinear",
+                    {"output_ql_output", "output_dql_scale", "output_dql_zero_point"},
+                    {"output_dql_output"});
   };
 }
 
@@ -131,7 +135,7 @@ TEST_F(QnnHTPBackendTests, LPBQMatMulFusionWithoutQL) {
                   /*opset_version=*/21,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
                   /*fp32_abs_err=*/1e-2f,
-                  /*log_severity =*/logging::Severity::kERROR,
+                  /*log_severity =*/OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                   /*verify_outputs=*/false);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "MatMul");

--- a/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/lpbqmatmul_fusion_without_ql_test.cc
@@ -13,7 +13,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "core/graph/node_attr_utils.h"
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/unittest_util/qdq_test_utils.h"
 #include "test/providers/qnn/qnn_test_utils.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_rank5_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_rank5_test.cc
@@ -3,9 +3,6 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
-#include "core/graph/graph.h"
-#include "core/graph/node_attr_utils.h"
-
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
 #include "gtest/gtest.h"

--- a/onnxruntime/test/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc
@@ -5,7 +5,6 @@
 
 #include <filesystem>
 
-#include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
@@ -25,34 +24,40 @@ GetTestModelFn BuildTestCaseScalar(
     bool reverse_input_order,
     std::optional<int64_t> softmax_axis = std::nullopt) {
   return [=, &input_def](ModelTestBuilder& builder) -> void {
-    NodeArg* input = MakeTestInput<float>(builder, input_def);
-    NodeArg* scale{nullptr};
+    MakeTestInput<float>(builder, "input", input_def);
     if (use_constant) {
       onnx::TensorProto scale_value_proto;
       scale_value_proto.set_data_type(ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
       utils::SetRawDataInTensorProto(scale_value_proto, reinterpret_cast<const char*>(&scale_value), sizeof(float));
-      scale = builder.MakeIntermediate();
-      builder.AddNode("Constant", {}, {scale}).AddAttribute("value", scale_value_proto);
+      ONNX_NAMESPACE::AttributeProto scale_attr;
+      scale_attr.set_name("value");
+      scale_attr.set_type(ONNX_NAMESPACE::AttributeProto_AttributeType_TENSOR);
+      *scale_attr.mutable_t() = scale_value_proto;
+      builder.AddNode("constant_node", "Constant", {}, {"scale"}, "", {scale_attr});
     } else {
-      scale = builder.MakeScalarInitializer<float>(scale_value);
+      builder.MakeScalarInitializer<float>("scale", scale_value);
     }
-    NodeArg* intermediate = builder.MakeIntermediate();
-    auto mul_inputs = reverse_input_order ? std::vector<NodeArg*>{scale, input} : std::vector<NodeArg*>{input, scale};
-    builder.AddNode("Mul", mul_inputs, {intermediate});
-    Node& softmax = builder.AddNode("Softmax", {intermediate}, {builder.MakeOutput()});
+    std::vector<std::string> mul_inputs = reverse_input_order
+                                              ? std::vector<std::string>{"scale", "input"}
+                                              : std::vector<std::string>{"input", "scale"};
+    builder.AddNode("mul", "Mul", mul_inputs, {"mul_output"});
+    builder.MakeOutput("softmax_output");
     if (softmax_axis.has_value()) {
-      softmax.AddAttribute("axis", softmax_axis.value());
+      builder.AddNode("softmax", "Softmax", {"mul_output"}, {"softmax_output"}, "",
+                      {builder.MakeScalarAttribute("axis", softmax_axis.value())});
+    } else {
+      builder.AddNode("softmax", "Softmax", {"mul_output"}, {"softmax_output"});
     }
   };
 }
 
 GetTestModelFn BuildTestCaseNoScalar(const TestInputDef<float>& input_def1, const TestInputDef<float>& input_def2) {
   return [&input_def1, input_def2](ModelTestBuilder& builder) -> void {
-    NodeArg* input = MakeTestInput<float>(builder, input_def1);
-    NodeArg* scale = MakeTestInput<float>(builder, input_def2);
-    NodeArg* intermediate = builder.MakeIntermediate();
-    builder.AddNode("Mul", {input, scale}, {intermediate});
-    builder.AddNode("Softmax", {intermediate}, {builder.MakeOutput()});
+    MakeTestInput<float>(builder, "input", input_def1);
+    MakeTestInput<float>(builder, "scale", input_def2);
+    builder.AddNode("mul", "Mul", {"input", "scale"}, {"mul_output"});
+    builder.MakeOutput("softmax_output");
+    builder.AddNode("softmax", "Softmax", {"mul_output"}, {"softmax_output"});
   };
 }
 

--- a/onnxruntime/test/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/scale_softmax_fusion_test.cc
@@ -5,8 +5,6 @@
 
 #include <filesystem>
 
-#include "core/graph/node_attr_utils.h"
-
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- The change modifies the recent added op testcases with public API and re-enables them.
    - `gather_transpose_reshape_fusion_test.cc`
    - `lpbqgemm_fusion_test.cc`
    - `lpbqgemm_fusion_without_ql_test.cc`
    - `lpbqmatmul_fusion_test.cc`
    - `lpbqmatmul_fusion_without_ql_test.cc`, 
    - `scale_softmax_fusion_test.cc`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- To avoid relying on private ORT Core headers/libraries, #23 reconstructed the QNN Test Framework using only ORT’s public headers and libraries.
- The newly added fusion test cases required several adjustments to work with the updated QNN test infrastructure. To keep the scope of #23 manageable, those tests were temporarily disabled and are now being re‑enabled with the necessary updates.

