### PR TITLE
Fix GlobalMaxPool with rank-3 input claimed support but failed compile

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -14,6 +14,23 @@
 namespace onnxruntime {
 namespace qnn {
 
+struct QnnPoolConfig {
+  const char* op;
+  const char* param_filter_size;
+  const char* param_stride;
+  const char* param_pad_amount;
+  const char* param_rounding_mode;
+  const char* param_count_pad_for_edges;
+};
+
+struct QnnPoolParams {
+  std::vector<uint32_t> filter_size;
+  std::vector<uint32_t> stride;
+  std::vector<uint32_t> pad_amount;
+  int32_t rounding_mode{0};
+  bool count_pad_for_edges{false};
+};
+
 class PoolOpBuilder : public BaseOpBuilder {
  public:
   PoolOpBuilder() : BaseOpBuilder("PoolOpBuilder") {}
@@ -43,9 +60,66 @@ class PoolOpBuilder : public BaseOpBuilder {
                                   std::vector<uint32_t>& stride,
                                   std::vector<uint32_t>& pad_amount,
                                   int32_t& rounding_mode,
-                                  std::vector<uint32_t>&& input_shape,
-                                  std::vector<uint32_t>&& output_shape) const;
+                                  gsl::span<const uint32_t> input_shape,
+                                  gsl::span<const uint32_t> output_shape) const;
+  Ort::Status AddQnnPoolParamWrappers(const OrtNodeUnit& node_unit,
+                                      const QnnPoolConfig& qnn_pool_config,
+                                      QnnPoolParams&& qnn_pool_params,
+                                      std::vector<std::string>& param_tensor_names,
+                                      QnnModelWrapper& qnn_model_wrapper) const;
+  Ort::Status AddQnnPoolNode(QnnModelWrapper& qnn_model_wrapper,
+                             const OrtNodeUnit& node_unit,
+                             std::vector<std::string>&& input_names,
+                             std::vector<std::string>&& param_tensor_names,
+                             const QnnPoolConfig& qnn_pool_config,
+                             const TensorInfo& input_info,
+                             bool requires_rank3_reshape,
+                             std::vector<uint32_t>&& intermediate_output_shape_4d,
+                             const Ort::Logger& logger,
+                             bool do_op_validation) const;
 };
+
+namespace {
+
+// Rank 4 (NHWC) -> QNN Pool2D, Rank 5 (NDHWC) -> QNN Pool3D.
+// Rank 3 inputs are reshaped to rank 4 before reaching here.
+Ort::Status GetQnnPoolConfig(bool is_max_pool, size_t rank, QnnPoolConfig& config) {
+  RETURN_IF_NOT(rank == 4 || rank == 5, "GetQnnPoolConfig expects rank 4 or 5.");
+
+  if (rank == 4 && is_max_pool) {
+    config = {QNN_OP_POOL_MAX_2D,
+              QNN_OP_POOL_MAX_2D_PARAM_FILTER_SIZE,
+              QNN_OP_POOL_MAX_2D_PARAM_STRIDE,
+              QNN_OP_POOL_MAX_2D_PARAM_PAD_AMOUNT,
+              QNN_OP_POOL_MAX_2D_PARAM_ROUNDING_MODE,
+              nullptr};
+  } else if (rank == 4) {
+    config = {QNN_OP_POOL_AVG_2D,
+              QNN_OP_POOL_AVG_2D_PARAM_FILTER_SIZE,
+              QNN_OP_POOL_AVG_2D_PARAM_STRIDE,
+              QNN_OP_POOL_AVG_2D_PARAM_PAD_AMOUNT,
+              QNN_OP_POOL_AVG_2D_PARAM_ROUNDING_MODE,
+              QNN_OP_POOL_AVG_2D_PARAM_COUNT_PAD_FOR_EDGES};
+  } else if (is_max_pool) {
+    config = {QNN_OP_POOL_MAX_3D,
+              QNN_OP_POOL_MAX_3D_PARAM_FILTER_SIZE,
+              QNN_OP_POOL_MAX_3D_PARAM_STRIDE,
+              QNN_OP_POOL_MAX_3D_PARAM_PAD_AMOUNT,
+              QNN_OP_POOL_MAX_3D_PARAM_ROUNDING_MODE,
+              nullptr};
+  } else {
+    config = {QNN_OP_POOL_AVG_3D,
+              QNN_OP_POOL_AVG_3D_PARAM_FILTER_SIZE,
+              QNN_OP_POOL_AVG_3D_PARAM_STRIDE,
+              QNN_OP_POOL_AVG_3D_PARAM_PAD_AMOUNT,
+              QNN_OP_POOL_AVG_3D_PARAM_ROUNDING_MODE,
+              QNN_OP_POOL_AVG_3D_PARAM_COUNT_PAD_FOR_EDGES};
+  }
+
+  return Ort::Status();
+}
+
+}  // namespace
 
 // Pool ops are sensitive with data layout, no special validation so far
 // The nodes from 1st call of GetCapability do not get layout transformer applied, it's still NCHW
@@ -66,7 +140,6 @@ Ort::Status PoolOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   size_t rank = input_shape.size();
   RETURN_IF_NOT(rank == 3 || rank == 4 || rank == 5, "QNN Pool only supports rank 3, 4, or 5!");
 
-  // ONNX MaxPool may have two outputs.
   RETURN_IF(node_unit.Outputs().size() > 1, "QNN Pool only supports 1 output!");
 
   OrtNodeAttrHelper node_helper(node_unit);
@@ -86,44 +159,9 @@ Ort::Status PoolOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
               ("QNN Pool operators do not support 'auto_pad' value: " + auto_pad).c_str());
   }
 
