### PR TITLE
Use Artifactory for CI artifacts

### DIFF
--- a/.github/actions/download-ci-artifact/action.yml
+++ b/.github/actions/download-ci-artifact/action.yml
@@ -1,0 +1,21 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+name: "Download CI Artifact"
+description: "Download a CI artifact from Artifactory"
+
+inputs:
+  name:
+    description: Name of the artifact to download
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download from Artifactory
+      shell: "${{ runner.os == 'Windows' && 'cmd' || 'bash' }}"
+      run: >
+        "${{ runner.os == 'Windows' && 'python.exe' || 'python3' }}"
+        qcom/scripts/artifactory/download_ci.py
+        --name "${{ inputs.name }}"

--- a/.github/actions/upload-ci-artifact/action.yml
+++ b/.github/actions/upload-ci-artifact/action.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+name: "Upload CI Artifact"
+description: "Upload a CI artifact to Artifactory"
+
+inputs:
+  src_pattern:
+    description: Pattern of files to upload, relative to build/
+    required: true
+    type: string
+  name:
+    description: Name of the artifact to create
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload to Artifactory
+      shell: "${{ runner.os == 'Windows' && 'cmd' || 'bash' }}"
+      run: >
+        "${{ runner.os == 'Windows' && 'python.exe' || 'python3' }}"
+        qcom/scripts/artifactory/publish_ci.py
+        --src-pattern ${{ inputs.src_pattern }}
+        --name "${{ inputs.name }}"

--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -118,7 +118,10 @@ env:
   # Cross compilation on Windows adds a folder to the build directory.
   BUILD_CONFIG_DIR: "${{ (inputs.target_os == 'windows' && ((inputs.build_runner_arch == 'X64' && inputs.target_arch != 'x86_64') || (inputs.build_runner_arch == 'ARM64' && inputs.target_arch != 'arm64'))) && 'Release/Release' || 'Release' }}"
 
+  TEST_ARCHIVE_EXT: "${{ inputs.target_os == 'linux' && 'tar.bz2' || 'zip' }}"
+
   ORT_VERSION_SUFFIX: "${{ inputs.version_suffix != '' && inputs.version_suffix || '' }}"
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
 
 jobs:
   build:
