### PR TITLE
[QnnBackendManager] Fix logger usage in shared-context scenario.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -161,12 +161,12 @@ Ort::Status ReadBinaryFromFile(const std::string& file_path, uint8_t* buffer, si
 }
 
 Ort::Status QnnBackendManager::ParseLoraConfig(std::string lora_config_path) {
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, ("Acquiring the QnnInterface " + lora_config_path).c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, ("Acquiring the QnnInterface " + lora_config_path).c_str());
 
   // QNN Lora Config file format should be a single line, with the graph name first,
   // followed by the qnn lora context binary path, separated by a semicolon (;)
   // Example: <graph_name>;<binary_path>
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, ("Loading Lora Config " + lora_config_path).c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, ("Loading Lora Config " + lora_config_path).c_str());
   std::ifstream file(lora_config_path);
   std::string line;
 
@@ -211,7 +211,7 @@ Ort::Status QnnBackendManager::ParseLoraConfig(std::string lora_config_path) {
     }
     file.close();
   } else {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Unable to load Lora Config " + lora_config_path).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, ("Unable to load Lora Config " + lora_config_path).c_str());
   }
 
   return Ort::Status();
@@ -231,7 +231,7 @@ Ort::Status QnnBackendManager::GetQnnInterfaceProvider(const char* lib_path,
 
   // Get QNN Interface providers
   F GetInterfaceProviders{nullptr};
-  GetInterfaceProviders = ResolveSymbol<F>(*backend_lib_handle, interface_provider_name, logger_);
+  GetInterfaceProviders = ResolveSymbol<F>(*backend_lib_handle, interface_provider_name, *logger_ptr_);
   RETURN_IF(nullptr == GetInterfaceProviders, "Failed to get QNN providers!");
 
   T** interface_providers{nullptr};
@@ -254,7 +254,7 @@ Ort::Status QnnBackendManager::GetQnnInterfaceProvider(const char* lib_path,
     std::ostringstream oss;
     oss << lib_path << " interface version: " << interface_version.major << "."
         << interface_version.minor << "." << interface_version.patch;
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, oss.str().c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, oss.str().c_str());
 
     // Check the interface's API version against the required version.
     // Major versions must match. The interface's minor version must be greater OR equal with a suitable patch version.
@@ -345,7 +345,7 @@ Ort::Status QnnBackendManager::LoadBackend() {
       << "." << backend_interface_version.minor << "." << backend_interface_version.patch
       << " backend provider name: " << backend_interface_provider->providerName
       << " backend id: " << backend_id_;
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
 
   return Ort::Status();
 }
@@ -409,14 +409,14 @@ Ort::Status QnnBackendManager::LoadQnnSerializerBackend() {
   oss1 << "Using QnnSaver/Ir version: " << serializer_interface_version.major << "."
        << serializer_interface_version.minor << "." << serializer_interface_version.patch
        << " provider name : " << serializer_interface_provider->providerName;
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, oss1.str().c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, oss1.str().c_str());
 
   std::ostringstream oss2;
   oss2 << "Intended backend provider name: " << backend_interface_provider->providerName
        << " backend id: " << backend_id_
        << " interface version: " << backend_interface_version.major
        << "." << backend_interface_version.minor << "." << backend_interface_version.patch;
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, oss2.str().c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, oss2.str().c_str());
 
   return Ort::Status();
 }
