### PR TITLE
Add support for NonZero

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -38,6 +38,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateMatMulNBitsOpBuilder("MatMulNBits", *this);
   CreateMeanOpBuilder("Mean", *this);
   CreateModOpBuilder("Mod", *this);
+  CreateNonZeroOpBuilder("NonZero", *this);
   CreatePadOpBuilder("Pad", *this);
   CreatePoolOpBuilder("AveragePool", *this);
   CreatePoolOpBuilder("GlobalAveragePool", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -153,5 +153,7 @@ void CreateTanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_r
 
 void CreateRoiAlignOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateNonZeroOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
@@ -96,23 +96,9 @@ Ort::Status NonZeroOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     const std::string cast_output_name = utils::UniqueNameGenerator().New(original_input_name, "_cast_fp16");
 
     // Create fp16 intermediate tensor.
-    QnnTensorWrapper cast_output_tensorwrapper(cast_output_name,
-                                               QNN_TENSOR_TYPE_NATIVE,
-                                               QNN_DATATYPE_FLOAT_16,
-                                               QnnQuantParamsWrapper(),
-                                               std::vector<uint32_t>(input_info.shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_output_tensorwrapper)),
-                  "Failed to add fp16 cast tensor.");
-
-    // Add Cast node: fp32 -> fp16.
-    const std::string cast_node_name = cast_output_name + "_cast_node";
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_CAST,
-                                                  {original_input_name},
-                                                  {cast_output_name},
-                                                  {}),
-                  "Failed to add Cast fp32->fp16 node");
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(cast_output_name + "_cast_node", original_input_name,
+                                                  cast_output_name, QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_16,
+                                                  QnnQuantParamsWrapper(), std::vector<uint32_t>(input_info.shape), do_op_validation));
 
     // Replace the input name with the casted fp16 tensor.
     input_names.back() = cast_output_name;
@@ -200,7 +186,8 @@ Ort::Status NonZeroOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                   QNN_OP_TRANSPOSE,
                                                   {nonzero_out_name},
                                                   {transpose_out_name},
-                                                  std::move(transpose_params)),
+                                                  std::move(transpose_params),
+                                                  do_op_validation),
                   "Failed to add Transpose node.");
 
     // Cast: int32 -> int64 for graph output.
@@ -217,7 +204,8 @@ Ort::Status NonZeroOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                   QNN_OP_CAST,
                                                   {transpose_out_name},
                                                   {output_name},
