### PR TITLE
[QNN EP] Support for Beta Parameter in Softmax and Log Softmax operation

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -176,6 +176,20 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
   size_t output_rank = output_info.shape.size();
 
+  // Builds the axis param and, for LogSoftmax, the beta param, into param_tensor_names.
+  auto AddAxisAndBetaParams = [&](std::vector<std::string>& param_tensor_names,
+                                  Qnn_Scalar_t effective_axis_scalar) {
+    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, effective_axis_scalar);
+    param_tensor_names.push_back(axis_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
+  };
+
   if (opset_version < 13) {
     std::string reshape_input_name = utils::GetUniqueName(orig_output_name, "_reshape");
 
@@ -185,16 +199,8 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
       axis_qnn_scalar.uint32Value = 1;
     }
 
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
-
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
+    AddAxisAndBetaParams(param_tensor_names, axis_qnn_scalar);
 
     QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
@@ -227,16 +233,8 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     // Override axis due to the actual shape after the inserted transpose node
     axis_qnn_scalar.uint32Value = static_cast<uint32_t>(output_rank) - 1;
 
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
-
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
+    AddAxisAndBetaParams(param_tensor_names, axis_qnn_scalar);
 
     QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
@@ -267,16 +265,8 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                        false,
                                                        is_graph_output));
   } else {
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
-
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
+    AddAxisAndBetaParams(param_tensor_names, axis_qnn_scalar);
 
     return ProcessOutputs(qnn_model_wrapper, node_unit,
                           std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -164,6 +164,14 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
   RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
 
+  // Beta is a QNN-specific extension supported only for LogSoftmax (not standard ONNX Softmax).
+  const bool is_log_softmax = (op_type == "LogSoftmax");
+  OrtNodeAttrHelper node_helper(node_unit);
+  const float beta = is_log_softmax ? node_helper.Get("beta", 1.0f) : 1.0f;
+  Qnn_Scalar_t beta_qnn_scalar = QNN_SCALAR_INIT;
+  beta_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
+  beta_qnn_scalar.floatValue = beta;
+
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
   size_t output_rank = output_info.shape.size();
@@ -181,6 +189,12 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     std::vector<std::string> param_tensor_names;
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
 
     QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
@@ -218,6 +232,12 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
+
     QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
@@ -251,6 +271,12 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     std::vector<std::string> param_tensor_names;
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
 
     return ProcessOutputs(qnn_model_wrapper, node_unit,
                           std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -176,20 +176,6 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
   size_t output_rank = output_info.shape.size();
 
-  // Builds the axis param and, for LogSoftmax, the beta param, into param_tensor_names.
-  auto AddAxisAndBetaParams = [&](std::vector<std::string>& param_tensor_names,
-                                  Qnn_Scalar_t effective_axis_scalar) {
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, effective_axis_scalar);
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
-
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
-  };
-
   if (opset_version < 13) {
     std::string reshape_input_name = utils::GetUniqueName(orig_output_name, "_reshape");
 
@@ -199,8 +185,16 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
       axis_qnn_scalar.uint32Value = 1;
     }
 
+    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    AddAxisAndBetaParams(param_tensor_names, axis_qnn_scalar);
+    param_tensor_names.push_back(axis_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
 
     QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
@@ -233,8 +227,16 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     // Override axis due to the actual shape after the inserted transpose node
     axis_qnn_scalar.uint32Value = static_cast<uint32_t>(output_rank) - 1;
 
+    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    AddAxisAndBetaParams(param_tensor_names, axis_qnn_scalar);
+    param_tensor_names.push_back(axis_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
 
     QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
@@ -265,8 +267,16 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                        false,
                                                        is_graph_output));
   } else {
+    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    AddAxisAndBetaParams(param_tensor_names, axis_qnn_scalar);
+    param_tensor_names.push_back(axis_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+    if (is_log_softmax) {
+      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
+      param_tensor_names.push_back(beta_param.GetParamTensorName());
+      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
+    }
 
     return ProcessOutputs(qnn_model_wrapper, node_unit,
                           std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -164,10 +164,10 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
   RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
 
-  // Beta is a QNN-specific extension supported only for LogSoftmax (not standard ONNX Softmax).
-  const bool is_log_softmax = (op_type == "LogSoftmax");
+  // Beta is a QNN-specific parameter supported for both Softmax and LogSoftmax. Defaults to 1.0.
   OrtNodeAttrHelper node_helper(node_unit);
-  const float beta = is_log_softmax ? node_helper.Get("beta", 1.0f) : 1.0f;
+  const float beta = node_helper.Get("beta", 1.0f);
+  const std::string beta_param_key = (op_type == "LogSoftmax") ? QNN_OP_LOG_SOFTMAX_PARAM_BETA : QNN_OP_SOFTMAX_PARAM_BETA;
   Qnn_Scalar_t beta_qnn_scalar = QNN_SCALAR_INIT;
   beta_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
   beta_qnn_scalar.floatValue = beta;
@@ -190,11 +190,9 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
+    QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), beta_param_key, beta_qnn_scalar);
+    param_tensor_names.push_back(beta_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
 
     QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
@@ -232,11 +230,9 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
+    QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), beta_param_key, beta_qnn_scalar);
+    param_tensor_names.push_back(beta_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
 
     QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
@@ -272,11 +268,9 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-    if (is_log_softmax) {
-      QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), QNN_OP_LOG_SOFTMAX_PARAM_BETA, beta_qnn_scalar);
-      param_tensor_names.push_back(beta_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-    }
+    QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(), beta_param_key, beta_qnn_scalar);
+    param_tensor_names.push_back(beta_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
 
     return ProcessOutputs(qnn_model_wrapper, node_unit,
                           std::move(input_names),

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -751,6 +751,85 @@ TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_SetAxis) {
                         ExpectedEPNodeAssignment::All);
 }
 
