### PR TITLE
Add Linux aarch64 OE GCC11.2 cross-compilation support for wheels and…

### DIFF
--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -34,6 +34,10 @@ on:
         description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
         type: string
         default: "['3.10','3.11','3.12','3.13']"
+      linux_aarch64_oe_gcc11_2_target_py_vsns:
+        description: "JSON list of Python versions to build for Linux aarch64 oe gcc 11.2"
+        type: string
+        default: "['3.10','3.11','3.12','3.13']"
       windows_target_archs:
         description: "JSON list of Windows architectures to build"
         type: string
@@ -96,17 +100,25 @@ jobs:
       upload_wheel: false
 
   build-linux-aarch64-oe-gcc11_2:
-      if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
-      uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
-      secrets: inherit
-      with:
-        nightly_build: ${{ inputs.nightly_build }}
-        target_os: linux
-        target_arch: aarch64_oe_gcc11_2
-        target_py_vsn: None
-        run_tests: false
-        upload_test_archive: true
-        upload_wheel: false
+    if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
+    strategy:
+      matrix:
+        target_py_vsn: ${{ fromJSON(inputs.linux_aarch64_oe_gcc11_2_target_py_vsns) }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: linux
+      target_arch: aarch64_oe_gcc11_2
+      target_py_vsn: ${{ matrix.target_py_vsn }}
+      run_tests: false
+      # Upload the test archive with the first Python version we encounter
+      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_oe_gcc11_2_target_py_vsns)[0] }}
+      upload_wheel: true
+      # build Zip with the first python version we encounter
+      build_zip: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_oe_gcc11_2_target_py_vsns)[0] }}
+      upload_zip: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_oe_gcc11_2_target_py_vsns)[0] }}
 
   build-linux-x86_64:
     if: ${{ inputs.build_linux_x86_64 }}

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -130,6 +130,26 @@ jobs:
         with:
           name: windows-x86_64-py3.14-wheels
 
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-aarch64_oe_gcc11_2-py3.10-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-aarch64_oe_gcc11_2-py3.11-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-aarch64_oe_gcc11_2-py3.12-wheels
+
+      - name: Download Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-aarch64_oe_gcc11_2-py3.13-wheels
+
       - name: Consolidate Wheels
         run: |
           mkdir "${{ github.workspace }}/build/dist"
@@ -144,6 +164,10 @@ jobs:
         run: |
           mkdir "${{ github.workspace }}/build/dist/x64"
           cp "${{ github.workspace }}/build/windows-x86_64/Release/dist/"*.whl "${{ github.workspace }}/build/dist/x64"
+
+      - name: Consolidate Wheels
+        run: |
+          cp "${{ github.workspace }}/build/linux-aarch64_oe_gcc11_2/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
 
       - name: Install Dependencies
         run: |

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -473,6 +473,14 @@ if (MSVC OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
       list(APPEND QNN_LIB_FILES ${EXTRA_HTP_LIB})
     elseif(${QNN_ARCH_ABI} STREQUAL "aarch64-ubuntu-gcc9.4")
       list(APPEND QNN_LIB_FILES "${onnxruntime_QNN_HOME}/lib/hexagon-v68/unsigned/libQnnHtpV68Skel.so")
+    elseif(${QNN_ARCH_ABI} STREQUAL "aarch64-oe-linux-gcc11.2")
+      file(GLOB EXTRA_HTP_LIB LIST_DIRECTORIES false "${onnxruntime_QNN_HOME}/lib/hexagon-v68/unsigned/libQnnHtpV68Skel.so"
+                                                    "${onnxruntime_QNN_HOME}/lib/hexagon-v69/unsigned/libQnnHtpV69Skel.so"
+                                                    "${onnxruntime_QNN_HOME}/lib/hexagon-v73/unsigned/libQnnHtpV73Skel.so"
+                                                    "${onnxruntime_QNN_HOME}/lib/hexagon-v75/unsigned/libQnnHtpV75Skel.so"
+                                                    "${onnxruntime_QNN_HOME}/lib/hexagon-v79/unsigned/libQnnHtpV79Skel.so"
+                                                    "${onnxruntime_QNN_HOME}/lib/hexagon-v81/unsigned/libQnnHtpV81Skel.so")
+      list(APPEND QNN_LIB_FILES ${EXTRA_HTP_LIB})
     endif()
     message(STATUS "QNN lib files: " ${QNN_LIB_FILES})
 endif()

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -337,7 +337,7 @@ class TaskLibrary:
                     "linux",
                     "aarch64_oe_gcc11_2",
                     self.__config,
-                    None,  # target-py_version
+                    self.__target_py_version,
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "archive",
@@ -516,10 +516,11 @@ class TaskLibrary:
                     "linux",
                     "aarch64_oe_gcc11_2",
                     self.__config,
-                    None,  # target-py-version
+                    self.__target_py_version,
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_zip=self.__build_zip,
                 )
             )
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -78,6 +78,7 @@ class BuildEpLinuxTask(BashScriptsWithVenvTask):
         mode: str,
         extra_args: Iterable[str] | None = None,
         env: Mapping[str, str] | None = None,