@@ -431,7 +431,7 @@ Ort::Status QnnBackendManager::LoadQnnSystemLib() {
 #else
   std::string system_lib_file = "libQnnSystem.so";
 #endif  // #ifdef _WIN32
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Loading QnnSystem lib");
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Loading QnnSystem lib");
   std::filesystem::path lib_file_path(backend_path_.c_str());
   std::string sys_file_path(lib_file_path.remove_filename().string() + system_lib_file);
   QnnSystemInterface_t* system_interface_provider{nullptr};
@@ -450,7 +450,7 @@ Ort::Status QnnBackendManager::LoadQnnSystemLib() {
   oss << "Found valid system interface, version: " << system_interface_version.major
       << "." << system_interface_version.minor
       << " backend provider name: " << system_interface_provider->providerName;
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
 
   system_lib_loaded_ = true;
   return Ort::Status();
@@ -509,9 +509,9 @@ void QnnLogging(const char* format,
 
 Ort::Status QnnBackendManager::InitializeQnnLog() {
   // Set Qnn log level align with Ort log level
-  auto ort_log_level = logger_.GetLoggingSeverityLevel();
+  auto ort_log_level = logger_ptr_->GetLoggingSeverityLevel();
   QnnLog_Level_t qnn_log_level = MapOrtSeverityToQNNLogLevel(ort_log_level);
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, ("Set Qnn log level: " + std::to_string(qnn_log_level)).c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, ("Set Qnn log level: " + std::to_string(qnn_log_level)).c_str());
 
   // NOTE: Even if logCreate() fails and QNN does not return a valid log_handle_, QNN may still
   // call the QnnLogging() callback. So, we have to make sure that QnnLogging() can handle calls
@@ -521,21 +521,21 @@ Ort::Status QnnBackendManager::InitializeQnnLog() {
   if (result != QNN_SUCCESS) {
     switch (result) {
       case QNN_COMMON_ERROR_NOT_SUPPORTED:
-        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Logging not supported in the QNN backend.");
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Logging not supported in the QNN backend.");
         break;
       case QNN_LOG_ERROR_INVALID_ARGUMENT:
-        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Invalid argument provided to QnnLog_create.");
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Invalid argument provided to QnnLog_create.");
         break;
       case QNN_LOG_ERROR_MEM_ALLOC:
-        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Memory allocation error during QNN logging initialization.");
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Memory allocation error during QNN logging initialization.");
         break;
       case QNN_LOG_ERROR_INITIALIZATION:
-        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Initialization of logging failed in the QNN backend.");
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Initialization of logging failed in the QNN backend.");
         break;
       default:
-        ORT_CXX_LOG(logger_,
-                    ORT_LOGGING_LEVEL_WARNING,
-                    "Unknown error occurred while initializing logging in the QNN backend.");
+        ORT_CXX_LOG_PTR(logger_ptr_,
+                        ORT_LOGGING_LEVEL_WARNING,
+                        "Unknown error occurred while initializing logging in the QNN backend.");
         break;
     }
   }
@@ -576,18 +576,19 @@ Ort::Status QnnBackendManager::ResetQnnLogLevel(std::optional<OrtLoggingLevel> o
   }
   RETURN_IF(nullptr == log_handle_, "Unable to update QNN Log Level. Invalid QNN log handle.");
 
-  OrtLoggingLevel actual_log_level = ort_log_level.has_value() ? *ort_log_level : logger_.GetLoggingSeverityLevel();
+  OrtLoggingLevel actual_log_level = ort_log_level.has_value() ? *ort_log_level
+                                                               : logger_ptr_->GetLoggingSeverityLevel();
   QnnLog_Level_t qnn_log_level = MapOrtSeverityToQNNLogLevel(actual_log_level);
 
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, ("Updating Qnn log level to: " + std::to_string(qnn_log_level)).c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, ("Updating Qnn log level to: " + std::to_string(qnn_log_level)).c_str());
 
   // Use the QnnLog_setLogLevel API to set the new log level
   Qnn_ErrorHandle_t result = qnn_interface_.logSetLogLevel(log_handle_, qnn_log_level);
   if (QNN_SUCCESS != result) {
     if (result == QNN_LOG_ERROR_INVALID_ARGUMENT) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Invalid log level argument provided to QnnLog_setLogLevel.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Invalid log level argument provided to QnnLog_setLogLevel.");
     } else if (result == QNN_LOG_ERROR_INVALID_HANDLE) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Invalid log handle provided to QnnLog_setLogLevel.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Invalid log handle provided to QnnLog_setLogLevel.");
     }
   }
   RETURN_IF(QNN_BACKEND_NO_ERROR != result,
@@ -597,7 +598,7 @@ Ort::Status QnnBackendManager::ResetQnnLogLevel(std::optional<OrtLoggingLevel> o
 
 Ort::Status QnnBackendManager::InitializeBackend() {
   if (true == backend_initialized_) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Backend initialized already.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Backend initialized already.");
     return Ort::Status();
   }
 
@@ -627,7 +628,7 @@ bool QnnBackendManager::IsDevicePropertySupported() {
   if (nullptr != qnn_interface_.propertyHasCapability) {
     auto rt = qnn_interface_.propertyHasCapability(QNN_PROPERTY_GROUP_DEVICE);
     if (QNN_PROPERTY_NOT_SUPPORTED == rt || QNN_PROPERTY_ERROR_UNKNOWN_KEY == rt) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Device property not supported or unknown to backend.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Device property not supported or unknown to backend.");
       return false;
     }
   }
@@ -637,13 +638,13 @@ bool QnnBackendManager::IsDevicePropertySupported() {
 
 Ort::Status QnnBackendManager::CreateDevice() {
   if (true == device_created_) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Device initialized already.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Device initialized already.");
     return Ort::Status();
   }
 
   // Create device if its property supported
   if (!IsDevicePropertySupported()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Skip to create device.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Skip to create device.");
     return Ort::Status();
   }
 
@@ -675,7 +676,7 @@ Ort::Status QnnBackendManager::CreateDevice() {
     }
   }
 
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Create device.");
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Create device.");
   if (nullptr != qnn_interface_.deviceCreate) {
     Qnn_ErrorHandle_t result = qnn_interface_.deviceCreate(log_handle_, device_configs_builder.GetQnnConfigs(), &device_handle_);
     if (QNN_SUCCESS != result) {
@@ -712,7 +713,7 @@ Ort::Status QnnBackendManager::InitializeProfiling() {
   }
 
   if (ProfilingLevel::OFF == profiling_level_merge_ || ProfilingLevel::INVALID == profiling_level_merge_) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Profiling turned off.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Profiling turned off.");
     return Ort::Status();
   }
 
@@ -720,14 +721,14 @@ Ort::Status QnnBackendManager::InitializeProfiling() {
   bool enable_optrace = false;
   if (ProfilingLevel::BASIC == profiling_level_merge_) {
     qnn_profile_level = QNN_PROFILE_LEVEL_BASIC;
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Profiling level set to basic.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Profiling level set to basic.");
   } else if (ProfilingLevel::DETAILED == profiling_level_merge_) {
     qnn_profile_level = QNN_PROFILE_LEVEL_DETAILED;
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Profiling level set to detailed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Profiling level set to detailed.");
   } else if (ProfilingLevel::OPTRACE == profiling_level_merge_) {
     qnn_profile_level = QNN_PROFILE_LEVEL_DETAILED;
     enable_optrace = true;
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Profiling level set to optrace.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Profiling level set to optrace.");
   }
 
   Qnn_ErrorHandle_t result = qnn_interface_.profileCreate(backend_handle_, qnn_profile_level, &profile_backend_handle_);
@@ -751,10 +752,10 @@ Ort::Status QnnBackendManager::InitializeProfiling() {
   }
 #else
   if (enable_optrace) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_WARNING,
-                "Profiling level set to optrace, but QNN SDK Version is older than 2.29.0. "
-                "Profiling level will be set to detailed instead.");
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_WARNING,
+                    "Profiling level set to optrace, but QNN SDK Version is older than 2.29.0. "
+                    "Profiling level will be set to detailed instead.");
   }
 #endif
 
@@ -843,24 +844,24 @@ void QnnBackendManager::ProcessContextFromBinListAsync(Qnn_ContextHandle_t conte
 
   std::lock_guard<std::mutex> guard(ep_context_handle_map_mutex_);
   if (!notifyParam) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_WARNING,
-                ("No known node names associated with context handle: " + context_ss.str()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_WARNING,
+                    ("No known node names associated with context handle: " + context_ss.str()).c_str());
     return;
   }
 
   std::vector<std::string>* ep_node_names = reinterpret_cast<std::vector<std::string>*>(notifyParam);
   for (const auto& node_name : *ep_node_names) {
     if (!(ep_context_handle_map_.emplace(node_name, context).second)) {
-      ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Unable to map " + context_ss.str() + " to " + node_name).c_str());
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_VERBOSE,
+                      ("Unable to map " + context_ss.str() + " to " + node_name).c_str());
     }
   }
 
   auto s = AddQnnContextHandle(context);
   if (!s.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING, ("Unable to add context " + context_ss.str()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING, ("Unable to add context " + context_ss.str()).c_str());
   }
 }
 
@@ -888,7 +889,9 @@ Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
   context_config_weight_sharing.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
   context_config_weight_sharing.customConfig = &custom_config;
 #else
-  LOGS(logger_, WARNING) << "Called CreateContextVtcmBackupBufferSharingEnabled() but QNN API version is older than 2.26!";
+  ORT_CXX_LOG_PTR(logger_ptr_,
+                  ORT_LOGGING_LEVEL_WARNING,
+                  "Called CreateContextVtcmBackupBufferSharingEnabled() but QNN API version is older than 2.26!");
 #endif
   QnnContext_Config_t context_priority_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, context_priority_config));
@@ -978,7 +981,7 @@ Ort::Status QnnBackendManager::ResetContextPriority() {
 
 Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing) {
   if (true == context_created_) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, "Context created already.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Context created already.");
     return Ort::Status();
   }
 
