### PR TITLE
Reset unique name generator between compile

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -212,7 +212,7 @@ Ort::Status BaseOpBuilder::ProcessInt64Tensors(QnnModelWrapper& qnn_model_wrappe
     // Insert cast to int32 if input dtype is int64
     if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
       const Qnn_TensorType_t tensor_type = QNN_TENSOR_TYPE_NATIVE;
-      const std::string cast_output_name = utils::GetUniqueName(input_names[i], "_cast_int32");
+      const std::string cast_output_name = utils::UniqueNameGenerator().New(input_names[i], "_cast_int32");
       if (!qnn_model_wrapper.IsQnnTensorWrapperExist(cast_output_name)) {
         Qnn_DataType_t qnn_data_type = QNN_DATATYPE_INT_32;
         const auto& input_i = node_unit.Inputs()[i];
@@ -296,8 +296,8 @@ Ort::Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
     }
 
     if (needs_int64_cast) {
-      const std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast_int64");
-      const std::string cast_input_name = utils::GetUniqueName(output_name, "_cast_int64");
+      const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit, "_cast_int64");
+      const std::string cast_input_name = utils::UniqueNameGenerator().New(output_name, "_cast_int64");
       QnnQuantParamsWrapper quant_params = output_info.quant_param.Copy();
       std::vector<uint32_t> cast_output_shape = output_info.shape;
 
@@ -312,8 +312,8 @@ Ort::Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
       // Store the cast node information for later addition
       cast_node_info_vec.emplace_back(CastNodeInfo{cast_node_name, cast_input_name, output_name});
     } else if (supported_qnn_data_type != output_info.qnn_data_type && is_graph_output && !do_op_validation) {
-      const std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast");
-      const std::string cast_input_name = utils::GetUniqueName(output_name, "_cast");
+      const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit, "_cast");
+      const std::string cast_input_name = utils::UniqueNameGenerator().New(output_name, "_cast");
       std::vector<uint32_t> cast_output_shape = output_info.shape;
       QnnTensorWrapper cast_input_tensorwrapper(cast_input_name,
                                                 QNN_TENSOR_TYPE_NATIVE,
@@ -337,7 +337,7 @@ Ort::Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
   }
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 qnn_op_type,
                                                 std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -68,7 +68,7 @@ Ort::Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_mod
   }
 
   // Build additional static input with value 0.
-  const std::string& input_name = utils::GetUniqueName(node_unit, "_notequal_zero");
+  const std::string& input_name = utils::UniqueNameGenerator().New(node_unit, "_notequal_zero");
 
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_UNDEFINED;
   ONNXTensorElementDataType input_type = input.type;
@@ -184,7 +184,7 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   const std::string qnn_op_type = IsFpToBoolCast(node_unit)
                                       ? QNN_OP_ELEMENT_WISE_NOT_EQUAL
                                       : GetQnnOpType(node_unit.OpType());
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 qnn_op_type,
                                                 std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -189,7 +189,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     TensorInfo input_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
 
-    std::string actual_name = input_info.is_initializer ? input1_name : utils::GetUniqueName(input1_name, "_transpose");
+    std::string actual_name = input_info.is_initializer ? input1_name : utils::UniqueNameGenerator().New(input1_name, "_transpose");
     input_names.push_back(actual_name);
 
     std::vector<uint32_t> actual_shape;
@@ -305,7 +305,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
 
       // Pop Conv weight. Insert Convert op after Weight
       input_names.pop_back();
-      std::string convert_output_name = utils::GetUniqueName(weight_input_name, "_convert");
+      std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
 
       RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
                                              weight_input_name,
@@ -541,7 +541,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
 
     if (input0_info.quant_param.IsPerTensor(/*include_bw*/ true) && input1_info.quant_param.IsQuantized()) {
-      const std::string bias_name = qnn::utils::GetUniqueName(node_unit, "_implicit_bias");
+      const std::string bias_name = qnn::utils::UniqueNameGenerator().New(node_unit, "_implicit_bias");
       std::vector<uint32_t> bias_shape = {input1_info.shape[0]};
       RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, input0_info.quant_param, input1_info.quant_param,
                                        std::move(bias_shape), bias_name, logger, input_names));