-  if (node_unit.Domain() == kMSInternalNHWCDomain) {  // Use QNN validation API if layout is NHWC.
+  if (node_unit.Domain() == kMSInternalNHWCDomain) {
     return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
   }
-
-  return Ort::Status();
-}
-
-Ort::Status AmendOutputShapeForRank3Pool(
-    gsl::span<const uint32_t> input_shape,   // {N, H, W, C}
-    gsl::span<const uint32_t> kernel_shape,  // {k_h, k_w}
-    gsl::span<const uint32_t> strides,       // {s_h, s_w}
-    gsl::span<const uint32_t> pads,
-    std::vector<uint32_t>& output_shape) {
-  RETURN_IF_NOT(input_shape.size() == 4, "Expecting input rank 4 for amending 1D Pool output shape.");
-  RETURN_IF_NOT(kernel_shape.size() == 2, "Expecting kernel size 2 for amending 1D Pool output shape.");
-  RETURN_IF_NOT(strides.size() == 2, "Expecting strides size 2 for amending 1D Pool output shape.");
-  RETURN_IF_NOT(pads.size() == 4, "Expecting pad size 4 for amending 1D Pool output shape.");
-
-  const uint32_t N = input_shape[0];
-  const uint32_t H = input_shape[1];
-  const uint32_t W = input_shape[2];
-  const uint32_t C = input_shape[3];
-  // pad the spatial dims
-  uint32_t padded_H = H + pads[0] + pads[2];
-  uint32_t padded_W = W + pads[1] + pads[3];
-  // floor-mode on NHWC
-  uint32_t out_H = (padded_H < kernel_shape[0])
-                       ? 0
-                       : (padded_H - kernel_shape[0]) / strides[0] + 1;
-  uint32_t out_W = (padded_W < kernel_shape[1])
-                       ? 0
-                       : (padded_W - kernel_shape[1]) / strides[1] + 1;
-
-  output_shape.resize(4);
-  output_shape[0] = N;
-  output_shape[1] = out_H;
-  output_shape[2] = out_W;
-  output_shape[3] = C;
 
   return Ort::Status();
 }
@@ -133,11 +171,10 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
                                                std::vector<uint32_t>& stride,
                                                std::vector<uint32_t>& pad_amount,
                                                int32_t& rounding_mode,
-                                               std::vector<uint32_t>&& input_shape,
-                                               std::vector<uint32_t>&& output_shape) const {
-  size_t rank = input_shape.size();
+                                               gsl::span<const uint32_t> input_shape,
+                                               gsl::span<const uint32_t> output_shape) const {
+  const size_t rank = input_shape.size();
 
-  // Param: filter_size.
   {
     auto raw_filter_size = node_helper.Get("kernel_shape", std::vector<uint32_t>(rank - 2, 1));
     if (raw_filter_size.size() == 1) {
@@ -147,7 +184,6 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
     }
   }
 
-  // Param: stride.
   {
     auto raw_stride = node_helper.Get("strides", std::vector<uint32_t>(rank - 2, 1));
     if (raw_stride.size() == 1) {
@@ -157,7 +193,6 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
     }
   }
 
-  // Param: dilations (NOT SUPPORTED by QNN).
   std::vector<uint32_t> dilations;
   {
     auto raw_dilations = node_helper.Get("dilations", std::vector<uint32_t>(rank - 2, 1));
@@ -168,7 +203,6 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
     }
   }
 