@@ -1051,7 +1054,7 @@ Ort::Status QnnBackendManager::ReleaseContext() {
 std::unique_ptr<unsigned char[]> QnnBackendManager::GetContextBinaryBuffer(uint64_t& written_buffer_size) {
   if (nullptr == qnn_interface_.contextGetBinarySize ||
       nullptr == qnn_interface_.contextGetBinary) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Failed to get valid function pointer.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Failed to get valid function pointer.");
     return nullptr;
   }
   if (contexts_.size() <= 0) {
@@ -1061,15 +1064,15 @@ std::unique_ptr<unsigned char[]> QnnBackendManager::GetContextBinaryBuffer(uint6
   // Generate all graphs in one single context
   Qnn_ErrorHandle_t rt = qnn_interface_.contextGetBinarySize(contexts_[0], &required_buffer_size);
   if (QNN_CONTEXT_NO_ERROR != rt) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_ERROR,
-                ("Failed to get QNN context binary size. Error: " + QnnErrorHandleToString(rt)).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_ERROR,
+                    ("Failed to get QNN context binary size. Error: " + QnnErrorHandleToString(rt)).c_str());
     return nullptr;
   }
 
   std::unique_ptr<unsigned char[]> context_buffer = std::make_unique<unsigned char[]>(required_buffer_size);
   if (nullptr == context_buffer) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Failed to allocate buffer for context cache.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Failed to allocate buffer for context cache.");
     return nullptr;
   }
 
@@ -1078,22 +1081,22 @@ std::unique_ptr<unsigned char[]> QnnBackendManager::GetContextBinaryBuffer(uint6
                                        required_buffer_size,
                                        &written_buffer_size);
   if (QNN_CONTEXT_NO_ERROR != rt) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_ERROR,
-                ("Failed to get context binary. Error: " + QnnErrorHandleToString(rt)).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_ERROR,
+                    ("Failed to get context binary. Error: " + QnnErrorHandleToString(rt)).c_str());
     return nullptr;
   }
 
   if (required_buffer_size < written_buffer_size) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_ERROR,
-                ("Context written buffer size: " + std::to_string(written_buffer_size) +
-                 " exceeds allocated buffer size: " + std::to_string(required_buffer_size))
-                    .c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_ERROR,
+                    ("Context written buffer size: " + std::to_string(written_buffer_size) +
+                     " exceeds allocated buffer size: " + std::to_string(required_buffer_size))
+                        .c_str());
     return nullptr;
   }
 
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Get context binary buffer succeed.");
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Get context binary buffer succeed.");
   return context_buffer;
 }
 
@@ -1147,15 +1150,15 @@ Ort::Status QnnBackendManager::GetMaxSpillFillBufferSize(unsigned char* buffer,
         auto spill_fill_buffer_size = htp_graph_info->contextBinaryGraphBlobInfoV1.spillFillBufferSize;
         max_spill_fill_buffer_size = spill_fill_buffer_size > max_spill_fill_buffer_size ? spill_fill_buffer_size : max_spill_fill_buffer_size;
       } else {
-        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Unknown context binary graph info blob version.");
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Unknown context binary graph info blob version.");
       }
     } else if (graphs_info[i].version == QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_2 ||
                graphs_info[i].version == QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_1) {
-      ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_VERBOSE,
-                  "Skip retrieve spill file buffer size, it is not supported with graph info v1 & v2.");
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_VERBOSE,
+                      "Skip retrieve spill file buffer size, it is not supported with graph info v1 & v2.");
     } else {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Unknown context binary graph info version.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Unknown context binary graph info version.");
     }
   }
 #else
@@ -1163,7 +1166,7 @@ Ort::Status QnnBackendManager::GetMaxSpillFillBufferSize(unsigned char* buffer,
   ORT_UNUSED_PARAMETER(buffer_length);
 #endif
 
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Get max spill fill buffer size completed.");
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Get max spill fill buffer size completed.");
   return Ort::Status();
 }
 
@@ -1218,9 +1221,9 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
   }
 
   RETURN_IF(graph_count < 1 || graphs_info == nullptr, "Failed to get graph info from Qnn cached context.");
-  ORT_CXX_LOG(logger_,
-              ORT_LOGGING_LEVEL_VERBOSE,
-              ("Graph count from QNN context: " + std::to_string(graph_count)).c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_,
+                  ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Graph count from QNN context: " + std::to_string(graph_count)).c_str());
 
   Qnn_ContextHandle_t context = nullptr;
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 26)
@@ -1255,9 +1258,9 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
 #endif
 
     QnnContext_Config_t* spill_fill_config_pointer = max_spill_fill_size > 0 ? &spill_fill_config : nullptr;
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_VERBOSE,
-                ("Max spill fill buffer size: " + std::to_string(max_spill_fill_size)).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_VERBOSE,
+                    ("Max spill fill buffer size: " + std::to_string(max_spill_fill_size)).c_str());
 
     const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_config_pointer, nullptr};
 
@@ -1315,7 +1318,7 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
   sys_ctx_handle = nullptr;
   context_created_ = true;
 
-  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Load from cached QNN Context completed.");
+  ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Load from cached QNN Context completed.");
   return Ort::Status();
 }
 
@@ -1329,18 +1332,18 @@ Ort::Status QnnBackendManager::SetupBackend(
     std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map) {
   std::lock_guard<std::recursive_mutex> lock(logger_recursive_mutex_);
   if (backend_setup_completed_) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Backend setup already!");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Backend setup already!");
 
     if (vtcm_backup_buffer_sharing_enabled_) {
       // If a context bin filepath has not been processed yet,
       // then a new context must be created for the set of context bins
       auto first_mapping_it = ep_context_handle_map_.find(context_bin_map.begin()->first);
       if (first_mapping_it == ep_context_handle_map_.end()) {
-        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Creating context for new set of context binaries");
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Creating context for new set of context binaries");
         return CreateContextVtcmBackupBufferSharingEnabled(context_bin_map);
       }
 
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Mapping contexts to new EP main context nodes");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Mapping contexts to new EP main context nodes");
 
       for (auto& it : context_bin_map) {
         auto context_bin_filepath = it.first;
@@ -1364,7 +1367,7 @@ Ort::Status QnnBackendManager::SetupBackend(
     status = LoadQnnSerializerBackend();
   }
   if (status.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "LoadBackend succeed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "LoadBackend succeed.");
   }
 
   if (status.IsOK() && (load_from_cached_context || need_load_system_lib)) {
@@ -1373,48 +1376,48 @@ Ort::Status QnnBackendManager::SetupBackend(
 
   if (status.IsOK()) {
     sdk_build_version_ = GetBackendBuildId();
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, ("Backend build version: " + sdk_build_version_).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, ("Backend build version: " + sdk_build_version_).c_str());
   }
 
   if (status.IsOK()) {
     status = InitializeQnnLog();
   }
   if (status.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "SetLogger succeed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "SetLogger succeed.");
   }
 
   if (status.IsOK()) {
     status = InitializeBackend();
   }
   if (status.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeBackend succeed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeBackend succeed.");
   }
 
   if (status.IsOK()) {
     status = CreateDevice();
   }
   if (status.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "CreateDevice succeed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "CreateDevice succeed.");
   }
 
   if (status.IsOK()) {
     status = InitializeProfiling();
   }
   if (status.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeProfiling succeed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeProfiling succeed.");
   }
 
   if (status.IsOK()) {
     RETURN_IF_ERROR(LoadOpPackage());
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "LoadOpPackage succeed.");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "LoadOpPackage succeed.");
   }
 
   bool enable_htp_weight_sharing = false;
   if (share_ep_contexts && !load_from_cached_context) {
 #if defined(__aarch64__) || defined(_M_ARM64)
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_WARNING,
-                "Weight sharing only available with offline generation on x64 platform, not work on real device.");
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_WARNING,
+                    "Weight sharing only available with offline generation on x64 platform, not work on real device.");
 #else
     enable_htp_weight_sharing = true;
 #endif