+        build_zip: bool = False,
     ) -> None:
         cmd = [
             str(REPO_ROOT / "qcom" / "scripts" / "linux" / "build.sh"),
@@ -95,6 +96,9 @@ class BuildEpLinuxTask(BashScriptsWithVenvTask):
 
         if qairt_sdk_root is not None:
             cmd.append(f"--qairt-sdk-root={qairt_sdk_root}")
+
+        if build_zip:
+            cmd.append("--build-zip")
 
         if extra_args is not None:
             cmd.extend(extra_args)

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -72,6 +72,13 @@ linux_oe_gcc112_toolchain:
   version: 20250402d
   url: http://ort-ep-win-01.na.qualcomm.com:8000/linux-oe-aarch64-gcc11.2-toolchain/linux-oe-aarch64-gcc11.2-toolchain-1-universal-{version}.tar.gz
   sha256: 1031825247827ad60189323aa5530490deae61547f4d9794ef9e0645e9207266
+llvm_linux_x86_64:
+  version: 16.0.4
+  platform_version: ubuntu-22.04
+  url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/clang+llvm-{version}-x86_64-linux-gnu-{platform_version}.tar.xz
+  sha256: fd464333bd55b482eb7385f2f4e18248eb43129a3cda4c0920ad9ac3c12bdacf
+  content_root: clang+llvm-{version}-x86_64-linux-gnu-{platform_version}
+  bindir: bin
 java_linux_x86_64: &java_linux_common
   major_version: 21
   version: 21.0.5

--- a/qcom/scripts/all/package_manager.py
+++ b/qcom/scripts/all/package_manager.py
@@ -287,7 +287,9 @@ class PackageManager:
 
     def __format(self, fmt_str: str) -> str:
         """Format a config file string, performing any necessary substitutions."""
-        replacements = {key: self.__config.get(key) for key in ["major_version", "os_arch", "version"]}
+        replacements = {
+            key: self.__config.get(key) for key in ["major_version", "os_arch", "platform_version", "version"]
+        }
         replacements["root_dir"] = self.get_root_dir()
         return fmt_str.format_map(replacements)
 

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -38,8 +38,13 @@ target_py_version=
 use_cache=1
 warnings_as_errors=1
 build_java=
+build_zip=
 for i in "$@"; do
   case $i in
+    --build-zip)
+      build_zip=1
+      shift
+      ;;
     --config=*)
       config="${i#*=}"
       shift
@@ -177,9 +182,15 @@ case "${target_platform}" in
           toolchain_root="$(get_linux_oe_gcc112_toolchain_root)"
           toolchain_cmake="${REPO_ROOT}/qcom/scripts/linux/linux-aarch64-gcc11.toolchain.cmake"
 
-          # We need $toolchain_root from the toolchain.cmake, but the toolchain.cmake is sometimes
-          # evaluated without the project's CMakeCache.txt entries. Pass it through the environment :-/
+          # We need $toolchain_root and $llvm_bindir from the toolchain.cmake, but the toolchain.cmake
+          # is sometimes evaluated without the project's CMakeCache.txt entries. Pass them through
+          # the environment :-/
           export ORT_BUILD_LINUX_TOOLCHAIN_ROOT="${toolchain_root}"