-  // Param: pad_amount.
   {
     auto raw_pad_amount = node_helper.Get("pads", std::vector<uint32_t>((rank - 2) * 2, 0));
     if (raw_pad_amount.size() == 2) {
@@ -179,10 +213,6 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
   }
 
   auto auto_pad = node_helper.Get("auto_pad", std::string("NOTSET"));
-  if (output_shape.size() == 3) {
-    // Calculate rank-4 output shape for rank-3 input.
-    RETURN_IF_ERROR(AmendOutputShapeForRank3Pool(input_shape, filter_size, stride, pad_amount, output_shape));
-  }
   if (auto_pad.compare("NOTSET") != 0) {
     for (size_t axis = 0; axis < rank - 2; ++axis) {
       uint32_t total_pads = (output_shape[axis + 1] - 1) * stride[axis] +
@@ -197,25 +227,137 @@ Ort::Status PoolOpBuilder::SetCommonPoolParams(const OrtNodeAttrHelper& node_hel
     }
   }
 
-  // Param: rounding_mode.
   rounding_mode = node_helper.Get("ceil_mode", rounding_mode);
 
   return Ort::Status();
 }
 
-bool SetPoolParam(const OrtNodeUnit& node_unit,
-                  const std::string& param_name,
-                  std::vector<uint32_t>&& parm_shape,
-                  std::vector<uint32_t>&& parm_data,
-                  std::vector<std::string>& param_tensor_names,
-                  QnnModelWrapper& qnn_model_wrapper) {
-  QnnParamWrapper qnn_param(node_unit.Index(),
-                            node_unit.Name(),
-                            param_name,
-                            std::move(parm_shape),
-                            std::move(parm_data));
-  param_tensor_names.push_back(qnn_param.GetParamTensorName());
-  return qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
+Ort::Status PoolOpBuilder::AddQnnPoolParamWrappers(const OrtNodeUnit& node_unit,
+                                                   const QnnPoolConfig& qnn_pool_config,
+                                                   QnnPoolParams&& qnn_pool_params,
+                                                   std::vector<std::string>& param_tensor_names,
+                                                   QnnModelWrapper& qnn_model_wrapper) const {
+  {
+    QnnParamWrapper filter_size_param(node_unit.Index(), node_unit.Name(),
+                                      qnn_pool_config.param_filter_size,
+                                      {static_cast<uint32_t>(qnn_pool_params.filter_size.size())},
+                                      std::move(qnn_pool_params.filter_size));
+    param_tensor_names.push_back(filter_size_param.GetParamTensorName());
+    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(filter_size_param)),
+                  "Failed to add param filter_size.");
+  }
+
+  {
+    QnnParamWrapper stride_param(node_unit.Index(), node_unit.Name(),
+                                 qnn_pool_config.param_stride,
+                                 {static_cast<uint32_t>(qnn_pool_params.stride.size())},
+                                 std::move(qnn_pool_params.stride));
+    param_tensor_names.push_back(stride_param.GetParamTensorName());
+    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(stride_param)),
+                  "Failed to add param stride.");
+  }
+
+  {
+    ReArrangePads(qnn_pool_params.pad_amount);
+    QnnParamWrapper pad_amount_param(node_unit.Index(), node_unit.Name(),
+                                     qnn_pool_config.param_pad_amount,
+                                     {static_cast<uint32_t>(qnn_pool_params.pad_amount.size() / 2), 2},
+                                     std::move(qnn_pool_params.pad_amount));
+    param_tensor_names.push_back(pad_amount_param.GetParamTensorName());
+    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_param)),
+                  "Failed to add param pad_amount.");
+  }
+
+  if (qnn_pool_params.rounding_mode != 0) {
+    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
+    scalar_param.dataType = QNN_DATATYPE_UINT_32;
+    scalar_param.int32Value = qnn_pool_params.rounding_mode;
+    QnnParamWrapper rounding_mode_param(node_unit.Index(),
+                                        node_unit.Name(),
+                                        qnn_pool_config.param_rounding_mode,
+                                        scalar_param);
+    param_tensor_names.push_back(rounding_mode_param.GetParamTensorName());
+    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(rounding_mode_param)),
+                  "Failed to add param rounding_mode.");
+  }
+
+  if (qnn_pool_config.param_count_pad_for_edges != nullptr) {
+    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
+    scalar_param.dataType = QNN_DATATYPE_BOOL_8;
+    scalar_param.bool8Value = static_cast<uint8_t>(qnn_pool_params.count_pad_for_edges);
+    QnnParamWrapper count_pad_param(node_unit.Index(),
+                                    node_unit.Name(),
+                                    qnn_pool_config.param_count_pad_for_edges,
+                                    scalar_param);
+    param_tensor_names.push_back(count_pad_param.GetParamTensorName());
+    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(count_pad_param)),
+                  "Failed to add param count_pad_for_edges.");
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status PoolOpBuilder::AddQnnPoolNode(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          std::vector<std::string>&& param_tensor_names,
+                                          const QnnPoolConfig& qnn_pool_config,
+                                          const TensorInfo& input_info,
+                                          bool requires_rank3_reshape,
+                                          std::vector<uint32_t>&& intermediate_output_shape_4d,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const {
+  if (!requires_rank3_reshape) {
+    return ProcessOutputs(qnn_model_wrapper,
+                          node_unit,
+                          std::move(input_names),
+                          std::move(param_tensor_names),
+                          logger,
+                          do_op_validation,
+                          qnn_pool_config.op);
+  }
+
+  const std::string& final_output_name = node_unit.Outputs()[0].name;
+  const std::string intermediate_output_name = utils::UniqueNameGenerator().New(final_output_name, "_reshape_after");
+  TensorInfo output_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+
+  QnnTensorWrapper intermediate_output_tensor(intermediate_output_name,
+                                              QNN_TENSOR_TYPE_NATIVE,
+                                              input_info.qnn_data_type,
+                                              output_info.quant_param.Copy(),
+                                              std::move(intermediate_output_shape_4d));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(intermediate_output_tensor)),
+                "Failed to add tensor for pool_out.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, qnn_pool_config.op),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                qnn_pool_config.op,
+                                                {input_names[0]},
+                                                {intermediate_output_name},
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
+                "Failed to create pool node for rank-3 input.");
+
+  const bool final_output_is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
+  const Qnn_TensorType_t final_output_tensor_type = final_output_is_graph_output ? QNN_TENSOR_TYPE_APP_READ
+                                                                                 : QNN_TENSOR_TYPE_NATIVE;
+  QnnTensorWrapper final_output_tensor(final_output_name,
+                                       final_output_tensor_type,
+                                       output_info.qnn_data_type,
+                                       output_info.quant_param.Copy(),
+                                       std::vector<uint32_t>(output_info.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)),
+                "Failed to add reshape after tensor.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_RESHAPE,
+                                                {intermediate_output_name},
+                                                {final_output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create reshape after node for pool op.");
+
+  return Ort::Status();
 }
 
 Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
