### PR TITLE
Fix nuget package uploads

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -192,7 +192,7 @@ jobs:
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-nuget"
-          src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/Qualcomm.ML.OnnxRuntime.QNN*.nupkg"
+          src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/Qualcomm.ML.OnnxRuntime.QNN*.nupkg"
 
       - name: Upload Zip to Artifactory
         if: ${{ inputs.upload_zip }}

--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -1,5 +1,5 @@
 ONNX Runtime QNN
-============
+================
 
 ONNX Runtime QNN is a plugin execution provider that brings Qualcomm hardware acceleration to ONNX Runtime — enabling high-performance AI inference on Qualcomm Snapdragon SoCs via the `Qualcomm AI Runtime SDK (QAIRT) <https://qpm.qualcomm.com/#/main/tools/details/Qualcomm_AI_Runtime_SDK>`_.
 

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -106,6 +106,12 @@ else {
     }
 }
 
+$BinDir = Join-Path $BuildDir $Config
+if ($CMakeGenerator -ne "Ninja") {
+    # Multi-config generators add an extra config directory.
+    $BinDir = Join-Path $BinDir $Config
+}
+
 $ArchArgs = @()
 if ($CMakeGenerator -eq "Ninja") {
     # We don't have Visual Studio to set up the build environment so do it
@@ -313,6 +319,14 @@ else {
                             $BuildBatPath = (Join-Path $RepoRoot "build.bat")
                             Assert-Success -ErrorMessage "Failed to build nuget" {
                                 & $BuildBatPath --skip_tests $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg
+
+                                $DistDir = Join-Path $BinDir "dist"
+                                if (-not (Test-Path $DistDir)) {
+                                    New-Item -ItemType Directory -Path $DistDir | Out-Null
+                                }
+                                foreach ($Pkg in (Get-ChildItem -File -Recurse -Path $BinDir -Filter "Qualcomm.ML.OnnxRuntime.QNN*.nupkg")) {
+                                    Copy-Item -Path $Pkg.FullName -Destination $DistDir
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
* Move nuget packages to `build/$os/$config/dist/` to avoid searching inaccessible directories under `build/$os/$config/_deps`