@@ -575,7 +575,7 @@ Ort::Status ConvOpBuilder::ProcessConv1DInputs(QnnModelWrapper& qnn_model_wrappe
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
 
     const std::string conv_input0_name = input0_info.is_initializer ? input0_name
-                                                                    : utils::GetUniqueName(input0_name, "_reshape");
+                                                                    : utils::UniqueNameGenerator().New(input0_name, "_reshape");
     input_names.push_back(conv_input0_name);
 
     if (!qnn_model_wrapper.IsQnnTensorWrapperExist(conv_input0_name)) {
@@ -632,7 +632,7 @@ Ort::Status ConvOpBuilder::ProcessConv1DInputs(QnnModelWrapper& qnn_model_wrappe
     TensorInfo input_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
 
-    std::string conv_weight_input_name = input_info.is_initializer ? input1_name : utils::GetUniqueName(input1_name, "_transpose");
+    std::string conv_weight_input_name = input_info.is_initializer ? input1_name : utils::UniqueNameGenerator().New(input1_name, "_transpose");
     input_names.push_back(conv_weight_input_name);
 
     // Create the shape after reshaping.
@@ -657,7 +657,7 @@ Ort::Status ConvOpBuilder::ProcessConv1DInputs(QnnModelWrapper& qnn_model_wrappe
       return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
     }
 
-    const std::string reshape_output = utils::GetUniqueName(input1_name, "_reshape");
+    const std::string reshape_output = utils::UniqueNameGenerator().New(input1_name, "_reshape");
     std::vector<uint8_t> unpacked_tensor;
     if (input_info.is_initializer) {
       //
@@ -1025,11 +1025,11 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
         output_shape[1],  // W
         output_shape[2],  // C
     };
-    const std::string conv_output_name = utils::GetUniqueName(output_name, "_conv");
+    const std::string conv_output_name = utils::UniqueNameGenerator().New(output_name, "_conv");
     QnnTensorWrapper output_tensorwrapper(conv_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type,
                                           output_quantize_param.Copy(), std::vector<uint32_t>(output_shape_2d));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   output_node_type,
                                                   std::move(input_names),
@@ -1054,7 +1054,7 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
                                           std::move(output_quantize_param), std::move(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   output_node_type,
                                                   std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
@@ -286,8 +286,8 @@ Ort::Status CreateMatMulTransposeAll(
   std::vector<uint32_t> input_shape1(input_info1.shape);
   std::swap(input_shape0[1], input_shape0[2]);
   std::swap(input_shape1[1], input_shape1[2]);
-  const std::string input_transpos0 = onnxruntime::qnn::utils::GetUniqueName(input_names[0], "_transpose");
-  const std::string input_transpos1 = onnxruntime::qnn::utils::GetUniqueName(input_names[1], "_transpose");
+  const std::string input_transpos0 = onnxruntime::qnn::utils::UniqueNameGenerator().New(input_names[0], "_transpose");
+  const std::string input_transpos1 = onnxruntime::qnn::utils::UniqueNameGenerator().New(input_names[1], "_transpose");
   const std::vector<uint32_t> transpose_perm{0, 2, 1, 3};
   RETURN_IF_ERROR(qnn_model_wrapper->AddTransposeNode(
       /*node_index=*/node_unit.Index(),
@@ -314,7 +314,7 @@ Ort::Status CreateMatMulTransposeAll(
   onnxruntime::qnn::TensorInfo matmul_output_info{};
   const auto& output = node_unit.Outputs()[0];
   RETURN_IF_ERROR(qnn_model_wrapper->GetTensorInfo(output, matmul_output_info));
-  const std::string matmul_output_name = onnxruntime::qnn::utils::GetUniqueName(node_unit, "_matmul");
+  const std::string matmul_output_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, "_matmul");
   std::vector<uint32_t> matmul_output_shape(matmul_output_info.shape);
   std::swap(matmul_output_shape[1], matmul_output_shape[2]);
   onnxruntime::qnn::QnnTensorWrapper matmul_output_wrapper(
@@ -324,7 +324,7 @@ Ort::Status CreateMatMulTransposeAll(
                 (node_unit.OpType() + " failed to add tensor.").c_str());
   std::vector<std::string> param_tensor_names = SetMatMulParamTensorNames(
       qnn_model_wrapper, node_unit, /*transpose_in0=*/false, /*transpose_in1=*/false);
-  RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(/*qnn_node_name=*/onnxruntime::qnn::utils::GetUniqueName(node_unit, QNN_OP_MAT_MUL),
+  RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(/*qnn_node_name=*/onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, QNN_OP_MAT_MUL),
                                                  /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                  /*qnn_node_type=*/QNN_OP_MAT_MUL,
                                                  /*input_names=*/{input_transpos1, input_transpos0},
@@ -372,7 +372,7 @@ Ort::Status CreateReduceSumMulBroadcastX(
   RETURN_IF_NOT(shape_in0.size() == 4, "CreateReduceSumMulBroadcastX expects input 0 to be rank 4");
   RETURN_IF_NOT(shape_in1.size() == 3, "CreateReduceSumMulBroadcastX expects input 1 to be rank 3");
   const std::vector<uint32_t> new_shape_in0{shape_in0[0], shape_in0[1], shape_in0[2], 1, shape_in0[3]};
-  const std::string reshape_out_name = onnxruntime::qnn::utils::GetUniqueName(input_names[0], "_reshape");
+  const std::string reshape_out_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(input_names[0], "_reshape");
   RETURN_IF_ERROR(qnn_model_wrapper->AddReshapeNode(
       /*input_name=*/input_names[0],
       /*output_name=*/reshape_out_name,
@@ -386,7 +386,7 @@ Ort::Status CreateReduceSumMulBroadcastX(
   // Multiply: reshaped in0 * in1
   // The output shape of the multiplication is determined by broadcasting the reshaped in0 of
   // (b, h, w, 1, c) and in1 (w, k, c) along the matching axes, resulting in (b, h, w, k, c).
-  const std::string mul_out_name = onnxruntime::qnn::utils::GetUniqueName(node_unit, "_mul");
+  const std::string mul_out_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, "_mul");
   std::vector<uint32_t> shape_out_mul{new_shape_in0[0], new_shape_in0[1], new_shape_in0[2], shape_in1[1], new_shape_in0[4]};
   onnxruntime::qnn::QnnTensorWrapper tensor_wrapper_mul(mul_out_name,
                                                         QNN_TENSOR_TYPE_NATIVE,
@@ -396,7 +396,7 @@ Ort::Status CreateReduceSumMulBroadcastX(
   RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(tensor_wrapper_mul)),
                 "CreateReduceSumMulBroadcastX: failed to AddTensorWrapper");
   RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(
-                    /*qnn_node_name=*/onnxruntime::qnn::utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_MULTIPLY),
+                    /*qnn_node_name=*/onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_MULTIPLY),
                     /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                     /*qnn_node_type=*/QNN_OP_ELEMENT_WISE_MULTIPLY,
                     /*input_names=*/{reshape_out_name, input_names[1]},
@@ -443,7 +443,7 @@ Ort::Status CreateReduceSumMulBroadcastX(
                 "CreateReduceSumMulBroadcastX: failed to AddTensorWrapper");
 
   RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(
-                    /*qnn_node_name=*/onnxruntime::qnn::utils::GetUniqueName(node_unit, QNN_OP_REDUCE_SUM),
+                    /*qnn_node_name=*/onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, QNN_OP_REDUCE_SUM),
                     /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                     /*qnn_node_type=*/QNN_OP_REDUCE_SUM,
                     /*input_names=*/{mul_out_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
@@ -138,7 +138,7 @@ Ort::Status ExpandOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   }  // if-else
 
   const std::string& output_name = node_unit.Outputs()[0].name;
-  std::string shape_input_name = utils::GetUniqueName(input_name, output_name);
+  std::string shape_input_name = utils::UniqueNameGenerator().New(input_name, output_name);
   QnnTensorWrapper input_tensorwrapper(shape_input_name, QNN_TENSOR_TYPE_STATIC, qnn_data_type,
                                        std::move(quantize_param), std::move(input_shape),
                                        std::move(shape_data));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/fusedmatmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/fusedmatmul_op_builder.cc
@@ -205,7 +205,7 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                    std::vector<uint32_t>(output_info.shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add final output tensor.");
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit.Name() + "_matmul"),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_matmul"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_MAT_MUL,
                                                   {input_a_for_matmul, input_b_for_matmul},
@@ -216,7 +216,7 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
   } else {
     // When alpha is not 1.0f, we need an intermediate tensor for MatMul output
     // and then apply alpha scaling
-    std::string matmul_output_name = utils::GetUniqueName(node_unit.Name() + "_matmul_output");
+    std::string matmul_output_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_matmul_output");
 
     QnnTensorWrapper matmul_output_tensor(matmul_output_name,
                                           QNN_TENSOR_TYPE_NATIVE,
@@ -235,7 +235,7 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                    std::vector<uint32_t>(output_info.shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add output tensor.");
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit.Name() + "_matmul"),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_matmul"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_MAT_MUL,
                                                   {input_a_for_matmul, input_b_for_matmul},
@@ -244,7 +244,7 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                   do_op_validation),
                   "Failed to create MatMul node for FusedMatMul.");
 
-    std::string alpha_tensor_name = utils::GetUniqueName(node_unit.Name() + "_alpha");
+    std::string alpha_tensor_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha");
     std::vector<uint32_t> alpha_shape{1};
     Qnn_DataType_t alpha_qnn_data_type = output_info.qnn_data_type;
     std::vector<uint8_t> alpha_data;
@@ -267,7 +267,7 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                           std::move(alpha_data));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(alpha_tensor_wrapper)), "Failed to add alpha tensor.");
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit.Name() + "_alpha_scale"),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha_scale"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_MULTIPLY,
                                                   {matmul_output_name, alpha_tensor_name},
@@ -319,7 +319,7 @@ Ort::Status FusedMatMulOpBuilder::HandleBatchTranspose(QnnModelWrapper& qnn_mode
                                                        std::string& transposed_name,
                                                        bool trans_mat,
                                                        bool do_op_validation) const {
-  transposed_name = utils::GetUniqueName(node_unit.Name() + "_transposed_" + input_name.substr(input_name.find_last_of('/') + 1));
+  transposed_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_transposed_" + input_name.substr(input_name.find_last_of('/') + 1));
 
   // Create perm vector for batch transpose
   std::vector<uint32_t> perm;
@@ -342,7 +342,7 @@ Ort::Status FusedMatMulOpBuilder::HandleBatchTranspose(QnnModelWrapper& qnn_mode
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(transposed_tensor)), "Failed to add transposed tensor.");
 
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                    utils::GetUniqueName(node_unit.Name() + "_transpose_" + input_name.substr(input_name.find_last_of('/') + 1)),
+                    utils::UniqueNameGenerator().New(node_unit.Name() + "_transpose_" + input_name.substr(input_name.find_last_of('/') + 1)),
                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                     QNN_OP_TRANSPOSE,
                     {input_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -201,7 +201,7 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
   if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
     assert(!indices_info.is_initializer);
     indices_casted_name += "_int32";
-    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::GetUniqueName(indices_name, QNN_OP_CAST),
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(indices_name, QNN_OP_CAST),
                                                   indices_name,
                                                   indices_casted_name,
                                                   QNN_TENSOR_TYPE_NATIVE,
@@ -230,9 +230,9 @@ Ort::Status GatherOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     const std::string& input0_name = input_names[0];
     TensorInfo input0_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
-    const std::string cast_output_name = utils::GetUniqueName(input0_name, "_bool_to_u8");
+    const std::string cast_output_name = utils::UniqueNameGenerator().New(input0_name, "_bool_to_u8");
     if (!qnn_model_wrapper.IsQnnTensorWrapperExist(cast_output_name)) {
-      RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::GetUniqueName(input0_name, QNN_OP_CAST),
+      RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(input0_name, QNN_OP_CAST),
                                                     input0_name,
                                                     cast_output_name,
                                                     QNN_TENSOR_TYPE_NATIVE,
@@ -286,7 +286,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(gather_output.shape, output_shape), "Cannot get shape");
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
 
-    const std::string gather_output_name = utils::GetUniqueName(output_name, "_u8_to_bool_in");
+    const std::string gather_output_name = utils::UniqueNameGenerator().New(output_name, "_u8_to_bool_in");
     QnnQuantParamsWrapper gather_quant_params(1.0f, 0);
     QnnTensorWrapper gather_output_wrapper(gather_output_name,
                                            QNN_TENSOR_TYPE_NATIVE,
@@ -295,7 +295,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                            std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(gather_output_wrapper)), "Failed to add tensor.");
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   GetQnnOpType(node_unit.OpType()),
                                                   std::move(input_names),
@@ -307,7 +307,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     TensorInfo output_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(gather_output, output_info));
     Qnn_TensorType_t output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::GetUniqueName(output_name, "_u8_to_bool"),
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(output_name, "_u8_to_bool"),
                                                   gather_output_name,
                                                   output_name,
                                                   output_tensor_type,
@@ -391,13 +391,13 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   // 3.2 BOOL: HTP requires BOOL -> U8 before Gather and U8 -> BOOL after
   if (cast_plan.needs_bool_cast) {
-    cast_plan.bool_cast_input_name = utils::GetUniqueName(output_name, "_u8_to_bool_in");
+    cast_plan.bool_cast_input_name = utils::UniqueNameGenerator().New(output_name, "_u8_to_bool_in");
   }
 
   // 3.3 Prepare int64 cast input tensor (created now, cast node added later)
   if (cast_plan.needs_int64_cast) {
-    cast_plan.int64_cast_node_name = utils::GetUniqueName(node_unit, "_int32_to_int64");
-    cast_plan.int64_cast_tensor_name = utils::GetUniqueName(output_name, "_int32_to_int64_in");
+    cast_plan.int64_cast_node_name = utils::UniqueNameGenerator().New(node_unit, "_int32_to_int64");
+    cast_plan.int64_cast_tensor_name = utils::UniqueNameGenerator().New(output_name, "_int32_to_int64_in");
     cast_plan.int64_cast_input_name = cast_plan.int64_cast_tensor_name;
 
     QnnTensorWrapper cast_input_tensorwrapper(cast_plan.int64_cast_tensor_name,
@@ -414,7 +414,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // 4.3 Reshape flow: gather -> reshape -> (optional cast)
   std::string gather_output_name = output_name;
   if (reshape_required) {
-    gather_output_name = utils::GetUniqueName(output_name, "_reshape");
+    gather_output_name = utils::UniqueNameGenerator().New(output_name, "_reshape");
   } else if (cast_plan.needs_bool_cast) {
     gather_output_name = cast_plan.bool_cast_input_name;
   } else if (cast_plan.needs_int64_cast) {
@@ -436,7 +436,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   QnnTensorWrapper gather_output_wrapper(gather_output_name, tensor_type, gather_qnn_data_type, gather_quant_params.Copy(),
                                          std::move(qnn_pre_reshape_output_shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(gather_output_wrapper)), "Failed to add tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 GetQnnOpType(node_unit.OpType()),
                                                 std::move(input_names),
@@ -460,7 +460,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                     gather_quant_params.Copy(), std::vector<uint32_t>(onnx_final_output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_output)), "Failed to add tensor.");
     std::string node_output_name = reshape_output_name;
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_RESHAPE),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_RESHAPE,
                                                   {gather_output_name},
@@ -474,7 +474,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   if (cast_plan.needs_bool_cast) {
     Qnn_TensorType_t output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
     const std::string cast_input = reshape_required ? cast_plan.bool_cast_input_name : gather_output_name;
-    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::GetUniqueName(output_name, "_u8_to_bool"),
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(output_name, "_u8_to_bool"),
                                                   cast_input,
                                                   output_name,
                                                   output_tensor_type,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gathernd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gathernd_op_builder.cc
@@ -141,7 +141,7 @@ Ort::Status GatherNDOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                            std::move(cast_output_shape));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(indices_cast_tensor)),
                     "Failed to add gather indices cast tensor.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(indices_tensor_name, QNN_OP_CAST),
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(indices_tensor_name, QNN_OP_CAST),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     QNN_OP_CAST,
                                                     {indices_tensor_name},
@@ -251,8 +251,8 @@ Ort::Status GatherNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
 
   // If a cast to int64 is needed, add the cast node
   if (needs_int64_cast) {
-    std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast_int64");
-    std::string cast_input_name = utils::GetUniqueName(output_name, "_cast_int64");
+    std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit, "_cast_int64");
+    std::string cast_input_name = utils::UniqueNameGenerator().New(output_name, "_cast_int64");
     std::string cast_output_name = output_name;
 
     // Create the cast input tensor wrapper - use qnn_output_shape for the intermediate tensor
@@ -272,9 +272,9 @@ Ort::Status GatherNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
 
   std::string gather_output_name = output_name;
   if (reshape_required) {
-    gather_output_name = utils::GetUniqueName(output_name, "_reshape");
+    gather_output_name = utils::UniqueNameGenerator().New(output_name, "_reshape");
   } else if (needs_int64_cast) {
-    gather_output_name = utils::GetUniqueName(output_name, "_cast_int64");
+    gather_output_name = utils::UniqueNameGenerator().New(output_name, "_cast_int64");
   }
 
   Qnn_TensorType_t tensor_type = (!reshape_required && is_graph_output)
@@ -286,7 +286,7 @@ Ort::Status GatherNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(gather_output_tensor)),
                 "Failed to add GatherND output tensor.");
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_GATHER_ND,
                                                 std::move(input_names),
@@ -304,10 +304,10 @@ Ort::Status GatherNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
     std::string node_output_name = output_name;
     if (needs_int64_cast) {
       // If needs_int64 is true, the output name should be the input name of the cast node
-      node_output_name = utils::GetUniqueName(output_name, "_cast_int64");
+      node_output_name = utils::UniqueNameGenerator().New(output_name, "_cast_int64");
     }
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_RESHAPE),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_RESHAPE,
                                                   {gather_output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -123,7 +123,7 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
       input_shape[0] = old_input_shape[1];
       input_shape[1] = old_input_shape[0];
       const std::string& node_input_name(input_name);
-      input_tensor_name = utils::GetUniqueName(input_tensor_name, "_transpose");
+      input_tensor_name = utils::UniqueNameGenerator().New(input_tensor_name, "_transpose");
       std::vector<uint32_t> perm{1, 0};
       RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(node_unit.Index(), node_input_name, input_tensor_name,
                                                          old_input_shape, perm, input_shape,
@@ -179,12 +179,12 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     std::vector<std::string> gemm_input_0_1;
     gemm_input_0_1.push_back(input_names[0]);
     gemm_input_0_1.push_back(input_names[1]);
-    const std::string fc_output_name = onnxruntime::qnn::utils::GetUniqueName(org_output_name, "_fc");
+    const std::string fc_output_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(org_output_name, "_fc");
     QnnTensorWrapper fully_connected_output(fc_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
                                             QnnQuantParamsWrapper(), std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fully_connected_output)),
                   "Failed to add FullyConnected output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_FULLY_CONNECTED),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_FULLY_CONNECTED),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_FULLY_CONNECTED,
                                                   std::move(gemm_input_0_1),
@@ -201,7 +201,7 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                   "Failed to add ElementWiseAdd output tensor.");
     std::string bias_name = input_names[2];
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_ADD),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_ADD),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_ADD,
                                                   {fc_output_name, bias_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instancenormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instancenormalization_op_builder.cc
@@ -97,7 +97,7 @@ Ort::Status InstanceNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrap
       input0_info.shape.size() == 3 && input0_info.shape[0] != 1) {
     const std::string& orig_input0_name = inputs[0].name;
     const std::string op_input0_name = input0_info.is_initializer ? orig_input0_name
-                                                                  : utils::GetUniqueName(orig_input0_name, "_reshape");
+                                                                  : utils::UniqueNameGenerator().New(orig_input0_name, "_reshape");
     input_names.push_back(op_input0_name);
 
     std::vector<uint8_t> initializer_data;
@@ -164,7 +164,7 @@ Ort::Status InstanceNormOpBuilder::ProcessScale(QnnModelWrapper& qnn_model_wrapp
     const Qnn_QuantizeParams_t& quant_param = tensor_info.quant_param.Get();
     if (tensor_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_8) {
       std::string convert_input_name = input_names.back();
-      std::string convert_output_name = utils::GetUniqueName(convert_input_name, "_convert_s8_to_u8");
+      std::string convert_output_name = utils::UniqueNameGenerator().New(convert_input_name, "_convert_s8_to_u8");
       RETURN_IF_ERROR(utils::InsertConvertOp(
           qnn_model_wrapper,
           convert_input_name,
@@ -225,7 +225,7 @@ Ort::Status InstanceNormOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& 
   //
 
   const std::string& orig_output_name = outputs[0].name;
-  std::string op_output_name = utils::GetUniqueName(orig_output_name, "_reshape");
+  std::string op_output_name = utils::UniqueNameGenerator().New(orig_output_name, "_reshape");
 
   std::vector<uint32_t> op_output_shape = {
       output_info.shape[0],  // N
@@ -237,7 +237,7 @@ Ort::Status InstanceNormOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& 
   QnnTensorWrapper output_tensorwrapper(op_output_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                         output_info.quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 GetQnnOpType(node_unit.OpType()),
                                                 std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/inverse_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/inverse_op_builder.cc
@@ -88,7 +88,7 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   const std::vector<uint32_t>& reshaped_shape{total_elements / kFlatDim, kFlatDim};
 
   // Reshape input to [-1, 4]
-  const std::string& reshape_output_name = utils::GetUniqueName(node_unit, "_reshape_output");
+  const std::string& reshape_output_name = utils::UniqueNameGenerator().New(node_unit, "_reshape_output");
   QnnTensorWrapper reshape_output(reshape_output_name,
                                   QNN_TENSOR_TYPE_NATIVE,
                                   input_info.qnn_data_type,
@@ -114,13 +114,13 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   constexpr uint32_t kSliceParamNum = 3;
 
   const std::vector<std::string>& sliced_output_names = {
-      utils::GetUniqueName(node_unit, "_slice_00_output"),
-      utils::GetUniqueName(node_unit, "_slice_01_output"),
-      utils::GetUniqueName(node_unit, "_slice_10_output"),
-      utils::GetUniqueName(node_unit, "_slice_11_output"),
+      utils::UniqueNameGenerator().New(node_unit, "_slice_00_output"),
+      utils::UniqueNameGenerator().New(node_unit, "_slice_01_output"),
+      utils::UniqueNameGenerator().New(node_unit, "_slice_10_output"),
+      utils::UniqueNameGenerator().New(node_unit, "_slice_11_output"),
   };
   for (uint32_t i = 0; i < 4; ++i) {
-    const std::string& param_name = utils::GetUniqueName(node_unit, "slice_param");
+    const std::string& param_name = utils::UniqueNameGenerator().New(node_unit, "slice_param");
     QnnParamWrapper ranges_paramwrapper(node_unit.Index(),
                                         param_name,
                                         QNN_OP_STRIDED_SLICE_PARAM_RANGES,
@@ -130,7 +130,7 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     std::vector<std::string>&& slice_param_tensor_name{ranges_paramwrapper.GetParamTensorName()};
     RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(ranges_paramwrapper)), "Failed to add param.");
 
-    const std::string& slice_name = utils::GetUniqueName(node_unit, "_slice");
+    const std::string& slice_name = utils::UniqueNameGenerator().New(node_unit, "_slice");
     // begin_mask
     uint32_t begin_mask = 0b01U;  // ignore dim = 0
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper,
@@ -168,8 +168,8 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   }
 
   // det([[a, b], [c, d]]) = ad - bc
-  const std::string& det_mul_0_name = utils::GetUniqueName(node_unit, "_det_mul_0");
-  const std::string& det_mul_0_output_name = utils::GetUniqueName(node_unit, "_det_mul_0_output");
+  const std::string& det_mul_0_name = utils::UniqueNameGenerator().New(node_unit, "_det_mul_0");
+  const std::string& det_mul_0_output_name = utils::UniqueNameGenerator().New(node_unit, "_det_mul_0_output");
   QnnTensorWrapper det_mul_0_output(det_mul_0_output_name,
                                     QNN_TENSOR_TYPE_NATIVE,
                                     input_info.qnn_data_type,
@@ -187,8 +187,8 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                 do_op_validation),
                 "Failed to add Inverse - Det - Mul(a, d) node.");
 
-  const std::string& det_mul_1_name = utils::GetUniqueName(node_unit, "_det_mul_1");
-  const std::string& det_mul_1_output_name = utils::GetUniqueName(node_unit, "_det_mul_1_output");
+  const std::string& det_mul_1_name = utils::UniqueNameGenerator().New(node_unit, "_det_mul_1");
+  const std::string& det_mul_1_output_name = utils::UniqueNameGenerator().New(node_unit, "_det_mul_1_output");
   QnnTensorWrapper det_mul_1_output(det_mul_1_output_name,
                                     QNN_TENSOR_TYPE_NATIVE,
                                     input_info.qnn_data_type,
@@ -206,8 +206,8 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                 do_op_validation),
                 "Failed to add Inverse - Det - Mul(b, c) node.");
 
-  const std::string& det_sub_name = utils::GetUniqueName(node_unit, "_det_sub");
-  const std::string& det_sub_output_name = utils::GetUniqueName(node_unit, "_det_sub_output");
+  const std::string& det_sub_name = utils::UniqueNameGenerator().New(node_unit, "_det_sub");
+  const std::string& det_sub_output_name = utils::UniqueNameGenerator().New(node_unit, "_det_sub_output");
   QnnTensorWrapper det_sub_output(det_sub_output_name,
                                   QNN_TENSOR_TYPE_NATIVE,
                                   input_info.qnn_data_type,
@@ -226,8 +226,8 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                 "Failed to add Inverse - Det - Sub(ad, bc) node.");
 
   // adj([[a, b], [c, d]]) = [d, b, a, c] * [1, -1, -1, 1]
-  const std::string& adj_cat_name = utils::GetUniqueName(node_unit, "_adj_concat");
-  const std::string& adj_cat_output_name = utils::GetUniqueName(node_unit, "_adj_concat_output");
+  const std::string& adj_cat_name = utils::UniqueNameGenerator().New(node_unit, "_adj_concat");
+  const std::string& adj_cat_output_name = utils::UniqueNameGenerator().New(node_unit, "_adj_concat_output");
   std::vector<std::string> concat_param_name;  // Will be modified in AddQnnScalar
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper,
                                          node_unit.Index(),
@@ -261,7 +261,7 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   std::vector<uint8_t> adj_mul_bytes(sizeof(adj_mul_tensor_value));
   std::memcpy(adj_mul_bytes.data(), adj_mul_tensor_value.data(), adj_mul_bytes.size());
 
-  const std::string& adj_mul_tensor_name = utils::GetUniqueName(node_unit, "_adj_mul_tensor");
+  const std::string& adj_mul_tensor_name = utils::UniqueNameGenerator().New(node_unit, "_adj_mul_tensor");
   QnnTensorWrapper adj_mul_tensor(adj_mul_tensor_name,
                                   QNN_TENSOR_TYPE_STATIC,
                                   input_info.qnn_data_type,
@@ -270,8 +270,8 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                   std::move(adj_mul_bytes));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(adj_mul_tensor)), "Failed to add tensor.");
 
-  const std::string& adj_mul_name = utils::GetUniqueName(node_unit, "_adj_mul");
-  const std::string& adj_mul_output_name = utils::GetUniqueName(node_unit, "_adj_mul_output");
+  const std::string& adj_mul_name = utils::UniqueNameGenerator().New(node_unit, "_adj_mul");
+  const std::string& adj_mul_output_name = utils::UniqueNameGenerator().New(node_unit, "_adj_mul_output");
   QnnTensorWrapper adj_mul_output(adj_mul_output_name,
                                   QNN_TENSOR_TYPE_NATIVE,
                                   input_info.qnn_data_type,
@@ -290,8 +290,8 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                 "Failed to add Inverse - Adj - Mul([d, b, a, c], [1, -1, -1, 1]) node.");
 
   // inverse = adj / det
-  const std::string& inverse_div_name = utils::GetUniqueName(node_unit, "_inv_div");
-  const std::string& inverse_div_output_name = utils::GetUniqueName(node_unit, "_inv_div_output");
+  const std::string& inverse_div_name = utils::UniqueNameGenerator().New(node_unit, "_inv_div");
+  const std::string& inverse_div_output_name = utils::UniqueNameGenerator().New(node_unit, "_inv_div_output");
   QnnTensorWrapper inverse_div_tensor(inverse_div_output_name,
                                       QNN_TENSOR_TYPE_NATIVE,
                                       input_info.qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/isnan_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/isnan_op_builder.cc
@@ -64,7 +64,7 @@ Ort::Status IsNanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   const std::string& org_output_name = node_unit.Outputs()[0].name;
   const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
   std::vector<uint32_t> output_shape = output_info.shape;
-  const std::string isnan_node_name = utils::GetUniqueName(node_unit, "_IsNan");
+  const std::string isnan_node_name = utils::UniqueNameGenerator().New(node_unit, "_IsNan");
 
   QnnTensorWrapper isnan_output(org_output_name,
                                 is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -93,7 +93,7 @@ Ort::Status LayerNormOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_input_info));
 
     if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_input_info.quant_param.IsQuantized()) {
-      const std::string bias_name = qnn::utils::GetUniqueName(node_unit, "_implicit_bias");
+      const std::string bias_name = qnn::utils::UniqueNameGenerator().New(node_unit, "_implicit_bias");
       std::vector<uint32_t> bias_shape = scale_input_info.shape;
       RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_input_info.quant_param,
                                        std::move(bias_shape), bias_name, logger, input_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
@@ -197,7 +197,7 @@ Ort::Status LSTMOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_w
                   "Failed to add input tensor for inserted StridedSlice or Reshape.");
 
     // params
-    const std::string node_name = utils::GetUniqueName(node_unit, QNN_OP_STRIDED_SLICE);
+    const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_STRIDED_SLICE);
 
     // ranges
     std::vector<uint32_t> ranges_data;
@@ -405,10 +405,10 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
     std::vector<uint32_t> qnn_input_indices = {1, 2, 3, 16};
     std::vector<int32_t> begins = {2, 3, 1, 0};
     std::vector<std::string> qnn_lstm_weight_name = {
-        utils::GetUniqueName(input_names[1], "_input_to_forget_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[1], "_input_to_cell_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[1], "_input_to_output_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[1], "_input_to_input_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_forget_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_cell_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_output_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_input_gate_weight_" + direction),
     };
     for (size_t i = 0; i < 4; i++) {
       std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
@@ -448,10 +448,10 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
     std::vector<uint32_t> qnn_input_indices = {4, 5, 6, 17};
     std::vector<int32_t> begins = {2, 3, 1, 0};
     std::vector<std::string> qnn_lstm_weight_name = {
-        utils::GetUniqueName(input_names[2], "_recurrent_to_forget_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[2], "_recurrent_to_cell_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[2], "_recurrent_to_output_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[2], "_recurrent_to_input_gate_weight_" + direction)};
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_forget_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_cell_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_output_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_input_gate_weight_" + direction)};
     for (size_t i = 0; i < 4; i++) {
       std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
                                                   {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
@@ -489,22 +489,22 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
     uint32_t new_axes_mask = 0b00U;
     std::vector<uint32_t> output_shape = {hidden_size};
     std::vector<std::string> qnn_lstm_bias_name = {
-        utils::GetUniqueName(node_unit, "_forget_gate_bias_" + direction),
-        utils::GetUniqueName(node_unit, "_cell_gate_bias_" + direction),
-        utils::GetUniqueName(node_unit, "_output_gate_bias_" + direction),
-        utils::GetUniqueName(node_unit, "_input_gate_bias_" + direction)};
+        utils::UniqueNameGenerator().New(node_unit, "_forget_gate_bias_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_cell_gate_bias_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_output_gate_bias_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_input_gate_bias_" + direction)};
     std::vector<uint32_t> qnn_input_indices = {7, 8, 9, 21};
     if (onnx_inputs.size() > 3 && onnx_inputs[3].Exists()) {
       std::vector<int32_t> begins = {2, 3, 1, 0, 6, 7, 5, 4};
       std::vector<std::string> onnx_lstm_bias_name = {
-          utils::GetUniqueName(input_names[3], "_input_to_forget_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_input_to_cell_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_input_to_output_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_input_to_input_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_recurrent_to_forget_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_recurrent_to_cell_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_recurrent_to_output_gate_bias_" + direction),
-          utils::GetUniqueName(input_names[3], "_recurrent_to_input_gate_bias_" + direction)};
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_forget_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_cell_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_output_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_input_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_forget_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_cell_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_output_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_input_gate_bias_" + direction)};
       for (size_t i = 0; i < 8; i++) {
         std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
                                                     {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}};
@@ -532,7 +532,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
                                                   input_tensor_infos[3].quant_param.Copy(), std::vector<uint32_t>(output_shape));
         RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_output_tensorwrapper)),
                       "QNN EP: Failed to add output tensor for inserted ElementWiseAdd node.");
-        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_ADD),
+        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_ADD),
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       QNN_OP_ELEMENT_WISE_ADD,
                                                       std::move(add_input_names),
@@ -544,7 +544,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
       }
     } else {
       // prepare zero bias
-      std::string zero_bias_name = utils::GetUniqueName(node_unit, "_zero_bias");
+      std::string zero_bias_name = utils::UniqueNameGenerator().New(node_unit, "_zero_bias");
       QnnTensorWrapper zero_bias_tensor_wrapper(zero_bias_name,
                                                 QNN_TENSOR_TYPE_STATIC,
                                                 input_tensor_infos[0].qnn_data_type,
@@ -574,9 +574,9 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
     std::vector<uint32_t> qnn_input_indices = {18, 19, 20};
     std::vector<int32_t> begins = {0, 2, 1};
     std::vector<std::string> qnn_lstm_weight_name = {
-        utils::GetUniqueName(input_names[7], "_cell_to_input_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[7], "_cell_to_forget_gate_weight_" + direction),
-        utils::GetUniqueName(input_names[7], "_cell_to_output_gate_weight_" + direction)};
+        utils::UniqueNameGenerator().New(input_names[7], "_cell_to_input_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[7], "_cell_to_forget_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[7], "_cell_to_output_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
       std::vector<std::vector<int32_t>> ranges = {
           {direction_idx, direction_idx + 1, 1},
@@ -618,7 +618,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
     std::vector<uint32_t> output_shape = {batch_size, hidden_size};
     for (size_t i = 0; i < 2; i++) {
       if (onnx_inputs.size() > src_indices[i] && onnx_inputs[src_indices[i]].Exists()) {
-        const std::string qnn_lstm_input_name = utils::GetUniqueName(input_names[src_indices[i]], direction);
+        const std::string qnn_lstm_input_name = utils::UniqueNameGenerator().New(input_names[src_indices[i]], direction);
         RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                                  /*node_unit=*/node_unit,
                                                  /*input_name=*/input_names[src_indices[i]],
@@ -638,7 +638,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
         qnn_lstm_input_names[qnn_input_indices[i]] = qnn_lstm_input_name;
       } else {
         // prepare zero initial values
-        std::string zero_initial_values_name = utils::GetUniqueName(node_name, std::string("_LSTM_initial_values_") + (i == 0 ? "h" : "c"));
+        std::string zero_initial_values_name = utils::UniqueNameGenerator().New(node_name, std::string("_LSTM_initial_values_") + (i == 0 ? "h" : "c"));
         QnnTensorWrapper zero_bias_tensor_wrapper(zero_initial_values_name,
                                                   QNN_TENSOR_TYPE_STATIC,
                                                   input_tensor_infos[0].qnn_data_type,
@@ -673,7 +673,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
       std::vector<std::vector<int32_t>> ranges = {{SafeInt<int32_t>(sequence_idx), SafeInt<int32_t>(sequence_idx + 1), 1},
                                                   {0, SafeInt<int32_t>(batch_size), 1},
                                                   {0, SafeInt<int32_t>(input_size), 1}};
-      std::string qnn_lstm_input_name = utils::GetUniqueName(input_names[0], "_cell_" + std::to_string(sequence_idx) + "_input");
+      std::string qnn_lstm_input_name = utils::UniqueNameGenerator().New(input_names[0], "_cell_" + std::to_string(sequence_idx) + "_input");
       std::vector<uint32_t> output_shape = {batch_size, input_size};
       RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                                /*node_unit=*/node_unit,
@@ -698,9 +698,9 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
     std::vector<uint32_t> qnn_lstm_output_shape = {batch_size, hidden_size};
 
     std::vector<std::string> qnn_lstm_output_names = {
-        utils::GetUniqueName(node_unit, "_QNN_LSTM_output_all_hidden_state_" + std::to_string(sequence_idx) + "_" + direction),
-        utils::GetUniqueName(node_unit, "_QNN_LSTM_output_cell_state_" + std::to_string(sequence_idx) + "_" + direction),
-        utils::GetUniqueName(node_unit, "_QNN_LSTM_output_hidden_state_" + std::to_string(sequence_idx) + "_" + direction)};
+        utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_all_hidden_state_" + std::to_string(sequence_idx) + "_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_cell_state_" + std::to_string(sequence_idx) + "_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_hidden_state_" + std::to_string(sequence_idx) + "_" + direction)};
     qnn_lstm_input_names[10] = qnn_lstm_output_names[2];  // update initial_h
     qnn_lstm_input_names[11] = qnn_lstm_output_names[1];  // update initial_c
     qnn_all_hidden_state_names[sequence_idx] = qnn_lstm_output_names[2];
@@ -714,7 +714,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
                     ("QNN EP: Failed to add " + std::to_string(j) + "th output tensor for QNN LSTM.").c_str());
     }
-    const std::string lstm_node_name = utils::GetUniqueName(node_unit, "_cell" + std::to_string(sequence_idx) + "_" + direction);
+    const std::string lstm_node_name = utils::UniqueNameGenerator().New(node_unit, "_cell" + std::to_string(sequence_idx) + "_" + direction);
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(lstm_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_LSTM,
                                                   std::move(qnn_lstm_input_names_i), std::move(qnn_lstm_output_names),
                                                   std::vector<std::string>(param_names), do_op_validation),
@@ -722,7 +722,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
   }
 
   // pack all timestamp outputs together for onnx output[0]
-  const std::string qnn_pack_output_name = utils::GetUniqueName(node_unit, "_QNN_LSTM_output_hidden_state_all_" + direction);
+  const std::string qnn_pack_output_name = utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_hidden_state_all_" + direction);
 
   // add pack for output[0]
   std::vector<std::string> pack_param_names;
@@ -757,7 +757,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
       {1, batch_size, hidden_size}};
   for (size_t i = 0; i < 3; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
-      const std::string reshape_output_name = is_bidirection ? utils::GetUniqueName(qnn_reshape_input_names[i], "_unsqueeze_" + direction) : onnx_outputs[i].name;
+      const std::string reshape_output_name = is_bidirection ? utils::UniqueNameGenerator().New(qnn_reshape_input_names[i], "_unsqueeze_" + direction) : onnx_outputs[i].name;
       RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/qnn_reshape_input_names[i],
                                                        /*output_name=*/reshape_output_name,
                                                        /*input_shape=*/qnn_lstm_output_shapes[i],
@@ -816,7 +816,7 @@ Ort::Status LSTMOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                      std::vector<uint32_t>(output_info.shape));
         RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(concat_output_tensorwrapper)),
                       "QNN EP: Failed to add output tensor for QNN Concat.");
-        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_CONCAT),
+        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_CONCAT),
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       QNN_OP_CONCAT,
                                                       {uni_lstm_output_names_forward[i], uni_lstm_output_names_reverse[i]},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -95,7 +95,7 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
   std::string actual_input_0_name = original_input_0_name;
 
   if (reshape_input_0) {
-    actual_input_0_name = utils::GetUniqueName(original_input_0_name, "_reshape");
+    actual_input_0_name = utils::UniqueNameGenerator().New(original_input_0_name, "_reshape");
     std::vector<uint32_t> shape_2d{1, input_0_info.shape[0]};
     QnnQuantParamsWrapper quant_param_2d = input_0_info.quant_param.Copy();
     RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_0_info.shape, shape_2d));