@@ -224,275 +366,87 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                        const Ort::Logger& logger,
                                                        bool do_op_validation) const {
   OrtNodeAttrHelper node_helper(node_unit);
-  // Get the NCHW from input data, use HW for the pool filter size and pool stride
   const auto& inputs = node_unit.Inputs();
-  std::vector<uint32_t> input_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input_shape), "Cannot get shape");
+  const std::string& op_type = node_unit.OpType();
+  const bool is_global_pool = (op_type == "GlobalMaxPool" || op_type == "GlobalAveragePool");
+  const bool is_avg_pool = (op_type == "AveragePool" || op_type == "GlobalAveragePool");
+  const bool is_max_pool = (op_type == "MaxPool" || op_type == "GlobalMaxPool");
 
-  // Reshape 3D input to 4D if necessary.
-  const auto& reshape_input = node_unit.Inputs()[0];
-  TensorInfo reshape_input_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(reshape_input, reshape_input_info));
+  std::vector<uint32_t> onnx_input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, onnx_input_shape), "Cannot get shape");
 
-  bool needs_reshape = false;
-  const std::string reshape_prior_out = utils::UniqueNameGenerator().New(input_names[0], "_reshape");
-  if (input_shape.size() == 3) {
-    needs_reshape = true;
-    // build new_shape = {N, 1, C, L}
-    std::vector<uint32_t> new_shape = {
-        input_shape[0],
-        1,
-        input_shape[1],
-        input_shape[2]};
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
 
-    QnnTensorWrapper reshape_prior_tensor(
-        reshape_prior_out,
-        QNN_TENSOR_TYPE_NATIVE,
-        reshape_input_info.qnn_data_type,
-        reshape_input_info.quant_param.Copy(),
-        std::move(new_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_prior_tensor)),
+  const bool requires_rank3_reshape = (onnx_input_shape.size() == 3);
+  std::vector<uint32_t> qnn_input_shape = onnx_input_shape;
+  std::vector<uint32_t> onnx_output_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Outputs()[0].shape, onnx_output_shape), "Cannot get shape");
+
+  std::vector<uint32_t> qnn_output_shape = onnx_output_shape;
+  std::vector<uint32_t> intermediate_output_shape_4d;
+  if (requires_rank3_reshape) {
+    qnn_input_shape = {onnx_input_shape[0], 1, onnx_input_shape[1], onnx_input_shape[2]};
+    qnn_output_shape = {onnx_output_shape[0], 1, onnx_output_shape[1], onnx_output_shape[2]};
+    intermediate_output_shape_4d = qnn_output_shape;
+  }
+
+  if (requires_rank3_reshape) {
+    const std::string reshaped_input_name = utils::UniqueNameGenerator().New(input_names[0], "_reshape");
+
+    QnnTensorWrapper reshaped_input_tensor(reshaped_input_name,
+                                           QNN_TENSOR_TYPE_NATIVE,
+                                           input_info.qnn_data_type,
+                                           input_info.quant_param.Copy(),
+                                           std::vector<uint32_t>(qnn_input_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshaped_input_tensor)),
                   "Failed to add reshape prior tensor.");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_RESHAPE,
-                                                  {input_names[0]},
-                                                  {reshape_prior_out},
-                                                  {},
-                                                  do_op_validation),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
+                                                  {input_names[0]}, {reshaped_input_name}, {}, do_op_validation),
                   "Failed to create reshape prior node for pool op.");
-    input_names[0] = reshape_prior_out;
-    input_shape = {input_shape[0], 1, input_shape[1], input_shape[2]};
+    input_names[0] = reshaped_input_name;
   }
 
-  const std::string& op_type = node_unit.OpType();
-  const size_t rank = input_shape.size();
+  const size_t rank = qnn_input_shape.size();
+  QnnPoolConfig qnn_pool_config;
+  RETURN_IF_ERROR(GetQnnPoolConfig(is_max_pool, rank, qnn_pool_config));
 
