### PR TITLE
[QNN EP] Add support for Plugin EP to get the version at runtime

### DIFF
--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -6,6 +6,7 @@
 import os
 
 from . import build_and_package_info  # noqa: F401
+from .build_and_package_info import __version__  # noqa: F401
 
 EP_NAME = "QNNExecutionProvider"
 


### PR DESCRIPTION
### Description

This change allows the user to get the version of QNN Plugin EP during runtime by running the following commands
```
import onnxruntime_qnn as qnn_ep
print(qnn_ep.__version__)
```

### Motivation and Context

Currently QNN EP does not have a method to check the version it is running during runtime. ORT supports this using `ort.__version__`. This change adds support to QNN EP for the same.