@@ -181,7 +181,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
     // Input[1] is a rank 1 tensor that needs to be reshaped.
     std::vector<uint32_t> shape_2d;
     QnnQuantParamsWrapper quant_param_2d = input_info_1.quant_param.Copy();
-    input_1_name = utils::GetUniqueName(org_input_1_name, "_reshape");
+    input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
     shape_2d = {input_info_1.shape[0], 1};
     RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_info_1.shape, shape_2d));
 
@@ -242,7 +242,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
     // insert Convert op after input1
     std::string convert_input_name = input_names.back();
     input_names.pop_back();
-    const std::string convert_output_name = utils::GetUniqueName(convert_input_name, "_convert");
+    const std::string convert_output_name = utils::UniqueNameGenerator().New(convert_input_name, "_convert");
     std::vector<uint32_t> input_1_shape = input_info_1.shape;
     if (reshape_input_1) {
       input_1_shape = {input_info_1.shape[0], 1};
@@ -296,14 +296,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   QnnQuantParamsWrapper quant_param_2d = input_info_1.quant_param.Copy();
   if (reshape_input_1) {
     // Input[1] is a rank 1 tensor that needs to be reshaped.
-    input_1_name = utils::GetUniqueName(org_input_1_name, "_reshape");
+    input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
 
     // FullyConnected requires input_1's shape to be [n, k].
     shape_2d = {1, input_info_1.shape[0]};
     RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_info_1.shape, shape_2d));
   } else {
     assert(input_info_1.shape.size() == 2);
-    input_1_name = utils::GetUniqueName(org_input_1_name, "_transpose");
+    input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_transpose");
     shape_2d = {input_info_1.shape[1], input_info_1.shape[0]};
     RETURN_IF_ERROR(quant_param_2d.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
   }
@@ -364,7 +364,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
 
     // Pop Conv weight. Insert Convert op after Weight
     input_names.pop_back();
-    std::string convert_output_name = utils::GetUniqueName(weight_input_name, "_convert");
+    std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
 
     RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
                                            weight_input_name,
@@ -420,7 +420,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   std::vector<uint32_t> op_output_shape = output_info.shape;
   QnnQuantParamsWrapper op_output_quant_param = output_info.quant_param.Copy();
   if (reshape_output) {
-    op_output_name = utils::GetUniqueName(org_output_name, "_reshape");
+    op_output_name = utils::UniqueNameGenerator().New(org_output_name, "_reshape");
     if (use_fully_connected && input_info_0.shape.size() > 2) {
       op_output_shape = {std::accumulate(input_info_0.shape.begin(), input_info_0.shape.end() - 1,
                                          static_cast<uint32_t>(1), std::multiplies<uint32_t>()),
@@ -446,7 +446,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                             op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(op_output_tensor_wrapper)),
                 "Failed to add output tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit), QNN_OP_PACKAGE_NAME_QTI_AISW,
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit), QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 use_fully_connected ? QNN_OP_FULLY_CONNECTED : QNN_OP_MAT_MUL,
                                                 std::move(input_names), {op_output_name},
                                                 std::move(param_tensor_names), do_op_validation),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -313,7 +313,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
   }
 
   // 2. Add Output for Pre Reshape(FullyConnected)
