### PR TITLE
[QNN EP] Add support for all params for Slice Op in QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
@@ -282,14 +282,34 @@ Ort::Status SliceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   RETURN_IF_ERROR(PrepareForComputeHelper(raw_starts, raw_ends, raw_axes, raw_steps, compute_metadata));
 
   const size_t input_rank = input_dimensions.size();
+
+  // Determine which axes were explicitly specified by the ONNX Slice op.
+  // Unspecified axes use default ranges (start=0, end=dim, step=1) and will have
+  // their begin_mask/end_mask bits set so QNN uses the full range for those dimensions.
+  InlinedHashSet<size_t> specified_axes;
+  if (raw_axes.empty()) {
+    // When axes are omitted, ONNX Slice implicitly specifies axes [0, ..., len(starts)-1].
+    for (size_t i = 0; i < raw_starts.size(); i++) {
+      specified_axes.insert(i);
+    }
+  } else {
+    for (const auto& axis : raw_axes) {
+      auto resolved = axis < 0 ? axis + static_cast<int64_t>(input_rank) : axis;
+      specified_axes.insert(static_cast<size_t>(resolved));
+    }
+  }
+
+  // Build the ranges parameter [rank, 3] with (begin, end, stride) per axis.
+  // Cast through int32_t first to correctly preserve the sign bit for negative values
+  // (e.g., end=-1 for backward slicing), since QNN interprets this data as INT_32.
   std::vector<uint32_t> ranges_dims{static_cast<uint32_t>(input_rank), 3};
   std::vector<uint32_t> ranges_data;
-  ranges_data.reserve(input_rank);
+  ranges_data.reserve(input_rank * 3);
 
   for (size_t i = 0; i < input_rank; i++) {
-    ranges_data.push_back(static_cast<uint32_t>(compute_metadata.starts_[i]));
-    ranges_data.push_back(static_cast<uint32_t>(compute_metadata.ends_[i]));
-    ranges_data.push_back(static_cast<uint32_t>(compute_metadata.steps_[i]));
+    ranges_data.push_back(static_cast<uint32_t>(static_cast<int32_t>(compute_metadata.starts_[i])));
+    ranges_data.push_back(static_cast<uint32_t>(static_cast<int32_t>(compute_metadata.ends_[i])));
+    ranges_data.push_back(static_cast<uint32_t>(static_cast<int32_t>(compute_metadata.steps_[i])));
   }
 
   QnnParamWrapper ranges_paramwrapper(node_unit.Index(),
@@ -297,13 +317,38 @@ Ort::Status SliceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
                                       QNN_OP_STRIDED_SLICE_PARAM_RANGES,
                                       std::move(ranges_dims),
                                       std::move(ranges_data),
-                                      true);
-  std::string param_tensor_name(ranges_paramwrapper.GetParamTensorName());
+                                      /*is_signed=*/true);
+  std::vector<std::string> param_tensor_names;
+  param_tensor_names.push_back(ranges_paramwrapper.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(ranges_paramwrapper));
+
+  // Compute begin_mask and end_mask bitmasks. For axes not explicitly specified by the
+  // ONNX Slice op, set the corresponding bits so QNN uses the full range for those dimensions.
+  uint32_t begin_mask = 0;
+  uint32_t end_mask = 0;
+  for (size_t i = 0; i < input_rank; i++) {
+    if (specified_axes.find(i) == specified_axes.end()) {
+      begin_mask |= (1U << static_cast<uint32_t>(i));
+      end_mask |= (1U << static_cast<uint32_t>(i));
+    }
+  }
+
+  if (begin_mask != 0) {
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           begin_mask, QNN_OP_STRIDED_SLICE_PARAM_BEGIN_MASK,
+                                           param_tensor_names));
+  }
+
+  if (end_mask != 0) {
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           end_mask, QNN_OP_STRIDED_SLICE_PARAM_END_MASK,
+                                           param_tensor_names));
+  }
+
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper,
                                  node_unit,
                                  std::move(input_names),
