### PR TITLE
Fix GCC 13 build errors in QNN provider and tests

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2316,7 +2316,7 @@ OrtStatus* ORT_API_CALL QnnEp::SetDynamicOptionsImpl(_In_ OrtEp* this_ptr,
         ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR, ("Invalid EP Workload Type: " + value).c_str());
         return ep->ort_api.CreateStatus(ORT_INVALID_ARGUMENT, "Genie Execution Not Set.");
       }
-      ep->genie_kv_cache_rewind_.store(rewind_value, std::memory_order_acq_rel);
+      ep->genie_kv_cache_rewind_.store(rewind_value, std::memory_order_release);
     } else if (key == kOrtEpDynamicOptionsWorkloadType) {
       if (value == "Default") {
         RETURN_IF_NOT_OK(ep->qnn_backend_manager_->ResetContextPriority());

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -210,9 +210,21 @@ TEST_F(QnnCPUBackendTests, ReshapeGemmFusion) {
   std::vector<int64_t> shape_data = {4, 2};
   std::vector<float> weight_data(6, 1.0f);
   std::vector<float> bias_data = {1.0f, 2.0f, 3.0f};
+// GCC 13 with -O2 inlines this call chain deeply enough that its data flow analyzer loses track of
+// std::variant's initialization state inside the copy constructor (variant:224), triggering a false
+// positive -Wmaybe-uninitialized. The warning is suppressed here because TestInputDef members are
+// properly initialized in all constructors; this is a known GCC 13 analysis limitation with
+// std::variant + lambda capture + deep inlining.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
   RunReshapeGemmTest(TestInputDef<float>({2, 2, 2}, false, input_data), TestInputDef<int64_t>({2}, true, shape_data),
                      TestInputDef<float>({2, 3}, true, weight_data), TestInputDef<float>({3}, true, bias_data),
                      ExpectedEPNodeAssignment::All);
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/util/env_var_utils.h
+++ b/onnxruntime/test/util/env_var_utils.h
@@ -127,7 +127,7 @@ std::optional<T> ParseEnvironmentVariable(const std::string& name) {
     return {};
   }
 
-  T parsed_value;
+  T parsed_value{};
   bool parse_res = TryParseStringWithClassicLocale(value_str, parsed_value);
   if (!parse_res) {
     std::cerr << "Failed to parse environment variable - name: \"" + name + "\", value: \"" + value_str + "\"" << std::endl;


### PR DESCRIPTION
### Description
This PR fixes two GCC 13 related build failures caused by code patterns that were previously tolerated by older compilers.

1. Fix invalid memory_order for std::atomic::store() in QNN EP
- std::atomic::store() does not permit memory_order_acq_rel per the C++ standard. The previous usage was undefined behavior. Older GCC versions only emitted a warning, while GCC 13 (as used in Ubuntu 24.04) treats this as a hard error (-Werror=invalid-memory-model).
- Replace memory_order_acq_rel with memory_order_release, which is the correct memory ordering for a pure store and preserves the intended synchronization semantics.

2. Fix GCC 13 -Wmaybe-uninitialized false positive in TestInputDef and parsed_value

- GCC 13 may emit a false positive -Wmaybe-uninitialized after deep inlining involving std::variant copy construction. All TestInputDef members are correctly initialized; the warning is due to a GCC 13 data flow analysis limitation.
- Suppress the warning locally with a guarded GCC diagnostic pragma and add a comment explaining the root cause and rationale.
- Changed T parsed_value; to T parsed_value{};. Value-initialization ensures the variable has a defined state before use, silencing the GCC 13 -Werror=maybe-uninitialized warning.

### Reference
- https://en.cppreference.com/w/cpp/atomic/atomic/store