@@ -1425,15 +1428,15 @@ Ort::Status QnnBackendManager::SetupBackend(
                                                  : CreateContext(enable_htp_weight_sharing);
 
     if (status.IsOK()) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "CreateContext succeed.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "CreateContext succeed.");
     }
   }
 
   if (status.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "QNN SetupBackend succeed");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "QNN SetupBackend succeed");
     backend_setup_completed_ = true;
   } else {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Failed to setup so cleaning up");
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Failed to setup so cleaning up");
     ReleaseResources();
   }
 
@@ -1470,10 +1473,14 @@ Ort::Status QnnBackendManager::SetHtpPowerConfigs(uint32_t htp_power_config_clie
   // to a different EP. Therefore, we have to check that backend setup actually completed before trying to
   // set an HTP power config ID. Otherwise, this causes a segfault because the QNN backend lib is unloaded.
   RETURN_IF_NOT(backend_setup_completed_, "Cannot set HTP power config ID if backend setup is not complete.");
-  RETURN_IF_ERROR(htp_power_config_manager_.AddRpcPollingTime(rpc_polling_time));
-  RETURN_IF_ERROR(htp_power_config_manager_.AddRpcControlLatency(rpc_control_latency));
-  RETURN_IF_ERROR(htp_power_config_manager_.AddHtpPerformanceMode(htp_performance_mode, htp_power_config_client_id));
-  RETURN_IF_ERROR(htp_power_config_manager_.SetPowerConfig(htp_power_config_client_id, GetQnnInterface()));
+  RETURN_IF_ERROR(htp_power_config_manager_.AddRpcPollingTime(rpc_polling_time, *logger_ptr_));
+  RETURN_IF_ERROR(htp_power_config_manager_.AddRpcControlLatency(rpc_control_latency, *logger_ptr_));
+  RETURN_IF_ERROR(htp_power_config_manager_.AddHtpPerformanceMode(htp_performance_mode,
+                                                                  htp_power_config_client_id,
+                                                                  *logger_ptr_));
+  RETURN_IF_ERROR(htp_power_config_manager_.SetPowerConfig(htp_power_config_client_id,
+                                                           GetQnnInterface(),
+                                                           *logger_ptr_));
 
   return Ort::Status();
 }
@@ -1488,22 +1495,26 @@ Ort::Status QnnBackendManager::SetPerThreadHtpPowerConfigs(const std::thread::id
   if (pre_run) {
     if (htp_power_configs.pre_run_perf_mode.has_value()) {
       RETURN_IF_ERROR(htp_power_config_manager_.AddHtpPerformanceMode(*htp_power_configs.pre_run_perf_mode,
-                                                                      htp_power_config_id));
+                                                                      htp_power_config_id,
+                                                                      *logger_ptr_));
     }
 
     if (htp_power_configs.rpc_control_latency.has_value()) {
-      RETURN_IF_ERROR(htp_power_config_manager_.AddRpcControlLatency(*htp_power_configs.rpc_control_latency));
+      RETURN_IF_ERROR(htp_power_config_manager_.AddRpcControlLatency(*htp_power_configs.rpc_control_latency,
+                                                                     *logger_ptr_));
     }
 
     if (htp_power_configs.rpc_polling_time.has_value()) {
-      RETURN_IF_ERROR(htp_power_config_manager_.AddRpcPollingTime(*htp_power_configs.rpc_polling_time));
+      RETURN_IF_ERROR(htp_power_config_manager_.AddRpcPollingTime(*htp_power_configs.rpc_polling_time,
+                                                                  *logger_ptr_));
     }
   } else if (htp_power_configs.post_run_perf_mode.has_value()) {
     RETURN_IF_ERROR(htp_power_config_manager_.AddHtpPerformanceMode(*htp_power_configs.post_run_perf_mode,
-                                                                    htp_power_config_id));
+                                                                    htp_power_config_id,
+                                                                    *logger_ptr_));
   }
 
-  RETURN_IF_ERROR(htp_power_config_manager_.SetPowerConfig(htp_power_config_id, GetQnnInterface()));
+  RETURN_IF_ERROR(htp_power_config_manager_.SetPowerConfig(htp_power_config_id, GetQnnInterface(), *logger_ptr_));
 
   return Ort::Status();
 }
@@ -1576,37 +1587,37 @@ void QnnBackendManager::ReleaseResources() {
 
   auto result = ReleaseContext();
   if (!result.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Failed to ReleaseContext: " + result.GetErrorMessage()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, ("Failed to ReleaseContext: " + result.GetErrorMessage()).c_str());
   }
 
   result = ReleaseProfilehandle();
   if (!result.IsOK()) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_ERROR,
-                ("Failed to ReleaseProfilehandle: " + result.GetErrorMessage()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_ERROR,
+                    ("Failed to ReleaseProfilehandle: " + result.GetErrorMessage()).c_str());
   }
 
   result = ReleaseDevice();
   if (!result.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Failed to ReleaseDevice: " + result.GetErrorMessage()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, ("Failed to ReleaseDevice: " + result.GetErrorMessage()).c_str());
   }
 
   result = ShutdownBackend();
   if (!result.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Failed to ShutdownBackend: " + result.GetErrorMessage()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, ("Failed to ShutdownBackend: " + result.GetErrorMessage()).c_str());
   }
 
   result = TerminateQnnLog();
   if (!result.IsOK()) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Failed to TerminateQnnLog: " + result.GetErrorMessage()).c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, ("Failed to TerminateQnnLog: " + result.GetErrorMessage()).c_str());
   }
 
   if (backend_lib_handle_) {
     result = UnloadLib(backend_lib_handle_);
     if (!result.IsOK()) {
-      ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_ERROR,
-                  ("Failed to unload backend library: " + result.GetErrorMessage()).c_str());
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_ERROR,
+                      ("Failed to unload backend library: " + result.GetErrorMessage()).c_str());
     }
   }
 
@@ -1634,17 +1645,17 @@ Ort::Status QnnBackendManager::ExtractBackendProfilingInfo(qnn::profile::Profili
 
   // ETW disabled previously, but enabled now
   if (ProfilingLevel::INVALID == profiling_level_etw_ && tracelogging_provider_ep_enabled) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_ERROR,
-                "ETW disabled previously, but enabled now. Can't do the switch! Won't output any profiling.");
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_ERROR,
+                    "ETW disabled previously, but enabled now. Can't do the switch! Won't output any profiling.");
     return Ort::Status();
   }
 
   // ETW enabled previously, but disabled now
   if (ProfilingLevel::INVALID != profiling_level_etw_ && !tracelogging_provider_ep_enabled) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_ERROR,
