### PR TITLE
disable cpu tests for roialign

### DIFF
--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -122,9 +122,8 @@ static void RunQDQRoiAlignOpTest(const TestInputDef<float>& input_def,
 //
 // CPU tests:
 //
-// Disabling CPU test for ARM64. ARM64 CI runner stalled.
-#if !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) && !defined(__aarch64__)
-TEST_F(QnnCPUBackendTests, TestRoialign) {
+// Disabling CPU tests. CPU kernel tests have potential problems that stalls on CI.
+TEST_F(QnnCPUBackendTests, DISABLED_TestRoialign) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
@@ -138,7 +137,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign) {
 }
 
 // QNN doesn't support coordinate_transformation_mode = output_half
-TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_output_half) {
+TEST_F(QnnCPUBackendTests, DISABLED_TestRoialign_Unsupported_output_half) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
@@ -152,7 +151,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_output_half) {
 }
 
 // QNN only supports pooling mode = average
-TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_mode_max) {
+TEST_F(QnnCPUBackendTests, DISABLED_TestRoialign_Unsupported_mode_max) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
@@ -166,7 +165,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_mode_max) {
 }
 
 // QNN doesn't support adaptive sampling_ratio (sampling_ratio = 0)
-TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
+TEST_F(QnnCPUBackendTests, DISABLED_TestRoialign_Unsupported_sampling_ratio) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
                     TestInputDef<int64_t>({1}, true, {0}),
@@ -178,7 +177,6 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
                      test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
-#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) && !defined(__aarch64__)
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -123,7 +123,7 @@ static void RunQDQRoiAlignOpTest(const TestInputDef<float>& input_def,
 // CPU tests:
 //
 // Disabling CPU test for ARM64. ARM64 CI runner stalled.
-#if !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) $$ !defined(__aarch64__)
+#if !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) && !defined(__aarch64__)
 TEST_F(QnnCPUBackendTests, TestRoialign) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
@@ -178,7 +178,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
                      test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
-#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) $$ !defined(__aarch64__)
+#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) && !defined(__aarch64__)
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/roialign_op_test.cc
+++ b/onnxruntime/test/providers/qnn/roialign_op_test.cc
@@ -123,7 +123,7 @@ static void RunQDQRoiAlignOpTest(const TestInputDef<float>& input_def,
 // CPU tests:
 //
 // Disabling CPU test for ARM64. ARM64 CI runner stalled.
-#if !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__)
+#if !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) $$ !defined(__aarch64__)
 TEST_F(QnnCPUBackendTests, TestRoialign) {
   RunRoiAlignOpTest(TestInputDef<float>({1, 1, 2, 2}, false, {1.0f, 2.0f, 3.0f, 4.0f}),
                     TestInputDef<float>({1, 4}, true, {0.0f, 0.0f, 1.0f, 1.0f}),
@@ -178,7 +178,7 @@ TEST_F(QnnCPUBackendTests, TestRoialign_Unsupported_sampling_ratio) {
                      test::MakeAttribute("spatial_scale", 1.0f)},
                     ExpectedEPNodeAssignment::None);
 }
-#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__)
+#endif  // !defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(__linux__) $$ !defined(__aarch64__)
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
disable x86 cpu tests for roialign.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


