### PR TITLE
Add uniqueness to schedule job CI artifacts

### DIFF
--- a/qcom/scripts/artifactory/artifactory.py
+++ b/qcom/scripts/artifactory/artifactory.py
@@ -60,6 +60,10 @@ class CiArtifactory(Artifactory):
         run_id = os.environ["GITHUB_RUN_ID"]
         self.__ref = os.environ.get("GITHUB_REF", f"{actor}/{run_id}")
 
+        # If this is an ad hoc job, avoid clobbering artifacts from earlier runs.
+        if os.environ["GITHUB_EVENT_NAME"] in ("schedule", "workflow_dispatch"):
+            self.__ref = f"{self.__ref}/{os.environ['GITHUB_RUN_ID']}"
+
     @property
     def artifact_root(self) -> str:
         return f"{super().repo_path}/ci/{self.__ref}/{self.__commit_hash[:10]}/{self.__name}"


### PR DESCRIPTION
### Description

Add a workflow-unique string to CI artifact paths when running ad hoc tasks.

### Motivation and Context

Nightly publishing jobs sometimes fail trying to upload wheels from the previous day because they're written into the same path and not expired in time.