-                                                  {}),
+                                                  {},
+                                                  do_op_validation),
                   "Failed to add Cast node.");
   } else {
     // Transpose output is the final native tensor.
@@ -234,7 +222,8 @@ Ort::Status NonZeroOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                   QNN_OP_TRANSPOSE,
                                                   {nonzero_out_name},
                                                   {output_name},
-                                                  std::move(transpose_params)),
+                                                  std::move(transpose_params),
+                                                  do_op_validation),
                   "Failed to add Transpose node.");
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
@@ -1,0 +1,249 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <unordered_set>
+
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// NonZero op builder.
+// Output shape is [rank_of_input, num_elements], where num_elements is the total number of
+// elements in the input (the maximum possible number of non-zero elements).
+class NonZeroOpBuilder : public BaseOpBuilder {
+ public:
+  NonZeroOpBuilder() : BaseOpBuilder("NonZeroOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(NonZeroOpBuilder);
+
+  // Override IsOpSupported to check backend type, consumer ops, and supported input types.
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status NonZeroOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit,
+                                            const Ort::Logger& logger) const {
+  // NonZero is only supported on HTP backend.
+  RETURN_IF_NOT(qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::HTP,
+                "NonZero is only supported on HTP backend.");
+
+  // NonZero output must have a static shape (no dynamic dims).
+  // The ONNX model should set the output shape to [rank, num_elements] where num_elements
+  // is the total number of elements in the input.
+  const auto& output = node_unit.Outputs()[0];
+  std::vector<uint32_t> output_shape;
+  RETURN_IF_NOT(QnnModelWrapper::GetOnnxShape(output.shape, output_shape),
+                "NonZero output shape must be static. Set shape to [rank, num_elements].");
+
+  const std::string& output_name = output.name;
+  if (qnn_model_wrapper.IsGraphOutput(output_name)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                "NonZero output is a graph output. QNN HTP pads unused elements with -1.");
+  }
+
+  // QNN HTP NonZero pads unused output elements with -1. Only these consumer ops handle -1 indices correctly.
+  static const std::unordered_set<std::string> allowed_consumers = {
+      "Gather", "GatherElements", "GatherND", "ScatterElements", "ScatterND", "Reshape", "Transpose"};
+
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
+  for (const OrtNode* consumer : node_unit.GetOutputNodes(ort_api)) {
+    std::string op = Ort::ConstNode(consumer).GetOperatorType();
+    RETURN_IF_NOT(allowed_consumers.count(op) == 1,
+                  ("NonZero consumer op '" + op + "' does not support -1 padded indices.").c_str());
+  }
+
+  // QNN HTP NonZero supported input types:
+  //   FLOAT_16, UFIXED_POINT_16, UFIXED_POINT_8, BOOL_8
+  // FLOAT_32 is also accepted here because ProcessInputs inserts a Cast(fp32 -> fp16).
+  return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
+}
+
+Ort::Status NonZeroOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit,
+                                            const Ort::Logger& logger,
+                                            std::vector<std::string>& input_names,
+                                            bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(do_op_validation);
+
+  const auto& inputs = node_unit.Inputs();
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
+
+  // HTP NonZero only supports FLOAT_16 (not FLOAT_32) for float inputs.
+  // Insert a Cast(fp32 -> fp16) node if needed.
+  if (input_info.qnn_data_type == QNN_DATATYPE_FLOAT_32) {
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+
+    const std::string& original_input_name = input_names.back();
+    const std::string cast_output_name = utils::UniqueNameGenerator().New(original_input_name, "_cast_fp16");
+
+    // Create fp16 intermediate tensor.
+    QnnTensorWrapper cast_output_tensorwrapper(cast_output_name,
+                                               QNN_TENSOR_TYPE_NATIVE,
+                                               QNN_DATATYPE_FLOAT_16,
+                                               QnnQuantParamsWrapper(),
+                                               std::vector<uint32_t>(input_info.shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(cast_output_tensorwrapper)),
+                  "Failed to add fp16 cast tensor.");
+
+    // Add Cast node: fp32 -> fp16.
+    const std::string cast_node_name = cast_output_name + "_cast_node";
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_CAST,
+                                                  {original_input_name},
+                                                  {cast_output_name},
+                                                  {}),
+                  "Failed to add Cast fp32->fp16 node");
+
+    // Replace the input name with the casted fp16 tensor.
+    input_names.back() = cast_output_name;
+  } else {
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status NonZeroOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                          const OrtNodeUnit& node_unit,
+                                                          std::vector<std::string>&& input_names,
+                                                          const Ort::Logger& logger,
+                                                          bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+
+  // Get input shape to compute maximum output size.
+  const auto& inputs = node_unit.Inputs();
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
+
+  const auto& input_shape = input_info.shape;
+  uint32_t input_rank = static_cast<uint32_t>(input_shape.size());
+  SafeInt<uint32_t> num_elements = 1;
+  for (uint32_t dim : input_shape) {
+    num_elements *= dim;
+  }
+
+  // QNN NonZero output shape: [num_nonzero_elements, rank_of_input] (transposed vs ONNX).
+  // ONNX NonZero output shape: [rank_of_input, num_nonzero_elements].
+  // Set num_nonzero_elements to max possible (total elements in input).
+  std::vector<uint32_t> qnn_nonzero_shape = {num_elements, input_rank};
+  std::vector<uint32_t> onnx_output_shape = {input_rank, num_elements};
+
+  const auto& outputs = node_unit.Outputs();
+  const std::string& output_name = outputs[0].name;
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
+
+  Qnn_DataType_t output_data_type = QNN_DATATYPE_INT_32;
+
+  // Chain: NonZero(int32, [N, rank]) -> Transpose(int32, [rank, N]) -> Cast(int64) if graph output.
+  const std::string nonzero_out_name = output_name + "_nonzero_out";
+  const std::string transpose_out_name = output_name + "_transposed";
+
+  // 1. NonZero output tensor: [num_elements, input_rank], int32, native.
+  QnnTensorWrapper nonzero_out_tensor(nonzero_out_name,
+                                      QNN_TENSOR_TYPE_NATIVE,
+                                      output_data_type,
+                                      QnnQuantParamsWrapper(),
+                                      std::vector<uint32_t>(qnn_nonzero_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(nonzero_out_tensor)),
+                "Failed to add NonZero output tensor.");
+
+  // Create the NonZero QNN node.
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_NON_ZERO,
+                                                std::move(input_names),
+                                                {nonzero_out_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to add NonZero node.");
+
+  // 2. Transpose: [num_elements, rank] -> [rank, num_elements] to match ONNX spec.
+  std::vector<uint32_t> perm = {1, 0};
+  QnnParamWrapper transpose_param(node_unit.Index(), node_unit.Name(), QNN_OP_TRANSPOSE_PARAM_PERM,
+                                  {static_cast<uint32_t>(perm.size())}, std::vector<uint32_t>(perm));
+  std::vector<std::string> transpose_params;
+  transpose_params.push_back(transpose_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(transpose_param));
+
+  if (is_graph_output) {
+    // Transpose output is native int32, then Cast to int64 for graph output.
+    QnnTensorWrapper transpose_out_tensor(transpose_out_name,
+                                          QNN_TENSOR_TYPE_NATIVE,
+                                          output_data_type,
+                                          QnnQuantParamsWrapper(),
+                                          std::vector<uint32_t>(onnx_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(transpose_out_tensor)),
+                  "Failed to add Transpose output tensor.");
+
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(transpose_out_name + "_transpose_node",
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_TRANSPOSE,
+                                                  {nonzero_out_name},
+                                                  {transpose_out_name},
+                                                  std::move(transpose_params)),
+                  "Failed to add Transpose node.");
+
+    // Cast: int32 -> int64 for graph output.
+    QnnTensorWrapper graph_output_tensor(output_name,
+                                         QNN_TENSOR_TYPE_APP_READ,
+                                         QNN_DATATYPE_INT_64,
+                                         QnnQuantParamsWrapper(),
+                                         std::vector<uint32_t>(onnx_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(graph_output_tensor)),
+                  "Failed to add graph output tensor.");
+
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(output_name + "_cast_node",
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_CAST,
+                                                  {transpose_out_name},
+                                                  {output_name},
+                                                  {}),
+                  "Failed to add Cast node.");
+  } else {
+    // Transpose output is the final native tensor.
+    QnnTensorWrapper transpose_out_tensor(output_name,
+                                          QNN_TENSOR_TYPE_NATIVE,
+                                          output_data_type,
+                                          QnnQuantParamsWrapper(),
+                                          std::vector<uint32_t>(onnx_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(transpose_out_tensor)),
+                  "Failed to add Transpose output tensor.");
+
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(output_name + "_transpose_node",
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_TRANSPOSE,
+                                                  {nonzero_out_name},
+                                                  {output_name},
+                                                  std::move(transpose_params)),
+                  "Failed to add Transpose node.");
+  }
+
+  return Ort::Status();
+}
+
+void CreateNonZeroOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<NonZeroOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1613,7 +1613,8 @@ void OrtSelectorManager::CreateSelectors() {
   // Register drop DQ ops
   OrtOpVersionsAndSelector::OpVersionsMap drop_dq_ops = {
       {"ArgMax", {}},
-      {"ArgMin", {}}};
+      {"ArgMin", {}},
+      {"NonZero", {}}};
   ort_selectors_.RegisterSelector(drop_dq_ops, std::make_unique<OrtDropDQNodeGroupSelector>());
 
   // Register unary ops