@@ -157,21 +160,28 @@ jobs:
           report_paths: |
             ${{ github.workspace }}/build/${{inputs.target_os}}-${{inputs.target_arch}}/${{ env.BUILD_CONFIG_DIR }}/*.results.xml
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ inputs.upload_test_archive }}
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         with:
-          name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Tests
-          retention-days: 7
-          path: |
-            ${{ github.workspace }}/build/onnxruntime-tests-${{inputs.target_os}}-${{ inputs.target_arch }}.*
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
-      - uses: actions/upload-artifact@v4
-        if: ${{ inputs.upload_wheel }}
+      - name: Upload Test Archive to Artifactory
+        if: ${{ inputs.upload_test_archive }}
+        uses: ./.github/actions/upload-ci-artifact
         with:
-          name: ORT ${{inputs.target_os}} ${{ inputs.target_arch }} Python ${{ inputs.target_py_vsn }} Wheel
-          retention-days: 7
-          path: |
-            ${{ github.workspace }}/build/${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime_qnn*.whl
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-tests"
+          src_pattern: "onnxruntime-tests-${{inputs.target_os}}-${{ inputs.target_arch }}.${{ env.TEST_ARCHIVE_EXT }}"
+
+      - name: Upload Wheel to Artifactory
+        if: ${{ inputs.upload_wheel }}
+        uses: ./.github/actions/upload-ci-artifact
+        with:
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-wheels"
+          src_pattern: "${{ inputs.target_os }}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime_qnn*.whl"
 
       - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload_nuget }}
@@ -202,11 +212,19 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/download-artifact@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         with:
-          name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Tests
-          path: |
-            ${{ github.workspace }}/build
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Download Tests from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-tests"
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
         run: >
@@ -245,11 +263,19 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/download-artifact@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         with:
-          name: ORT ${{inputs.target_os}} ${{ inputs.target_arch }} Python ${{ inputs.target_py_vsn }} Wheel
-          path: |
-            ${{ github.workspace }}/build/${{inputs.target_os}}-${{inputs.target_arch}}/${{env.BUILD_CONFIG_DIR}}/dist
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-wheels"
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Wheel
         run: >

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -26,13 +26,14 @@ on:
       # Cross-compiling from X64 to ARM64 is faster with our runners, but cannot produce a wheel.
       windows_arm64_runner_arch:
         type: string
-        default: "ARM64"
+        default: X64
       target_py_vsn:
         default: "3.12"
         type: string
 
 env:
   ORT_NIGHTLY_BUILD: "${{ inputs.nightly_build == true && '1' || '0' }}"
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
 
 jobs:
 
@@ -76,12 +77,14 @@ jobs:
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
-      nightly_build: ${{ inputs.nightly_build }}
-      build_runner_arch: ${{ inputs.windows_arm64_runner_arch }}
       target_arch: arm64
-      upload_wheel: ${{ inputs.windows_arm64_runner_arch == 'ARM64' }}
-      target_py_vsn: ${{ inputs.windows_arm64_runner_arch == 'ARM64' && inputs.target_py_vsn || 'None' }}
+      build_runner_arch: ${{ inputs.windows_arm64_runner_arch }}
       test_runner_arch: arm64
+      upload_wheel: ${{ inputs.windows_arm64_runner_arch == 'ARM64' && inputs.target_py_vsn }}
+      upload_test_archive: ${{ inputs.windows_arm64_runner_arch != 'ARM64' }}
+      build_test_same_runner: ${{ inputs.windows_arm64_runner_arch == 'ARM64' }}
+      target_py_vsn: ${{ inputs.windows_arm64_runner_arch == 'ARM64' && inputs.target_py_vsn || 'None' }}
+      nightly_build: ${{ inputs.nightly_build }}
 
   build-and-test-windows-arm64ec:
     if: ${{ inputs.do_all }}
@@ -125,15 +128,24 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        with:
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
       - name: Build Android
         run: |
           python3 qcom/build_and_test.py archive_ort_android_aarch64
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Test Archive to Artifactory
+        uses: ./.github/actions/upload-ci-artifact
         with:
-          name: ORT android aarch64 pynone Tests
-          path: |
-            ${{ github.workspace }}/build/onnxruntime-tests-android-aarch64.zip
+          name: "android-aarch64-pyNone-tests"
+          src_pattern: onnxruntime-tests-android-aarch64.zip
 
  # Intentionally not "test-android-aarch64" to avoid breaking required PR checks
   test-android:

--- a/.github/workflows/qualcomm-internal-clean-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-clean-artifacts.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+name: Qualcomm Internal Clean Artifacts
+description: Periodically impose a retention policy on Artifactory Artifacts
+
+on:
+  schedule:
+    - cron: "0 8 * * *"  # Every day at 1am in San Diego/PDT (8am UTC)
+  workflow_dispatch:
+
+env:
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
+
+jobs:
+  clean-ci-artifacts:
+    name: "Clean temporary CI artifacts"
+    runs-on: [self-hosted]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        with:
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Delete old CI artifacts
+        run: >
+          jf rt delete
+          --spec "${{ github.workspace }}/qcom/scripts/artifactory/aql/expired_ci_artifacts.json"
+          --spec-vars "repo=${{ env.BUILD_ARTIFACTORY_REPO }}"
+
+      # This is a bit of a hack, but there does not appear to be a way to do this nicely without
+      # a server-side plugin. Instead, we just use a CLI-side plugin several times. Eventually
+      # it will converge and do nothing.
+      - name: Prune empty folders
+        run: |
+          jf plugin install rm-empty
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet
+          jf rm-empty folders ${{ env.BUILD_ARTIFACTORY_REPO }}/ci/ --quiet

--- a/.github/workflows/qualcomm-internal-qdc-test.yml
+++ b/.github/workflows/qualcomm-internal-qdc-test.yml
@@ -33,6 +33,7 @@ on:
 env:
   # The QDC results folder is a bit odd
   QDC_RESULTS_ARCH: "${{ (inputs.target_os == 'linux' && inputs.target_arch == 'aarch64_oe_gcc11_2') && 'qualcomm_linux' || 'android' }}"
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
 
 jobs:
   test:
@@ -46,11 +47,19 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/download-artifact@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         with:
-          name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} pynone Tests
-          path: |
-            ${{ github.workspace }}/build
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Download Tests from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-pyNone-tests"
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} pynone
         env:

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -29,6 +29,9 @@ on:
         type: boolean
         default: true
 
+env:
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
+
 jobs:
   build-wheels:
     uses: ./.github/workflows/qualcomm-internal-build-wheels.yml
@@ -44,12 +47,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      # We only publish this for AI Hub to use and they only want x86_64 Linux
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
         with:
-          name: ORT linux x86_64 Python 3.10 Wheel
-          path: ${{ github.workspace }}/build/dist
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      # We only publish this for AI Hub to use and they only want x86_64 Linux
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64-py3.10-wheels
+
+      - name: Consolidate Wheels
+        run: |
+          mkdir "${{ github.workspace }}/build/dist"
+          cp "${{ github.workspace }}/build/linux-x86_64/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
 
       - name: Create config file
         run: |

--- a/qcom/docs/setup_linux_build_vm.sh
+++ b/qcom/docs/setup_linux_build_vm.sh
@@ -61,6 +61,8 @@ env_tmpfile=$(mktemp --suffix=-runner-env)
 cat > "${env_tmpfile}" <<EOF
 LANG=en_US.UTF-8
 HOME=${runner_home}
+TMPDIR=${runner_root}/tmp
+JFROG_CLI_HOME_DIR=${runner_root}/jfrog-home
 
 ORT_BUILD_DOCKER_CCACHE_ROOT=${runner_home}/docker-ccache
 ORT_BUILD_PACKAGE_CACHE_PATH=${runner_home}/ort-package-cache
@@ -70,6 +72,8 @@ EOF
 chmod 644 "${env_tmpfile}"
 sudo -u ortqnnepci cp "${env_tmpfile}" "${runner_root}/.env"
 rm "${env_tmpfile}"
+
+mkdir -p "${runner_root}/jfrog_home/jfrog-home/security/certs"
 
 ##################
 # Configure ccache

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -118,7 +118,7 @@ nuget_windows_x86_64:
   version: 7.0.1
   url: https://dist.nuget.org/win-x86-commandline/v{version}/nuget.exe
   md5: c51179f8b404bbf7f7b8e457240cc09d
-  is_installer: False
+  is_installer: false
 onnx_models:
   version: 2025-10-02
   url: http://ort-ep-win-01.na.qualcomm.com:8000/onnx-models/onnx-models-{version}.tar.gz

--- a/qcom/scripts/all/package_manager.py
+++ b/qcom/scripts/all/package_manager.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import logging
 import os
+import platform
 import shutil
 import ssl
 import subprocess
@@ -42,6 +43,10 @@ DEFAULT_MAX_CACHE_SIZE_BYTES = int(
 DEFAULT_TOOLS_DIR = Path(os.environ.get("ORT_BUILD_TOOLS_PATH", REPO_ROOT / "build" / "tools"))
 
 CAFILE = os.environ.get("REQUESTS_CA_BUNDLE", certifi.where())
+
+
+def is_host_windows():
+    return platform.uname().system == "Windows"
 
 
 class FileCache:
@@ -230,7 +235,8 @@ class PackageManager:
             return
         package_path = self.__fetch()
 
-        if package_path.suffix == ".exe":
+        on_win = is_host_windows()
+        if (on_win and package_path.suffix == ".exe") or (not on_win and package_path.suffix == ""):
             if self.__config.get("is_installer", True):
                 self.__run_installer(package_path)
             else:
@@ -239,6 +245,8 @@ class PackageManager:
                 tool_dir.mkdir(parents=True, exist_ok=True)
                 tools_path = tool_dir / package_path.name
                 shutil.copyfile(package_path, tools_path)
+                if not on_win:
+                    tools_path.chmod(0o755)
         else:
             # Similar to downloads, we extract to a temporary directory and rename on
             # success to avoid partial extractions if we get killed.
@@ -279,7 +287,7 @@ class PackageManager:
 
     def __format(self, fmt_str: str) -> str:
         """Format a config file string, performing any necessary substitutions."""
-        replacements = {key: self.__config.get(key) for key in ["major_version", "version"]}
+        replacements = {key: self.__config.get(key) for key in ["major_version", "os_arch", "version"]}
         replacements["root_dir"] = self.get_root_dir()
         return fmt_str.format_map(replacements)
 

--- a/qcom/scripts/artifactory/aql/expired_ci_artifacts.json
+++ b/qcom/scripts/artifactory/aql/expired_ci_artifacts.json
@@ -1,0 +1,17 @@
+{
+    "files": [
+        {
+            "aql": {
+                "items.find": {
+                    "repo": "${repo}",
+                    "$and": [
+                        {
+                            "created": { "$before": "1d" },
+                            "path": { "$match": "ci/*" }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/qcom/scripts/artifactory/artifactory.py
+++ b/qcom/scripts/artifactory/artifactory.py
@@ -1,0 +1,79 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+
+
+class Artifactory:
+    def __init__(self) -> None:
+        self.__repo = os.environ["BUILD_ARTIFACTORY_REPO"]
+        if len(self.__repo) == 0:
+            raise ValueError("BUILD_ARTIFACTORY_REPO not set")
+
+    @property
+    def repo_path(self) -> str:
+        return self.__repo
+
+    def download(self, src_pattern: str, destination: Path) -> None:
+        # jf rt download preserves all the extra bookkeeping stuff we put into the path.
+        # Download everything into a tempdir and copy into the final destination.
+        with tempfile.TemporaryDirectory(prefix="ArtifactoryDownload-") as tmpdir:
+            self.__run(
+                [
+                    "rt",
+                    "download",
+                    src_pattern,
+                    f"{tmpdir}/",
+                ],
+                cwd=None,
+            )
+            relpath = "/".join(src_pattern.split("/")[1:])
+            logging.info(f"Copying everything under {Path(tmpdir) / relpath} to {destination}.")
+            shutil.copytree(Path(tmpdir) / relpath, destination, dirs_exist_ok=True)
+
+    def upload(self, cwd: Path, src_pattern: str, destination: str) -> None:
+        self.__run(
+            [
+                "rt",
+                "upload",
+                src_pattern,
+                destination,
+            ],
+            cwd,
+        )
+
+    def __run(self, args: Iterable[str], cwd: Path | None) -> None:
+        cmd = ["jf", *args]
+        logging.debug(f"Running {cmd} from {cwd}")
+        subprocess.run(args=cmd, cwd=cwd, check=True)
+
+
+class CiArtifactory(Artifactory):
+    def __init__(self) -> None:
+        super().__init__()
+        self.__commit_hash = os.environ["GITHUB_SHA"]
+        actor = os.environ["GITHUB_ACTOR"] if os.environ["GITHUB_ACTOR"] != "" else "main"
+        run_id = os.environ["GITHUB_RUN_ID"]
+        self.__ref = os.environ.get("GITHUB_REF", f"{actor}/{run_id}")
+
+    @property
+    def artifact_root(self) -> str:
+        return f"{super().repo_path}/ci/{self.__ref}/{self.__commit_hash[:10]}"
+
+
+def initialize_logging(name: str) -> None:
+    log_format = f"[%(asctime)s] [{name}] [%(levelname)s] %(message)s"
+    logging.basicConfig(level=logging.DEBUG, format=log_format, force=True)
+
+
+def valid_artifact_name(proposed_name: str) -> str:
+    if not re.match(r"^[a-zA-Z][a-zA-Z0-9-\._]*$", proposed_name):
+        raise ValueError(f"{proposed_name} is not a valid artifact name.")
+    return proposed_name

--- a/qcom/scripts/artifactory/download_ci.py
+++ b/qcom/scripts/artifactory/download_ci.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import argparse
+from pathlib import Path
+
+from artifactory import CiArtifactory, initialize_logging, valid_artifact_name
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent.absolute()
+
+
+class DownloadCiArtifact:
+    def __init__(self, name: str, destination: Path) -> None:
+        self.__name = name
+        self.__destination = destination
+        self.__client = CiArtifactory()
+
+    @property
+    def source(self) -> str:
+        return f"{self.__client.artifact_root}/{self.__name}/"
+
+    def run(self) -> None:
+        self.__client.download(self.source, self.__destination)
+
+
+if __name__ == "__main__":
+    initialize_logging("download_ci.py")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", type=valid_artifact_name, required=True, help="Artifact name")
+    parser.add_argument("--dest-root", type=Path, default=REPO_ROOT / "build", help="Root directory of artifacts")
+
+    args = parser.parse_args()
+
+    DownloadCiArtifact(
+        args.name,
+        args.dest_root,
+    ).run()

--- a/qcom/scripts/artifactory/publish_ci.py
+++ b/qcom/scripts/artifactory/publish_ci.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import argparse
+from pathlib import Path
+
+from artifactory import CiArtifactory, initialize_logging, valid_artifact_name
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent.absolute()
+
+
+class PublishCiArtifact:
+    def __init__(self, name: str, build_dir: Path, src_pattern: str) -> None:
+        self.__name = name
+        self.__build_dir = build_dir
+        self.__src_pattern = src_pattern
+        self.__client = CiArtifactory()
+
+    @property
+    def destination(self) -> str:
+        return f"{self.__client.artifact_root}/{self.__name}/"
+
+    def run(self) -> None:
+        self.__client.upload(self.__build_dir, self.__src_pattern, self.destination)
+
+
+if __name__ == "__main__":
+    initialize_logging("publish_ci.py")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", type=valid_artifact_name, required=True, help="Artifact name")
+    parser.add_argument("--src-root", type=Path, default=REPO_ROOT / "build", help="Root directory of artifacts")
+    parser.add_argument("--src-pattern", type=str, required=True, help="Artifact file pattern, relative to SRC_ROOT.")
+
+    args = parser.parse_args()
+
+    PublishCiArtifact(
+        args.name,
+        args.src_root,
+        args.src_pattern,
+    ).run()


### PR DESCRIPTION
### Description

Re-enable building on x64 Windows runners whenever possible, making use of Artifactory to host temporary artifacts.

* Introduce `upload-ci-artifact` and `download-ci-artifact` actions.
* Use new actions in place of GitHub's artifact actions in most places.
* Add a scheduled job to prune after a day.

### Motivation and Context

When this repo moved from internally-hosted GitHub to public GitHub, our self-hosted runners started randomly suffering very long artifact download times -- fetching a Windows test archive could take half an hour instead of a few seconds. Our analysis concludes this is the result of network security measures outside of our control. To mitigate, we avoided temporary artifacts and started building and testing on the same machine whenever possible. This caused a huge increase in pressure on our limited ARM64 Windows runners, motivating this change.