+// Tests accuracy of QDQ LogSoftmax (opset 13) with default axis.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_DefaultAxis) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint16_t>("LogSoftmax",
+                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                         {},  // Uses default axis of -1 for opset 13
+                         13,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,
+                         true);  // Use com.microsoft domain for Q/DQ ops
+}
+
+// Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_NonLastAxis) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint16_t>("LogSoftmax",
+                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                         {test::MakeAttribute("axis", static_cast<int64_t>(1))},
+                         13,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,
+                         true);  // Use com.microsoft domain for Q/DQ ops
+}
+
+// Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_NonLastAxis_LargeInput) {
+  const std::vector<float> input_data = GetFloatDataInRange(-50.0f, 50.0f, 124);
+  RunQDQOpTest<uint8_t>("LogSoftmax",
+                        {TestInputDef<float>({1, 124, 1}, false, input_data)},
+                        {test::MakeAttribute("axis", static_cast<int64_t>(1))},
+                        13,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_NonLastAxis_LargeInput) {
+  const std::vector<float> input_data = GetFloatDataInRange(-50.0f, 50.0f, 124);
+  RunQDQOpTest<uint16_t>("LogSoftmax",
+                         {TestInputDef<float>({1, 124, 1}, false, input_data)},
+                         {test::MakeAttribute("axis", static_cast<int64_t>(1))},
+                         13,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,
+                         true);  // Use com.microsoft domain for Q/DQ ops
+}
+
+// Tests accuracy of QDQ LogSoftmax (opset < 13) with default axis.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_U16_DefaultAxis) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint16_t>("LogSoftmax",
+                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                         {},  // Uses default axis of 1 for opset < 13
+                         11,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,
+                         true);  // Use com.microsoft domain for Q/DQ ops
+}
+
+// Test QDQ LogSoftmax (opset < 13) with axis=0 is supported by QNN EP.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_Axis0) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint8_t>("LogSoftmax",
+                        {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                        {test::MakeAttribute("axis", static_cast<int64_t>(0))},
+                        11,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// Test QNN EP correctly handles the QNN-specific beta attribute on LogSoftmax (opset 13).
+// With beta=1.0 (the default), the output must match the standard LogSoftmax.
+TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_WithBeta) {
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint8_t>("LogSoftmax",
+                        {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                        {test::MakeAttribute("beta", 1.0f)},  // Explicit default beta; QNN passes it through
+                        13,
+                        ExpectedEPNodeAssignment::All);
+}
+
 // Test accuracy of QDQ Abs op.
 TEST_F(QnnHTPBackendTests, UnaryOp_Abs) {
   RunQDQOpTest<uint8_t>("Abs",

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -775,29 +775,6 @@ TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_NonLastAxis) {
                          true);  // Use com.microsoft domain for Q/DQ ops
 }
 
-// Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
-// Uses 124 elements (large count) but a moderate value range [-10, 10]
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_NonLastAxis_LargeInput) {
-  const std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 124);
-  RunQDQOpTest<uint8_t>("LogSoftmax",
-                        {TestInputDef<float>({1, 124, 1}, false, input_data)},
-                        {test::MakeAttribute("axis", static_cast<int64_t>(1))},
-                        13,
-                        ExpectedEPNodeAssignment::All);
-}
-
-// Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_NonLastAxis_LargeInput) {
-  const std::vector<float> input_data = GetFloatDataInRange(-50.0f, 50.0f, 124);
-  RunQDQOpTest<uint16_t>("LogSoftmax",
-                         {TestInputDef<float>({1, 124, 1}, false, input_data)},
-                         {test::MakeAttribute("axis", static_cast<int64_t>(1))},
-                         13,
-                         ExpectedEPNodeAssignment::All,
-                         kOnnxDomain,
-                         true);  // Use com.microsoft domain for Q/DQ ops
-}
-
 // Tests accuracy of QDQ LogSoftmax (opset < 13) with default axis.
 TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_U16_DefaultAxis) {
   std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -776,8 +776,9 @@ TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_NonLastAxis) {
 }
 
 // Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