--- a/onnxruntime/test/providers/qnn/nonzero_test.cc
+++ b/onnxruntime/test/providers/qnn/nonzero_test.cc
@@ -1,0 +1,196 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Helper to build a NonZero test model.
+// Output shape is [rank, num_elements] where num_elements is the total number of elements
+// in the input tensor (max possible non-zero count).
+template <typename DataType>
+static GetTestModelFn BuildNonZeroTestCase(const std::vector<int64_t>& input_shape,
+                                           const std::vector<DataType>& input_data) {
+  TestInputDef<DataType> input_def(input_shape, false, input_data);
+  int64_t input_rank = static_cast<int64_t>(input_shape.size());
+  int64_t num_elements = 1;
+  for (int64_t dim : input_shape) {
+    num_elements *= dim;
+  }
+
+  return [input_def, input_rank, num_elements](ModelTestBuilder& builder) {
+    MakeTestInput<DataType>(builder, "X", input_def);
+    builder.AddNode("nonzero_node", "NonZero", {"X"}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{input_rank, num_elements});
+  };
+}
+
+static ProviderOptions HtpProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  return provider_options;
+}
+
+// NonZero-specific test runner that handles padded output comparison.
+// QNN returns [rank, num_elements] (padded to max), while CPU EP returns [rank, actual_count].
+// This compares only the valid region of the QNN output against the CPU EP baseline.
+static void RunNonZeroTest(const GetTestModelFn& build_test_case,
+                           int opset_version,
+                           ExpectedEPNodeAssignment expected_ep_assignment =
+                               ExpectedEPNodeAssignment::All,
+                           ProviderOptions provider_options = HtpProviderOptions()) {
+  const std::unordered_map<std::string, int> domain_to_version = {{"", opset_version}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  build_test_case(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  // Run on CPU EP -> expected output [rank, actual_count]
+  std::vector<Ort::Value> expected;
+  InferenceModelCPU(model_data, "NonZero_CPU", helper.feeds_, expected);
+
+  // Run on QNN EP -> actual output [rank, num_elements] (padded)
+  std::vector<Ort::Value> actual;
+  InferenceModel(model_data, "NonZero_QNN", provider_options,
+                 expected_ep_assignment, helper.feeds_, actual);
+
+  // NonZero has exactly one output
+  uint32_t output_idx = 0;
+
+  auto exp_shape = expected[output_idx].GetTensorTypeAndShapeInfo().GetShape();
+  auto act_shape = actual[output_idx].GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(exp_shape.size(), 2) << "NonZero output must be 2D";
+  ASSERT_EQ(act_shape.size(), 2) << "NonZero output must be 2D";
+
+  int64_t rows = exp_shape[0];
+  int64_t exp_cols = exp_shape[1];
+  int64_t act_cols = act_shape[1];
+  ASSERT_EQ(rows, act_shape[0]) << "Rank dimension mismatch";
+  ASSERT_GE(act_cols, exp_cols) << "QNN output should be >= CPU output in column count";
+
+  const int64_t* exp_data = expected[output_idx].GetTensorData<int64_t>();
+  const int64_t* act_data = actual[output_idx].GetTensorData<int64_t>();
+  for (int64_t r = 0; r < rows; ++r) {
+    for (int64_t c = 0; c < exp_cols; ++c) {
+      EXPECT_EQ(exp_data[r * exp_cols + c], act_data[r * act_cols + c])
+          << "Mismatch at [" << r << ", " << c << "]";
+    }
+  }
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+//
+// HTP tests:
+//
+
+// Input: [0, 1, 0, 2, 0] -> non-zero at indices 1, 3
+TEST_F(QnnHTPBackendTests, NonZero_1D_Float) {
+  RunNonZeroTest(BuildNonZeroTestCase<float>({5}, {0.0f, 1.0f, 0.0f, 2.0f, 0.0f}), 11);
+}
+
+// Input: [[1, 0, 3], [0, 5, 0]] -> non-zero at (0,0), (0,2), (1,1)
+TEST_F(QnnHTPBackendTests, NonZero_2D_Float) {
+  RunNonZeroTest(BuildNonZeroTestCase<float>({2, 3}, {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f}), 11);
+}
+
+// Input (QDQ uint8): [[1, 0, 3], [0, 5, 0]] -> non-zero at (0,0), (0,2), (1,1)
+// Pattern: float input -> Q(u8) -> DQ(u8) -> NonZero -> int64 output
+TEST_F(QnnHTPBackendTests, NonZero_2D_QDQ_Uint8) {
+  std::vector<float> input_data = {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f};
+  TestInputDef<float> input_def({2, 3}, false, input_data);
+  int64_t input_rank = 2;
+  int64_t num_elements = 6;  // 2 * 3
+
+  auto qdq_model_fn = [input_def, input_rank, num_elements](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "X", input_def);
+    std::string dq_out = AddQDQNodePair<uint8_t>(builder, "qdq_in", "X", 0.02f, uint8_t(0));
+    builder.AddNode("nonzero_node", "NonZero", {dq_out}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{input_rank, num_elements});
+  };
+
+  RunNonZeroTest(qdq_model_fn, 11);
+}
+
+// Input (QDQ uint8): [[1, 0, 3], [0, 4.1, 0]] -> non-zero at (0,0), (0,2), (1,1)
+// Pattern: float input -> Q(u16) -> DQ(u16) -> NonZero -> int64 output
+TEST_F(QnnHTPBackendTests, NonZero_2D_QDQ_Uint16) {
+  std::vector<float> input_data = {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f};
+  TestInputDef<float> input_def({2, 3}, false, input_data);
+  int64_t input_rank = 2;
+  int64_t num_elements = 6;  // 2 * 3
+
+  auto qdq_model_fn = [input_def, input_rank, num_elements](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "X", input_def);
+    std::string dq_out = AddQDQNodePair<uint16_t>(builder, "qdq_in", "X", 0.02f, uint16_t(0));
+    builder.AddNode("nonzero_node", "NonZero", {dq_out}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{input_rank, num_elements});
+  };
+
+  RunNonZeroTest(qdq_model_fn, 21);
+}
+
+// Input (bool): [[true, false, true], [false, true, false]] -> non-zero at (0,0), (0,2), (1,1)
+TEST_F(QnnHTPBackendTests, NonZero_2D_Bool) {
+  RunNonZeroTest(BuildNonZeroTestCase<bool>({2, 3}, {true, false, true, false, true, false}), 11);
+}
+
+// Input (bool, 3D): [[[T,F,T],[F,T,F]], [[T,T,F],[F,F,T]]]
+TEST_F(QnnHTPBackendTests, NonZero_3D_Bool) {
+  RunNonZeroTest(BuildNonZeroTestCase<bool>({2, 2, 3},
+                                            {true, false, true, false, true, false,
+                                             true, true, false, false, false, true}),
+                 11);
+}
+
+// Input (bool, 3D): [[[F,F,F],[F,F,F]], [[F,F,F],[F,F,F]]]
+TEST_F(QnnHTPBackendTests, NonZero_3D_Bool_All_False) {
+  RunNonZeroTest(BuildNonZeroTestCase<bool>({2, 2, 3},
+                                            {false, false, false, false, false, false,
+                                             false, false, false, false, false, false}),
+                 11);
+}
+
+// All non-zero: [[1, 2], [3, 4]] -> every element is non-zero
+TEST_F(QnnHTPBackendTests, NonZero_AllNonZero) {
+  RunNonZeroTest(BuildNonZeroTestCase<float>({2, 2}, {1.0f, 2.0f, 3.0f, 4.0f}), 11);
+}
+
+// All zero: [[0, 0], [0, 0]] -> every element is zero
+TEST_F(QnnHTPBackendTests, NonZero_AllZero) {
+  RunNonZeroTest(BuildNonZeroTestCase<float>({2, 2}, {0, 0, 0, 0}), 11);
+}
+
+// Negative test: NonZero with dynamic output shape should not be assigned to QNN EP.
+TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape_Negative) {
+  auto build_model = [](ModelTestBuilder& builder) {
+    TestInputDef<float> input_def({2, 3}, false, {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f});
+    MakeTestInput<float>(builder, "X", input_def);
+    builder.AddNode("nonzero_node", "NonZero", {"X"}, {"Y"}, kOnnxDomain);
+    // Dynamic output shape: [rank, -1]
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{2, -1});
+  };
+
+  RunNonZeroTest(build_model, 11, ExpectedEPNodeAssignment::None);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/nonzero_test.cc
+++ b/onnxruntime/test/providers/qnn/nonzero_test.cc
@@ -176,6 +176,84 @@ TEST_F(QnnHTPBackendTests, NonZero_AllZero) {
   RunNonZeroTest(BuildNonZeroTestCase<float>({2, 2}, {0, 0, 0, 0}), 11);
 }
 