-  const std::string pre_reshape_name = utils::GetUniqueName(output_tensor_name, "_pre_reshape");
+  const std::string pre_reshape_name = utils::UniqueNameGenerator().New(output_tensor_name, "_pre_reshape");
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output_tensor, output_info));
   std::vector<uint32_t> pre_reshape_shape(2);
@@ -331,7 +331,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)), "Failed to add tensor.");
 
   // 3. Add FullyConnected Op
-  const std::string fully_connected_node_name = utils::GetUniqueName(node_unit, QNN_OP_FULLY_CONNECTED);
+  const std::string fully_connected_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_FULLY_CONNECTED);
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(fully_connected_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_FULLY_CONNECTED,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mean_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mean_op_builder.cc
@@ -50,11 +50,11 @@ Ort::Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.shape, output_shape), "Failed to get output shape.");
     std::vector<uint8_t> unpackage_data(sizeof(float));
 
-    const std::string add_output = utils::GetUniqueName(sum_output, "_add" + std::to_string(i));
+    const std::string add_output = utils::UniqueNameGenerator().New(sum_output, "_add" + std::to_string(i));
     QnnTensorWrapper add_tensor(add_output, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
                                 QnnQuantParamsWrapper(), std::move(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_tensor)), "Failed to add Add tensor wrapper.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_ADD),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_ADD),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_ADD,
                                                   {sum_output, input_names[i]},
@@ -72,7 +72,7 @@ Ort::Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   std::vector<uint8_t> divisor_data(sizeof(float));
   memcpy(divisor_data.data(), &divisor, sizeof(float));
 
-  const std::string divisor_name = utils::GetUniqueName(sum_output, "_divisor");
+  const std::string divisor_name = utils::UniqueNameGenerator().New(sum_output, "_divisor");
 
   QnnTensorWrapper divisor_tensor(divisor_name, QNN_TENSOR_TYPE_STATIC, input_info.qnn_data_type,
                                   QnnQuantParamsWrapper(), std::move(scalar_shape), std::move(divisor_data));
@@ -91,7 +91,7 @@ Ort::Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add output tensor wrapper.");
   std::vector<std::string> div_inputs = {sum_output, divisor_name};
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_DIVIDE),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_DIVIDE),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_DIVIDE,
                                                 {sum_output, divisor_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
@@ -88,8 +88,8 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
 
   if (is_cast_required) {
     target_tensor_type = QNN_DATATYPE_FLOAT_32;
-    std::string cast_a_name = utils::GetUniqueName(node_unit, "_Cast_A");
-    std::string cast_a_output_name = utils::GetUniqueName(node_unit, "_Cast_A_output");
+    std::string cast_a_name = utils::UniqueNameGenerator().New(node_unit, "_Cast_A");
+    std::string cast_a_output_name = utils::UniqueNameGenerator().New(node_unit, "_Cast_A_output");
     QnnTensorWrapper cast_a_output(cast_a_output_name,
                                    QNN_TENSOR_TYPE_NATIVE,
                                    target_tensor_type,
@@ -110,8 +110,8 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
     TensorInfo input_B_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], input_B_info));
     std::vector<uint32_t> input_B_shape = input_B_info.shape;
-    std::string cast_b_name = utils::GetUniqueName(node_unit, "_Cast_B");
-    std::string cast_b_output_name = utils::GetUniqueName(node_unit, "_Cast_B_output");
+    std::string cast_b_name = utils::UniqueNameGenerator().New(node_unit, "_Cast_B");
+    std::string cast_b_output_name = utils::UniqueNameGenerator().New(node_unit, "_Cast_B_output");
     QnnTensorWrapper cast_b_output(cast_b_output_name,
                                    QNN_TENSOR_TYPE_NATIVE,
                                    target_tensor_type,
@@ -137,8 +137,8 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
     div_input.push_back(input_a_name);
     div_input.push_back(input_b_name);
 
-    std::string div_name = utils::GetUniqueName(node_unit, "_Div");
-    std::string div_output_name = utils::GetUniqueName(node_unit, "_Div_output");
+    std::string div_name = utils::UniqueNameGenerator().New(node_unit, "_Div");
+    std::string div_output_name = utils::UniqueNameGenerator().New(node_unit, "_Div_output");
     QnnTensorWrapper div_output(div_output_name,
                                 QNN_TENSOR_TYPE_NATIVE,
                                 target_tensor_type,
@@ -156,8 +156,8 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                   "Failed to add Mod - ElementWiseDiv node.");
 
     // 2. ElementWiseFloor
-    std::string floor_name = utils::GetUniqueName(node_unit, "_Floor");
-    std::string floor_output_name = utils::GetUniqueName(node_unit, "_Floor_output");
+    std::string floor_name = utils::UniqueNameGenerator().New(node_unit, "_Floor");
+    std::string floor_output_name = utils::UniqueNameGenerator().New(node_unit, "_Floor_output");
     QnnTensorWrapper floor_output(floor_output_name,
                                   QNN_TENSOR_TYPE_NATIVE,
                                   target_tensor_type,
@@ -178,8 +178,8 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
     std::vector<std::string> mul_input;
     mul_input.push_back(input_b_name);
     mul_input.push_back(floor_output_name);
-    std::string mul_name = utils::GetUniqueName(node_unit, "_Mul");
-    std::string mul_output_name = utils::GetUniqueName(node_unit, "_Mul_output");
+    std::string mul_name = utils::UniqueNameGenerator().New(node_unit, "_Mul");
+    std::string mul_output_name = utils::UniqueNameGenerator().New(node_unit, "_Mul_output");
     QnnTensorWrapper mul_output(mul_output_name,
                                 QNN_TENSOR_TYPE_NATIVE,
                                 target_tensor_type,
@@ -200,8 +200,8 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
     std::vector<std::string> sub_input;
     sub_input.push_back(input_a_name);
     sub_input.push_back(mul_output_name);
-    std::string sub_name = utils::GetUniqueName(node_unit, "_Sub");
-    std::string sub_output_name = is_cast_required ? utils::GetUniqueName(node_unit, "_Sub_output") : org_output_name;
+    std::string sub_name = utils::UniqueNameGenerator().New(node_unit, "_Sub");
+    std::string sub_output_name = is_cast_required ? utils::UniqueNameGenerator().New(node_unit, "_Sub_output") : org_output_name;
     QnnTensorWrapper mod_output(sub_output_name,
                                 is_cast_required ? QNN_TENSOR_TYPE_NATIVE : op_output_tensor_type,
                                 is_cast_required ? target_tensor_type : output_info.qnn_data_type,
@@ -219,7 +219,7 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                   "Failed to add Mod - ElementWiseSub node.");
 
     if (is_cast_required) {
-      std::string output_cast_name = utils::GetUniqueName(node_unit, "_output_Cast");
+      std::string output_cast_name = utils::UniqueNameGenerator().New(node_unit, "_output_Cast");
       QnnTensorWrapper casted_mod_output(org_output_name,
                                          op_output_tensor_type,
                                          output_info.qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -314,14 +314,14 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
       pad_output_shape.push_back(input_shape[i] + pad_amount[2 * i] + pad_amount[2 * i + 1]);
     }
 
-    std::string pad_output_name = utils::GetUniqueName(node_unit, "_Pad_output");
+    std::string pad_output_name = utils::UniqueNameGenerator().New(node_unit, "_Pad_output");
 
     if (has_positive) {
       // Step 1. Add Pad to handle any positive values
       TensorInfo input_info = {};
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
 
-      std::string pad_name = utils::GetUniqueName(node_unit, "_Pad");
+      std::string pad_name = utils::UniqueNameGenerator().New(node_unit, "_Pad");
       QnnTensorWrapper pad_output(pad_output_name,
                                   QNN_TENSOR_TYPE_NATIVE,
                                   input_info.qnn_data_type,
@@ -385,7 +385,7 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
 
     // Create Slice Node
     std::vector<std::string> slice_input_name = has_positive ? std::vector<std::string>{pad_output_name} : input_names;
-    std::string slice_name = utils::GetUniqueName(node_unit, "_Slice");
+    std::string slice_name = utils::UniqueNameGenerator().New(node_unit, "_Slice");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(slice_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_STRIDED_SLICE,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -235,7 +235,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(reshape_input, reshape_input_info));
 
   bool needs_reshape = false;
-  const std::string reshape_prior_out = utils::GetUniqueName(input_names[0], "_reshape");
+  const std::string reshape_prior_out = utils::UniqueNameGenerator().New(input_names[0], "_reshape");
   if (input_shape.size() == 3) {
     needs_reshape = true;
     // build new_shape = {N, 1, C, L}
@@ -253,7 +253,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
         std::move(new_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_prior_tensor)),
                   "Failed to add reshape prior tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_RESHAPE),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_RESHAPE,
                                                   {input_names[0]},
@@ -450,7 +450,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   const auto& outputs = node_unit.Outputs();
   const std::string real_out = outputs[0].name;
-  const std::string pool_out = utils::GetUniqueName(real_out, "_reshape_after");
+  const std::string pool_out = utils::UniqueNameGenerator().New(real_out, "_reshape_after");
   TensorInfo output_info{};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
   bool is_graph_output = qnn_model_wrapper.IsGraphOutput(real_out);
@@ -464,7 +464,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pool_tensor)), "Failed to add tensor for pool_out");
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, op_type),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, op_type),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 GetQnnOpType(op_type),
                                                 {reshape_prior_out},
@@ -483,7 +483,7 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_after_tensor)),
                 "Failed to add reshape after tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_RESHAPE),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_RESHAPE,
                                                 {pool_out},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/quickgelu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/quickgelu_op_builder.cc
