### PR TITLE
Re-enable MaxPool/MatMul tests due to QNN HTP accuracy fix (QAIRT‑2.44)

### DIFF
--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -264,8 +264,7 @@ TEST_F(QnnCPUBackendTests, MatMulOp) {
 //
 // HTP tests:
 //
-// Disable this for now as the QNN HTP backend is not stable on different versions and platforms so it failed randomly.
-TEST_F(QnnHTPBackendTests, DISABLED_MatMulOp) {
+TEST_F(QnnHTPBackendTests, MatMulOp) {
   // RunMatMulOpTest(shape_0, shape_1, is_initializer_0, is_initializer_1, expected_ep_assignment,
   // opset, f32_abs_err)
   RunMatMulOpTest({2, 3}, {3, 2}, false, false, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);

--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -358,12 +358,7 @@ TEST_F(QnnHTPBackendTests, MaxPool_Ceil_HTP_u8) {
                             ExpectedEPNodeAssignment::All);
 }
 
-// QNN v2.13: Inaccuracy detected for output 'output', element 58367.
-// Output quant params: scale=0.078431375324726105, zero_point=127.
-// Expected val: 5.6846914291381836
-// QNN QDQ val: -5.3333334922790527 (err 11.018024444580078)
-// CPU QDQ val: 5.6470589637756348 (err 0.037632465362548828)
-TEST_F(QnnHTPBackendTests, DISABLED_MaxPool_Large_Input2_Ceil_HTP_u8) {
+TEST_F(QnnHTPBackendTests, MaxPool_Large_Input2_Ceil_HTP_u8) {
   RunQDQPoolOpTest<uint8_t>("MaxPool",
                             TestInputDef<float>({1, 128, 16, 113}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
                             {test::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2}),


### PR DESCRIPTION
### Description
QNN HTP has fixed the accuracy issues related to MaxPool and MatMul starting from QAIRT‑2.44. Re‑enable the corresponding unit tests:
- QnnHTPBackendTests.DISABLED_MatMulOp
- MaxPool_Large_Input2_Ceil_HTP_u8