+          export ORT_BUILD_LLVM_BINDIR="$(get_llvm_bindir)"
+
+          # The wheel is built on an x86_64 host but targets aarch64; override the
+          # platform tag so the wheel is correctly named linux_aarch64.
+          export ONNXRUNTIME_WHEEL_PLAT_NAME="linux_aarch64"
 
           platform_args+=(--cmake_extra_defines
                           CMAKE_TOOLCHAIN_FILE:FILEPATH="${toolchain_cmake}"
@@ -283,11 +294,24 @@ else
 
     python "${REPO_ROOT}/qcom/scripts/all/fetch_cmake_deps.py"
 
+    zip_args=()
+    if [ -n "${build_zip}" ]; then
+      log_info "Building zip asset."
+      zip_args+=(--build_zip_asset)
+      if [ -n "${ORT_VERSION_SUFFIX:-}" ]; then
+        zip_args+=(--version_suffix "${ORT_VERSION_SUFFIX}")
+      fi
+      if [ "${target_arch}" == "aarch64_oe_gcc11_2" ]; then
+        zip_args+=(--zip_asset_target_arch "aarch64")
+      fi
+    fi
+
     "${python_for_build}" ${REPO_ROOT}/tools/ci_build/build.py \
       "${action_args[@]}" \
       "${common_args[@]}" \
       "${qnn_args[@]}" \
-      "${platform_args[@]}"
+      "${platform_args[@]}" \
+      "${zip_args[@]}"
   fi
 
   if [ -n "${run_tests}" ]; then

--- a/qcom/scripts/linux/linux-aarch64-gcc11.toolchain.cmake
+++ b/qcom/scripts/linux/linux-aarch64-gcc11.toolchain.cmake
@@ -30,10 +30,11 @@ set(LINUX_TOOLCHAIN_PLATFORM "armv8a-oe-linux")
 
 set(LINUX_TOOLCHAIN_SYSROOT "${LINUX_TOOLCHAIN_ROOT}/sysroots/${LINUX_TOOLCHAIN_PLATFORM}")
 
-if(APPLE)
-  set(LLVM_ROOT "/opt/homebrew/Cellar/llvm@16/16.0.6_1/bin")
-else()
-  set(LLVM_ROOT "/usr/lib/llvm-16/bin")
+# the LLVM bin directory, passed in via the environment since toolchain files are
+# sometimes evaluated without the project's CMakeCache.txt
+set(LLVM_ROOT "$ENV{ORT_BUILD_LLVM_BINDIR}")
+if (NOT IS_DIRECTORY "${LLVM_ROOT}")
+  message(FATAL_ERROR "LLVM_ROOT ${LLVM_ROOT} is not a directory. Set ORT_BUILD_LLVM_BINDIR to the LLVM bin directory.")
 endif()
 
 ##

--- a/qcom/scripts/linux/tools.sh
+++ b/qcom/scripts/linux/tools.sh
@@ -88,6 +88,13 @@ function get_linux_oe_gcc112_toolchain_root() {
 }
 
 #
+# Get the directory containing LLVM/Clang binaries, installing them if necessary.
+#
+function get_llvm_bindir() {
+    get_package_bindir llvm_$(get_host_platform)
+}
+
+#
 # Get the directory containing ninja, installing it if necessary.
 #
 function get_ninja_bindir() {

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,8 @@ manylinux_tags = [
     "manylinux_2_34_aarch64",
 ]
 is_manylinux = environ.get("AUDITWHEEL_PLAT", None) in manylinux_tags
+linux_aarch64_tags = ["linux_aarch64"]
+is_linux_aarch64 = environ.get("ONNXRUNTIME_WHEEL_PLAT_NAME", None) in linux_aarch64_tags
 
 
 class build_ext(_build_ext):  # noqa: N801
@@ -102,6 +104,11 @@ try:
             _bdist_wheel.finalize_options(self)
             if not is_manylinux:
                 self.root_is_pure = False
+            # Allow callers to override the wheel platform tag, e.g. when
+            # cross-compiling for a different architecture.
+            plat_name_override = environ.get("ONNXRUNTIME_WHEEL_PLAT_NAME", None)
+            if plat_name_override:
+                self.plat_name = plat_name_override
 
         def run(self):
             _bdist_wheel.run(self)
@@ -158,6 +165,21 @@ if platform.system() == "Linux" or platform.system() == "AIX":
         "libQnnSystem.so",
         "libHtpPrepare.so",
     ]
+    if is_linux_aarch64:
+        qnn_deps.extend(
+            [
+                "libQnnHtpV69Skel.so",
+                "libQnnHtpV69Stub.so",
+                "libQnnHtpV73Skel.so",
+                "libQnnHtpV73Stub.so",
+                "libQnnHtpV75Skel.so",
+                "libQnnHtpV75Stub.so",
+                "libQnnHtpV79Skel.so",
+                "libQnnHtpV79Stub.so",
+                "libQnnHtpV81Skel.so",
+                "libQnnHtpV81Stub.so",
+            ]
+        )
     dl_libs.extend(qnn_deps)
 else:
     # QNN-EP is built as shared libs
@@ -185,7 +207,7 @@ else:
     ]
     libs.extend(qnn_deps)
 