-                "ETW enabled previously, but disabled now. Can't do the switch! Won't output any profiling.");
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_ERROR,
+                    "ETW enabled previously, but disabled now. Can't do the switch! Won't output any profiling.");
     return Ort::Status();
   }
 
@@ -1653,9 +1664,9 @@ Ort::Status QnnBackendManager::ExtractBackendProfilingInfo(qnn::profile::Profili
 
   RETURN_IF(nullptr == profile_backend_handle_, "Backend profile handle not valid.");
 
-  ORT_CXX_LOG(logger_,
-              ORT_LOGGING_LEVEL_VERBOSE,
-              ("Extracting profiling events for graph " + profiling_info.graph_name).c_str());
+  ORT_CXX_LOG_PTR(logger_ptr_,
+                  ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Extracting profiling events for graph " + profiling_info.graph_name).c_str());
 
   const QnnProfile_EventId_t* profile_events{nullptr};
   uint32_t num_events{0};
@@ -1671,21 +1682,21 @@ Ort::Status QnnBackendManager::ExtractBackendProfilingInfo(qnn::profile::Profili
   }
 
   if (num_events > 0) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_VERBOSE,
-                ("profile_events: " + std::to_string(*profile_events) +
-                 " num_events: " + std::to_string(num_events))
-                    .c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_VERBOSE,
+                    ("profile_events: " + std::to_string(*profile_events) +
+                     " num_events: " + std::to_string(num_events))
+                        .c_str());
 
     bool backendSupportsExtendedEventData = false;
     Qnn_ErrorHandle_t resultPropertyHasCapability =
         qnn_interface_.propertyHasCapability(QNN_PROPERTY_PROFILE_SUPPORTS_EXTENDED_EVENT);
     uint16_t errorCodePropertyHasCapability = static_cast<uint16_t>(resultPropertyHasCapability & 0xFFFF);
     if (errorCodePropertyHasCapability == QNN_PROPERTY_SUPPORTED) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "The QNN backend supports extended event data.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "The QNN backend supports extended event data.");
       backendSupportsExtendedEventData = true;
     } else {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "The QNN backend does not support extended event data.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "The QNN backend does not support extended event data.");
     }
 
     profiling_info.csv_output_filepath = profiling_file_path_;
@@ -1715,17 +1726,17 @@ Ort::Status QnnBackendManager::ExtractBackendProfilingInfo(qnn::profile::Profili
 #endif
 
     if (!profiling_file_path_.empty()) {
-      ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Wrote QNN profiling events (" + std::to_string(num_events) +
-                   ") to file (" + profiling_file_path_ + ")")
-                      .c_str());
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_VERBOSE,
+                      ("Wrote QNN profiling events (" + std::to_string(num_events) +
+                       ") to file (" + profiling_file_path_ + ")")
+                          .c_str());
     }
 
     if (tracelogging_provider_ep_enabled) {
-      ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Wrote QNN profiling events (" + std::to_string(num_events) + ") to ETW").c_str());
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_VERBOSE,
+                      ("Wrote QNN profiling events (" + std::to_string(num_events) + ") to ETW").c_str());
     }
   }
 
@@ -1742,11 +1753,11 @@ Ort::Status QnnBackendManager::ExtractProfilingSubEvents(QnnProfile_EventId_t pr
             ("Failed to get profile sub events. Error: " + QnnErrorHandleToString(result)).c_str());
 
   if (num_sub_events > 0) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_VERBOSE,
-                ("profile_sub_events: " + std::to_string(*profile_sub_events) +
-                 " num_sub_events: " + std::to_string(num_sub_events))
-                    .c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_VERBOSE,
+                    ("profile_sub_events: " + std::to_string(*profile_sub_events) +
+                     " num_sub_events: " + std::to_string(num_sub_events))
+                        .c_str());
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
     QnnSystemProfile_ProfileEventV1_t* parent_system_event = nullptr;
@@ -1767,9 +1778,9 @@ Ort::Status QnnBackendManager::ExtractProfilingSubEvents(QnnProfile_EventId_t pr
       RETURN_IF_ERROR(ExtractProfilingSubEvents(subevent_id, profile_writer, useExtendedEventData));
     }
 
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_VERBOSE,
-                ("Wrote QNN profiling sub events (" + std::to_string(num_sub_events) + ")").c_str());
+    ORT_CXX_LOG_PTR(logger_ptr_,
+                    ORT_LOGGING_LEVEL_VERBOSE,
+                    ("Wrote QNN profiling sub events (" + std::to_string(num_sub_events) + ")").c_str());
   }
 
   return Ort::Status();
@@ -2030,16 +2041,15 @@ Ort::Status QnnBackendManager::AddQnnContextHandle(Qnn_ContextHandle_t raw_conte
   auto free_context_handle = [this](Qnn_ContextHandle_t raw_context_handle) {
     const auto free_result = qnn_interface_.contextFree(raw_context_handle, nullptr);
     if (free_result != QNN_CONTEXT_NO_ERROR) {
-      ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_ERROR,
-                  ("qnn_interface.contextFree() failed: " + utils::GetVerboseQnnErrorMessage(qnn_interface_, free_result)).c_str());
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_ERROR,
+                      ("qnn_interface.contextFree() failed: " + utils::GetVerboseQnnErrorMessage(qnn_interface_, free_result)).c_str());
     }
   };
 
   // take ownership of `raw_context_handle`
   auto context_handle = UniqueQnnContextHandle(raw_context_handle, free_context_handle);
-  auto mem_handle_manager = std::make_unique<QnnContextMemHandleManager>(GetQnnInterface(), raw_context_handle,
-                                                                         logger_);
+  auto mem_handle_manager = std::make_unique<QnnContextMemHandleManager>(GetQnnInterface(), raw_context_handle);
 
   auto context_handle_record = std::make_shared<QnnContextHandleRecord>();
   context_handle_record->context_handle = std::move(context_handle);
