### PR TITLE
disable roialign cpu linux test

### DIFF
--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -123,7 +123,7 @@ static void RunQDQRoiAlignOpTest(const TestInputDef<float>& input_def,
 // CPU tests:
 //
 // Disabling CPU test for ARM64. ARM64 CI runner stalled.
-#if !defined(_M_ARM64) && !defined(_M_ARM64EC)
+#if !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__)
 TEST_F(QnnCPUBackendTests, TestRoialign) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
@@ -178,7 +178,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
                      test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
-#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC)
+#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__)
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Seeing Roialign Linux CPU test also stall on CI. Disable it.