+// NonZero -> Gather pattern with two Gather consumers to verify multiple consumers are handled.
+// Graph:
+//   mask -> NonZero -> [1, N] -> Reshape -> [N] (int64) -> Cast -> [N] (int32) -+-> Gather(data1) -> output1
+//                                                                                +-> Gather(data2) -> output2
+// NonZero output is declared as a graph output with static shape [1, num_elements] so QNN EP can claim it.
+// All mask elements are non-zero to avoid CPU/QNN shape mismatch from NonZero padding.
+TEST_F(QnnHTPBackendTests, NonZero_Gather_1D_Int32) {
+  std::vector<float> mask_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};  // non-zero at indices 0,1,2,3,4
+  std::vector<int32_t> data1 = {10, 20, 30, 40, 50};
+  std::vector<int32_t> data2 = {100, 200, 300, 400, 500};
+  int64_t num_elements = 5;
+
+  auto build_model = [mask_data, data1, data2, num_elements](ModelTestBuilder& builder) {
+    TestInputDef<float> mask_def({num_elements}, false, mask_data);
+    MakeTestInput<float>(builder, "mask", mask_def);
+
+    // NonZero: output [1, num_elements] — declared as graph output with static shape
+    // so QNN EP sees fixed dims and can claim the node
+    builder.AddNode("nonzero_node", "NonZero", {"mask"}, {"nonzero_out"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("nonzero_out", std::vector<int64_t>{1, num_elements});
+
+    // Reshape [1, num_elements] -> [num_elements]
+    builder.Make1DInitializer<int64_t>("reshape_shape", {num_elements});
+    builder.AddNode("reshape_node", "Reshape", {"nonzero_out", "reshape_shape"}, {"indices_i64"}, kOnnxDomain);
+
+    // Cast int64 -> int32 (HTP requires int32 indices for Gather)
+    builder.AddNode("cast_node", "Cast", {"indices_i64"}, {"indices_i32"}, kOnnxDomain,
+                    {test::MakeAttribute("to", int64_t(ONNX_NAMESPACE::TensorProto_DataType_INT32))});
+
+    // First Gather: data1[indices]
+    builder.MakeInitializer<int32_t>("data1", {num_elements}, data1);
+    builder.AddNode("gather_node1", "Gather", {"data1", "indices_i32"}, {"output1"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", int64_t(0))});
+    builder.MakeOutput<int32_t>("output1", std::vector<int64_t>{num_elements});
+
+    // Second Gather: data2[indices]
+    builder.MakeInitializer<int32_t>("data2", {num_elements}, data2);
+    builder.AddNode("gather_node2", "Gather", {"data2", "indices_i32"}, {"output2"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", int64_t(0))});
+    builder.MakeOutput<int32_t>("output2", std::vector<int64_t>{num_elements});
+  };
+
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  build_model(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  // Run on CPU EP
+  std::vector<Ort::Value> expected;
+  InferenceModelCPU(model_data, "NonZero_Gather_CPU", helper.feeds_, expected);
+
+  // Run on QNN EP (all nodes assigned)
+  std::vector<Ort::Value> actual;
+  InferenceModel(model_data, "NonZero_Gather_QNN", HtpProviderOptions(),
+                 ExpectedEPNodeAssignment::All, helper.feeds_, actual);
+
+  // Outputs: index 0 = NonZero graph output, index 1 = Gather1 output, index 2 = Gather2 output
+  for (size_t out_idx : {1, 2}) {
+    auto exp_shape = expected[out_idx].GetTensorTypeAndShapeInfo().GetShape();
+    auto act_shape = actual[out_idx].GetTensorTypeAndShapeInfo().GetShape();
+    ASSERT_EQ(exp_shape, act_shape) << "Shape mismatch for output " << out_idx;
+
+    auto element_count = expected[out_idx].GetTensorTypeAndShapeInfo().GetElementCount();
+    const int32_t* exp_data = expected[out_idx].GetTensorData<int32_t>();
+    const int32_t* act_data = actual[out_idx].GetTensorData<int32_t>();
+    for (size_t i = 0; i < element_count; ++i) {
+      EXPECT_EQ(exp_data[i], act_data[i]) << "Mismatch at output " << out_idx << " index " << i;
+    }
+  }
+}
+
 // Negative test: NonZero with dynamic output shape should not be assigned to QNN EP.
 TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape_Negative) {
   auto build_model = [](ModelTestBuilder& builder) {


### PR DESCRIPTION

### Description
Adds support for NonZero Op


### Motivation and Context
- NonZero op's output is of dynamic shape. This implementation sets the output shape to be [rank, num_inputs]. Current test framework also does not handle dynamic shapes well so the PR updates them (See: is_dynamic_output) or relaxes the checks in one place.
- HTP's output would be in transposed form of shape [num_inputs, rank]. So, this op builder explicitly adds a transpose to match with onnx format [rank, num_inputs]
- This op only supports a few combinations of inputs and outputs (See: https://docs.qualcomm.com/doc/80-63442-10/topic/HtpOpDefSupplement.html#nonzero). IsOpSupported, ProcessInputs account for the subset of combinations supported by HTP.  