-  // QNN constants for construction.
-  std::string qnn_op_type;
-  std::string param_filter_size;
-  std::string param_stride;
-  std::string param_pad_amount;
-  std::string param_count_pad_for_edges;
-  std::string param_rounding_mode;
-  if (rank == 4) {
-    if (op_type == "MaxPool" || op_type == "GlobalMaxPool") {
-      qnn_op_type = QNN_OP_POOL_MAX_2D;
-      param_filter_size = QNN_OP_POOL_MAX_2D_PARAM_FILTER_SIZE;
-      param_stride = QNN_OP_POOL_MAX_2D_PARAM_STRIDE;
-      param_pad_amount = QNN_OP_POOL_MAX_2D_PARAM_PAD_AMOUNT;
-      param_rounding_mode = QNN_OP_POOL_MAX_2D_PARAM_ROUNDING_MODE;
-    } else {
-      qnn_op_type = QNN_OP_POOL_AVG_2D;
-      param_filter_size = QNN_OP_POOL_AVG_2D_PARAM_FILTER_SIZE;
-      param_stride = QNN_OP_POOL_AVG_2D_PARAM_STRIDE;
-      param_pad_amount = QNN_OP_POOL_AVG_2D_PARAM_PAD_AMOUNT;
-      param_count_pad_for_edges = QNN_OP_POOL_AVG_2D_PARAM_COUNT_PAD_FOR_EDGES;
-      param_rounding_mode = QNN_OP_POOL_AVG_2D_PARAM_ROUNDING_MODE;
-    }
-  } else {
-    if (op_type == "MaxPool" || op_type == "GlobalMaxPool") {
-      qnn_op_type = QNN_OP_POOL_MAX_3D;
-      param_filter_size = QNN_OP_POOL_MAX_3D_PARAM_FILTER_SIZE;
-      param_stride = QNN_OP_POOL_MAX_3D_PARAM_STRIDE;
-      param_pad_amount = QNN_OP_POOL_MAX_3D_PARAM_PAD_AMOUNT;
-      param_rounding_mode = QNN_OP_POOL_MAX_3D_PARAM_ROUNDING_MODE;
-    } else {
-      qnn_op_type = QNN_OP_POOL_AVG_3D;
-      param_filter_size = QNN_OP_POOL_AVG_3D_PARAM_FILTER_SIZE;
-      param_stride = QNN_OP_POOL_AVG_3D_PARAM_STRIDE;
-      param_pad_amount = QNN_OP_POOL_AVG_3D_PARAM_PAD_AMOUNT;
-      param_count_pad_for_edges = QNN_OP_POOL_AVG_3D_PARAM_COUNT_PAD_FOR_EDGES;
-      param_rounding_mode = QNN_OP_POOL_AVG_3D_PARAM_ROUNDING_MODE;
-    }
+  QnnPoolParams qnn_pool_params;
+  qnn_pool_params.filter_size.assign(qnn_input_shape.begin() + 1, qnn_input_shape.begin() + rank - 1);
+  qnn_pool_params.stride = qnn_pool_params.filter_size;
+  qnn_pool_params.pad_amount.assign((rank - 2) * 2, 0);
+
+  if (!is_global_pool) {
+    RETURN_IF_ERROR(SetCommonPoolParams(node_helper,
+                                        qnn_pool_params.filter_size,
+                                        qnn_pool_params.stride,
+                                        qnn_pool_params.pad_amount,
+                                        qnn_pool_params.rounding_mode,
+                                        qnn_input_shape,
+                                        qnn_output_shape));
   }
 
-  // Default parameters for GlobalMaxPool/GlobalAveragePool with filter and stride in spatial shapes.
-  // Note that input is already in spatial-first layout.
-  std::vector<uint32_t> filter_size(input_shape.begin() + 1, input_shape.begin() + rank - 1);
-  std::vector<uint32_t> filter_size_dim{static_cast<uint32_t>(rank - 2)};
-  std::vector<uint32_t> stride(filter_size);
-  std::vector<uint32_t> stride_dim{static_cast<uint32_t>(rank - 2)};
-  std::vector<uint32_t> pad_amount((rank - 2) * 2, 0);
-  std::vector<uint32_t> pad_amount_dim{static_cast<uint32_t>(rank - 2), 2};
-  int32_t rounding_mode = 0;
+  qnn_pool_params.count_pad_for_edges = is_avg_pool &&
+                                        (is_global_pool || node_helper.Get("count_include_pad", static_cast<int64_t>(0)) != 0);
 
   std::vector<std::string> param_tensor_names;
-  if (op_type == "GlobalMaxPool") {
-    RETURN_IF_NOT(SetPoolParam(node_unit,
-                               param_filter_size,
-                               std::move(filter_size_dim),
-                               std::move(filter_size),
-                               param_tensor_names,
-                               qnn_model_wrapper),
-                  "Failed to add param filter_size.");
-    RETURN_IF_NOT(SetPoolParam(node_unit,
-                               param_stride,
-                               std::move(stride_dim),
-                               std::move(stride),
-                               param_tensor_names,
-                               qnn_model_wrapper),
-                  "Failed to add param stride.");
-    RETURN_IF_NOT(SetPoolParam(node_unit,
-                               param_pad_amount,
-                               std::move(pad_amount_dim),
-                               std::move(pad_amount),
-                               param_tensor_names,
-                               qnn_model_wrapper),
-                  "Failed to add param pad_amount.");
+  RETURN_IF_ERROR(AddQnnPoolParamWrappers(node_unit,
+                                          qnn_pool_config,
+                                          std::move(qnn_pool_params),
+                                          param_tensor_names,
+                                          qnn_model_wrapper));
 
-    RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
-                                   std::move(input_names),
-                                   std::move(param_tensor_names),
-                                   logger,
-                                   do_op_validation,
-                                   qnn_op_type));
-    return Ort::Status();
-  }
-
-  if (op_type == "MaxPool" || op_type == "AveragePool") {
-    const auto& outputs = node_unit.Outputs();
-    std::vector<uint32_t> output_shape;
-    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(outputs[0].shape, output_shape), "Cannot get shape");
-
-    RETURN_IF_ERROR(SetCommonPoolParams(node_helper,
-                                        filter_size,
-                                        stride,
-                                        pad_amount,
-                                        rounding_mode,
-                                        std::move(input_shape),
-                                        std::move(output_shape)));
-  }
-
-  // Construct param wrappers.
-  RETURN_IF_NOT(SetPoolParam(node_unit,
-                             param_filter_size,
-                             std::move(filter_size_dim),
-                             std::move(filter_size),
-                             param_tensor_names,
-                             qnn_model_wrapper),
-                "Failed to add param filter_size.");
-  RETURN_IF_NOT(SetPoolParam(node_unit,
-                             param_stride,
-                             std::move(stride_dim),
-                             std::move(stride),
-                             param_tensor_names,
-                             qnn_model_wrapper),
-                "Failed to add param stride.");
-  std::vector<uint32_t> pad_amount_qnn = pad_amount;
-  ReArrangePads(pad_amount_qnn);
-  RETURN_IF_NOT(SetPoolParam(node_unit,
-                             param_pad_amount,
-                             std::move(pad_amount_dim),
-                             std::move(pad_amount_qnn),  // QNN expects pads in [begin, end] order.
-                             param_tensor_names,
-                             qnn_model_wrapper),
-                "Failed to add param pad_amount.");
-
-  if (0 != rounding_mode) {
-    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-    scalar_param.dataType = QNN_DATATYPE_UINT_32;
-    scalar_param.int32Value = rounding_mode;
-    QnnParamWrapper rounding_mode_param_wrapper(node_unit.Index(),
-                                                node_unit.Name(),
-                                                param_rounding_mode,
-                                                scalar_param);
-    param_tensor_names.push_back(rounding_mode_param_wrapper.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(rounding_mode_param_wrapper)),
-                  "Failed to add param rounding_mode.");
-  }
-  if (op_type == "GlobalAveragePool") {
-    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-    scalar_param.dataType = QNN_DATATYPE_BOOL_8;
-    scalar_param.bool8Value = 1;
-    QnnParamWrapper count_pad_for_edges_param(node_unit.Index(),
-                                              node_unit.Name(),
-                                              param_count_pad_for_edges,
-                                              scalar_param);
-    param_tensor_names.push_back(count_pad_for_edges_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(count_pad_for_edges_param)),
-                  "Failed to add param count_pad_for_edges.");
-  } else if (op_type == "AveragePool") {
-    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-    scalar_param.dataType = QNN_DATATYPE_BOOL_8;
-    scalar_param.bool8Value = static_cast<uint8_t>(node_helper.Get("count_include_pad", static_cast<int64_t>(0)) != 0);
-    QnnParamWrapper count_pad_for_edges_param(node_unit.Index(),
-                                              node_unit.Name(),
-                                              param_count_pad_for_edges,
-                                              scalar_param);
-    param_tensor_names.push_back(count_pad_for_edges_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(count_pad_for_edges_param)),
-                  "Failed to add param count_include_pad.");
-  }
-
-  // exit for common rank-4 pool processing.
-  if (!needs_reshape) {
-    RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper,
-                                   node_unit,
-                                   std::move(input_names),
-                                   std::move(param_tensor_names),
-                                   logger,
-                                   do_op_validation,
-                                   qnn_op_type));
-
-    return Ort::Status();
-  }
-
-  // Calculate rank-4 output shape for rank-3 input.
-  std::vector<uint32_t> onnx_in_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, onnx_in_shape), "Cannot get shape");
-  if (onnx_in_shape.size() == 3) {
-    onnx_in_shape = {onnx_in_shape[0], 1, onnx_in_shape[1], onnx_in_shape[2]};
-  }
-
-  std::vector<uint32_t> pooled_shape;
-  RETURN_IF_ERROR(AmendOutputShapeForRank3Pool(onnx_in_shape, filter_size, stride, pad_amount, pooled_shape));
-
-  const auto& outputs = node_unit.Outputs();
-  const std::string real_out = outputs[0].name;
-  const std::string pool_out = utils::UniqueNameGenerator().New(real_out, "_reshape_after");
-  TensorInfo output_info{};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
-  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(real_out);
-  Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-  QnnTensorWrapper pool_tensor(
-      pool_out,
-      QNN_TENSOR_TYPE_NATIVE,
-      reshape_input_info.qnn_data_type,
-      output_info.quant_param.Copy(),
-      std::move(pooled_shape));
-
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pool_tensor)), "Failed to add tensor for pool_out");
-
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, op_type),
-                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                GetQnnOpType(op_type),
-                                                {reshape_prior_out},
-                                                {pool_out},
-                                                std::move(param_tensor_names),
-                                                do_op_validation),
-                "Failed to create pool node for rank-3 input.");
-
-  std::vector<uint32_t> final_shape3d = output_info.shape;
-  QnnTensorWrapper reshape_after_tensor(
-      real_out,
-      tensor_type,
-      output_info.qnn_data_type,
-      output_info.quant_param.Copy(),
-      std::move(final_shape3d));
-
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_after_tensor)),
-                "Failed to add reshape after tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
-                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                QNN_OP_RESHAPE,
-                                                {pool_out},
-                                                {real_out},
-                                                {},
-                                                do_op_validation),
-                "Failed to create reshape after node for pool op.");
-
-  return Ort::Status();
+  return AddQnnPoolNode(qnn_model_wrapper,
+                        node_unit,
+                        std::move(input_names),
+                        std::move(param_tensor_names),
+                        qnn_pool_config,
+                        input_info,
+                        requires_rank3_reshape,
+                        std::move(intermediate_output_shape_4d),
+                        logger,
+                        do_op_validation);
 }
 
 Ort::Status PoolOpBuilder::OverrideOutputQuantParam(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/test/providers/qnn/averagepool_test.cc
+++ b/onnxruntime/test/providers/qnn/averagepool_test.cc
@@ -122,6 +122,40 @@ TEST_F(QnnCPUBackendTests, GlobalAveragePool_3D) {
                        ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnCPUBackendTests, GlobalAveragePoolRank3) {
+  RunAveragePoolOpTest("GlobalAveragePool",
+                       {TestInputDef<float>({1, 8, 5}, false, -10.0f, 10.0f)},
+                       {},
+                       ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, AveragePoolRank3) {
+  RunAveragePoolOpTest("AveragePool",
+                       {TestInputDef<float>({1, 3, 5}, false, -10.0f, 10.0f)},
+                       {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                        test::MakeAttribute("strides", std::vector<int64_t>{1}),
+                        test::MakeAttribute("pads", std::vector<int64_t>{1, 1})},
+                       ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, AveragePoolRank3AutopadSameUpper) {
+  RunAveragePoolOpTest("AveragePool",
+                       {TestInputDef<float>({1, 3, 4}, false, -10.0f, 10.0f)},
+                       {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                        test::MakeAttribute("strides", std::vector<int64_t>{2}),
+                        test::MakeAttribute("auto_pad", "SAME_UPPER")},
+                       ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, AveragePoolRank3AutopadSameLower) {
+  RunAveragePoolOpTest("AveragePool",
+                       {TestInputDef<float>({1, 3, 4}, false, -10.0f, 10.0f)},
+                       {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                        test::MakeAttribute("strides", std::vector<int64_t>{2}),
+                        test::MakeAttribute("auto_pad", "SAME_LOWER")},
+                       ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:
@@ -210,6 +244,86 @@ TEST_F(QnnHTPBackendTests, AveragePool_3D_AutoPad_SAME_LOWER_u8) {
   RunQDQAveragePoolOpTest<uint8_t>("AveragePool",
                                    {TestInputDef<float>({1, 2, 8, 8, 8}, false, -10.0f, 10.0f)},
                                    {test::MakeAttribute("kernel_shape", std::vector<int64_t>{2, 2, 2}),
+                                    test::MakeAttribute("auto_pad", "SAME_LOWER")},
+                                   ExpectedEPNodeAssignment::All);
+}
+
+// Covers the NHWC reshape-back path in pool_op_builder.
+TEST_F(QnnHTPBackendTests, GlobalAveragePoolRank3U8) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 1 * 8 * 5);
+  RunQDQAveragePoolOpTest<uint8_t>("GlobalAveragePool",
+                                   {TestInputDef<float>({1, 8, 5}, false, input_data)},
+                                   {},
+                                   ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, AveragePool1DFusedQnnNodePresent) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({1, 3, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 9)));
+    builder.MakeOutput("output");
+
+    builder.AddNode("avgpool", "AveragePool",
+                    {"input"},
+                    {"output"},
+                    "",
+                    {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                     test::MakeAttribute("strides", std::vector<int64_t>{3}),
+                     test::MakeAttribute("pads", std::vector<int64_t>{0, 0}),
+                     test::MakeAttribute("auto_pad", "NOTSET")});
+  };
+
+  ProviderOptions options;
+  options["backend_type"] = "htp";
+
+  std::function<void(const Graph&)> check_num_nodes = [](const Graph& graph) {
+    int number_of_nodes = graph.NumberOfNodes();
+    EXPECT_EQ(number_of_nodes, 1) << "Expected 1 fused QNN node for AveragePool rank-3 input.";
+  };
+
+  RunQnnModelTest(build_test_case,
+                  options,
+                  18,
+                  ExpectedEPNodeAssignment::All,
+                  1e-5,
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  true,
+                  &check_num_nodes);
+}
+
+TEST_F(QnnHTPBackendTests, AveragePoolRank3U8) {
+  RunQDQAveragePoolOpTest<uint8_t>("AveragePool",
+                                   {TestInputDef<float>({1, 3, 5}, false, -10.0f, 10.0f)},
+                                   {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                                    test::MakeAttribute("strides", std::vector<int64_t>{1}),
+                                    test::MakeAttribute("pads", std::vector<int64_t>{1, 1})},
+                                   ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, AveragePoolRank3CountIncludePadU8) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 1 * 3 * 5);
+  RunQDQAveragePoolOpTest<uint8_t>("AveragePool",
+                                   {TestInputDef<float>({1, 3, 5}, false, input_data)},
+                                   {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                                    test::MakeAttribute("strides", std::vector<int64_t>{1}),
+                                    test::MakeAttribute("pads", std::vector<int64_t>{1, 1}),
+                                    test::MakeAttribute("count_include_pad", static_cast<int64_t>(1))},
+                                   ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, AveragePoolRank3AutoPadSameUpperU8) {
+  RunQDQAveragePoolOpTest<uint8_t>("AveragePool",
+                                   {TestInputDef<float>({1, 3, 4}, false, -10.0f, 10.0f)},
+                                   {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                                    test::MakeAttribute("strides", std::vector<int64_t>{2}),
+                                    test::MakeAttribute("auto_pad", "SAME_UPPER")},
+                                   ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, AveragePoolRank3AutoPadSameLowerU8) {
+  RunQDQAveragePoolOpTest<uint8_t>("AveragePool",
+                                   {TestInputDef<float>({1, 3, 4}, false, -10.0f, 10.0f)},
+                                   {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),
+                                    test::MakeAttribute("strides", std::vector<int64_t>{2}),
                                     test::MakeAttribute("auto_pad", "SAME_LOWER")},
                                    ExpectedEPNodeAssignment::All);
 }

--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -182,6 +182,13 @@ TEST_F(QnnCPUBackendTests, GlobalMaxPool_3D) {
                 ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnCPUBackendTests, GlobalMaxPoolRank3) {
+  RunPoolOpTest("GlobalMaxPool",
+                TestInputDef<float>({1, 8, 5}, false, -10.0f, 10.0f),
+                {},
+                ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:
@@ -474,6 +481,32 @@ TEST_F(QnnHTPBackendTests, GlobalMaxPool_LargeInput2_u8) {
                             TestInputDef<float>({1, 64, 384, 576}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
                             {},
                             ExpectedEPNodeAssignment::All);
+}
+
+// Covers the NHWC reshape-back path in pool_op_builder.
+TEST_F(QnnHTPBackendTests, GlobalMaxPoolRank3U8) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 1 * 8 * 5);
+  RunQDQPoolOpTest<uint8_t>("GlobalMaxPool",
+                            TestInputDef<float>({1, 8, 5}, false, input_data),
+                            {},
+                            ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GlobalMaxPoolRank3LargeInputU8) {
+  RunQDQPoolOpTest<uint8_t>("GlobalMaxPool",
+                            TestInputDef<float>({1, 8400, 80}, false, -10.0f, 10.0f),
+                            {},
+                            ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GlobalMaxPoolRank3U16) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 1 * 8 * 5);
+  RunQDQPoolOpTest<uint16_t>("GlobalMaxPool",
+                             TestInputDef<float>({1, 8, 5}, false, input_data),
+                             {},
+                             ExpectedEPNodeAssignment::All,
+                             /*opset=*/18,
+                             /*use_contrib_qdq_ops=*/true);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Issue
`GlobalMaxPool`/`GlobalAveragePool` with rank-3 input claimed support in `IsOpSupported` but failed at QNN graph compile. The rank-3→rank-4 reshape logic only existed in the `MaxPool`/`AveragePool` (windowed) code path, not the global pool path.

```
 [ONNXRuntimeError] : 1 : FAIL : Node 'model_420/tf.math.reduce_max_3/Max_token_513' OpType:GlobalMaxPool with domain:com.ms.internal.nhwc was inserted using the NHWC format as requested by QnnExecutionProvider, but was not selected by that EP. This means the graph is now invalid as there will not be an EP able to run the node. This could be a bug in layout transformer, or in the GetCapability implementation of the EP.
```

### Fix
Unified rank-3 handling for all pool ops — reshape 3D→4D before the QNN pool node, then reshape back to 3D after. This runs for both windowed and global pool variants. Also refactored to reduce indirection and improve readability.