### PR TITLE
Install Qualcomm Device Cloud SDK from Software Center instead of internal PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+venv-pkg-manager/
 ENV/
 env.bak/
 venv.bak/

--- a/qcom/ep_build/tasks/python.py
+++ b/qcom/ep_build/tasks/python.py
@@ -19,12 +19,21 @@ from ..task import (
     RunInTempDirectoryTask,
     Task,
 )
-from ..tools import PythonExecutableArchT, get_model_zoo_root, get_onnx_models_root, get_python_executable
+from ..tools import PythonExecutableArchT, get_model_zoo_root, get_onnx_models_root, get_package_content_dir, get_python_executable
 from ..util import (
     MSFT_CI_REQUIREMENTS_RELPATH,
     REPO_ROOT,
 )
 from .build import BuildConfigT, TargetPyVersionT, get_ort_version
+
+
+def _get_qdc_sdk_wheel() -> Path:
+    """Return the path to the QDC SDK wheel, downloading and extracting it if necessary."""
+    sdk_dir = get_package_content_dir(None, "qualcomm_device_cloud_sdk")
+    wheels = list(sdk_dir.glob("qualcomm_device_cloud_sdk-*.whl"))
+    if not wheels:
+        raise FileNotFoundError(f"Could not find Qualcomm Device Cloud SDK wheel in {sdk_dir}")
+    return wheels[0]
 
 
 def uv_pip_install_cmd(
@@ -59,19 +68,32 @@ class PipInstallTask(RunExecutablesWithVenvTask):
         )
 
 
-class PipInstallQcomDevRequirements(PipInstallTask):
+class PipInstallQcomDevRequirements(RunExecutablesWithVenvTask):
     def __init__(
         self,
         group_name: str | None,
         venv_path: Path,
         qdc: bool,
     ) -> None:
-        requirements: str = "requirements.txt"
-        index_url: str | None = None
+        requirements: str = "requirements-qdc.txt" if qdc else "requirements.txt"
+        req_path = REPO_ROOT / "qcom" / requirements
         if qdc:
-            requirements = "requirements-qdc.txt"
-            index_url = "http://ort-ep-win-01.na.qualcomm.com:8080"
-        super().__init__(group_name, venv_path, requirements=[REPO_ROOT / "qcom" / requirements], index_url=index_url)
+            super().__init__(
+                group_name,
+                venv=venv_path,
+                executables_and_args=lambda: [
+                    uv_pip_install_cmd(
+                        requirements=[req_path],
+                        packages=[_get_qdc_sdk_wheel()],
+                    )
+                ],
+            )
+        else:
+            super().__init__(
+                group_name,
+                venv=venv_path,
+                executables_and_args=[uv_pip_install_cmd(requirements=[req_path])],
+            )
 
 
 class CreateOrtVenvTask(CompositeTask):