@@ -2073,13 +2083,15 @@ Ort::Status QnnBackendManager::GetOrRegisterContextMemHandle(Qnn_ContextHandle_t
   auto& context_mem_handle_manager = context_handle_record->mem_handles;
 
   bool did_register{};
-  RETURN_IF_ERROR(context_mem_handle_manager->GetOrRegister(shared_memory_address, qnn_tensor,
-                                                            mem_handle, did_register));
+  RETURN_IF_ERROR(context_mem_handle_manager->GetOrRegister(shared_memory_address,
+                                                            qnn_tensor,
+                                                            mem_handle,
+                                                            did_register,
+                                                            *logger_ptr_));
 
   if (did_register) {
     HtpSharedMemoryAllocator::AllocationCleanUpFn unregister_mem_handle =
-        [&logger = logger_,
-         shared_memory_address,
+        [shared_memory_address,
          weak_backend_manager = weak_from_this(),
          weak_context_handle_record = std::weak_ptr{context_handle_record}](
             void* /* allocation_base_address */) {
@@ -2104,7 +2116,7 @@ Ort::Status QnnBackendManager::GetOrRegisterContextMemHandle(Qnn_ContextHandle_t
                 << shared_memory_address
                 << ", error: "
                 << unregister_status.GetErrorMessage();
-            ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_ERROR, oss.str().c_str());
+            ORT_CXX_LOG(OrtLoggingManager::GetDefaultLogger(), ORT_LOGGING_LEVEL_ERROR, oss.str().c_str());
           }
         };
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -152,9 +152,9 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
         soc_model_(config.soc_model),
         op_packages_(config.op_packages),
         skip_qnn_version_check_(config.skip_qnn_version_check),
-        htp_power_config_manager_(power::HtpPowerConfigManager(logger)),
+        htp_power_config_manager_(power::HtpPowerConfigManager()),
         api_ptrs_(api_ptrs),
-        logger_(logger) {
+        logger_ptr_(&logger) {
   }
 
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QnnBackendManager);
@@ -292,6 +292,8 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // NOTE: This function indirectly locks the internal `logger_recursive_mutex_` via nested function calls.
   void ReleaseResources();
 
+  void ResetLogger(const Ort::Logger& logger) { logger_ptr_ = &logger; }
+
  private:
   Ort::Status LoadBackend();
 
@@ -357,7 +359,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   std::string GetBackendBuildId() {
     char* backend_build_id{nullptr};
     if (QNN_SUCCESS != qnn_interface_.backendGetBuildId((const char**)&backend_build_id)) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Unable to get build Id from the backend.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Unable to get build Id from the backend.");
     }
     return (backend_build_id == nullptr ? std::string("") : std::string(backend_build_id));
   }
@@ -407,57 +409,57 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
       if (result != QNN_SUCCESS) {
         switch (result) {
           case QNN_BACKEND_ERROR_INVALID_ARGUMENT:
-            ORT_CXX_LOG(logger_,
-                        ORT_LOGGING_LEVEL_ERROR,
-                        "Invalid argument, please check if op package path or interface provider is NULL.");
+            ORT_CXX_LOG_PTR(logger_ptr_,
+                            ORT_LOGGING_LEVEL_ERROR,
+                            "Invalid argument, please check if op package path or interface provider is NULL.");
             break;
           case QNN_BACKEND_ERROR_OP_PACKAGE_NOT_FOUND:
-            ORT_CXX_LOG(logger_,
-                        ORT_LOGGING_LEVEL_ERROR,
-                        ("Could not open op package path. op_pack_path: " + op_package.path).c_str());
+            ORT_CXX_LOG_PTR(logger_ptr_,
+                            ORT_LOGGING_LEVEL_ERROR,
+                            ("Could not open op package path. op_pack_path: " + op_package.path).c_str());
             break;
           case QNN_BACKEND_ERROR_OP_PACKAGE_IF_PROVIDER_NOT_FOUND:
-            ORT_CXX_LOG(logger_,
-                        ORT_LOGGING_LEVEL_ERROR,
-                        "Could not find interfaceProvider symbol in op package library.");
+            ORT_CXX_LOG_PTR(logger_ptr_,
+                            ORT_LOGGING_LEVEL_ERROR,
+                            "Could not find interfaceProvider symbol in op package library.");
             break;
           case QNN_BACKEND_ERROR_OP_PACKAGE_REGISTRATION_FAILED:
-            ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Op package registration failed.");
+            ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Op package registration failed.");
             break;
           case QNN_BACKEND_ERROR_OP_PACKAGE_UNSUPPORTED_VERSION:
-            ORT_CXX_LOG(logger_,
-                        ORT_LOGGING_LEVEL_ERROR,
-                        "Op package has interface version not supported by this backend.");
+            ORT_CXX_LOG_PTR(logger_ptr_,
+                            ORT_LOGGING_LEVEL_ERROR,
+                            "Op package has interface version not supported by this backend.");
             break;
           case QNN_BACKEND_ERROR_NOT_SUPPORTED:
-            ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Op package registration is not supported.");
+            ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Op package registration is not supported.");
             break;
           case QNN_BACKEND_ERROR_INVALID_HANDLE:
-            ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "backend is not a valid handle.");
+            ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "backend is not a valid handle.");
             break;
           case QNN_BACKEND_ERROR_OP_PACKAGE_DUPLICATE:
-            ORT_CXX_LOG(logger_,
-                        ORT_LOGGING_LEVEL_ERROR,
-                        "OpPackageName+OpName must be unique. Op package content information can be be obtained with"
-                        "QnnOpPackage interface. Indicates that an Op with the same package name and op name was"
-                        "already registered.");
+            ORT_CXX_LOG_PTR(logger_ptr_,
+                            ORT_LOGGING_LEVEL_ERROR,
+                            "OpPackageName+OpName must be unique. Op package content information can be be obtained with"
+                            "QnnOpPackage interface. Indicates that an Op with the same package name and op name was"
+                            "already registered.");
             break;
           case QNN_COMMON_ERROR_SYSTEM_COMMUNICATION:
-            ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "SSR occurrence (successful recovery).");
+            ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "SSR occurrence (successful recovery).");
             break;
           case QNN_COMMON_ERROR_SYSTEM_COMMUNICATION_FATAL:
-            ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "SSR occurrence (unsuccessful recovery).");
+            ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "SSR occurrence (unsuccessful recovery).");
             break;
           default:
