### PR TITLE
Restore dynamic-shape fallback using TensorTypeAndShape_HasShape

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -679,14 +679,19 @@ bool QnnModelWrapper::ComposeQnnGraph(bool build_json_qnn_graph) {
   return true;
 }
 
-bool QnnModelWrapper::GetOnnxShape(const std::vector<int64_t>& onnx_shape, std::vector<uint32_t>& shape) {
+bool QnnModelWrapper::GetOnnxShape(const std::optional<std::vector<int64_t>>& onnx_shape, std::vector<uint32_t>& shape) {
+  // Don't support dynamic shape.
+  if (onnx_shape == std::nullopt) {
+    return false;
+  }
+
   // Set shape to 1 for scalar.
-  if (onnx_shape.size() < 1) {
+  if (onnx_shape->size() < 1) {
     shape.push_back(1);
     return true;
   }
 
-  for (const int64_t& dim : onnx_shape) {
+  for (const int64_t& dim : onnx_shape.value()) {
     if (dim < 0) {
       return false;
     }
@@ -790,8 +795,8 @@ Ort::Status QnnModelWrapper::IsPerChannelQuantized(const OrtNodeUnitIODef& io_de
     axis = io_def.quant_param->axis.value_or(1);  // 1 is default axis for Q/DQ ops.
     if (axis < 0) {
       // Normalize negative axis by adding rank.
-      std::vector<int64_t> tensor_shape = io_def.shape;
-      RETURN_IF_NOT(!tensor_shape.empty(), "NULL tensor shape proto");
+      std::vector<uint32_t> tensor_shape;
+      RETURN_IF_NOT(GetOnnxShape(io_def.shape, tensor_shape), "Cannot get shape");
 
       const auto rank = tensor_shape.size();
       RETURN_IF_NOT(rank > 0, "Per-channel quantized tensor should be of rank > 0");

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -681,7 +681,7 @@ bool QnnModelWrapper::ComposeQnnGraph(bool build_json_qnn_graph) {
 
 bool QnnModelWrapper::GetOnnxShape(const std::optional<std::vector<int64_t>>& onnx_shape, std::vector<uint32_t>& shape) {
   // Don't support dynamic shape.
-  if (onnx_shape == std::nullopt) {
+  if (!onnx_shape.has_value()) {
     return false;
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -192,7 +192,7 @@ class QnnModelWrapper {
   }
 
   // static bool GetOnnxShape(const NodeArg& node_arg, std::vector<uint32_t>& shape);
-  static bool GetOnnxShape(const std::vector<int64_t>& onnx_shape, std::vector<uint32_t>& shape);
+  static bool GetOnnxShape(const std::optional<std::vector<int64_t>>& onnx_shape, std::vector<uint32_t>& shape);
 
   bool IsQnnTensorWrapperExist(const std::string& tensor_name) const;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gather_transpose_reshape_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gather_transpose_reshape_fusion.cc
@@ -121,7 +121,8 @@ static bool ValidateAndComputeFusionParams(
     std::vector<uint32_t>& perm_4d) {
   // Input must be rank-5 with fully static shape.
   const OrtNodeUnitIODef& x_def = gather.Inputs()[0];
-  const std::vector<int64_t>& x_shape = x_def.shape;
+  std::vector<uint32_t> x_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(x_def.shape, x_shape)) return false;
   if (x_shape.size() != 5) return false;
   for (int64_t d : x_shape)
     if (d <= 0) return false;
@@ -135,16 +136,21 @@ static bool ValidateAndComputeFusionParams(
   // Indices must be rank-2 and constant.
   if (gather.Inputs().size() < 2) return false;
   const OrtNodeUnitIODef& idx_def = gather.Inputs()[1];
-  if (idx_def.shape.size() != 2 || idx_def.shape[0] <= 0 || idx_def.shape[1] <= 0) return false;
+  std::vector<uint32_t> idx_def_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(idx_def.shape, idx_def_shape)) return false;
+  if (idx_def_shape.size() != 2 || idx_def_shape[0] <= 0 || idx_def_shape[1] <= 0) return false;
   if (!qnn_model_wrapper.IsConstantInput(idx_def.name)) return false;
-  idx0 = idx_def.shape[0];
-  idx1 = idx_def.shape[1];
+  idx0 = idx_def_shape[0];
+  idx1 = idx_def_shape[1];
 
   // Indices must cover exactly the gathered dimension.
   if (x_shape[4] != idx0 * idx1) return false;
 
   // Gather output must be rank-6.
-  if (gather.Outputs().empty() || gather.Outputs()[0].shape.size() != 6) return false;
+  if (gather.Outputs().empty()) return false;
+  std::vector<uint32_t> gather_out_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(gather.Outputs()[0].shape, gather_out_shape)) return false;
+  if (gather_out_shape.size() != 6) return false;
 
   // Detect row-major / col-major index pattern.
   const OrtValueInfo* idx_vi = qnn_model_wrapper.GetConstantTensor(idx_def.name);
@@ -163,10 +169,16 @@ static bool ValidateAndComputeFusionParams(
   if (tail != std::unordered_set<int64_t>{3, 4, 5}) return false;
 
   // Transpose output must be rank-6.
-  if (transpose.Outputs().empty() || transpose.Outputs()[0].shape.size() != 6) return false;
+  if (transpose.Outputs().empty()) return false;
+  std::vector<uint32_t> transpose_out_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(transpose.Outputs()[0].shape, transpose_out_shape)) return false;
+  if (transpose_out_shape.size() != 6) return false;
 
   // Reshape output must be rank < 6.
-  if (reshape.Outputs().empty() || reshape.Outputs()[0].shape.size() >= 6) return false;
+  if (reshape.Outputs().empty()) return false;
+  std::vector<uint32_t> reshape_out_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(reshape.Outputs()[0].shape, reshape_out_shape)) return false;
+  if (reshape_out_shape.size() >= 6) return false;
 
   // Compute 4D permutation: dims 0,1,2 merge to 0; old dim k -> new dim k-2 for k in {3,4,5}.
   perm_4d.resize(4);

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -456,8 +456,8 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
       params_.bwScaleOffsetEncoding.offset = 0;
     }
   } else if (!is_per_tensor && is_int4_type) {
-    const std::vector<int64_t> io_shape = io_def.shape;
-    RETURN_IF(io_shape.empty(), "Input/output tensor proto must have a shape");
+    std::vector<uint32_t> io_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(io_def.shape, io_shape), "Cannot get shape");
     const int32_t io_rank = static_cast<int32_t>(io_shape.size());
 
     constexpr int64_t DEFAULT_QDQ_AXIS = 1;
@@ -499,8 +499,8 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
     params_.bwAxisScaleOffsetEncoding.scales = scales_span.data();
     params_.bwAxisScaleOffsetEncoding.offsets = zps_span.data();
   } else if (!is_per_tensor && !is_int4_type) {
-    const std::vector<int64_t> io_shape = io_def.shape;
-    RETURN_IF(io_shape.empty(), "Input/output tensor proto must have a shape");
+    std::vector<uint32_t> io_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(io_def.shape, io_shape), "Cannot get shape");
     const int32_t io_rank = static_cast<int32_t>(io_shape.size());
 
     constexpr int64_t DEFAULT_QDQ_AXIS = 1;

--- a/onnxruntime/core/providers/qnn/ort_api.cc
+++ b/onnxruntime/core/providers/qnn/ort_api.cc
@@ -46,15 +46,17 @@ OrtStatus* ParseOrtValueInfo(const OrtValueInfo* io,
   ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
   RETURN_IF_NOT_NULL(ort_api.GetTensorElementType(type_shape, &elem_type));
 
-  // TODO: Is it possible shape not exist? And how should it be handled?
-  // ort_api.TensorTypeAndShape_HasShape can be used for checking
-  size_t num_dims = 0;
-  RETURN_IF_NOT_NULL(ort_api.GetDimensionsCount(type_shape, &num_dims));
+  std::optional<std::vector<int64_t>> shape = std::nullopt;
 
-  std::vector<int64_t> shape;
-  shape.resize(num_dims, 0);
-  if (num_dims > 0) {
-    RETURN_IF_NOT_NULL(ort_api.GetDimensions(type_shape, shape.data(), shape.size()));
+  if (ort_api.TensorTypeAndShape_HasShape(type_shape)) {
+    size_t num_dims = 0;
+    RETURN_IF_NOT_NULL(ort_api.GetDimensionsCount(type_shape, &num_dims));
+
+    std::vector<int64_t> actual_shape(num_dims, 0);
+    if (num_dims > 0) {
+      RETURN_IF_NOT_NULL(ort_api.GetDimensions(type_shape, actual_shape.data(), actual_shape.size()));
+    }
+    shape = std::move(actual_shape);
   }
 
   result = OrtNodeUnitIODef{name ? name : "", elem_type, shape, quant_param};
@@ -197,7 +199,7 @@ std::vector<OrtNodeUnitIODef> GetQDQIODefs(const OrtNode* target_node,
   for (size_t io_idx = 0; io_idx < num_ios; ++io_idx) {
     if (target_node_ios[io_idx] == nullptr) {
       // Optional IO.
-      io_defs.push_back(OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt});
+      io_defs.push_back(OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt});
       continue;
     }
 
@@ -210,7 +212,7 @@ std::vector<OrtNodeUnitIODef> GetQDQIODefs(const OrtNode* target_node,
       auto parse_status = ParseOrtValueInfo(target_node_ios[io_idx], std::nullopt, ort_api, regular_io_def);
       if (parse_status != nullptr) {
         ort_api.ReleaseStatus(parse_status);
-        regular_io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+        regular_io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
       }
       io_defs.push_back(regular_io_def);
     }
@@ -263,13 +265,13 @@ OrtStatus* OrtNodeUnit::InitForSingleNode(const OrtApi& ort_api) {
     auto input_status = ParseOrtValueInfo(inputs_data[0], quant_param, ort_api, input_def);
     if (input_status != nullptr) {
       ort_api.ReleaseStatus(input_status);
-      input_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+      input_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
     }
 
     auto output_status = ParseOrtValueInfo(outputs_data[0], std::nullopt, ort_api, output_def);
     if (output_status != nullptr) {
       ort_api.ReleaseStatus(output_status);
-      output_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+      output_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
     }
 
     inputs_.push_back(input_def);
@@ -282,13 +284,13 @@ OrtStatus* OrtNodeUnit::InitForSingleNode(const OrtApi& ort_api) {
     auto input_status = ParseOrtValueInfo(inputs_data[0], std::nullopt, ort_api, input_def);
     if (input_status != nullptr) {
       ort_api.ReleaseStatus(input_status);
-      input_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+      input_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
     }
 
     auto output_status = ParseOrtValueInfo(outputs_data[0], quant_param, ort_api, output_def);
     if (output_status != nullptr) {
       ort_api.ReleaseStatus(output_status);
-      output_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+      output_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
     }
 
     inputs_.push_back(input_def);
@@ -300,12 +302,12 @@ OrtStatus* OrtNodeUnit::InitForSingleNode(const OrtApi& ort_api) {
       OrtNodeUnitIODef io_def;
       if (io == nullptr) {
         // Nullptr indicates optional.
-        io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+        io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
       } else {
         auto parse_status = ParseOrtValueInfo(io, std::nullopt, ort_api, io_def);
         if (parse_status != nullptr) {
           ort_api.ReleaseStatus(parse_status);
-          io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+          io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
         }
       }
       inputs_.push_back(io_def);
@@ -317,12 +319,12 @@ OrtStatus* OrtNodeUnit::InitForSingleNode(const OrtApi& ort_api) {
       OrtNodeUnitIODef io_def;
       if (io == nullptr) {
         // Not sure whether output would be optional.
-        io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+        io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
       } else {
         auto parse_status = ParseOrtValueInfo(io, std::nullopt, ort_api, io_def);
         if (parse_status != nullptr) {
           ort_api.ReleaseStatus(parse_status);
-          io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, {}, std::nullopt};
+          io_def = OrtNodeUnitIODef{"", ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED, std::nullopt, std::nullopt};
         }
       }
       outputs_.push_back(io_def);

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -219,7 +219,7 @@ struct OrtNodeUnitIODef {
 
   std::string name;
   ONNXTensorElementDataType type;
-  std::vector<int64_t> shape;
+  std::optional<std::vector<int64_t>> shape;
   std::optional<QuantParam> quant_param;
 
   bool Exists() const noexcept { return !name.empty(); }


### PR DESCRIPTION

### Description
This PR uses ort_api.TensorTypeAndShape_HasShape to first verify whether a valid input shape actually exists before attempting to retrieve it in ort_api.cc. This ensures that operators receiving dynamic shapes correctly fall back to the CPU EP when needed, preventing the issue where downstream tensor shapes are incorrectly inferred as [1]. The behavior now aligns with the intended and previously existing handling before the ABI cleanup.



### Motivation and Context
In the ABI flow, a previous cleanup removed the node_arg parameter from QnnModelWrapper::GetOnnxShape(), since node_arg is an internal ORT variable. This cleanup also eliminated the associated nullptr check on node_arg.Shape().
However, removing this check inadvertently caused certain dynamic‑shape ops to be assigned to the QNN EP when they should have fallen back to CPU. This resulted in invalid shape propagation —often filling shapes as [1]—and ultimately triggered execution errors.