@@ -121,13 +143,15 @@ class CreateQdcVenvTask(CompositeTask):
             group_name=None,
             tasks=[
                 CreateVenvTask(python_executable=python_executable, venv_path=venv_path),
-                PipInstallTask(
+                RunExecutablesWithVenvTask(
                     f"Installing QDC build requirements into {venv_path}",
-                    venv_path,
-                    requirements=[
-                        REPO_ROOT / "qcom" / "requirements-qdc.txt",
+                    venv=venv_path,
+                    executables_and_args=lambda: [
+                        uv_pip_install_cmd(
+                            requirements=[REPO_ROOT / "qcom" / "requirements-qdc.txt"],
+                            packages=[_get_qdc_sdk_wheel()],
+                        )
                     ],
-                    index_url="http://ort-ep-win-01.na.qualcomm.com:8080",
                 ),
             ],
         )

--- a/qcom/ep_build/tasks/python.py
+++ b/qcom/ep_build/tasks/python.py
@@ -23,8 +23,8 @@ from ..tools import (
     PythonExecutableArchT,
     get_model_zoo_root,
     get_onnx_models_root,
-    get_package_content_dir,
     get_python_executable,
+    get_qualcomm_device_cloud_sdk_root,
 )
 from ..util import (
     MSFT_CI_REQUIREMENTS_RELPATH,
@@ -33,21 +33,16 @@ from ..util import (
 from .build import BuildConfigT, TargetPyVersionT, get_ort_version
 
 
-def _get_qdc_sdk_wheel(venv: Path | None = None) -> Path:
-    """Return the path to the QDC SDK wheel, downloading and extracting it if necessary."""
-    sdk_dir = get_package_content_dir(venv, "qualcomm_device_cloud_sdk")
-    wheels = list(sdk_dir.glob("qualcomm_device_cloud_sdk-*.whl"))
-    if not wheels:
-        raise FileNotFoundError(f"Could not find Qualcomm Device Cloud SDK wheel in {sdk_dir}")
-    return wheels[0]
-
-
 def uv_pip_install_cmd(
-    requirements: Iterable[Path] = [], packages: Iterable[Path] = [], index_url: str | None = None
+    requirements: Iterable[Path] = [],
+    packages: Iterable[Path] = [],
+    find_links: Iterable[Path] = [],
+    index_url: str | None = None,
 ) -> list[str]:
     cmd = (
         ["uv", "pip", "install", "--native-tls"]
         + [f"--requirement={r}" for r in requirements]
+        + [f"--find-links={p}" for p in find_links]
         + [str(p) for p in packages]
     )
     if index_url is not None:
@@ -83,6 +78,7 @@ class PipInstallQcomDevRequirements(RunExecutablesWithVenvTask):
     ) -> None:
         requirements: str = "requirements-qdc.txt" if qdc else "requirements.txt"
         req_path = REPO_ROOT / "qcom" / requirements
+        package_manager_venv = venv_path.parent / (venv_path.name + "-pkg-manager")
         if qdc:
             super().__init__(
                 group_name,
@@ -90,7 +86,7 @@ class PipInstallQcomDevRequirements(RunExecutablesWithVenvTask):
                 executables_and_args=lambda: [
                     uv_pip_install_cmd(
                         requirements=[req_path],
-                        packages=[_get_qdc_sdk_wheel(venv_path)],
+                        find_links=[get_qualcomm_device_cloud_sdk_root(package_manager_venv)],
                     )
                 ],
             )
@@ -145,22 +141,24 @@ class CreateOrtVenvTask(CompositeTask):
 
 class CreateQdcVenvTask(CompositeTask):
     def __init__(self, python_executable: Path, venv_path: Path) -> None:
+        pkg_manager_venv = venv_path.parent / (venv_path.name + "-pkg-manager")
         super().__init__(
             group_name=None,
             tasks=[
-                CreateVenvTask(python_executable=python_executable, venv_path=venv_path),
+                CreateVenvTask(python_executable=python_executable, venv_path=pkg_manager_venv),
                 PipInstallTask(
-                    f"Installing package manager requirements into {venv_path}",
-                    venv_path,
+                    f"Installing package manager requirements into {pkg_manager_venv}",
+                    pkg_manager_venv,
                     requirements=[REPO_ROOT / "qcom" / "requirements.txt"],
                 ),
+                CreateVenvTask(python_executable=python_executable, venv_path=venv_path),
                 RunExecutablesWithVenvTask(
                     f"Installing QDC build requirements into {venv_path}",
                     venv=venv_path,
                     executables_and_args=lambda: [
                         uv_pip_install_cmd(
                             requirements=[REPO_ROOT / "qcom" / "requirements-qdc.txt"],
-                            packages=[_get_qdc_sdk_wheel(venv_path)],
+                            find_links=[get_qualcomm_device_cloud_sdk_root(pkg_manager_venv)],
                         )
                     ],
                 ),

--- a/qcom/ep_build/tasks/python.py
+++ b/qcom/ep_build/tasks/python.py
@@ -19,7 +19,13 @@ from ..task import (
     RunInTempDirectoryTask,
     Task,
 )
-from ..tools import PythonExecutableArchT, get_model_zoo_root, get_onnx_models_root, get_package_content_dir, get_python_executable
+from ..tools import (
+    PythonExecutableArchT,
+    get_model_zoo_root,
+    get_onnx_models_root,
+    get_package_content_dir,
+    get_python_executable,
+)
 from ..util import (
     MSFT_CI_REQUIREMENTS_RELPATH,
     REPO_ROOT,
@@ -27,9 +33,9 @@ from ..util import (
 from .build import BuildConfigT, TargetPyVersionT, get_ort_version
 
 
-def _get_qdc_sdk_wheel() -> Path:
+def _get_qdc_sdk_wheel(venv: Path | None = None) -> Path:
     """Return the path to the QDC SDK wheel, downloading and extracting it if necessary."""
-    sdk_dir = get_package_content_dir(None, "qualcomm_device_cloud_sdk")
+    sdk_dir = get_package_content_dir(venv, "qualcomm_device_cloud_sdk")
     wheels = list(sdk_dir.glob("qualcomm_device_cloud_sdk-*.whl"))
     if not wheels:
         raise FileNotFoundError(f"Could not find Qualcomm Device Cloud SDK wheel in {sdk_dir}")
@@ -84,7 +90,7 @@ class PipInstallQcomDevRequirements(RunExecutablesWithVenvTask):
                 executables_and_args=lambda: [
                     uv_pip_install_cmd(
                         requirements=[req_path],
-                        packages=[_get_qdc_sdk_wheel()],
+                        packages=[_get_qdc_sdk_wheel(venv_path)],
                     )
                 ],
             )
@@ -143,13 +149,18 @@ class CreateQdcVenvTask(CompositeTask):
             group_name=None,
             tasks=[
                 CreateVenvTask(python_executable=python_executable, venv_path=venv_path),
+                PipInstallTask(
+                    f"Installing package manager requirements into {venv_path}",
+                    venv_path,
+                    requirements=[REPO_ROOT / "qcom" / "requirements.txt"],
+                ),
                 RunExecutablesWithVenvTask(
                     f"Installing QDC build requirements into {venv_path}",
                     venv=venv_path,
                     executables_and_args=lambda: [
                         uv_pip_install_cmd(
                             requirements=[REPO_ROOT / "qcom" / "requirements-qdc.txt"],
-                            packages=[_get_qdc_sdk_wheel()],
+                            packages=[_get_qdc_sdk_wheel(venv_path)],
                         )
                     ],
                 ),

--- a/qcom/ep_build/tools.py
+++ b/qcom/ep_build/tools.py
@@ -26,6 +26,10 @@ def get_onnx_models_root(package_manager_venv: Path | None) -> Path:
     return get_package_content_dir(package_manager_venv, "onnx_models")
 
 
+def get_qualcomm_device_cloud_sdk_root(package_manager_venv: Path | None) -> Path:
+    return get_package_content_dir(package_manager_venv, "qualcomm_device_cloud_sdk")
+
+
 def get_package_bin_dir(package_manager_venv: Path | None, package: str) -> Path:
     install_package(package_manager_venv, package)
     return Path(_package_action(package_manager_venv, package, "print-bin-dir"))

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -181,3 +181,6 @@ qairt:
   url: https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/{version}/v{version}.zip
   content_root: qairt/{version}
   bindir: bin
+qualcomm_device_cloud_sdk:
+  version: 0.3.0
+  url: https://softwarecenter.qualcomm.com/api/download/software/tools/Qualcomm_Device_Cloud_SDK/Windows/{version}/qualcomm_device_cloud_sdk-{version}.zip

--- a/qcom/requirements-qdc.txt
+++ b/qcom/requirements-qdc.txt
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: MIT
 
 -r requirements.txt
-qdc-public-api-client == 0.0.14

--- a/qcom/requirements-qdc.txt
+++ b/qcom/requirements-qdc.txt
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 -r requirements.txt
+qualcomm_device_cloud_sdk==0.3.0

--- a/qcom/scripts/all/qdc_runner.py
+++ b/qcom/scripts/all/qdc_runner.py
@@ -25,36 +25,36 @@ import backoff
 import requests
 from package_manager import PackageManager
 from prettytable import PrettyTable
-from qdc_public_api_client import Client
-from qdc_public_api_client.api.artifacts import (
-    post_artifacts_startupload,
-    post_artifacts_uuid_continueupload,
-    post_artifacts_uuid_endupload,
+from qualcomm_device_cloud_sdk import Client
+from qualcomm_device_cloud_sdk.api.artifacts import (
+    post_artifacts_start_upload,
+    post_artifacts_uuid_continue_upload,
+    post_artifacts_uuid_end_upload,
 )
-from qdc_public_api_client.api.jobs import (
-    get_jobs_downloadlogs,
-    get_jobs_id,
+from qualcomm_device_cloud_sdk.api.jobs import (
+    get_jobs_download_logs,
+    get_jobs_job_id,
     get_jobs_job_id_logs,
     post_jobs,
     post_jobs_job_id_abort,
 )
-from qdc_public_api_client.models.artifact_type import ArtifactType
-from qdc_public_api_client.models.artifact_type_0 import ArtifactType0
-from qdc_public_api_client.models.create_job_type_0 import CreateJobType0
-from qdc_public_api_client.models.error_message_type_0 import ErrorMessageType0
-from qdc_public_api_client.models.job_logs_type_0 import JobLogsType0
-from qdc_public_api_client.models.job_mode import JobMode
-from qdc_public_api_client.models.job_result import JobResult
-from qdc_public_api_client.models.job_state import JobState
-from qdc_public_api_client.models.job_submission_parameter import JobSubmissionParameter
-from qdc_public_api_client.models.job_type import JobType
-from qdc_public_api_client.models.job_type_0 import JobType0
-from qdc_public_api_client.models.log_upload_status import LogUploadStatus
-from qdc_public_api_client.models.post_artifacts_uuid_continueupload_body import (
-    PostArtifactsUuidContinueuploadBody,
+from qualcomm_device_cloud_sdk.models.artifact_type import ArtifactType
+from qualcomm_device_cloud_sdk.models.artifact_type_0 import ArtifactType0
+from qualcomm_device_cloud_sdk.models.create_job_type_0 import CreateJobType0
+from qualcomm_device_cloud_sdk.models.error_message_type_0 import ErrorMessageType0
+from qualcomm_device_cloud_sdk.models.job_logs_type_0 import JobLogsType0
+from qualcomm_device_cloud_sdk.models.job_mode import JobMode
+from qualcomm_device_cloud_sdk.models.job_result import JobResult
+from qualcomm_device_cloud_sdk.models.job_state import JobState
+from qualcomm_device_cloud_sdk.models.job_submission_parameter import JobSubmissionParameter
+from qualcomm_device_cloud_sdk.models.job_type import JobType
+from qualcomm_device_cloud_sdk.models.job_type_0 import JobType0
+from qualcomm_device_cloud_sdk.models.log_upload_status import LogUploadStatus
+from qualcomm_device_cloud_sdk.models.post_artifacts_uuid_continue_upload_body import (
+    PostArtifactsUuidContinueUploadBody,
 )
-from qdc_public_api_client.models.test_framework import TestFramework
-from qdc_public_api_client.types import File, Response, Unset
+from qualcomm_device_cloud_sdk.models.test_framework import TestFramework
+from qualcomm_device_cloud_sdk.types import File, Response, Unset
 
 REPO_ROOT = Path(__file__).parent.parent.parent.parent.absolute()
 
@@ -329,7 +329,7 @@ class QdcClient:
 
     @retry_with_backoff()
     def post_artifacts_startupload(self, *args, **kwargs) -> Response["ArtifactType0 | None"]:
-        result = post_artifacts_startupload.sync_detailed(
+        result = post_artifacts_start_upload.sync_detailed(
             client=self._client,
             *args,  # noqa: B026
             **kwargs,
@@ -351,7 +351,7 @@ class QdcClient:
 
     @retry_with_backoff()
     def post_artifacts_uuid_endupload(self, *args, **kwargs) -> Response["ArtifactType0 | None"]:
-        result = post_artifacts_uuid_endupload.sync_detailed(
+        result = post_artifacts_uuid_end_upload.sync_detailed(
             client=self._client,
             *args,  # noqa: B026
             **kwargs,
@@ -362,7 +362,7 @@ class QdcClient:
 
     @retry_with_backoff()
     def post_artifacts_uuid_continueupload(self, *args, **kwargs) -> Response["ArtifactType0 | None"]:
-        result = post_artifacts_uuid_continueupload.sync_detailed(
+        result = post_artifacts_uuid_continue_upload.sync_detailed(
             client=self._client,
             *args,  # noqa: B026
             **kwargs,
@@ -384,7 +384,7 @@ class QdcClient:
 
     @retry_with_backoff()
     def get_jobs_id(self, *args, **kwargs) -> Response["JobType0 | None"]:
-        result = get_jobs_id.sync_detailed(
+        result = get_jobs_job_id.sync_detailed(
             client=self._client,
             *args,  # noqa: B026
             **kwargs,
@@ -413,7 +413,7 @@ class QdcClient:
 
     @retry_with_backoff()
     def _download_zipped_log(self, qdc_log_path: PurePosixPath) -> Response[File]:
-        result = get_jobs_downloadlogs.sync_detailed(client=self._client, path=str(qdc_log_path))
+        result = get_jobs_download_logs.sync_detailed(client=self._client, path=str(qdc_log_path))
         if isinstance(result, ErrorMessageType0):
             raise RuntimeError(result.message)
         if result is None:
@@ -622,7 +622,7 @@ class QdcRunner:
         ):
             return self._client.post_artifacts_uuid_continueupload(
                 uuid=artifact_upload_uuid,
-                body=PostArtifactsUuidContinueuploadBody(
+                body=PostArtifactsUuidContinueUploadBody(
                     file=File(
                         payload=buffer,
                         file_name="artifact.zip",


### PR DESCRIPTION
### Description

Switch the QDC Python client install from the internal self-hosted PyPI serve to the publicly released Qualcomm Device Cloud SDK on Software Center. The SDK zip is registered in `packages.yml` and downloaded via `package_manager.py`. The extracted wheel is passed directly to `uv pip install` alongside `requirements-qdc.txt`, letting the resolver satisfy the existing `qdc-public-api-client` requirement from the local wheel. The wheel is resolved lazily at execution time so the download only occurs when the QDC venv task actually runs.

### Motivation and Context

Even after `Qualcomm Device Cloud SDK v0.3.0` was released on the `Qualcomm Software Center`, the build was still pulling it from an internal PyPI service, creating an unnecessary dependency on internal infrastructure. This change removes that dependency