+// Uses 124 elements (large count) but a moderate value range [-10, 10]
 TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_NonLastAxis_LargeInput) {
-  const std::vector<float> input_data = GetFloatDataInRange(-50.0f, 50.0f, 124);
+  const std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 124);
   RunQDQOpTest<uint8_t>("LogSoftmax",
                         {TestInputDef<float>({1, 124, 1}, false, input_data)},
                         {test::MakeAttribute("axis", static_cast<int64_t>(1))},
@@ -816,17 +817,6 @@ TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_Axis0) {
                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
                         {test::MakeAttribute("axis", static_cast<int64_t>(0))},
                         11,
-                        ExpectedEPNodeAssignment::All);
-}
-
-// Test QNN EP correctly handles the QNN-specific beta attribute on LogSoftmax (opset 13).
-// With beta=1.0 (the default), the output must match the standard LogSoftmax.
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_WithBeta) {
-  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
-  RunQDQOpTest<uint8_t>("LogSoftmax",
-                        {TestInputDef<float>({1, 2, 3}, false, input_data)},
-                        {test::MakeAttribute("beta", 1.0f)},  // Explicit default beta; QNN passes it through
-                        13,
                         ExpectedEPNodeAssignment::All);
 }
 

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -751,52 +751,6 @@ TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_SetAxis) {
                         ExpectedEPNodeAssignment::All);
 }
 
-// Tests accuracy of QDQ LogSoftmax (opset 13) with default axis.
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_DefaultAxis) {
-  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
-  RunQDQOpTest<uint16_t>("LogSoftmax",
-                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
-                         {},  // Uses default axis of -1 for opset 13
-                         13,
-                         ExpectedEPNodeAssignment::All,
-                         kOnnxDomain,
-                         true);  // Use com.microsoft domain for Q/DQ ops
-}
-
-// Test that QDQ LogSoftmax (opset 13) with axis != -1 is supported by QNN EP.
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax13_U16_NonLastAxis) {
-  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
-  RunQDQOpTest<uint16_t>("LogSoftmax",
-                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
-                         {test::MakeAttribute("axis", static_cast<int64_t>(1))},
-                         13,
-                         ExpectedEPNodeAssignment::All,
-                         kOnnxDomain,
-                         true);  // Use com.microsoft domain for Q/DQ ops
-}
-
-// Tests accuracy of QDQ LogSoftmax (opset < 13) with default axis.
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_U16_DefaultAxis) {
-  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
-  RunQDQOpTest<uint16_t>("LogSoftmax",
-                         {TestInputDef<float>({1, 2, 3}, false, input_data)},
-                         {},  // Uses default axis of 1 for opset < 13
-                         11,
-                         ExpectedEPNodeAssignment::All,
-                         kOnnxDomain,
-                         true);  // Use com.microsoft domain for Q/DQ ops
-}
-
-// Test QDQ LogSoftmax (opset < 13) with axis=0 is supported by QNN EP.
-TEST_F(QnnHTPBackendTests, UnaryOp_LogSoftmax11_Axis0) {
-  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
-  RunQDQOpTest<uint8_t>("LogSoftmax",
-                        {TestInputDef<float>({1, 2, 3}, false, input_data)},
-                        {test::MakeAttribute("axis", static_cast<int64_t>(0))},
-                        11,
-                        ExpectedEPNodeAssignment::All);
-}
-
 // Test accuracy of QDQ Abs op.
 TEST_F(QnnHTPBackendTests, UnaryOp_Abs) {
   RunQDQOpTest<uint8_t>("Abs",


### PR DESCRIPTION
### Description

- Add support for the QNN-specific beta attribute for the `Softmax` and `LogSoftmax` operator in the QNN EP `SoftmaxOpBuilder`. 
- The beta value is set to default `1.0f` forwarded to QNN.

### Motivation and Context

The QNN backend supports a beta parameter for the `Softmax` and `LogSoftmax` operator that scales the input before applying the operation. `ORT QNN EP` was not forwarding this attribute to QNN as it is not an ORT attribute. This resulted in operator disparity between `QAIRT Native` and `ORT Graph`. This change resolved the disparity.