-                                 {param_tensor_name},
+                                 std::move(param_tensor_names),
                                  logger,
                                  do_op_validation, GetQnnOpType(node_unit.OpType())));
   return Ort::Status();

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
@@ -11,9 +11,9 @@
 namespace onnxruntime {
 namespace test {
 
-void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
-                        const std::string& op,
-                        size_t count) {
+// Loads the QNN JSON graph from the given dump directory.
+// Returns true on success and populates `root`. Emits gtest failures on error.
+static bool LoadQnnGraphJson(const std::filesystem::path& dump_dir, nlohmann::json& root) {
   std::filesystem::path json_path;
   for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
     if (entry.is_regular_file() && entry.path().extension() == ".json" &&
@@ -22,16 +22,26 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
       break;
     }
   }
-  ASSERT_FALSE(json_path.empty()) << "No QNN JSON graph file found in " << dump_dir;
+
+  EXPECT_FALSE(json_path.empty()) << "No QNN JSON graph file found in " << dump_dir;
+  if (json_path.empty()) return false;
 
   std::ifstream json_file(json_path);
-  ASSERT_TRUE(json_file.is_open()) << "Failed to open QNN JSON graph: " << json_path;
+  EXPECT_TRUE(json_file.is_open()) << "Failed to open QNN JSON graph: " << json_path;
+  if (!json_file.is_open()) return false;
 
-  nlohmann::json root;
   json_file >> root;
 
-  ASSERT_TRUE(root.contains("graph") && root["graph"].contains("nodes"))
+  EXPECT_TRUE(root.contains("graph") && root["graph"].contains("nodes"))
       << "JSON missing 'graph.nodes' field in: " << json_path;
+  return root.contains("graph") && root["graph"].contains("nodes");
+}
+
+void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
+                        const std::string& op,
+                        size_t count) {
+  nlohmann::json root;
+  if (!LoadQnnGraphJson(dump_dir, root)) return;
 
   size_t actual_count = 0;
   for (const auto& [node_name, node_json] : root["graph"]["nodes"].items()) {
@@ -42,7 +52,26 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
 
   EXPECT_EQ(actual_count, count)
       << "QNN op '" << op << "': expected " << count
-      << " occurrence(s), found " << actual_count << " in " << json_path;
+      << " occurrence(s), found " << actual_count;
+}
+
+void AssertOpHasScalarParam(const std::filesystem::path& dump_dir,
+                            const std::string& op_type,
+                            const std::string& param_name) {
+  nlohmann::json root;
+  if (!LoadQnnGraphJson(dump_dir, root)) return;
+
+  for (const auto& [node_name, node_json] : root["graph"]["nodes"].items()) {
+    if (node_json.value("type", "") != op_type) continue;
+
+    EXPECT_TRUE(node_json.contains("scalar_params") &&
+                node_json["scalar_params"].contains(param_name))
+        << "QNN op '" << op_type << "' (node '" << node_name
+        << "') is missing scalar param '" << param_name << "'";
+    return;
+  }
+
+  ADD_FAILURE() << "No QNN op of type '" << op_type << "' found in graph";
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
@@ -16,5 +16,12 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
                         const std::string& op,
                         size_t count = 1);
 
+// Asserts that a QNN op of the given type has a specific scalar parameter set.
+// Searches all nodes in the compiled QNN graph JSON for a node matching `op_type`,
+// then checks that `param_name` exists in its "scalar_params".
+void AssertOpHasScalarParam(const std::filesystem::path& dump_dir,
+                            const std::string& op_type,
+                            const std::string& param_name);
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/slice_test.cc
+++ b/onnxruntime/test/providers/qnn/slice_test.cc
@@ -3,11 +3,13 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
 #include <string>
 #include "core/graph/graph.h"
 #include "core/graph/node_attr_utils.h"
 
 #include "test/providers/qnn/qnn_test_utils.h"
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
 #include "gtest/gtest.h"
@@ -203,6 +205,86 @@ TEST_F(QnnHTPBackendTests, SliceU8_MultAxes_LargeEnd) {
                            TestInputDef<int64_t>({2}, true, {0, 1}),      // axes
                            TestInputDef<int64_t>({2}, true, {1, 1}),      // steps
                            ExpectedEPNodeAssignment::All);
+}
+
+// Test 8-bit QDQ Slice on a partial subset of axes for a 3D tensor.
+// Slices only axis 1 of a [2,4,3] tensor, leaving axes 0 and 2 unsliced.
+// This exercises the begin_mask/end_mask parameters for unspecified axes.
+TEST_F(QnnHTPBackendTests, SliceU8_PartialAxes_3D) {
+  RunSliceQDQTest<uint8_t>(TestInputDef<float>({2, 4, 3}, false, 0.0f, 1.0f),
+                           TestInputDef<int64_t>({1}, true, {1}),  // starts: axis 1 from index 1
+                           TestInputDef<int64_t>({1}, true, {3}),  // ends: axis 1 to index 3
+                           TestInputDef<int64_t>({1}, true, {1}),  // axes: only axis 1
+                           TestInputDef<int64_t>({1}, true, {1}),  // steps: step 1
+                           ExpectedEPNodeAssignment::All);
+}
+
+// Test 8-bit QDQ Slice on a single axis of a 4D tensor.
+// Slices only axis 2 of a [1,3,4,2] tensor, leaving axes 0, 1, and 3 unsliced.
+// This exercises begin_mask/end_mask with multiple unspecified axes.
+TEST_F(QnnHTPBackendTests, SliceU8_PartialAxes_4D) {
+  RunSliceQDQTest<uint8_t>(TestInputDef<float>({1, 3, 4, 2}, false, 0.0f, 1.0f),
+                           TestInputDef<int64_t>({1}, true, {0}),  // starts: axis 2 from index 0
+                           TestInputDef<int64_t>({1}, true, {2}),  // ends: axis 2 to index 2
+                           TestInputDef<int64_t>({1}, true, {2}),  // axes: only axis 2
+                           TestInputDef<int64_t>({1}, true, {1}),  // steps: step 1
+                           ExpectedEPNodeAssignment::All);
+}
+
+// Test 8-bit QDQ Slice with negative step (backward slicing).
+// Slices axis 0 of a [4,3] tensor in reverse.
+TEST_F(QnnHTPBackendTests, SliceU8_NegativeStep) {
+  RunSliceQDQTest<uint8_t>(TestInputDef<float>({4, 3}, false, 0.0f, 1.0f),
+                           TestInputDef<int64_t>({1}, true, {3}),   // starts: axis 0 from index 3
+                           TestInputDef<int64_t>({1}, true, {0}),   // ends: axis 0 to index 0 (exclusive)
+                           TestInputDef<int64_t>({1}, true, {0}),   // axes: only axis 0
+                           TestInputDef<int64_t>({1}, true, {-1}),  // steps: step -1 (reverse)
+                           ExpectedEPNodeAssignment::All);
+}
+
+// Test int32 Slice on a partial subset of axes for a 3D tensor on HTP.
+TEST_F(QnnHTPBackendTests, SliceInt32_PartialAxes_3D) {
+  RunSliceNonQDQOnHTP<int32_t>(TestInputDef<int32_t>({2, 4, 3}, false, -50, 50),
+                                TestInputDef<int64_t>({1}, true, {1}),  // starts
+                                TestInputDef<int64_t>({1}, true, {3}),  // ends
+                                TestInputDef<int64_t>({1}, true, {1}),  // axes: only axis 1
+                                TestInputDef<int64_t>({1}, true, {1}),  // steps
+                                ExpectedEPNodeAssignment::All);
+}
+
+// Verify that begin_mask and end_mask scalar params are present on the QNN StridedSlice node
+// when slicing a partial subset of axes. Dumps the QNN graph to JSON and inspects it.
+// Uses a non-QDQ int32 model to directly test the op builder's parameter generation.
+TEST_F(QnnHTPBackendTests, SliceInt32_PartialAxes_VerifyMaskParams) {
+  const std::filesystem::path json_qnn_graph_dir = "SliceInt32_PartialAxes_VerifyMaskParams";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  // Slice only axis 1 of a [2,4,3] int32 tensor. Axes 0 and 2 are unspecified,
+  // so begin_mask and end_mask should have bits 0 and 2 set.
+  auto model_builder = BuildOpTestCase<int32_t, int64_t>(
+      "Slice_node", "Slice",
+      {TestInputDef<int32_t>({2, 4, 3}, false, -50, 50)},
+      {TestInputDef<int64_t>({1}, true, {1}),   // starts
+       TestInputDef<int64_t>({1}, true, {3}),   // ends
+       TestInputDef<int64_t>({1}, true, {1}),   // axes: only axis 1
+       TestInputDef<int64_t>({1}, true, {1})},  // steps
+      {});
+
+  RunQnnModelTest(model_builder,
+                  provider_options,
+                  13,
+                  ExpectedEPNodeAssignment::All);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "StridedSlice");
+  AssertOpHasScalarParam(json_qnn_graph_dir, "StridedSlice", "begin_mask");
+  AssertOpHasScalarParam(json_qnn_graph_dir, "StridedSlice", "end_mask");
 }
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/slice_test.cc
+++ b/onnxruntime/test/providers/qnn/slice_test.cc
@@ -245,11 +245,11 @@ TEST_F(QnnHTPBackendTests, SliceU8_NegativeStep) {
 // Test int32 Slice on a partial subset of axes for a 3D tensor on HTP.
 TEST_F(QnnHTPBackendTests, SliceInt32_PartialAxes_3D) {
   RunSliceNonQDQOnHTP<int32_t>(TestInputDef<int32_t>({2, 4, 3}, false, -50, 50),
-                                TestInputDef<int64_t>({1}, true, {1}),  // starts
-                                TestInputDef<int64_t>({1}, true, {3}),  // ends
-                                TestInputDef<int64_t>({1}, true, {1}),  // axes: only axis 1
-                                TestInputDef<int64_t>({1}, true, {1}),  // steps
-                                ExpectedEPNodeAssignment::All);
+                               TestInputDef<int64_t>({1}, true, {1}),  // starts
+                               TestInputDef<int64_t>({1}, true, {3}),  // ends
+                               TestInputDef<int64_t>({1}, true, {1}),  // axes: only axis 1
+                               TestInputDef<int64_t>({1}, true, {1}),  // steps
+                               ExpectedEPNodeAssignment::All);
 }
 
 // Verify that begin_mask and end_mask scalar params are present on the QNN StridedSlice node


### PR DESCRIPTION


### Description
- Slice Op in QNN EP has some missing params such as begin_mask, end_mask, shrink_axis and new_axes_mask
- This PR adds support for the missing params to run fully on the NPU
- Added unit tests and additional helper function to fetch the params added to the Op after the run on NPU.



### Motivation and Context
- A few params of QNN HTP Op for Slice was not supported as part of the original QNN EP op builder