@@ -44,16 +44,16 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
   const bool skip_alpha_mul = std::abs(alpha - 1.0f) < alpha_epsilon;
 
   std::string sigmoid_input_name;
-  std::string sigmoid_output_name = utils::GetUniqueName(node_unit.Name() + "_sigmoid");
+  std::string sigmoid_output_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_sigmoid");
 
   if (skip_alpha_mul) {
     sigmoid_input_name = input_name;
   } else {
-    const std::string alpha_mul_output_name = utils::GetUniqueName(node_unit.Name() + "_alpha_mul");
+    const std::string alpha_mul_output_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha_mul");
     sigmoid_input_name = alpha_mul_output_name;
 
     // The alpha tensor data type should match the input data type for element-wise multiply
-    std::string alpha_tensor_name = utils::GetUniqueName(node_unit.Name() + "_alpha");
+    std::string alpha_tensor_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha");
     std::vector<uint32_t> alpha_shape{1};
     Qnn_DataType_t alpha_qnn_data_type = input_info.qnn_data_type;
     std::vector<uint8_t> alpha_data;
@@ -84,7 +84,7 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
                   "Failed to add alpha_mul_output tensor.");
 
     // Step 1: Create Mul node for alpha * x
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit.Name() + "_alpha_mul"),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha_mul"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_MULTIPLY,
                                                   {alpha_tensor_name, input_name},
@@ -112,7 +112,7 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
                 "Failed to add output tensor.");
 
   // Step 2: Create Sigmoid node for sigmoid(alpha * x) or sigmoid(x)
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit.Name() + "_sigmoid"),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_sigmoid"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_SIGMOID,
                                                 {sigmoid_input_name},
@@ -122,7 +122,7 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
                 "Failed to create sigmoid node.");
 
   // Step 3: Create Mul node for x * sigmoid(alpha * x) or x * sigmoid(x)
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit.Name() + "_final_mul"),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_final_mul"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_MULTIPLY,
                                                 {input_name, sigmoid_output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/randomuniformlike_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/randomuniformlike_op_builder.cc
@@ -44,7 +44,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input_tensor.shape, input_shape),
                 ("Failed to get shape for input tensor: " + input_tensor_name).c_str());
 
-  const std::string shape_tensor_name = utils::GetUniqueName(input_tensor_name, "_shape");
+  const std::string shape_tensor_name = utils::UniqueNameGenerator().New(input_tensor_name, "_shape");
   std::vector<uint8_t> shape_data(input_shape.size() * sizeof(uint32_t));
   memcpy(shape_data.data(), input_shape.data(), shape_data.size());
   std::vector<uint32_t> shape_tensor_shape = {static_cast<uint32_t>(input_shape.size())};
@@ -69,7 +69,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model
     std::vector<uint8_t> seed_data(sizeof(float));
     memcpy(seed_data.data(), &seed_value, sizeof(float));
 
-    const std::string seed_tensor_name = utils::GetUniqueName(input_tensor_name, "_ort_qnn_ep_seed");
+    const std::string seed_tensor_name = utils::UniqueNameGenerator().New(input_tensor_name, "_ort_qnn_ep_seed");
 
     QnnTensorWrapper seed_tensor(seed_tensor_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_FLOAT_32,
                                  QnnQuantParamsWrapper(), std::move(scalar_shape), std::move(seed_data));
@@ -133,7 +133,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrap
 
   if (need_dequantize) {
     // Create an intermediate tensor with UFIXED_POINT_8 data type
-    const std::string intermediate_output_name = utils::GetUniqueName(output_name, "_uint8");
+    const std::string intermediate_output_name = utils::UniqueNameGenerator().New(output_name, "_uint8");
 
     // Calculate quantization parameters based on low and high values
     QnnQuantParamsWrapper quantize_param;
@@ -152,7 +152,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrap
 
     // Create the RandomUniformLike node with uint8 output
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit),
+                      utils::UniqueNameGenerator().New(node_unit),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_RANDOM_UNIFORM_LIKE,
                       std::move(input_names),
@@ -173,7 +173,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrap
 
     // Create a Dequantize node to convert from uint8 to float32
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_dequantize"),
+                      utils::UniqueNameGenerator().New(node_unit, "_dequantize"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_DEQUANTIZE,
                       {intermediate_output_name},
@@ -194,7 +194,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrap
 
     // Create the RandomUniformLike node with the original data type output
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit),
+                      utils::UniqueNameGenerator().New(node_unit),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_RANDOM_UNIFORM_LIKE,
                       std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -51,7 +51,7 @@ Ort::Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qn
   ORT_UNUSED_PARAMETER(logger);
 
   // Create a constant tensor for the divisor (1.0)
-  std::string divisor_name = utils::GetUniqueName(node_unit, "_divisor");
+  std::string divisor_name = utils::UniqueNameGenerator().New(node_unit, "_divisor");
   std::vector<uint32_t> divisor_shape{1};
   std::vector<uint8_t> divisor_data;
 
@@ -93,7 +93,7 @@ Ort::Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qn
                                         output_info.quant_param.Copy(), std::move(output_info.shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add output tensor.");
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_DIVIDE,
                                                 {divisor_name, input_names[0]},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -244,11 +244,11 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
     // Step 1: y_pow2 = x * x, using ElementWiseMultiply instead of ElementWisePower so we don't need to add a new
     // initializer tensor for the power value. The performance difference is negligible.
-    const std::string pow2_output_name = utils::GetUniqueName(input_name, "_pow2");
+    const std::string pow2_output_name = utils::UniqueNameGenerator().New(input_name, "_pow2");
     QnnTensorWrapper pow2_tensorwrapper(pow2_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
                                         std::move(input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pow2_tensorwrapper)), "AddTensorWrapper failed");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_MULTIPLY),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_MULTIPLY),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_MULTIPLY,
                                                   {input_name, input_name},
@@ -258,11 +258,11 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                   "CreateQnnNode failed");
 
     // Step 2: y_pow2_sum = ReduceSum(y_pow2)
-    const std::string reduce_output_name = utils::GetUniqueName(input_name, "_sum");
+    const std::string reduce_output_name = utils::UniqueNameGenerator().New(input_name, "_sum");
     QnnTensorWrapper reduce_tensorwrapper(reduce_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
                                           std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reduce_tensorwrapper)), "AddTensorWrapper failed");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_REDUCE_SUM),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_REDUCE_SUM),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_REDUCE_SUM,
                                                   {pow2_output_name},
