### PR TITLE
Add another case we need to split GEMM

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -152,7 +152,9 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                        std::vector<std::string>&& input_names,
                                                        const Ort::Logger& logger,
                                                        bool do_op_validation) const {
-  // FullyConnected dosen't support 2d bias with shape [N, M], In this case, decompose Gemm into FullyConnected + Add for compatibility.
+  // Decompose Gemm into FullyConnected + Add when:
+  // 1. Bias (input C) has 2D shape [N, M] where N != 1 (FC doesn't support this shape), OR
+  // 2. Bias is an intermediate (NATIVE) tensor produced by another op (QNN FC requires static bias).
   bool split_gemm = false;
   if (node_unit.Inputs().size() == 3) {
     auto& input_c = node_unit.Inputs()[2];
@@ -161,6 +163,12 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
     // Split when input_c has 2d shape and not [1, M]
     split_gemm = (input_c_shape.size() == 2 && input_c_shape.at(0) != 1);
+
+    // Split when bias is an intermediate (NATIVE) tensor produced by another op.
+    // ORT's MatMulAddFusion can fuse MatMul+Add->Gemm where the Add's other input
+    // is an intermediate tensor (e.g., output of another MatMul). QNN FC requires
+    // bias to be either STATIC (constant) or APP_WRITE (graph input), not NATIVE.
+    split_gemm = split_gemm || qnn_model_wrapper.GetTensorType(input_c.name) == QNN_TENSOR_TYPE_NATIVE;
   }
 
   if (split_gemm) {

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -496,6 +496,68 @@ TEST_F(QnnHTPBackendTests, Gemm_TransAB_Dynamic_B_And_Bias) {
                                         ExpectedEPNodeAssignment::All);
 }
 
+// Reproduces the CLIP text projection averaging pattern where ORT's MatMulAddFusion
+// creates Gemm nodes with intermediate (NATIVE) bias:
+//   A1 -> MatMul(W) -> mm1  (stays as MatMul)
+//   A2 -> Gemm(W, C=mm1)   -> add1  (C is NATIVE)
+//   A3 -> Gemm(W, C=add1)  -> add2  (C is NATIVE)
+//   A4 -> Gemm(W, C=add2)  -> add3  (C is NATIVE)
+namespace {
+GetTestModelFn BuildGemmFromMatMulAddTestCase(int64_t K, int64_t N) {
+  return [K, N](ModelTestBuilder& builder) {
+    constexpr int64_t batch = 1;
+    const std::vector<int64_t> input_shape = {batch, K};
+    const std::vector<int64_t> weight_shape = {K, N};
+
+    // 4 dynamic inputs
+    builder.MakeInput<float>("A1", input_shape, -1.0f, 1.0f);
+    builder.MakeInput<float>("A2", input_shape, -1.0f, 1.0f);
+    builder.MakeInput<float>("A3", input_shape, -1.0f, 1.0f);
+    builder.MakeInput<float>("A4", input_shape, -1.0f, 1.0f);
+
+    // Shared static weight
+    builder.MakeInitializer<float>("W", weight_shape, -1.0f, 1.0f);
+
+    // 4 MatMul nodes
+    builder.AddNode("matmul_1", "MatMul", {"A1", "W"}, {"mm1"});
+    builder.AddNode("matmul_2", "MatMul", {"A2", "W"}, {"mm2"});
+    builder.AddNode("matmul_3", "MatMul", {"A3", "W"}, {"mm3"});
+    builder.AddNode("matmul_4", "MatMul", {"A4", "W"}, {"mm4"});
+
+    // Chain of Adds: add1 = mm1 + mm2, add2 = add1 + mm3, add3 = add2 + mm4
+    builder.AddNode("add_1", "Add", {"mm1", "mm2"}, {"add1"});
+    builder.AddNode("add_2", "Add", {"add1", "mm3"}, {"add2"});
+    builder.AddNode("add_3", "Add", {"add2", "mm4"}, {"add3"});
+
+    builder.MakeOutput("add3");
+  };
+}
+}  // namespace
+
+TEST_F(QnnHTPBackendTests, GemmFromMatMulAddNonStaticBias) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildGemmFromMatMulAddTestCase(/*K=*/4, /*N=*/3),
+                  provider_options,
+                  /*opset=*/18,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+TEST_F(QnnCPUBackendTests, GemmFromMatMulAddNonStaticBias) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildGemmFromMatMulAddTestCase(/*K=*/4, /*N=*/3),
+                  provider_options,
+                  /*opset=*/18,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if defined(_M_ARM64)

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -542,8 +542,8 @@ TEST_F(QnnHTPBackendTests, GemmFromMatMulAddNonStaticBias) {
   RunQnnModelTest(BuildGemmFromMatMulAddTestCase(/*K=*/4, /*N=*/3),
                   provider_options,
                   /*opset=*/18,
-                  ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-2f);
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-3f);
 }
 
 TEST_F(QnnCPUBackendTests, GemmFromMatMulAddNonStaticBias) {
@@ -554,8 +554,7 @@ TEST_F(QnnCPUBackendTests, GemmFromMatMulAddNonStaticBias) {
   RunQnnModelTest(BuildGemmFromMatMulAddTestCase(/*K=*/4, /*N=*/3),
                   provider_options,
                   /*opset=*/18,
-                  ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Description
Split when bias is an intermediate (NATIVE) tensor produced by another op.

### Motivation and Context

1. ORT's `MatMulAddFusion`** (runs before QNN EP sees the graph) fuses `MatMul + Add → Gemm`. This is a general ORT graph optimization that fires whenever it sees the pattern — it doesn't know or care what the Add's second input is.

2. **The problematic pattern** — CLIP-style text projection averaging:
   ```
   mm1 = MatMul(A1, W)
   mm2 = MatMul(A2, W)
   add1 = mm1 + mm2          ← MatMulAddFusion fires: becomes Gemm(A1, W, C=mm2)
   add2 = add1 + mm3         ← MatMulAddFusion fires: becomes Gemm(A1(?), W, C=add1)
   ```
   After fusion, the `C` (bias) input to Gemm is `mm2` or `add1` — an **intermediate NATIVE tensor**, not a constant or graph input.

3. **QNN `FullyConnected` constraint**: QNN's FC op requires the bias to be `STATIC` (initializer/constant) or `APP_WRITE` (graph input). It **cannot accept a `NATIVE` tensor** (intermediate output of another op) as bias. This would cause a validation/compilation failure.

4. **The fix**: When the bias is `NATIVE`, decompose `Gemm → FC(A, W) + ElementWiseAdd(fc_output, C)`. The Add op has no such restriction on input types.


Fixes following issue: 
```
Node(s) placed on [CPUExecutionProvider]. Number of nodes: 17
DequantizeLinear (QcQuantizeOp_model.box_head.conv1_ctr.0.weight_dq)
DequantizeLinear (QcQuantizeOp_model.box_head.conv1_offset.0.weight_dq)
DequantizeLinear (QcQuantizeOp_model.box_head.conv1_size.0.weight_dq)
DequantizeLinear (QcQuantizeOp_model.box_head.conv5_offset.weight_dq)
DequantizeLinear (QcQuantizeOp_val_176_dq)
DequantizeLinear (QcQuantizeOp_val_22_dq)
DequantizeLinear (QcQuantizeOp_val_26_dq)
Gemm (node_MatMul_21/MatMulAddFusion)
Gemm (node_MatMul_23/MatMulAddFusion)
Gemm (node_MatMul_131/MatMulAddFusion)
DequantizeLinear (node_MatMul_21/MatMulAddFusion_bias_dq)
DequantizeLinear (node_MatMul_23/MatMulAddFusion_bias_dq)
DequantizeLinear (node_MatMul_131/MatMulAddFusion_bias_dq)
DequantizeLinear (node_Conv_145_bias_dq)
DequantizeLinear (node_Conv_137_bias_dq)
DequantizeLinear (node_Conv_141_bias_dq)
DequantizeLinear (node_conv2d_11_bias_dq)
```