### PR TITLE
Shorten CI artifact retention to 18 hours

### DIFF
--- a/qcom/scripts/artifactory/aql/expired_ci_artifacts.json
+++ b/qcom/scripts/artifactory/aql/expired_ci_artifacts.json
@@ -6,7 +6,7 @@
                     "repo": "${repo}",
                     "$and": [
                         {
-                            "created": { "$before": "1d" },
+                            "created": { "$before": "1080minutes" },
                             "path": { "$match": "ci/*" }
                         }
                     ]


### PR DESCRIPTION
### Description

Shorten the official retention of temporary CI artifacts to 18 hours.

### Motivation and Context

While the scheduled job continues to run only every 24 hours, this should alleviate problems with the daily release job attempting to publish the previous day's wheels.

