### PR TITLE
Fix Pad and Div ops unit test failures

### DIFF
--- a/onnxruntime/test/providers/qnn/pad_test.cc
+++ b/onnxruntime/test/providers/qnn/pad_test.cc
@@ -77,7 +77,15 @@ GetTestQDQModelFn<QuantType> BuildPadQDQTestCase(const TestInputDef<float>& data
   return [data_def, pads_def, constant_value_def, attrs, has_constant_value, constant_value_quantized](
              ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
     MakeTestInput(builder, "data", data_def);
-    const QuantParams<QuantType> data_qparams = GetTestInputQuantParams<QuantType>(data_def);
+
+    QuantParams<QuantType> data_qparams;
+    if (has_constant_value) {
+      std::vector<TestInputDef<float>> data_defs = {data_def, constant_value_def};
+      data_qparams = GetTestInputsQuantParams<QuantType>(data_defs);
+    } else {
+      data_qparams = GetTestInputQuantParams<QuantType>(data_def);
+    }
+
     const std::string data_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_data", "data", data_qparams.scale, data_qparams.zero_point);
 
@@ -396,13 +404,11 @@ TEST_F(QnnHTPBackendTests, PadReflectMode_FP32_as_FP16) {
                2e-3f);
 }
 
-// HTP\HTP\src\hexagon\prepare\graph_prepare.cc:203:ERROR:could not create op: q::flat_from_vtcm
-// HTP\HTP\src\hexagon\prepare\graph_prepare.cc:1238:ERROR:Op 0x104100000011 preparation failed with err:-1
-// Completed stage: Graph Transformations and Optimizations (13372 us)
-// QnnDsp <E> "node" generated: could not create op
-// QnnDsp <E> RouterWindows graph prepare failed 12
-// QnnDsp <E> Failed to finalize graph (id: 1) with err 1002
-TEST_F(QnnHTPBackendTests, DISABLED_PadReflectMode_FP32_as_FP16_big_data) {
+// Since QAIRT 2.35, default float precision on QNN HTP became FP16.
+// Converting FP32 -> FP16 -> FP32 may introduce minor accuracy loss.
+// For example, a value of 8.00300312 could become 8.00000095 after the conversion.
+// The expected difference is approximately 0.00300217, so the tolerance is adjusted to 4e-3f.
+TEST_F(QnnHTPBackendTests, PadReflectMode_FP32_as_FP16_big_data) {
   bool has_constant_value_input = true;
   bool enable_fp16_precision = true;
   RunPadOpTest(TestInputDef<float>({1, 4, 512, 512}, false, GetFloatDataInRange(1.0f, 10.0f, 4 * 512 * 512)),
@@ -414,7 +420,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_PadReflectMode_FP32_as_FP16_big_data) {
                has_constant_value_input,
                18,  // opset
                enable_fp16_precision,
-               2e-3f);
+               4e-3f);
 }
 
 TEST_F(QnnHTPBackendTests, PadNoConstantNegValue_FP32_as_FP16) {
@@ -621,14 +627,7 @@ TEST_F(QnnHTPBackendTests, Pad4dMix) {
                            true);
 }
 
-// Inaccuracy detected for output 'output', element 0.
-// Output quant params: scale=0.035294119268655777, zero_point=0.
-// Expected val: 9
-// QNN QDQ val: 8.0117654800415039 (err 0.98823451995849609)
-// CPU QDQ val: 9 (err 0)
-// QNN limitation? pad_constant_value has to be within the range of input[0].
-// Here pad_constant_value = 9.0 > max(input[0]) = 8.0
-TEST_F(QnnHTPBackendTests, DISABLED_Pad4dOutOfRangePadConstantValue) {
+TEST_F(QnnHTPBackendTests, Pad4dOutOfRangePadConstantValue) {
   RunQDQPadOpTest<uint8_t>(TestInputDef<float>({1, 2, 2, 2}, false,
                                                {1.0f, 2.0f,
                                                 3.0f, 4.0f,
@@ -639,6 +638,22 @@ TEST_F(QnnHTPBackendTests, DISABLED_Pad4dOutOfRangePadConstantValue) {
                            {test::MakeAttribute("mode", "constant")},
                            ExpectedEPNodeAssignment::All,
                            true);
+}
+
+TEST_F(QnnHTPBackendTests, Pad4dOutOfRangePadNonQuantizedConstantValue) {
+  bool has_constant_value_input = true;
+  bool constant_value_quantized = false;
+  RunQDQPadOpTest<uint8_t>(TestInputDef<float>({1, 2, 2, 2}, false,
+                                               {1.0f, 2.0f,
+                                                3.0f, 4.0f,
+                                                5.0f, 6.0f,
+                                                7.0f, 8.0f}),
+                           TestInputDef<int64_t>({8}, true, {0, 0, 0, 1, 0, 0, 0, 1}),
+                           TestInputDef<float>({1}, true, {9.0f}),  // pad_constant_value out of input[0] range
+                           {test::MakeAttribute("mode", "constant")},
+                           ExpectedEPNodeAssignment::All,
+                           has_constant_value_input,
+                           constant_value_quantized);
 }
 
 TEST_F(QnnHTPBackendTests, Pad5d) {

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -329,6 +329,24 @@ inline QuantParams<QType> GetTestInputQuantParams(const TestInputDef<float>& inp
 }
 
 template <typename QType>
+inline QuantParams<QType> GetTestInputsQuantParams(const std::vector<TestInputDef<float>>& input_defs,
+                                                   bool symmetric = false) {
+  // We initialize the value using std::numeric_limits<float>::lowest() to ensure that negative values are
+  // also handled correctly.
+  std::pair<float, float> frange = {std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest()};
+
+  // Compute global range across all inputs
+  for (const auto& input_def : input_defs) {
+    const auto input_range = input_def.GetRange();
+    frange.first = std::min(frange.first, input_range.first);
+    frange.second = std::max(frange.second, input_range.second);
+  }
+
+  // Compute QuantParams using combined range.
+  return QuantParams<QType>::Compute(frange.first, frange.second, symmetric);
+}
+
+template <typename QType>
 static void GetTestInputQuantParamsPerChannel(const TestInputDef<float>& input_def, std::vector<float>& scales,
                                               std::vector<QType>& zero_points, size_t axis, bool symmetric = false) {
   const auto f32_ranges = input_def.GetRangePerChannel(axis);

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -1072,16 +1072,11 @@ TEST_F(QnnHTPBackendTests, BinaryOp_Div4D_U16_SmallInputs) {
                          true);  // Use com.microsoft Q/DQ ops
 }
 
-// TODO: Enable when this is fixed.
-// QNN v2.13: Inaccuracy detected for output 'output', element 2551923.
-// Output quant params: scale=4100.92626953125, zero_point=126.
-// Expected val: -277957.3125
-// QNN QDQ val: 0 (err 277957.3125)
-// CPU QDQ val: -516716.71875 (err 238759.40625)
-TEST_F(QnnHTPBackendTests, DISABLED_BinaryOp_Div4D_LargeInputs) {
+// Create non-zero second input to avoid zero divisor cases.
+TEST_F(QnnHTPBackendTests, BinaryOp_Div4D_LargeInputs) {
   RunQDQOpTest<uint8_t>("Div",
                         {TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f),
-                         TestInputDef<float>({1, 3, 768, 1152}, false, -1.0f, 1.0f)},
+                         TestInputDef<float>({1, 3, 768, 1152}, false, 1.0f, 2.0f)},
                         {},
                         17,
                         ExpectedEPNodeAssignment::All);


### PR DESCRIPTION
### Description
Fix three issues causing Pad and Div unit test failures:

1. Tolerance Adjustment for FP16 Precision: Updated tests to allow higher tolerance due to FP32 → FP16 → FP32 conversions introduced by HTP default precision change.
2. Correct Input Encoding for Pad QDQ Models: Fixed logic in qnn_test_util.h to properly account for constant padding values when computing input encoding.
3. Adjust Div's second input to avoid zero divisor cases.


### Motivation and Context
Recent HTP precision change (FP32 → FP16) introduced minor accuracy loss, causing failures in Pad op tests. Incorrect handling of constant padding values in QDQ models led to wrong input encoding computation. These fixes ensure accurate quantization handling and restore test coverage for Pad op functionality.