-            ORT_CXX_LOG(logger_,
-                        ORT_LOGGING_LEVEL_ERROR,
-                        "Unknown error occurred while initializing logging in the QNN backend.");
+            ORT_CXX_LOG_PTR(logger_ptr_,
+                            ORT_LOGGING_LEVEL_ERROR,
+                            "Unknown error occurred while initializing logging in the QNN backend.");
             break;
         }
       }
       RETURN_IF(QNN_SUCCESS != result,
                 ("Failed to register op package to backend. Error: " + QnnErrorHandleToString(result)).c_str());
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Successfully register the op package.");
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_ERROR, "Successfully register the op package.");
       std::string op_package_for_registration = op_package.interface;
       std::string suffix = "InterfaceProvider";
       if (op_package_for_registration.size() >= suffix.size() &&
@@ -536,7 +538,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   QnnHtpDevice_Arch_t htp_arch_internal_ = QNN_HTP_DEVICE_ARCH_NONE;
 
   const ApiPtrs api_ptrs_;
-  const Ort::Logger& logger_;
+  const Ort::Logger* logger_ptr_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.cc
@@ -13,19 +13,19 @@
 namespace onnxruntime::qnn {
 
 QnnContextMemHandleManager::QnnContextMemHandleManager(const QNN_INTERFACE_VER_TYPE& qnn_interface,
-                                                       Qnn_ContextHandle_t context,
-                                                       const Ort::Logger& logger)
-    : qnn_interface_{qnn_interface},
-      context_{context},
-      logger_{logger} {
+                                                       Qnn_ContextHandle_t context)
+    : qnn_interface_{qnn_interface}, context_{context} {
 }
 
 QnnContextMemHandleManager::~QnnContextMemHandleManager() {
   Clear();
 }
 
-Ort::Status QnnContextMemHandleManager::GetOrRegister(void* shared_memory_address, const Qnn_Tensor_t& qnn_tensor,
-                                                      Qnn_MemHandle_t& qnn_mem_handle, bool& did_register) {
+Ort::Status QnnContextMemHandleManager::GetOrRegister(void* shared_memory_address,
+                                                      const Qnn_Tensor_t& qnn_tensor,
+                                                      Qnn_MemHandle_t& qnn_mem_handle,
+                                                      bool& did_register,
+                                                      const Ort::Logger& logger) {
   const auto qnn_tensor_rank = GetQnnTensorRank(qnn_tensor);
   auto* const qnn_tensor_dims = GetQnnTensorDims(qnn_tensor);
   const auto qnn_tensor_data_type = GetQnnTensorDataType(qnn_tensor);
@@ -78,7 +78,7 @@ Ort::Status QnnContextMemHandleManager::GetOrRegister(void* shared_memory_addres
          << ", offset: " << shared_memory_info.offset
          << ", fd: " << shared_memory_info.fd
          << ")";
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, oss1.str().c_str());
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, oss1.str().c_str());
 
     Qnn_MemHandle_t raw_mem_handle{};
     const auto register_result = qnn_interface_.memRegister(context_, &mem_descriptor, 1, &raw_mem_handle);
@@ -89,10 +89,10 @@ Ort::Status QnnContextMemHandleManager::GetOrRegister(void* shared_memory_addres
 
     std::ostringstream oss2;
     oss2 << "Registered QNN mem handle. mem_handle: " << raw_mem_handle;
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, oss2.str().c_str());
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, oss2.str().c_str());
 
-    // NOTE: Must use the default ORT logger inside this lambda. Don't capture this->logger_ because it may be deleted
-    // by the time we need to unregister all memory handles. This happens when this->logger_ is a session logger:
+    // NOTE: Must use the default ORT logger inside this lambda. Don't capture logger because it may be deleted
+    // by the time we need to unregister all memory handles. This happens when logger is a session logger:
     //   ~InferenceSession() -> ~Logger() -> ~QnnExecutionProvider() -> ~QnnBackendManager() ->
     //   ~QnnContextMemHandleManager() -> unregister_mem_handle() segfault
     const auto unregister_mem_handle = [&qnn_interface = this->qnn_interface_](Qnn_MemHandle_t raw_mem_handle) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_context_mem_handle_manager.h
@@ -18,8 +18,7 @@ namespace onnxruntime::qnn {
 // The associated QNN context is expected to be in scope for the lifetime of the QnnContextMemHandleManager.
 class QnnContextMemHandleManager {
  public:
-  QnnContextMemHandleManager(const QNN_INTERFACE_VER_TYPE& qnn_interface, Qnn_ContextHandle_t qnn_context,
-                             const Ort::Logger& logger);
+  QnnContextMemHandleManager(const QNN_INTERFACE_VER_TYPE& qnn_interface, Qnn_ContextHandle_t qnn_context);
 
   ~QnnContextMemHandleManager();
 
@@ -27,8 +26,11 @@ class QnnContextMemHandleManager {
 
   // Gets an existing QNN mem handle or registers a new one.
   // `qnn_mem_handle` is set to the QNN mem handle and `did_register` is true if `qnn_mem_handle` was newly registered.
-  Ort::Status GetOrRegister(void* shared_memory_address, const Qnn_Tensor_t& qnn_tensor,
-                            Qnn_MemHandle_t& qnn_mem_handle, bool& did_register);
+  Ort::Status GetOrRegister(void* shared_memory_address,
+                            const Qnn_Tensor_t& qnn_tensor,
+                            Qnn_MemHandle_t& qnn_mem_handle,
+                            bool& did_register,
+                            const Ort::Logger& logger);
 
   Ort::Status Unregister(void* shared_memory_address);
 
@@ -37,7 +39,6 @@ class QnnContextMemHandleManager {
  private:
   const QNN_INTERFACE_VER_TYPE& qnn_interface_;
   Qnn_ContextHandle_t context_;
-  const Ort::Logger& logger_;
 
   // assume Qnn_MemHandle_t is a pointer and able to be wrapped with std::unique_ptr
   static_assert(std::is_pointer_v<Qnn_MemHandle_t>);

--- a/onnxruntime/core/providers/qnn/builder/qnn_htp_power_config_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_htp_power_config_manager.cc
@@ -14,14 +14,14 @@ namespace onnxruntime {
 namespace qnn {
 namespace power {
 
-HtpPowerConfigManager::HtpPowerConfigManager(const Ort::Logger& logger) : logger_(logger) {
+HtpPowerConfigManager::HtpPowerConfigManager() {
   constexpr int kMaxNumConfigs = 3;
   power_configs_.reserve(kMaxNumConfigs);
 }
 
 HtpPowerConfigManager::~HtpPowerConfigManager() {}
 
-Ort::Status HtpPowerConfigManager::AddRpcPollingTime(uint32_t rpc_polling_time) {
+Ort::Status HtpPowerConfigManager::AddRpcPollingTime(uint32_t rpc_polling_time, const Ort::Logger& logger) {
   RETURN_IF(rpc_polling_time > kMaxRpcPolling,
             ("Cannot set RPC polling time to " + std::to_string(rpc_polling_time) +
              ". Max allowable RPC polling time is: " + std::to_string(kMaxRpcPolling))
@@ -30,11 +30,11 @@ Ort::Status HtpPowerConfigManager::AddRpcPollingTime(uint32_t rpc_polling_time) 
   RETURN_IF(rpc_polling_time_set_, "There is already a pending RPC polling time config");
 
   if (rpc_polling_time == last_set_rpc_polling_time_) {
-    ORT_CXX_LOG(logger_,
+    ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("Requested rpc polling time is the same as last set (" + std::to_string(last_set_rpc_polling_time_) + "). Ignoring request").c_str());
   } else {
-    ORT_CXX_LOG(logger_,
+    ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("Updating rpc polling time to: " + std::to_string(rpc_polling_time) + "us.").c_str());
     auto& rpc_polling_time_cfg = power_configs_.emplace_back();
@@ -47,16 +47,16 @@ Ort::Status HtpPowerConfigManager::AddRpcPollingTime(uint32_t rpc_polling_time) 
   return Ort::Status();
 }
 
-Ort::Status HtpPowerConfigManager::AddRpcControlLatency(uint32_t rpc_control_latency) {
+Ort::Status HtpPowerConfigManager::AddRpcControlLatency(uint32_t rpc_control_latency, const Ort::Logger& logger) {
   RETURN_IF(rpc_control_latency_set_, "There is already a pending RPC control latency config");
   if (rpc_control_latency == last_set_rpc_control_latency_) {
-    ORT_CXX_LOG(logger_,
+    ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("Requested rpc control latency is the same as last set (" +
                  std::to_string(last_set_rpc_control_latency_) + "). Ignoring request")
                     .c_str());
   } else {
-    ORT_CXX_LOG(logger_,
+    ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("Updating rpc control latency to: " + std::to_string(rpc_control_latency) + "us.").c_str());
     auto& rpc_control_latency_cfg = power_configs_.emplace_back();
@@ -95,17 +95,18 @@ static std::string_view PerformanceModeToString(HtpPerformanceMode htp_performan
 }
 
 Ort::Status HtpPowerConfigManager::AddHtpPerformanceMode(HtpPerformanceMode htp_performance_mode,
-                                                         uint32_t htp_power_config_client_id) {
+                                                         uint32_t htp_power_config_client_id,
+                                                         const Ort::Logger& logger) {
   RETURN_IF(htp_performance_mode_set_, "There is already a pending HTP performance mode config");
   if (htp_performance_mode == last_set_htp_performance_mode_) {
-    ORT_CXX_LOG(logger_,
+    ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("Requested htp performance mode is the same as last set (" +
                  std::string(PerformanceModeToString(last_set_htp_performance_mode_)) +
                  "). Ignoring request")
                     .c_str());
   } else {
-    ORT_CXX_LOG(logger_,
+    ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("Updating htp performance mode to: " +
                  std::string(PerformanceModeToString(htp_performance_mode)) + ".")
@@ -126,7 +127,8 @@ Ort::Status HtpPowerConfigManager::AddHtpPerformanceMode(HtpPerformanceMode htp_
 }
 
 Ort::Status HtpPowerConfigManager::SetPowerConfig(uint32_t htp_power_config_client_id,
-                                                  const QNN_INTERFACE_VER_TYPE& qnn_interface) {
+                                                  const QNN_INTERFACE_VER_TYPE& qnn_interface,
+                                                  const Ort::Logger& logger) {
   if (!power_configs_.empty()) {
     QnnDevice_Infrastructure_t qnn_device_infra = nullptr;
     auto status = qnn_interface.deviceGetInfrastructure(&qnn_device_infra);
@@ -152,7 +154,7 @@ Ort::Status HtpPowerConfigManager::SetPowerConfig(uint32_t htp_power_config_clie
     htp_performance_mode_set_ = false;
     power_configs_.clear();
   } else {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "SetPowerConfig called but no configs to be set.");
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, "SetPowerConfig called but no configs to be set.");
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_htp_power_config_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_htp_power_config_manager.h
@@ -20,30 +20,32 @@ namespace power {
 // updates power configurations for the HTP backend
 class HtpPowerConfigManager {
  public:
-  HtpPowerConfigManager(const Ort::Logger& logger);
+  HtpPowerConfigManager();
   ~HtpPowerConfigManager();
 
   // Stages a new rpc polling time for next power config update
   // If the value is the same as the last previously set, then
   // there will be no new rpc polling time staged
-  Ort::Status AddRpcPollingTime(uint32_t rpc_polling_time);
+  Ort::Status AddRpcPollingTime(uint32_t rpc_polling_time, const Ort::Logger& logger);
 
   // Stages a new rpc control latency for next power config update
   // If the value is the same as the last previously set, then
   // there will be no new rpc control latency staged
-  Ort::Status AddRpcControlLatency(uint32_t rpc_control_latency);
+  Ort::Status AddRpcControlLatency(uint32_t rpc_control_latency, const Ort::Logger& logger);
 
   // Stages a new performance mode for next power config update
   // If the value is the same as the last previously set, then
   // there will be no new performance mode staged
   Ort::Status AddHtpPerformanceMode(HtpPerformanceMode htp_performance_mode,
-                                    uint32_t htp_power_config_client_id);
+                                    uint32_t htp_power_config_client_id,
+                                    const Ort::Logger& logger);
 
   // Takes all configs staged for update and attempts to update
   // the HTP power configurations. If there is nothing staged,
   // then no attempt will be made.
   Ort::Status SetPowerConfig(uint32_t htp_power_config_client_id,
-                             const QNN_INTERFACE_VER_TYPE& qnn_interface);
+                             const QNN_INTERFACE_VER_TYPE& qnn_interface,
+                             const Ort::Logger& logger);
 
  private:
   // Sets voltage corner votes for HTP based on the given performance mode
@@ -60,8 +62,6 @@ class HtpPowerConfigManager {
   bool htp_performance_mode_set_ = false;
 
   std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> power_configs_;
-
-  const Ort::Logger& logger_;
 };
 }  // namespace power
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -89,6 +89,11 @@ namespace onnxruntime {
     }                                                   \
   } while (0)
 
+// Convenient macro for logging with an Ort::Logger pointer, espeically in QnnBackendManager.
+// This macro avoids the necessity of parentheses (i.e., (*logger_ptr)) in every ORT_CXX_LOG call.
+// This macro can be removed once ORT_CXX_LOG is fixed to properly wrap given logger with parentheses.
+#define ORT_CXX_LOG_PTR(logger_ptr, message_severity, message) ORT_CXX_LOG((*logger_ptr), message_severity, message)
+
 // QNN-EP COPY START
 // Below are macors copied from core/common/common.h directly.
 #ifdef _WIN32

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -839,6 +839,9 @@ QnnEp::QnnEp(QnnEpFactory& factory,
       ((context_cache_enabled_ && share_ep_contexts_) || enable_vtcm_backup_buffer_sharing_) &&
       SharedContext::GetInstance().GetSharedQnnBackendManager()) {
     qnn_backend_manager_ = SharedContext::GetInstance().GetSharedQnnBackendManager();
+    // Reset QnnBackendManager's logger to the one in current session as original one could be deleted along with the
+    // previous session.
+    qnn_backend_manager_->ResetLogger(logger_);
     // Clear the QnnBackendManager from singleton to stop the resource share
     if (stop_share_ep_contexts_) {
       SharedContext::GetInstance().ResetSharedQnnBackendManager();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Update QnnBackendManager to cache logger as a pointer instead of a constant reference to allow updating. Revise all logging usage accordingly. Note that any class below QnnBackendManager should not cache logger anymore but pass the logger in each function call.
Affected classes
- `QnnContextMemHandleManager`
- `HtpPowerConfigManager`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
In shared-context scenario, QnnBackendManager is shared accross several ORT sessions. Since the cached logger in QnnBackendManager is a session logger, it is destroyed along with the session desctruction. That is, the logger cannot be used in the following sessions and must be updated to a new session logger.

