### PR TITLE
[QNN EP] Skip WIN_AMD 64 Wheel upload

### DIFF
--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -244,7 +244,7 @@ class WheelUpleveler(ArtifactUpleveler):
 
     def _should_skip_artifact(self, artifact_filename: str) -> bool:
         """Skip win_amd64 wheels"""
-        return "win_amd64.whl" in artifact_filename
+        return artifact_filename.endswith("win_amd64.whl")
 
     def update_artifacts(self, artifact_list: list[str], input_dir: str, output_dir: str) -> None:
         """Update wheel package versions."""

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -119,6 +119,10 @@ class ArtifactUpleveler(ABC):
         """Helper method to get credentials from environment variables."""
         return self.credential_manager.get_credentials(repository_index)
 
+    def _should_skip_artifact(self, artifact_filename: str) -> bool:
+        """Return True if this artifact should be skipped during download. Override in subclasses."""
+        return False
+
     @property
     @abstractmethod
     def artifact_format(self) -> str:
@@ -158,6 +162,15 @@ class ArtifactUpleveler(ABC):
 
         # Extract artifact file links
         artifact_list = [line.split('"')[1] for line in response.text.splitlines() if self.artifact_suffix in line]
+
+        # Filter out skipped artifacts
+        filtered_list = []
+        for artifact in artifact_list:
+            if self._should_skip_artifact(artifact_filename=artifact):
+                logging.info(f"Skipping artifact: {artifact}")
+            else:
+                filtered_list.append(artifact)
+        artifact_list = filtered_list
 
         if not artifact_list:
             raise RuntimeError(
@@ -228,6 +241,10 @@ class WheelUpleveler(ArtifactUpleveler):
     @property
     def artifact_format(self) -> str:
         return "wheel"
+
+    def _should_skip_artifact(self, artifact_filename: str) -> bool:
+        """Skip win_amd64 wheels"""
+        return "win_amd64.whl" in artifact_filename
 
     def update_artifacts(self, artifact_list: list[str], input_dir: str, output_dir: str) -> None:
         """Update wheel package versions."""


### PR DESCRIPTION
### Description
This change skips AMD64 wheels when they are uploaded to PyPI. 

### Motivation and Context

Change is needed as the AMD64 wheels are all greater than 100 MB in size.