-if is_manylinux:
+if is_manylinux or is_linux_aarch64:
     data = list(dl_libs)
 else:
     data = list(libs)

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1101,6 +1101,7 @@ def main():
                 args.zip_asset_name_suffix,
                 args.version_suffix,
                 use_ninja=(args.cmake_generator == "Ninja"),
+                target_arch=args.zip_asset_target_arch,
             )
 
     if args.gen_doc:

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -392,6 +392,13 @@ def add_packaging_args(parser: argparse.ArgumentParser) -> None:
         "--zip_asset_name_suffix",
         help="Suffix for zip asset name (used for nightly builds).",
     )
+    parser.add_argument(
+        "--zip_asset_target_arch",
+        type=str,
+        default=None,
+        help="Target architecture for zip asset (e.g., 'aarch64', 'x64'). "
+        "If not specified, the local machine architecture is used.",
+    )
 
 
 def add_java_binding_args(parser: argparse.ArgumentParser) -> None:

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -83,6 +83,16 @@ def get_qnn_asset_file_list():
             "libQnnHtpPrepare.so",
             "libQnnHtpV68Skel.so",
             "libQnnHtpV68Stub.so",
+            "libQnnHtpV69Skel.so",
+            "libQnnHtpV69Stub.so",
+            "libQnnHtpV73Skel.so",
+            "libQnnHtpV73Stub.so",
+            "libQnnHtpV75Skel.so",
+            "libQnnHtpV75Stub.so",
+            "libQnnHtpV79Skel.so",
+            "libQnnHtpV79Stub.so",
+            "libQnnHtpV81Skel.so",
+            "libQnnHtpV81Stub.so",
             "libQnnIr.so",
             "libQnnSaver.so",
             "libQnnSystem.so",
@@ -99,6 +109,7 @@ def build_zip_asset(
     zip_name_suffix=None,
     version_suffix="",
     use_ninja=False,
+    target_arch=None,
 ):
     """
     Build zip asset packages containing QNN EP and dependencies.
@@ -110,6 +121,8 @@ def build_zip_asset(
         zip_name_suffix: Optional suffix for zip filename
         version_suffix: Optional version suffix for zip filename
         use_ninja: Whether Ninja generator was used
+        target_arch: Optional target architecture for cross-compilation (e.g., 'aarch64', 'x64').
+                     If None, the local machine architecture is used.
 
     Returns:
         list[Path]: List of created zip file paths
@@ -138,7 +151,10 @@ def build_zip_asset(
         platform_abbr = {"windows": "win"}
         if platform_name in platform_abbr:
             platform_name = platform_abbr[platform_name]
-        arch = platform.machine().lower()
+        if target_arch is not None:
+            arch = target_arch.lower()
+        else:
+            arch = platform.machine().lower()
         if arch == "amd64":
             arch = "x64"
         elif arch == "x86_64":
@@ -254,6 +270,14 @@ Examples:
 
     parser.add_argument("--use_ninja", action="store_true", help="Whether Ninja generator was used for build")
 
+    parser.add_argument(
+        "--target_arch",
+        type=str,
+        default=None,
+        help="Target architecture for cross-compilation (e.g., 'aarch64', 'x64'). "
+        "If not specified, the local machine architecture is used.",
+    )
+
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
 
     args = parser.parse_args()
@@ -274,6 +298,7 @@ Examples:
             zip_name_suffix=args.suffix,
             version_suffix=args.version_suffix,
             use_ninja=args.use_ninja,
+            target_arch=args.target_arch,
         )
 
         print(f"Successfully created {len(created_zips)} zip package(s):")


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Add CI workflow jobs to build Python 3.11–3.14 wheels for linux/aarch64_oe_gcc11_2
- Fix build_and_test.py to pass target_py_version and build_zip flag to aarch64 OE GCC11.2 tasks
- Add --build-zip flag to build.sh; invoke pkg_assets.py post-build to produce zip archives
- Add llvm_linux_x86_64 package entry to packages.yml and get_llvm_bindir() helper in tools.sh
- Replace hardcoded LLVM paths in toolchain.cmake with ORT_BUILD_LLVM_BINDIR env var
- Set ONNXRUNTIME_WHEEL_PLAT_NAME=linux_aarch64 during cross-compilation for correct wheel naming
- Support ONNXRUNTIME_WHEEL_PLAT_NAME override in setup.py bdist_wheel
- Add --target_arch flag to pkg_assets.py for cross-compilation zip naming


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Add Linux aarch64 OE GCC11.2 cross-compilation support for wheels and zips


