### PR TITLE
Add README, release notes, and documents in the zip archive

### DIFF
--- a/cmake/onnxruntime_providers_qnn_abi.cmake
+++ b/cmake/onnxruntime_providers_qnn_abi.cmake
@@ -125,7 +125,7 @@
     endif()
   endif()
 
-  # Copy License to output directory
+  # Copy License, README, and release notes to output directory
   add_custom_command(
     TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
@@ -137,7 +137,35 @@
     COMMAND ${CMAKE_COMMAND} -E copy
         ${REPO_ROOT}/LICENSE
         $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${REPO_ROOT}/README.md
+        ${REPO_ROOT}/docs/release-notes.txt
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/
   )
+  # Create document destination directory first to ensure it exists
+  add_custom_command(
+    TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/docs/execution_providers
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/docs/images
+    COMMENT "Creating document destination directory"
+  )
+  # Copy documents to output docs directory to preserve the file structure and maintain document links
+  add_custom_command(
+    TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${REPO_ROOT}/docs/execution_providers/QNN-ExecutionProvider.md
+        ${REPO_ROOT}/docs/execution_providers/build.md
+        ${REPO_ROOT}/docs/execution_providers/development.md
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/docs/execution_providers
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${REPO_ROOT}/docs/images/qnn_ep_quant_workflow.png
+        ${REPO_ROOT}/docs/images/quantization_mixed_precision_1.png
+        ${REPO_ROOT}/docs/images/quantization_mixed_precision_2.png
+        # Used in README.md
+        ${REPO_ROOT}/docs/images/ONNX_Runtime_logo_dark.png
+        $<TARGET_FILE_DIR:${onnxruntime_providers_qnn_abi_target}>/docs/images
+  )
+
   if (EXISTS "${onnxruntime_QNN_HOME}/LICENSE.pdf")
     add_custom_command(
       TARGET ${onnxruntime_providers_qnn_abi_target} POST_BUILD

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -155,14 +155,38 @@ def build_zip_asset(
 
         # Get list of files to include
         asset_files = get_qnn_asset_file_list()
-        asset_files.extend(["LICENSE", "Qualcomm_LICENSE.pdf", "Privacy.md", "ThirdPartyNotices.txt"])
+        asset_files.extend(
+            [
+                "LICENSE",
+                "Qualcomm_LICENSE.pdf",
+                "Privacy.md",
+                "ThirdPartyNotices.txt",
+                "README.md",
+                "release-notes.txt",
+            ]
+        )
+        doc_md_files = ["QNN-ExecutionProvider.md", "build.md", "development.md"]
+        doc_png_files = [
+            "qnn_ep_quant_workflow.png",
+            "quantization_mixed_precision_1.png",
+            "quantization_mixed_precision_2.png",
+            "ONNX_Runtime_logo_dark.png",  # Used in README.md
+        ]
+        asset_files.extend(doc_md_files)
+        asset_files.extend(doc_png_files)
 
         # Collect and verify files exist
         missing_files = []
         found_files = []
 
         for filename in asset_files:
-            file_path = os.path.join(cwd, filename)
+            if filename in doc_md_files:
+                file_path = os.path.join(cwd, "docs", "execution_providers", filename)
+            elif filename in doc_png_files:
+                file_path = os.path.join(cwd, "docs", "images", filename)
+            else:
+                file_path = os.path.join(cwd, filename)
+
             if os.path.exists(file_path):
                 found_files.append((filename, file_path))
                 log.debug(f"Found asset file: {file_path}")
@@ -182,13 +206,13 @@ def build_zip_asset(
         log.info(f"Creating zip: {zip_path}")
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for filename, file_path in found_files:
+                arcname = os.path.relpath(file_path, cwd)
                 # TODO: we will remove this once the rename completed.
-                zip_filename = filename
                 if "onnxruntime_providers_qnn_abi" in filename:
-                    zip_filename = filename.replace("_abi", "")
+                    arcname = arcname.replace("_abi", "")
 
-                zipf.write(file_path, zip_filename)
-                log.debug(f"Added to zip: {zip_filename}")
+                zipf.write(file_path, arcname)
+                log.debug(f"Added to zip: {arcname}")
 
         log.info(f"Created zip asset: {zip_path} ({len(found_files)} files)")
         created_zips.append(zip_path)


### PR DESCRIPTION
### Description
Add README, release notes, and documents in the zip archive.
- Preserve the file structure to maintain document links

### Motivation and Context
Miss README, release notes, and documents in the zip archive.