### PR TITLE
Remove workaround for broken QNN_IR_GRAPH_CUSTOM_CONFIG_INIT macro

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -68,12 +68,6 @@ static const char* DlError() {
 #endif
 }
 
-// Workaround for a missing comma in QNN_IR_GRAPH_CUSTOM_CONFIG_INIT.
-static QnnIrGraph_CustomConfig_t EmptyIrGraphConfig() {
-  return {
-      QNN_IR_GRAPH_CONFIG_OPTION_SERIALIZATION, {QNN_IR_GRAPH_SERIALIZATION_TYPE_FLAT_BUFFER, ""}};
-}
-
 class QnnIrConfig : public QnnSerializerConfig {
  public:
   QnnIrConfig(std::string backend_path, std::string dlc_dir)
@@ -109,7 +103,7 @@ class QnnIrConfig : public QnnSerializerConfig {
 
  private:
   static QnnConfigsBuilder<QnnGraph_Config_t, QnnIrGraph_CustomConfig_t> MakeConfigsBuilder() {
-    return QnnConfigsBuilder<QnnGraph_Config_t, QnnIrGraph_CustomConfig_t>(QNN_GRAPH_CONFIG_INIT, EmptyIrGraphConfig());
+    return QnnConfigsBuilder<QnnGraph_Config_t, QnnIrGraph_CustomConfig_t>(QNN_GRAPH_CONFIG_INIT, QNN_IR_GRAPH_CUSTOM_CONFIG_INIT);
   }
 
   std::filesystem::path dlc_dir_;


### PR DESCRIPTION
### Motivation and Context

The QAIRT macro `QNN_IR_GRAPH_CUSTOM_CONFIG_INIT` was previously missing a semicolon.