@@ -277,7 +277,7 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     QnnTensorWrapper sqrt_tensorwrapper(output.name, output_tensor_type, qnn_data_type,
                                         QnnQuantParamsWrapper(), std::move(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sqrt_tensorwrapper)), "AddTensorWrapper failed");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_ELEMENT_WISE_SQUARE_ROOT),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_SQUARE_ROOT),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_SQUARE_ROOT,
                                                   {reduce_output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rope_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rope_op_builder.cc
@@ -249,7 +249,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
 
   if (is_4d_input) {
     // Transpose from [B, NH, S, HS] to [B, S, NH, HS]
-    normalized_tensor = utils::GetUniqueName(node_unit, "_transpose_input");
+    normalized_tensor = utils::UniqueNameGenerator().New(node_unit, "_transpose_input");
     std::vector<uint32_t> transpose_perm = {0, 2, 1, 3};
     RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
         node_unit.Index(), current_tensor, normalized_tensor,
@@ -258,7 +258,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
         false, false));
   } else {
     // Reshape from [B, S, NH*HS] to [B, S, NH, HS]
-    normalized_tensor = utils::GetUniqueName(node_unit, "_reshape_input");
+    normalized_tensor = utils::UniqueNameGenerator().New(node_unit, "_reshape_input");
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(
         current_tensor, normalized_tensor,
         input_shape, normalized_shape,
@@ -270,7 +270,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   // x_rotate = x[..., :rotary_dim]
   // x_tail = x[..., rotary_dim:] (if rotary_dim < head_size)
 
-  std::string x_rotate_name = utils::GetUniqueName(node_unit, "_x_rotate");
+  std::string x_rotate_name = utils::UniqueNameGenerator().New(node_unit, "_x_rotate");
   std::vector<uint32_t> x_rotate_shape = {batch_size, seq_len, num_heads_val, rotary_dim};
 
   // Create StridedSlice for x_rotate: slice last dimension [0:rotary_dim]
@@ -314,7 +314,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
 
     // Create StridedSlice node
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_slice_rotate"),
+                      utils::UniqueNameGenerator().New(node_unit, "_slice_rotate"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_STRIDED_SLICE,
                       std::move(slice_input_names),
@@ -327,7 +327,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   // Create x_tail if rotary_dim < head_size
   std::string x_tail_name;
   if (rotary_dim < head_size) {
-    x_tail_name = utils::GetUniqueName(node_unit, "_x_tail");
+    x_tail_name = utils::UniqueNameGenerator().New(node_unit, "_x_tail");
     std::vector<uint32_t> x_tail_shape = {batch_size, seq_len, num_heads_val, head_size - rotary_dim};
 
     std::vector<std::string> slice_input_names = {normalized_tensor};
@@ -360,7 +360,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
 
     // Create StridedSlice node
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_slice_tail"),
+                      utils::UniqueNameGenerator().New(node_unit, "_slice_tail"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_STRIDED_SLICE,
                       std::move(slice_input_names),
@@ -371,8 +371,8 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // Step 3: Split x_rotate into x1 and x2 based on interleaved flag
-  std::string x1_name = utils::GetUniqueName(node_unit, "_x1");
-  std::string x2_name = utils::GetUniqueName(node_unit, "_x2");
+  std::string x1_name = utils::UniqueNameGenerator().New(node_unit, "_x1");
+  std::string x2_name = utils::UniqueNameGenerator().New(node_unit, "_x2");
   std::vector<uint32_t> x1_x2_shape = {batch_size, seq_len, num_heads_val, rotary_half_dim};
 
   if (interleaved) {
@@ -416,7 +416,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                     "Failed to add x1 tensor");
 
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetUniqueName(node_unit, "_slice_x1"),
+                        utils::UniqueNameGenerator().New(node_unit, "_slice_x1"),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_STRIDED_SLICE,
                         std::move(slice_input_names),
@@ -465,7 +465,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                     "Failed to add x2 tensor");
 
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetUniqueName(node_unit, "_slice_x2"),
+                        utils::UniqueNameGenerator().New(node_unit, "_slice_x2"),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_STRIDED_SLICE,
                         std::move(slice_input_names),
@@ -512,7 +512,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
 
     // Create Split node
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_split"),
+                      utils::UniqueNameGenerator().New(node_unit, "_split"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_SPLIT,
                       std::move(split_input_names),
@@ -533,7 +533,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
 
     // Gather cos_cache
     {
-      std::string cos_gathered = utils::GetUniqueName(node_unit, "_cos_gathered");
+      std::string cos_gathered = utils::UniqueNameGenerator().New(node_unit, "_cos_gathered");
       std::vector<std::string> gather_input_names = {cos_cache_name, position_ids_name};
       std::vector<std::string> gather_param_names;
 
@@ -555,7 +555,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                     "Failed to add cos_gathered tensor");
 
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetUniqueName(node_unit, "_gather_cos"),
+                        utils::UniqueNameGenerator().New(node_unit, "_gather_cos"),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_GATHER,
                         std::move(gather_input_names),
@@ -569,7 +569,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
 
     // Gather sin_cache
     {
-      std::string sin_gathered = utils::GetUniqueName(node_unit, "_sin_gathered");
+      std::string sin_gathered = utils::UniqueNameGenerator().New(node_unit, "_sin_gathered");
       std::vector<std::string> gather_input_names = {sin_cache_name, position_ids_name};
       std::vector<std::string> gather_param_names;
 
@@ -589,7 +589,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                     "Failed to add sin_gathered tensor");
 
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetUniqueName(node_unit, "_gather_sin"),
+                        utils::UniqueNameGenerator().New(node_unit, "_gather_sin"),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_GATHER,
                         std::move(gather_input_names),
@@ -603,8 +603,8 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // Reshape cos/sin to [B, S, 1, rotary_half_dim] for broadcasting
-  std::string cos_broadcast = utils::GetUniqueName(node_unit, "_cos_broadcast");
-  std::string sin_broadcast = utils::GetUniqueName(node_unit, "_sin_broadcast");
+  std::string cos_broadcast = utils::UniqueNameGenerator().New(node_unit, "_cos_broadcast");
+  std::string sin_broadcast = utils::UniqueNameGenerator().New(node_unit, "_sin_broadcast");
   std::vector<uint32_t> broadcast_shape = {batch_size, seq_len, 1, rotary_half_dim};
 
   // Get cos/sin current shape
@@ -645,7 +645,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   // imag = sin * x1 + cos * x2
 
   // cos * x1
-  std::string cos_x1 = utils::GetUniqueName(node_unit, "_cos_x1");
+  std::string cos_x1 = utils::UniqueNameGenerator().New(node_unit, "_cos_x1");
   {
     std::vector<std::string> mul_input_names = {cos_broadcast, x1_name};
     QnnTensorWrapper cos_x1_tensor(cos_x1, QNN_TENSOR_TYPE_NATIVE,
@@ -655,7 +655,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add cos_x1 tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_mul_cos_x1"),
+                      utils::UniqueNameGenerator().New(node_unit, "_mul_cos_x1"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_MULTIPLY,
                       std::move(mul_input_names),
@@ -666,7 +666,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // sin * x2
-  std::string sin_x2 = utils::GetUniqueName(node_unit, "_sin_x2");
+  std::string sin_x2 = utils::UniqueNameGenerator().New(node_unit, "_sin_x2");
   {
     std::vector<std::string> mul_input_names = {sin_broadcast, x2_name};
     QnnTensorWrapper sin_x2_tensor(sin_x2, QNN_TENSOR_TYPE_NATIVE,
@@ -676,7 +676,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add sin_x2 tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_mul_sin_x2"),
+                      utils::UniqueNameGenerator().New(node_unit, "_mul_sin_x2"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_MULTIPLY,
                       std::move(mul_input_names),
@@ -687,7 +687,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // real = cos * x1 - sin * x2
-  std::string real = utils::GetUniqueName(node_unit, "_real");
+  std::string real = utils::UniqueNameGenerator().New(node_unit, "_real");
   {
     std::vector<std::string> sub_input_names = {cos_x1, sin_x2};
     QnnTensorWrapper real_tensor(real, QNN_TENSOR_TYPE_NATIVE,
@@ -697,7 +697,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add real tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_sub_real"),
+                      utils::UniqueNameGenerator().New(node_unit, "_sub_real"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_SUBTRACT,
                       std::move(sub_input_names),
@@ -708,7 +708,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // sin * x1
-  std::string sin_x1 = utils::GetUniqueName(node_unit, "_sin_x1");
+  std::string sin_x1 = utils::UniqueNameGenerator().New(node_unit, "_sin_x1");
   {
     std::vector<std::string> mul_input_names = {sin_broadcast, x1_name};
     QnnTensorWrapper sin_x1_tensor(sin_x1, QNN_TENSOR_TYPE_NATIVE,
@@ -718,7 +718,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add sin_x1 tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_mul_sin_x1"),
+                      utils::UniqueNameGenerator().New(node_unit, "_mul_sin_x1"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_MULTIPLY,
                       std::move(mul_input_names),
@@ -729,7 +729,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // cos * x2
-  std::string cos_x2 = utils::GetUniqueName(node_unit, "_cos_x2");
+  std::string cos_x2 = utils::UniqueNameGenerator().New(node_unit, "_cos_x2");
   {
     std::vector<std::string> mul_input_names = {cos_broadcast, x2_name};
     QnnTensorWrapper cos_x2_tensor(cos_x2, QNN_TENSOR_TYPE_NATIVE,
@@ -739,7 +739,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add cos_x2 tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_mul_cos_x2"),
+                      utils::UniqueNameGenerator().New(node_unit, "_mul_cos_x2"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_MULTIPLY,
                       std::move(mul_input_names),
@@ -750,7 +750,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // imag = sin * x1 + cos * x2
-  std::string imag = utils::GetUniqueName(node_unit, "_imag");
+  std::string imag = utils::UniqueNameGenerator().New(node_unit, "_imag");
   {
     std::vector<std::string> add_input_names = {sin_x1, cos_x2};
     QnnTensorWrapper imag_tensor(imag, QNN_TENSOR_TYPE_NATIVE,
@@ -760,7 +760,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add imag tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_add_imag"),
+                      utils::UniqueNameGenerator().New(node_unit, "_add_imag"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_ADD,
                       std::move(add_input_names),
@@ -771,19 +771,19 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   }
 
   // Step 6: Recombine real and imag based on interleaved flag
-  std::string x_rotated = utils::GetUniqueName(node_unit, "_x_rotated");
+  std::string x_rotated = utils::UniqueNameGenerator().New(node_unit, "_x_rotated");
   std::vector<uint32_t> x_rotated_shape = {batch_size, seq_len, num_heads_val, rotary_dim};
 
   if (interleaved) {
     // Interleave real and imag: stack along new axis then reshape
     // Stack to create [..., rotary_half_dim, 2]
-    std::string stacked = utils::GetUniqueName(node_unit, "_stacked");
+    std::string stacked = utils::UniqueNameGenerator().New(node_unit, "_stacked");
     std::vector<uint32_t> stacked_shape = {batch_size, seq_len, num_heads_val, rotary_half_dim, 2};
 
     // QNN doesn't have a direct Stack op, so we'll use Concat with Reshape
     // First reshape real and imag to add a dimension
-    std::string real_reshaped = utils::GetUniqueName(node_unit, "_real_reshaped");
-    std::string imag_reshaped = utils::GetUniqueName(node_unit, "_imag_reshaped");
+    std::string real_reshaped = utils::UniqueNameGenerator().New(node_unit, "_real_reshaped");
+    std::string imag_reshaped = utils::UniqueNameGenerator().New(node_unit, "_imag_reshaped");
     std::vector<uint32_t> reshaped_for_stack = {batch_size, seq_len, num_heads_val, rotary_half_dim, 1};
 
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(
@@ -818,7 +818,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                     "Failed to add stacked tensor");
 
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::GetUniqueName(node_unit, "_concat_stack"),
+                        utils::UniqueNameGenerator().New(node_unit, "_concat_stack"),
                         QNN_OP_PACKAGE_NAME_QTI_AISW,
                         QNN_OP_CONCAT,
                         std::move(concat_input_names),
@@ -855,7 +855,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add x_rotated tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_concat_rotated"),
+                      utils::UniqueNameGenerator().New(node_unit, "_concat_rotated"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_CONCAT,
                       std::move(concat_input_names),
@@ -868,7 +868,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
   // Step 7: Concatenate x_rotated with x_tail (if exists)
   std::string output_normalized = x_rotated;
   if (rotary_dim < head_size) {
-    output_normalized = utils::GetUniqueName(node_unit, "_output_normalized");
+    output_normalized = utils::UniqueNameGenerator().New(node_unit, "_output_normalized");
     std::vector<std::string> concat_input_names = {x_rotated, x_tail_name};
     std::vector<std::string> concat_param_names;
 
@@ -887,7 +887,7 @@ Ort::Status RopeOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& qnn_model_w
                   "Failed to add output_normalized tensor");
 
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(node_unit, "_concat_tail"),
+                      utils::UniqueNameGenerator().New(node_unit, "_concat_tail"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_CONCAT,
                       std::move(concat_input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -398,7 +398,7 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   }
 
   if (op_type == "LeakyRelu") {
-    std::string input_name = utils::GetUniqueName(node_unit.Name(), "_alpha");
+    std::string input_name = utils::UniqueNameGenerator().New(node_unit.Name(), "_alpha");
     RETURN_IF_ERROR(ProcessAlphaAttributeAsInput(qnn_model_wrapper, node_unit, input_name));
     input_names.push_back(input_name);
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -93,7 +93,7 @@ Ort::Status SoftmaxOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     Given an input with shape=(3, 4, 5) and axis=0. Its behavior is to reshape the input to (1, 60), perform softmax,
     and then reshape back to (3, 4, 5).
     */
-    std::string reshape_output_name = utils::GetUniqueName(input_name, "_reshape");
+    std::string reshape_output_name = utils::UniqueNameGenerator().New(input_name, "_reshape");
     std::vector<uint32_t> reshape_output_shape = FlattenShapeFromAxis(input_info.shape, axis);
 
     // Input is dynamic, so add reshape node before input.
@@ -115,7 +115,7 @@ Ort::Status SoftmaxOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     input dimension.
     QNN EP is able to support arbitrary axis attribute by wrapping transposes around the operator.
     */
-    std::string transpose_output_name = utils::GetUniqueName(input_name, "_transpose");
+    std::string transpose_output_name = utils::UniqueNameGenerator().New(input_name, "_transpose");
     std::vector<uint32_t> transpose_perm;
     RETURN_IF_ERROR(utils::GetPermToLastAxis(static_cast<uint32_t>(axis),
                                              static_cast<uint32_t>(input_rank),
@@ -169,7 +169,7 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   size_t output_rank = output_info.shape.size();
 
   if (opset_version < 13) {
-    std::string reshape_input_name = utils::GetUniqueName(orig_output_name, "_reshape");
+    std::string reshape_input_name = utils::UniqueNameGenerator().New(orig_output_name, "_reshape");
 
     std::vector<uint32_t> reshape_input_shape = FlattenShapeFromAxis(output_info.shape, axis);
     if (axis == 0) {
@@ -185,7 +185,7 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   GetQnnOpType(node_unit.OpType()),
                                                   std::move(input_names),
@@ -204,7 +204,7 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                      false,
                                                      is_graph_output));
   } else if (is_qpu_backend && axis != static_cast<int32_t>(output_rank) - 1) {
-    std::string transpose_input_name = utils::GetUniqueName(orig_output_name, "_transpose");
+    std::string transpose_input_name = utils::UniqueNameGenerator().New(orig_output_name, "_transpose");
 
     std::vector<uint32_t> transpose_input_shape = output_info.shape;
     transpose_input_shape[output_rank - 1] = output_info.shape[axis];
@@ -221,7 +221,7 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   GetQnnOpType(node_unit.OpType()),
                                                   std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/stft_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/stft_op_builder.cc
@@ -112,7 +112,7 @@ Ort::Status STFTOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
     // Create the ExpandDims node
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::GetUniqueName(signal_input_name, "_expand_dims"),
+                      utils::UniqueNameGenerator().New(signal_input_name, "_expand_dims"),
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_EXPAND_DIMS,
                       {signal_input_name},
@@ -294,7 +294,7 @@ Ort::Status STFTOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   qnn_model_wrapper.AddParamWrapper(std::move(onesided_param_wrapper));
 
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                    utils::GetUniqueName(node_unit),
+                    utils::UniqueNameGenerator().New(node_unit),
                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                     QNN_OP_STFT,
                     std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
@@ -66,21 +66,21 @@ Ort::Status TanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
 
   // Create intermediate tensor for Sin output
-  std::string sin_output_name = utils::GetUniqueName(node_unit, "_sin_out");
+  std::string sin_output_name = utils::UniqueNameGenerator().New(node_unit, "_sin_out");
   QnnTensorWrapper sin_output_tensor_wrapper(sin_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
                                              input_info.quant_param.Copy(), std::vector<uint32_t>(input_info.shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sin_output_tensor_wrapper)),
                 "Failed to add Sin output tensor.");
 
   // Create intermediate tensor for Cos output
-  std::string cos_output_name = utils::GetUniqueName(node_unit, "_cos_out");
+  std::string cos_output_name = utils::UniqueNameGenerator().New(node_unit, "_cos_out");
   QnnTensorWrapper cos_output_tensor_wrapper(cos_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
                                              input_info.quant_param.Copy(), std::vector<uint32_t>(input_info.shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cos_output_tensor_wrapper)),
                 "Failed to add Cos output tensor.");
 
   // Create Sin node: input -> sin_out
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, "_Sin"),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_Sin"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_SIN,
                                                 {input_names[0]},
@@ -90,7 +90,7 @@ Ort::Status TanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                 "Failed to create Sin node.");
 
   // Create Cos node: input -> cos_out
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, "_Cos"),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_Cos"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_COS,
                                                 {input_names[0]},
@@ -108,7 +108,7 @@ Ort::Status TanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                 "Failed to add output tensor.");
 
   // Create Div node: sin_out / cos_out -> output
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, "_Div"),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_Div"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_DIVIDE,
                                                 {sin_output_name, cos_output_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/thresholdedrelu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/thresholdedrelu_op_builder.cc
@@ -151,7 +151,7 @@ Ort::Status ThresholdedReluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
   std::vector<uint8_t> alpha_bytes;
   RETURN_IF_ERROR(SetAlphaByte(input_info.qnn_data_type, alpha_bytes, negtive_alpha));
 
-  std::string negtive_alpha_tensor_name = utils::GetUniqueName(node_unit, "_alpha");
+  std::string negtive_alpha_tensor_name = utils::UniqueNameGenerator().New(node_unit, "_alpha");
   QnnTensorWrapper negtive_alpha_tensorwrapper(negtive_alpha_tensor_name,
                                                QNN_TENSOR_TYPE_STATIC,
                                                input_info.qnn_data_type,
@@ -163,8 +163,8 @@ Ort::Status ThresholdedReluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
   // input -> add -> relu -> sign -> mul -> output
   //       --------------------------/
   // 1. Add
-  std::string add_name = utils::GetUniqueName(node_unit, "_Add");
-  std::string add_output_name = utils::GetUniqueName(node_unit, "_Add_output");
+  std::string add_name = utils::UniqueNameGenerator().New(node_unit, "_Add");
+  std::string add_output_name = utils::UniqueNameGenerator().New(node_unit, "_Add_output");
   QnnTensorWrapper add_output(add_output_name,
                               QNN_TENSOR_TYPE_NATIVE,
                               input_info.qnn_data_type,
@@ -183,8 +183,8 @@ Ort::Status ThresholdedReluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
                 "Failed to add ThresholdRelu - Sub node.");
 
   // 2. Relu
-  std::string relu_name = utils::GetUniqueName(node_unit, "_Relu");
-  std::string relu_output_name = utils::GetUniqueName(node_unit, "_Relu_output");
+  std::string relu_name = utils::UniqueNameGenerator().New(node_unit, "_Relu");
+  std::string relu_output_name = utils::UniqueNameGenerator().New(node_unit, "_Relu_output");
 
   QnnTensorWrapper relu_output(relu_output_name,
                                QNN_TENSOR_TYPE_NATIVE,
@@ -204,8 +204,8 @@ Ort::Status ThresholdedReluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
                 "Failed to add ThresholdRelu - Relu node.");
 
   // 3. Sign
-  std::string sign_name = utils::GetUniqueName(node_unit, "_Sign");
-  std::string sign_output_name = utils::GetUniqueName(node_unit, "_Sign_output");
+  std::string sign_name = utils::UniqueNameGenerator().New(node_unit, "_Sign");
+  std::string sign_output_name = utils::UniqueNameGenerator().New(node_unit, "_Sign_output");
   QnnTensorWrapper sign_output(sign_output_name,
                                QNN_TENSOR_TYPE_NATIVE,
                                input_info.qnn_data_type,
@@ -224,7 +224,7 @@ Ort::Status ThresholdedReluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
                 "Failed to add ThresholdRelu - Sign node.");
 
   // 4. Mul
-  std::string mul_name = utils::GetUniqueName(node_unit, "_Mul");
+  std::string mul_name = utils::UniqueNameGenerator().New(node_unit, "_Mul");
   QnnTensorWrapper mul_output(org_output_name,
                               op_output_tensor_type,
                               output_info.qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
@@ -86,7 +86,7 @@ Ort::Status TopKOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // Add Transpose to permute axis to the last.
-  const std::string transpose_output_name = utils::GetUniqueName(input_names[0], "_transpose");
+  const std::string transpose_output_name = utils::UniqueNameGenerator().New(input_names[0], "_transpose");
   std::vector<uint32_t> transpose_perm;
   RETURN_IF_ERROR(utils::GetPermToLastAxis(static_cast<uint32_t>(axis),
                                            static_cast<uint32_t>(input_rank),
@@ -175,7 +175,7 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     // Since user may not be aware of the additional Transpose, the original output name of TopK node must be used by
     // the additional Transpose node which has the same output as original TopK node.
     const std::string& output_name = output.name;
-    const std::string transpose_input_name = utils::GetUniqueName(output_name, "_transpose");
+    const std::string transpose_input_name = utils::UniqueNameGenerator().New(output_name, "_transpose");
     transpose_input_names.push_back(std::move(transpose_input_name));
 
     // Since the input of TopK node is permuted, its output shape must be manually calculated.
@@ -197,7 +197,7 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   }
 
   // Add TopK node.
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 GetQnnOpType(node_unit.OpType()),
                                                 std::move(input_names),
@@ -228,7 +228,7 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     bool is_cast_required = output_idx == 1 && output_info.qnn_data_type == QNN_DATATYPE_INT_64 && is_graph_output;
     std::string cast_input_name = "";
     if (is_cast_required) {
-      cast_input_name = utils::GetUniqueName(transpose_output_name, "_cast");
+      cast_input_name = utils::UniqueNameGenerator().New(transpose_output_name, "_cast");
       // For the same reason described above, the original output name is now used by this Cast.
       transpose_output_name = cast_input_name;
       // Since additional Cast is added, below Transpose is no longer graph output.
@@ -254,7 +254,7 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                  output_info.quant_param.Copy(),
                                                  std::vector<uint32_t>(output_info.shape));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_output_tensorwrapper)), "Failed to add tensor.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit, QNN_OP_CAST),
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_CAST),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                     QNN_OP_CAST,
                                                     {cast_input_name},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/transpose_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/transpose_op_builder.cc
@@ -110,8 +110,8 @@ Ort::Status TransposeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
 
   // If a cast to int64 is needed, add the cast node
   if (needs_int64_cast) {
-    std::string cast_node_name = utils::GetUniqueName(node_unit, "_cast_int64");
-    std::string cast_input_name = utils::GetUniqueName(output_name, "_cast_int64");
+    std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit, "_cast_int64");
+    std::string cast_input_name = utils::UniqueNameGenerator().New(output_name, "_cast_int64");
     std::string cast_output_name = output_name;
 
     // Create the cast input tensor wrapper
@@ -139,7 +139,7 @@ Ort::Status TransposeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
 
   output_names.push_back(output_name);
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_TRANSPOSE,
                                                 std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -184,6 +184,8 @@ const OrtNodeUnit& QnnModel::GetNodeUnit(const OrtNode* node,
 }
 
 Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
+  utils::UniqueNameGenerator().Reset();
+
   RETURN_IF(context.onnx_input_names == nullptr, "onnx_input_names is required for ComposeGraph");
   RETURN_IF(context.onnx_output_names == nullptr, "onnx_output_names is required for ComposeGraph");
   RETURN_IF(context.model_settings == nullptr, "model_settings is required for ComposeGraph");

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -341,7 +341,7 @@ bool QnnModelWrapper::ProcessBF16OutputConversion(const std::string& qnn_node_na
     if (IsGraphOutput(output_name) &&
         (tensor_dtype == QNN_DATATYPE_FLOAT_32 || tensor_dtype == QNN_DATATYPE_BFLOAT_16)) {
       // For FP32 graph outputs, insert Cast node to convert BF16 back to FP32
-      std::string bf16_output_name = utils::GetUniqueName(output_name, "_bf16_intermediate");
+      std::string bf16_output_name = utils::UniqueNameGenerator().New(output_name, "_bf16_intermediate");
 
       if (!IsQnnTensorWrapperExist(bf16_output_name)) {
         std::vector<uint32_t> shape = tensor_wrapper.GetTensorDims();
@@ -884,7 +884,7 @@ Ort::Status QnnModelWrapper::AddReshapeNode(const std::string& input_name, const
   RETURN_IF_NOT(AddTensorWrapper(std::move(output_tensorwrapper)),
                 "QNN EP: Failed to add output tensor for inserted Reshape.");
 
-  RETURN_IF_NOT(CreateQnnNode(utils::GetUniqueName(output_name, QNN_OP_RESHAPE),
+  RETURN_IF_NOT(CreateQnnNode(utils::UniqueNameGenerator().New(output_name, QNN_OP_RESHAPE),
                               QNN_OP_PACKAGE_NAME_QTI_AISW,
                               QNN_OP_RESHAPE,
                               {input_name},
@@ -950,7 +950,7 @@ Ort::Status QnnModelWrapper::AddTransposeNode(size_t node_index,
                                         quantize_param.Copy(),
                                         std::move(output_shape_copy));
   RETURN_IF_NOT(AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-  RETURN_IF_NOT(CreateQnnNode(utils::GetUniqueName(output_name, QNN_OP_TRANSPOSE),
+  RETURN_IF_NOT(CreateQnnNode(utils::UniqueNameGenerator().New(output_name, QNN_OP_TRANSPOSE),
                               QNN_OP_PACKAGE_NAME_QTI_AISW,
                               QNN_OP_TRANSPOSE,
                               {input_name},
@@ -979,7 +979,7 @@ Ort::Status QnnModelWrapper::AddNoopReshapeNode(const std::string& node_name,
   std::string output_name = output_tensor_wrapper.GetName();
   RETURN_IF_NOT(AddTensorWrapper(std::move(output_tensor_wrapper)), "Failed to add no-op output tensor.");
 
-  RETURN_IF_NOT(CreateQnnNode(utils::GetUniqueName(node_name),
+  RETURN_IF_NOT(CreateQnnNode(utils::UniqueNameGenerator().New(node_name),
                               QNN_OP_PACKAGE_NAME_QTI_AISW,
                               QNN_OP_RESHAPE,
                               {input_name},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.cc
@@ -222,7 +222,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   if (!validate) {
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(channel_shuffle_input)), "Failed to add input");
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(channel_shuffle_output)), "Failed to add output");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(onnxruntime::qnn::utils::GetUniqueName(*transpose_tail),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(onnxruntime::qnn::utils::UniqueNameGenerator().New(*transpose_tail),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_CHANNEL_SHUFFLE,
                                                   {cs_input_def.name},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_q_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_q_fusion.cc
@@ -91,7 +91,7 @@ static Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& q_node_unit,
                                          bool validate) {
   assert(dq_node_unit.OpType() == DEQUANTIZE_LINEAR && q_node_unit.OpType() == QUANTIZE_LINEAR);
-  const auto& node_name = utils::GetUniqueName(dq_node_unit);
+  const auto& node_name = utils::UniqueNameGenerator().New(dq_node_unit);
   const OrtNodeUnitIODef& input_def = dq_node_unit.Inputs()[0];
   const OrtNodeUnitIODef& output_def = q_node_unit.Outputs()[0];
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gather_transpose_reshape_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gather_transpose_reshape_fusion.cc
@@ -225,9 +225,9 @@ static Ort::Status CreateOrValidateOnQnn(
   const uint32_t factor0 = (index_pattern == GatherIndicesPattern::kColMajor) ? u_idx1 : u_idx0;
   const uint32_t factor1 = (index_pattern == GatherIndicesPattern::kColMajor) ? u_idx0 : u_idx1;
 
-  const std::string r1_out = utils::GetUniqueName(*gather, "_gtr_r1_out");
-  const std::string col_t_out = utils::GetUniqueName(*gather, "_gtr_col_t_out");
-  const std::string main_t_out = utils::GetUniqueName(*gather, "_gtr_main_t_out");
+  const std::string r1_out = utils::UniqueNameGenerator().New(*gather, "_gtr_r1_out");
+  const std::string col_t_out = utils::UniqueNameGenerator().New(*gather, "_gtr_col_t_out");
+  const std::string main_t_out = utils::UniqueNameGenerator().New(*gather, "_gtr_main_t_out");
 
   // Reshape rank-5 input to rank-4: [d0,d1,d2,d3,d4] -> [merged, d3, factor0, factor1]
   const std::vector<uint32_t> r1_shape = {merged, d3, factor0, factor1};

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -234,7 +234,7 @@ static Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnitIODef& final_output,
                                          bool validate) {
   assert(node_units.size() >= 4);
-  const auto& node_name = utils::GetUniqueName(*node_units[0]);
+  const auto& node_name = utils::UniqueNameGenerator().New(*node_units[0]);
 
   QnnTensorWrapper input_tensor;
   QnnTensorWrapper output_tensor;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/hardsigmoid_mul_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/hardsigmoid_mul_fusion.cc
@@ -108,7 +108,7 @@ static Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& mul_node_unit,
                                          bool validate) {
   assert(hardsigmoid_node_unit.OpType() == "HardSigmoid" && mul_node_unit.OpType() == "Mul");
-  const auto& node_name = utils::GetUniqueName(hardsigmoid_node_unit);
+  const auto& node_name = utils::UniqueNameGenerator().New(hardsigmoid_node_unit);
   const OrtNodeUnitIODef& input_def = hardsigmoid_node_unit.Inputs()[0];
   const OrtNodeUnitIODef& output_def = mul_node_unit.Outputs()[0];
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
@@ -224,7 +224,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
          act_dql_node_unit.OpType() == "DequantizeLinear" &&
          gemm_node_unit.OpType() == "Gemm" &&
          output_ql_node_unit.OpType() == "QuantizeLinear");
-  const auto& node_name = utils::GetUniqueName(gemm_node_unit);
+  const auto& node_name = utils::UniqueNameGenerator().New(gemm_node_unit);
   const OrtNodeUnitIODef& act_dql_input_1_def = act_dql_node_unit.Inputs()[0];
   const OrtNodeUnitIODef& w_dql_input_1_def = w_dql_node_unit.Inputs()[0];
   const OrtNodeUnitIODef& output_def = output_ql_node_unit.Outputs()[0];

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
@@ -158,7 +158,7 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
   std::string actual_input_0_name = original_input_0_name;
 
   if (reshape_input_0) {
-    actual_input_0_name = utils::GetUniqueName(original_input_0_name, "_reshape");
+    actual_input_0_name = utils::UniqueNameGenerator().New(original_input_0_name, "_reshape");
     std::vector<uint32_t> shape_2d{1, input_0_info.shape[0]};
     QnnQuantParamsWrapper quant_param_2d = input_0_info.quant_param.Copy();
     RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_0_info.shape, shape_2d));
@@ -432,7 +432,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                     (matmul_node_unit.OpType() == "MatMul"),
                 "Invalid Matmul LPBQ pattern identified");
 
-  const auto& node_name = utils::GetUniqueName(matmul_node_unit);
+  const auto& node_name = utils::UniqueNameGenerator().New(matmul_node_unit);
 
   std::vector<std::string> input_names;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
@@ -114,7 +114,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                               std::move(pre_reshape_output_shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pre_reshape_output_wrapper)), "Failed to add tensor.");
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(pre_reshape_node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(pre_reshape_node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_RESHAPE,
                                                 {pre_reshape_input.name},
@@ -164,7 +164,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                       std::move(d2s_output_shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(d2s_output_wrapper)), "Failed to add tensor.");
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(einsum_node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(einsum_node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_DEPTH_TO_SPACE,
                                                 {pre_reshape_output.name},
@@ -199,7 +199,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                                std::move(post_reshape_output_info.shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(post_reshape_output_wrapper)), "Failed to add tensor.");
 
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(post_reshape_node_unit),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(post_reshape_node_unit),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_TRANSPOSE,
                                                 {einsum_output.name},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -162,7 +162,7 @@ bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape
 Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& reshape_node_unit,
                                   const OrtNodeUnit& gemm_node_unit, const Ort::Logger& logger, bool validate) {
   assert(reshape_node_unit.OpType() == "Reshape" && gemm_node_unit.OpType() == "Gemm");
-  const auto& node_name = utils::GetUniqueName(gemm_node_unit);
+  const auto& node_name = utils::UniqueNameGenerator().New(gemm_node_unit);
   const OrtNodeUnitIODef& input_def = reshape_node_unit.Inputs()[0];
   const OrtNodeUnitIODef& weight_def = gemm_node_unit.Inputs()[1];
   const OrtNodeUnitIODef* bias_def_ptr = nullptr;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_rank5.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_rank5.cc
@@ -379,7 +379,7 @@ Ort::Status CreateOrValidateOnQnn(
                 "Failed to add the first Reshape's output tensor.");
 
   // Create Reshape1 node.
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(reshape1->Name()),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(reshape1->Name()),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_RESHAPE,
                                                 {reshape1_input.name},
@@ -410,7 +410,7 @@ Ort::Status CreateOrValidateOnQnn(
   RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(perm_param)), "Failed to add Transpose perm param.");
 
   // Create Transpose node.
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(transpose->Name()),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(transpose->Name()),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_TRANSPOSE,
                                                 {reshape1_output.name},
@@ -435,7 +435,7 @@ Ort::Status CreateOrValidateOnQnn(
                 "Failed to add the second Reshape's output tensor.");
 
   // Create Reshape2 node.
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(reshape2->Name()),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(reshape2->Name()),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_RESHAPE,
                                                 {transpose_output.name},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.cc
@@ -235,7 +235,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(mul_input_other, fused_softmax_input));
   RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(softmax_output, fused_softmax_output));
 
-  const std::string node_name = onnxruntime::qnn::utils::GetUniqueName(softmax_node_unit);
+  const std::string node_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(softmax_node_unit);
   if (validate) {
     RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(node_name,
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/udo_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/udo_fusion.cc
@@ -117,7 +117,7 @@ static Ort::Status CreateOrValidateOnQnn(
   ORT_UNUSED_PARAMETER(do_op_validation);
 
   const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
-  const std::string node_name = utils::GetUniqueName(node_unit);
+  const std::string node_name = utils::UniqueNameGenerator().New(node_unit);
 
   // get qnn inputs
   const auto& inputs = node_unit.Inputs();

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -787,34 +787,7 @@ Ort::Status GetQnnDataType(const bool is_quantized_tensor,
   return Ort::Status();
 }
 
-std::string GetUniqueName(const std::string& base, std::string_view suffix) {
-  std::string name = base;
-  if (!suffix.empty()) {
-    name += suffix;
-  }
-  {
-    static std::unordered_map<std::string, int> counter;
-    static std::mutex counter_mutex;
-    std::lock_guard<std::mutex> lock(counter_mutex);
 
-    int& count = counter[name];
-    if (count++ > 0) {
-      return name + "_" + std::to_string(count);
-    }
-  }
-  return name;
-}
-
-std::string GetUniqueName(const OrtNodeUnit& node_unit, std::string_view suffix) {
-  // Preserve node name when exist. Otherwise, use op type with index
-  std::string base;
-  if (!node_unit.Name().empty()) {
-    base = node_unit.Name();
-  } else {
-    base = node_unit.OpType() + std::to_string(node_unit.Index());
-  }
-  return GetUniqueName(base, suffix);
-}
 
 bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
                                Qnn_DataType_t& qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -787,8 +787,6 @@ Ort::Status GetQnnDataType(const bool is_quantized_tensor,
   return Ort::Status();
 }
 
-
-
 bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
                                Qnn_DataType_t& qnn_data_type,
                                bool is_quantized) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -22,6 +22,37 @@ namespace onnxruntime {
 namespace qnn {
 namespace utils {
 
+void UniqueNameGeneratorImpl::Reset() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  counter_.clear();
+}
+
+std::string UniqueNameGeneratorImpl::New(std::string_view base, std::string_view suffix) {
+  std::string name(base);
+  if (!suffix.empty()) {
+    name.append(suffix);
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  int& count = counter_[name];
+  if (count++ > 0) {
+    name.append("_").append(std::to_string(count));
+  }
+  return name;
+}
+
+std::string UniqueNameGeneratorImpl::New(const OrtNodeUnit& node_unit, std::string_view suffix) {
+  const std::string base = node_unit.Name();
+  if (base.empty()) {
+    return New(node_unit.OpType() + std::to_string(node_unit.Index()), suffix);
+  }
+  return New(base, suffix);
+}
+
+UniqueNameGeneratorImpl& UniqueNameGenerator() {
+  static UniqueNameGeneratorImpl instance;
+  return instance;
+}
+
 size_t GetElementSizeByType(const Qnn_DataType_t& data_type) {
   const static std::unordered_map<Qnn_DataType_t, size_t> data_type_to_size = {
       {QNN_DATATYPE_INT_8, 1},
@@ -1492,7 +1523,7 @@ Ort::Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
                                                 QnnQuantParamsWrapper(scale, offset),
                                                 std::move(output_shape_copy));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(convert_output_tensorwrapper)), "Failed to add tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::GetUniqueName(convert_output_name, QNN_OP_CONVERT),
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(UniqueNameGenerator().New(convert_output_name, QNN_OP_CONVERT),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_CONVERT,
                                                 {convert_input_name},

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -127,50 +127,16 @@ Ort::Status GetQnnDataType(const bool is_quantized_tensor,
 // (e.g., "_2") when the same base + suffix combination is requested more than once.
 class UniqueNameGeneratorImpl {
  public:
-  void Reset() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    counter_.clear();
-  }
-
-  std::string New(std::string_view base, std::string_view suffix = {}) {
-    std::string name(base);
-    if (!suffix.empty()) {
-      name.append(suffix);
-    }
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      int& count = counter_[name];
-      if (count++ > 0) {
-        name.append("_").append(std::to_string(count));
-      }
-    }
-    return name;
-  }
-
-  std::string New(const OrtNodeUnit& node_unit, std::string_view suffix = {}) {
-    const std::string base = node_unit.Name();
-    if (base.empty()) {
-      return New(node_unit.OpType() + std::to_string(node_unit.Index()), suffix);
-    }
-    return New(base, suffix);
-  }
+  void Reset();
+  std::string New(std::string_view base, std::string_view suffix = {});
+  std::string New(const OrtNodeUnit& node_unit, std::string_view suffix = {});
 
  private:
   std::unordered_map<std::string, int> counter_;
   std::mutex mutex_;
 };
 
-inline UniqueNameGeneratorImpl& UniqueNameGenerator() {
-  static UniqueNameGeneratorImpl instance;
-  return instance;
-}
-
-inline std::string GetUniqueName(std::string_view base, std::string_view suffix = {}) {
-  return UniqueNameGenerator().New(base, suffix);
-}
-inline std::string GetUniqueName(const OrtNodeUnit& node_unit, std::string_view suffix = {}) {
-  return UniqueNameGenerator().New(node_unit, suffix);
-}
+UniqueNameGeneratorImpl& UniqueNameGenerator();
 
 bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
                                Qnn_DataType_t& qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -7,14 +7,16 @@
 #include <cctype>
 #include <cstring>
 #include <functional>
+#include <mutex>
 #include <numeric>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <unordered_set>
 
 #include <gsl/gsl>
 
@@ -121,11 +123,54 @@ Ort::Status GetQnnDataType(const bool is_quantized_tensor,
                            const ONNXTensorElementDataType onnx_data_type,
                            Qnn_DataType_t& tensor_data_type);
 
-// Returns an unique name string based on a base string and an optional suffix.
-std::string GetUniqueName(const std::string& base, std::string_view suffix = {});
+// Name generator that produces unique QNN node names by appending a counter suffix,
+// (e.g., "_2") when the same base + suffix combination is requested more than once.
+class UniqueNameGeneratorImpl {
+ public:
+  void Reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    counter_.clear();
+  }
 
-// Returns an unique name string from its name or op type and index, plus an optional suffix.
-std::string GetUniqueName(const OrtNodeUnit& node_unit, std::string_view suffix = {});
+  std::string New(std::string_view base, std::string_view suffix = {}) {
+    std::string name(base);
+    if (!suffix.empty()) {
+      name.append(suffix);
+    }
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      int& count = counter_[name];
+      if (count++ > 0) {
+        name.append("_").append(std::to_string(count));
+      }
+    }
+    return name;
+  }
+
+  std::string New(const OrtNodeUnit& node_unit, std::string_view suffix = {}) {
+    std::string_view base = node_unit.Name();
+    if (base.empty()) {
+      return New(node_unit.OpType() + std::to_string(node_unit.Index()), suffix);
+    }
+    return New(base, suffix);
+  }
+
+ private:
+  std::unordered_map<std::string, int> counter_;
+  std::mutex mutex_;
+};
+
+inline UniqueNameGeneratorImpl& UniqueNameGenerator() {
+  static UniqueNameGeneratorImpl instance;
+  return instance;
+}
+
+inline std::string GetUniqueName(std::string_view base, std::string_view suffix = {}) {
+  return UniqueNameGenerator().New(base, suffix);
+}
+inline std::string GetUniqueName(const OrtNodeUnit& node_unit, std::string_view suffix = {}) {
+  return UniqueNameGenerator().New(node_unit, suffix);
+}
 
 bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
                                Qnn_DataType_t& qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -148,7 +148,7 @@ class UniqueNameGeneratorImpl {
   }
 
   std::string New(const OrtNodeUnit& node_unit, std::string_view suffix = {}) {
-    std::string_view base = node_unit.Name();
+    const std::string base = node_unit.Name();
     if (base.empty()) {
       return New(node_unit.OpType() + std::to_string(node_unit.Index()), suffix);
     }

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -3,7 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
-#include <set>
+#include <unordered_set>
 #include <string>
 #include <thread>
 
@@ -2413,7 +2413,7 @@ TEST_F(QnnCPUBackendTests, GetUniqueNameResetBetweenCompilations) {
   auto tmp_dir = fs::temp_directory_path() / "qnn_unique_name_test";
   fs::create_directories(tmp_dir);
 
-  auto compile_and_get_node_names = [&](const std::string& sub_dir) -> std::set<std::string> {
+  auto compile_and_get_node_names = [&](const std::string& sub_dir) -> std::unordered_set<std::string> {
     auto json_dir = tmp_dir / sub_dir;
     fs::create_directories(json_dir);
 
@@ -2425,7 +2425,7 @@ TEST_F(QnnCPUBackendTests, GetUniqueNameResetBetweenCompilations) {
 
     RunQnnModelTest(model_fn, provider_options, 13, ExpectedEPNodeAssignment::All);
 
-    std::set<std::string> node_names;
+    std::unordered_set<std::string> node_names;
     for (const auto& entry : fs::directory_iterator(json_dir)) {
       if (entry.path().extension() == ".json") {
         std::ifstream ifs(entry.path());

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <string>
 #include <thread>
 
@@ -2399,6 +2400,51 @@ TEST_F(QnnCPUBackendTests, GraphInputOutputOrderMatchesOnnxOffloadGraphIoQuantiz
     EXPECT_EQ(output_names[1], "qdq1_out_dq_out");
     EXPECT_EQ(output_names[2], "qdq3_out_dq_out");
   }
+}
+
+// Verify GetUniqueName counter resets between compilations in the same process.
+TEST_F(QnnCPUBackendTests, GetUniqueNameResetBetweenCompilations) {
+  auto model_fn = BuildOpTestCase<float>(
+      "Sigmoid_node", "Sigmoid",
+      {TestInputDef<float>({1, 2, 3}, false, {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f})},
+      {}, {});
+
+  namespace fs = std::filesystem;
+  auto tmp_dir = fs::temp_directory_path() / "qnn_unique_name_test";
+  fs::create_directories(tmp_dir);
+
+  auto compile_and_get_node_names = [&](const std::string& sub_dir) -> std::set<std::string> {
+    auto json_dir = tmp_dir / sub_dir;
+    fs::create_directories(json_dir);
+
+    ProviderOptions provider_options;
+    provider_options["backend_type"] = "cpu";
+    provider_options["offload_graph_io_quantization"] = "0";
+    provider_options["dump_json_qnn_graph"] = "1";
+    provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+    RunQnnModelTest(model_fn, provider_options, 13, ExpectedEPNodeAssignment::All);
+
+    std::set<std::string> node_names;
+    for (const auto& entry : fs::directory_iterator(json_dir)) {
+      if (entry.path().extension() == ".json") {
+        std::ifstream ifs(entry.path());
+        nlohmann::json j;
+        ifs >> j;
+        for (auto& [name, _] : j["graph"]["nodes"].items()) {
+          node_names.insert(name);
+        }
+      }
+    }
+    return node_names;
+  };
+
+  auto names_1 = compile_and_get_node_names("run1");
+  auto names_2 = compile_and_get_node_names("run2");
+  fs::remove_all(tmp_dir);
+
+  ASSERT_FALSE(names_1.empty());
+  EXPECT_EQ(names_1, names_2);
 }
 
 #endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
## Changes:

- Static counter in GetUniqueName leaked across ComposeGraph calls in
the same process;
- Refactor into UniqueNameGeneratorImpl class and reset at ComposeGraph entry.
