### PR TITLE
Bump ORT core to 1.24.4

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -35,7 +35,7 @@ microsoft_wil;https://github.com/microsoft/wil/archive/refs/tags/v1.0.250325.1.z
 mimalloc;https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.1.zip;d5ee7d34223d0567892db5179849939c8769dc41
 mp11;https://github.com/boostorg/mp11/archive/refs/tags/boost-1.82.0.zip;9bc9e01dffb64d9e0773b2e44d2f22c51aace063
 onnx;https://github.com/onnx/onnx/archive/refs/tags/v1.20.1.zip;30b80c81a1a381188896e86abe460c3c3f3091fd
-ort_core;https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.24.1.zip;40f1ef624d88d6b77b29da2fec142a4527cb403e
+ort_core;https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.24.4.zip;c05dbfeb4841d9d1d0760ddb26d30d6d24352a67
 # Use the latest commit of 10.9-GA
 onnx_tensorrt;https://github.com/onnx/onnx-tensorrt/archive/d5dce67db7c2e64b07e055571f5ec06f7f254de2.zip;01114d3b67650857281fa50faa2e412130a63b69
 protobuf;https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.zip;7cf2733949036c7d52fda017badcab093fe73bfa

--- a/cmake/patches/ort_core/0001-cpp-model-test-runner-uses-plugin-EP.patch
+++ b/cmake/patches/ort_core/0001-cpp-model-test-runner-uses-plugin-EP.patch
@@ -2258,12 +2258,13 @@ index 71f9050730..1e879bf5df 100644
 -                         "qnn_saver_path", "htp_graph_finalization_optimization_mode", "qnn_context_priority",
 -                         "htp_arch", "enable_htp_fp16_precision", "offload_graph_io_quantization",
 -                         "enable_htp_spill_fill_buffer", "enable_htp_shared_memory_allocator", "dump_json_qnn_graph",
--                         "json_qnn_graph_dir", "disable_file_mapped_weights", "htp_bf16_enable", "enable_vtcm_backup_buffer_sharing"});
+-                         "json_qnn_graph_dir", "disable_file_mapped_weights", "htp_bf16_enable", "enable_vtcm_backup_buffer_sharing", "extended_udma"});
 +                              "rpc_control_latency", "vtcm_mb", "soc_model", "device_id", "htp_performance_mode", "op_packages",
 +                             "qnn_saver_path", "htp_graph_finalization_optimization_mode", "qnn_context_priority",
 +                             "htp_arch", "enable_htp_fp16_precision", "offload_graph_io_quantization",
 +                             "enable_htp_spill_fill_buffer", "enable_htp_shared_memory_allocator", "dump_json_qnn_graph",
-+                             "json_qnn_graph_dir", "disable_file_mapped_weights", "htp_bf16_enable", "enable_vtcm_backup_buffer_sharing"});
++                             "json_qnn_graph_dir", "disable_file_mapped_weights", "htp_bf16_enable", "enable_vtcm_backup_buffer_sharing", "extended_udma"});
+ 
      for (const auto& provider_option : provider_options) {
        const std::string& key = provider_option.first;
        const std::string& value = provider_option.second;


### PR DESCRIPTION
### Description
* ORT 1.24.4 includes a fix for an access violation when the EP queries producer/consumer info on a missing optional input/output: https://github.com/microsoft/onnxruntime/pull/27644.
* Bumping to 1.24.4 in anticipation of unit tests that will require that fix.


