### PR TITLE
Use Internal Artifactory for Packages

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -187,21 +187,19 @@ jobs:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-wheels"
           src_pattern: "${{ inputs.target_os }}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime_qnn*.whl"
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload NuGet to Artifactory
         if: ${{ inputs.upload_nuget }}
+        uses: ./.github/actions/upload-ci-artifact
         with:
-          name: ORT ${{inputs.target_os}} ${{ inputs.target_arch }} Python ${{ inputs.target_py_vsn }} QNN NuGet Package
-          retention-days: 7
-          path: |
-            ${{ github.workspace }}/build/${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/Qualcomm.ML.OnnxRuntime.QNN*.nupkg
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-nuget"
+          src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/Qualcomm.ML.OnnxRuntime.QNN*.nupkg"
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload Zip to Artifactory
         if: ${{ inputs.upload_zip }}
+        uses: ./.github/actions/upload-ci-artifact
         with:
-          name: ORT ${{inputs.target_os}} ${{ inputs.target_arch }} Python ${{ inputs.target_py_vsn }} Zip Asset
-          retention-days: 7
-          path: |
-            ${{ github.workspace }}/build/${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime-qnn*.zip
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-zip"
+          src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime-qnn*.zip"
 
   test:
     name: "test-${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}"

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -176,19 +176,34 @@ jobs:
         with:
           name: windows-x86_64-py3.14-wheels
 
-      # TODO(mbadnara): Switch to download-ci-artifact
-      - name: Download Artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ORT windows arm64 Python 3.11 QNN NuGet Package
-          path: ${{ github.workspace }}/build/nuget
+      - name: Verify wheel artifacts
+        run: |
+          count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
+          echo "Found $count wheel(s)"
+          # 1 linux x86_64 + 3 win archs × 4 py versions = 13 expected
+          [ "$count" -ge 13 ] || { echo "ERROR: Expected at least 13 wheels, found $count"; exit 1; }
 
-      # TODO(mbadnara): Switch to download-ci-artifact
-      - name: Download Artifact
-        uses: actions/download-artifact@v8
+      - name: Download NuGet from Artifactory
+        uses: ./.github/actions/download-ci-artifact
         with:
-          name: ORT windows arm64 Python 3.11 Zip Asset
-          path: ${{ github.workspace }}/build/zip
+          name: windows-arm64-py3.11-nuget
+
+      - name: Verify NuGet artifact
+        run: |
+          count=$(find "${{ github.workspace }}/build/windows-arm64/Release" -maxdepth 1 -name "*.nupkg" | wc -l)
+          echo "Found $count NuGet package(s)"
+          [ "$count" -ge 1 ] || { echo "ERROR: Expected at least 1 NuGet package, found $count"; exit 1; }
+
+      - name: Download Zip from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.11-zip
+
+      - name: Verify Zip artifact
+        run: |
+          count=$(find "${{ github.workspace }}/build/windows-arm64/Release/dist" -maxdepth 1 -name "*.zip" | wc -l)
+          echo "Found $count Zip archive(s)"
+          [ "$count" -ge 1 ] || { echo "ERROR: Expected at least 1 Zip archive, found $count"; exit 1; }
 
       - name: Merge AMD Wheels
         run: |

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -176,34 +176,15 @@ jobs:
         with:
           name: windows-x86_64-py3.14-wheels
 
-      - name: Verify wheel artifacts
-        run: |
-          count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
-          echo "Found $count wheel(s)"
-          # 1 linux x86_64 + 3 win archs × 4 py versions = 13 expected
-          [ "$count" -ge 13 ] || { echo "ERROR: Expected at least 13 wheels, found $count"; exit 1; }
-
       - name: Download NuGet from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-nuget
 
-      - name: Verify NuGet artifact
-        run: |
-          count=$(find "${{ github.workspace }}/build/windows-arm64/Release" -maxdepth 1 -name "*.nupkg" | wc -l)
-          echo "Found $count NuGet package(s)"
-          [ "$count" -ge 1 ] || { echo "ERROR: Expected at least 1 NuGet package, found $count"; exit 1; }
-
       - name: Download Zip from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-zip
-
-      - name: Verify Zip artifact
-        run: |
-          count=$(find "${{ github.workspace }}/build/windows-arm64/Release/dist" -maxdepth 1 -name "*.zip" | wc -l)
-          echo "Found $count Zip archive(s)"
-          [ "$count" -ge 1 ] || { echo "ERROR: Expected at least 1 Zip archive, found $count"; exit 1; }
 
       - name: Merge AMD Wheels
         run: |
@@ -224,6 +205,26 @@ jobs:
           rm -fr "${{ github.workspace }}/build/dist/x86_64/" "${{ github.workspace }}/build/dist/arm64ec/"
           find "${{ github.workspace }}/build/windows-arm64ec" -name "*.whl" -delete
           find "${{ github.workspace }}/build/windows-x86_64" -name "*.whl" -delete
+
+      - name: Verify wheel artifacts
+        run: |
+          # After merge: 1 linux x86_64 + 4 arm64 + 4 merged AMD = 9 wheels
+          # (arm64ec and x86_64 originals are deleted by the merge step above)
+          count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
+          echo "Found $count wheel(s)"
+          [ "$count" -eq 9 ] || { echo "ERROR: Expected 9 wheels, found $count"; exit 1; }
+
+      - name: Verify NuGet artifact
+        run: |
+          count=$(find "${{ github.workspace }}/build" -name "*.nupkg" | wc -l)
+          echo "Found $count NuGet package(s)"
+          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 NuGet package, found $count"; exit 1; }
+
+      - name: Verify Zip artifact
+        run: |
+          count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
+          echo "Found $count Zip archive(s)"
+          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 Zip archive, found $count"; exit 1; }
 
       - name: Set QA Build Tag
         run: |

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   workflow_call:
-    inputs:
+    inputs: &common_inputs
       nightly_build:
         description: "If true, include a verbose version string in file names."
         type: boolean
@@ -28,8 +28,11 @@ on:
         type: string
         default: "['3.11','3.12','3.13','3.14']"
       skip_publish:
+        description: "If true, skip publishing artifacts (dry run)."
         type: boolean
         default: false
+  workflow_dispatch:
+    inputs: *common_inputs
 
 env:
   BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
@@ -126,6 +129,13 @@ jobs:
         with:
           name: windows-x86_64-py3.14-wheels
 
+      - name: Verify wheel artifacts
+        run: |
+          count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
+          echo "Found $count wheel(s)"
+          # 3 win archs × 4 py versions = 12 expected
+          [ "$count" -ge 12 ] || { echo "ERROR: Expected at least 12 wheels, found $count"; exit 1; }
+
       - name: Consolidate Wheels
         run: |
           mkdir "${{ github.workspace }}/build/dist"
@@ -179,12 +189,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Download Nuget package from Artifactory
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v5
         with:
-          name: ORT windows arm64 Python 3.11 QNN NuGet Package
-          path: ${{ github.workspace }}/build/nuget
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Download NuGet from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.11-nuget
+
+      - name: Verify NuGet artifact
+        shell: powershell
+        run: |
+          $count = (Get-ChildItem -Path "${{ github.workspace }}\build\windows-arm64\Release" -Filter "*.nupkg").Count
+          Write-Host "Found $count NuGet package(s)"
+          if ($count -lt 1) { Write-Error "Expected at least 1 NuGet package, found $count"; exit 1 }
 
       - name: Publish
         if: ${{ !inputs.skip_publish }}
@@ -203,7 +227,7 @@ jobs:
           uv pip install -r .\qcom\requirements.txt
 
           . ".\qcom\scripts\upleveling\upload_nupkg_to_artifactory.ps1" `
-            -InputDir "${{ github.workspace }}\build\nuget"
+            -InputDir "${{ github.workspace }}\build\windows-arm64\Release"
 
   upload-zip-workflow:
     name: "Upload zip artifatcs to Artifactory"
@@ -213,12 +237,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Download Zip package from Artifactory
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v5
         with:
-          name: ORT windows arm64 Python 3.11 Zip Asset
-          path: ${{ github.workspace }}/build/zip
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Download Zip from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.11-zip
+
+      - name: Verify Zip artifact
+        run: |
+          count=$(find "${{ github.workspace }}/build/windows-arm64/Release/dist" -maxdepth 1 -name "*.zip" | wc -l)
+          echo "Found $count Zip archive(s)"
+          [ "$count" -ge 1 ] || { echo "ERROR: Expected at least 1 Zip archive, found $count"; exit 1; }
 
       - name: Publish
         if: ${{ !inputs.skip_publish }}
@@ -237,7 +274,7 @@ jobs:
 
           # Upload files using the upload script
           ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
-            "${{ github.workspace }}/build/zip" \
+            "${{ github.workspace }}/build/windows-arm64/Release/dist" \
             "$NETRC_FILE"
 
           # Clean up the temporary .netrc file

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -129,13 +129,6 @@ jobs:
         with:
           name: windows-x86_64-py3.14-wheels
 
-      - name: Verify wheel artifacts
-        run: |
-          count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
-          echo "Found $count wheel(s)"
-          # 3 win archs × 4 py versions = 12 expected
-          [ "$count" -ge 12 ] || { echo "ERROR: Expected at least 12 wheels, found $count"; exit 1; }
-
       - name: Consolidate Wheels
         run: |
           mkdir "${{ github.workspace }}/build/dist"
@@ -163,6 +156,13 @@ jobs:
             "${{ github.workspace }}/build/dist/x64" \
             "${{ github.workspace }}/build/dist/arm64ec" \
             "${{ github.workspace }}/build/dist"
+
+      - name: Verify wheel artifacts
+        run: |
+          # After merge: 4 arm64 + 4 merged AMD wheels in build/dist/
+          count=$(find "${{ github.workspace }}/build/dist" -name "*.whl" | wc -l)
+          echo "Found $count wheel(s) in build/dist"
+          [ "$count" -eq 8 ] || { echo "ERROR: Expected 8 wheels in build/dist, found $count"; exit 1; }
 
       - name: Check Wheels
         run: |
@@ -206,9 +206,9 @@ jobs:
       - name: Verify NuGet artifact
         shell: powershell
         run: |
-          $count = (Get-ChildItem -Path "${{ github.workspace }}\build\windows-arm64\Release" -Filter "*.nupkg").Count
+          $count = (Get-ChildItem -Path "${{ github.workspace }}\build" -Recurse -Filter "*.nupkg").Count
           Write-Host "Found $count NuGet package(s)"
-          if ($count -lt 1) { Write-Error "Expected at least 1 NuGet package, found $count"; exit 1 }
+          if ($count -ne 1) { Write-Error "Expected 1 NuGet package, found $count"; exit 1 }
 
       - name: Publish
         if: ${{ !inputs.skip_publish }}
@@ -253,9 +253,9 @@ jobs:
 
       - name: Verify Zip artifact
         run: |
-          count=$(find "${{ github.workspace }}/build/windows-arm64/Release/dist" -maxdepth 1 -name "*.zip" | wc -l)
+          count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
           echo "Found $count Zip archive(s)"
-          [ "$count" -ge 1 ] || { echo "ERROR: Expected at least 1 Zip archive, found $count"; exit 1; }
+          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 Zip archive, found $count"; exit 1; }
 
       - name: Publish
         if: ${{ !inputs.skip_publish }}


### PR DESCRIPTION
- Migrates NuGet and Zip artifact storage fully to internal CI artifact storage by replacing all remaining `actions/download-artifact` and `actions/upload-artifact` calls with the internal `upload-ci-artifact` / `download-ci-artifact` actions. 
- Adds a manual trigger and file-count sanity checks to the release workflows so dry runs can validate the artifact pipeline end-to-end without publishing.
- NuGet and Zip build outputs are now stored via the internal artifact mechanism, removing the last uses of the external artifact storage action
- Replaced the two remaining external artifact download calls with internal equivalents
- Added exact file-count checks for wheels, NuGet, and Zip that run after the wheel merge step
- Added a manual dispatch trigger for dry-run testing with `skip_publish`

