### PR TITLE
[QNN EP] Enablement of 64-bit UDMA mode in QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1207,7 +1207,7 @@ Ort::Status QnnBackendManager::ResetContextPriority() {
   return SetContextPriority(context_priority_);
 }
 
-Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing) {
+Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing, bool enable_htp_extended_udma_mode) {
   if (true == context_created_) {
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, "Context created already.");
     return Ort::Status();
@@ -1223,8 +1223,16 @@ Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing) {
   QnnContext_Config_t context_priority_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, context_priority_config));
 
+  QnnContext_Config_t context_config_extended_udma = QNN_CONTEXT_CONFIG_INIT;
+  QnnHtpContext_CustomConfig_t udma_custom_config;
+  udma_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_USE_EXTENDED_UDMA;
+  udma_custom_config.useExtendedUdma = enable_htp_extended_udma_mode;
+  context_config_extended_udma.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+  context_config_extended_udma.customConfig = &udma_custom_config;
+
   const QnnContext_Config_t* npu_context_configs[] = {&context_priority_config,
                                                       &context_config_weight_sharing,
+                                                      &context_config_extended_udma,
                                                       nullptr};
 
   const QnnContext_Config_t* empty_context_configs[] = {nullptr};
@@ -1659,7 +1667,8 @@ Ort::Status QnnBackendManager::SetupBackend(
     bool enable_vtcm_backup_buffer_sharing,
     bool enable_file_mapped_weights,
     std::shared_ptr<qnn::RpcMemLibrary> rpcmem_library,
-    std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map) {
+    std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map,
+    bool enable_htp_extended_udma_mode) {
   std::lock_guard<std::recursive_mutex> lock(logger_recursive_mutex_);
   if (backend_setup_completed_) {
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Backend setup already!");
@@ -1771,7 +1780,7 @@ Ort::Status QnnBackendManager::SetupBackend(
 
   if (status.IsOK() && (vtcm_backup_buffer_sharing_enabled_ || !load_from_cached_context)) {
     status = vtcm_backup_buffer_sharing_enabled_ ? CreateContextVtcmBackupBufferSharingEnabled(context_bin_map)
-                                                 : CreateContext(enable_htp_weight_sharing);
+                                                 : CreateContext(enable_htp_weight_sharing, enable_htp_extended_udma_mode);
 
     if (status.IsOK()) {
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "CreateContext succeed.");

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -186,7 +186,8 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
       bool enable_vtcm_backup_buffer_sharing,
       bool enable_file_mapped_weights,
       std::shared_ptr<qnn::RpcMemLibrary> rpcmem_library,
-      std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map);
+      std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map,
+      bool enable_htp_extended_udma_mode = false);
 
   Ort::Status CreateHtpPowerCfgId(uint32_t deviceId, uint32_t coreId, uint32_t& htp_power_config_id);
 
@@ -342,7 +343,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   Ort::Status ReleaseProfilehandle();
 
-  Ort::Status CreateContext(bool enable_htp_weight_sharing);
+  Ort::Status CreateContext(bool enable_htp_weight_sharing, bool enable_htp_extended_udma_mode);
 
   Ort::Status GetFileSizeIfValid(const std::string& filepath, size_t& file_size);
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -957,6 +957,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     }
   }
 
+  static const std::string QNN_HTP_EXTENDED_UDMA_MODE = "extended_udma";
+  enable_htp_extended_udma_mode_ = ParseBoolOption(ort_api,
+                                                   session_options_,
+                                                   FormatEPConfigKey(QNN_HTP_EXTENDED_UDMA_MODE),
+                                                   false,
+                                                   logger_);
+
   // Option to skip QNN API interface version check to use other QNN library other than default.
   static const std::string SKIP_QNN_VERSION_CHECK = "skip_qnn_version_check";
   auto skip_qnn_version_check = ParseBoolOption(ort_api,
@@ -1467,7 +1474,8 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
                                                           ep->enable_vtcm_backup_buffer_sharing_,
                                                           ep->enable_file_mapped_weights_,
                                                           ep->rpcmem_library_,
-                                                          context_bin_map);
+                                                          context_bin_map,
+                                                          ep->enable_htp_extended_udma_mode_);
 
   context_bin_map.clear();
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -191,6 +191,7 @@ class QnnEp : public OrtEp, public ApiPtrs {
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";
+  bool enable_htp_extended_udma_mode_ = false;
 
   // Whether this is set depends on a session option enabling it and if the RPCMEM dynamic library is available.
   // This is potentially shared with HtpSharedMemoryAllocator which may be returned by CreatePreferredAllocators().

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -2520,6 +2520,32 @@ TEST_F(QnnCPUBackendTests, GetUniqueNameResetBetweenCompilations) {
   EXPECT_EQ(names_1, names_2);
 }
 
+// Test extended UDMA mode on supported hardware (should run successfully)
+TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
+#if defined(_WIN32)
+  if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V79)) {
+    GTEST_SKIP() << "Test requires HTP arch >= V81 for extended UDMA support.";
+  }
+#endif
+  // Create provider options with extended UDMA mode enabled
+  ProviderOptions options;
+  options["backend_type"] = "htp";
+  options["offload_graph_io_quantization"] = "0";
+  options["htp_arch"] = "81";
+  options["extended_udma"] = "1";
+
+  // Define a simple model with Add operation
+  auto input_defs = {TestInputDef<float>({1, 3, 4, 4}, false, -10.0f, 10.0f),
+                     TestInputDef<float>({1, 3, 4, 4}, false, -10.0f, 10.0f)};
+
+  // Run the test - this should succeed because v81 supports extended UDMA
+  RunQnnModelTest(BuildOpTestCase<float>("Add_node", "Add", input_defs, {}, {}, kOnnxDomain),
+                  options,
+                  13,
+                  ExpectedEPNodeAssignment::All,
+                  0.008f);
+}
+
 #endif  // !defined(ORT_MINIMAL_BUILD)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -2521,12 +2521,11 @@ TEST_F(QnnCPUBackendTests, GetUniqueNameResetBetweenCompilations) {
 }
 
 // Test extended UDMA mode on supported hardware (should run successfully)
-TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
 #if defined(_WIN32)
+TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V79)) {
     GTEST_SKIP() << "Test requires HTP arch >= V81 for extended UDMA support.";
   }
-#endif
   // Create provider options with extended UDMA mode enabled
   ProviderOptions options;
   options["backend_type"] = "htp";
@@ -2545,6 +2544,7 @@ TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
                   ExpectedEPNodeAssignment::All,
                   0.008f);
 }
+#endif  // defined(_WIN32)
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 


### PR DESCRIPTION


### Description
- Ported enablement of extended UDMA mode with ABI EP adaptations including unit test gated to v81+ hardware.
- Adds extended_udma provider option that configures the mode on HTP context creation, enabling far-mapping of weights and spill/fill buffers for v81+ devices.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


