### PR TITLE
add reshape-gemm-reshape-reshape fusion

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -88,7 +88,7 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"Gather", {GatherTransposeReshapeFusion::TryFusion}},
     {"HardSigmoid", {HardSigmoidMulFusion::TryFusion}},
     {"MatMul", {LowPowerBlockQuantizedMatMulFusion::TryFusion}},
-    {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmReshapeReshapeFusion::TryFusion, ReshapeGemmReshapeFusion::TryFusion, ReshapeGemmFusion::TryFusion}},
+    {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmFusionGroup::TryFusion4, ReshapeGemmFusionGroup::TryFusion3, ReshapeGemmFusionGroup::TryFusion2}},
     {"Mul", {ScaleSoftmaxFusion::TryFusion}},
     {"Cast", {CastLoneQFusion::TryFusion}},
     {"Erf", {GeluFusion::TryFusion}},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -88,7 +88,7 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"Gather", {GatherTransposeReshapeFusion::TryFusion}},
     {"HardSigmoid", {HardSigmoidMulFusion::TryFusion}},
     {"MatMul", {LowPowerBlockQuantizedMatMulFusion::TryFusion}},
-    {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmFusion::TryFusion}},
+    {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmReshapeReshapeFusion::TryFusion, ReshapeGemmReshapeFusion::TryFusion, ReshapeGemmFusion::TryFusion}},
     {"Mul", {ScaleSoftmaxFusion::TryFusion}},
     {"Cast", {CastLoneQFusion::TryFusion}},
     {"Erf", {GeluFusion::TryFusion}},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_node_group/utils.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
@@ -599,6 +600,11 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeFusion::TryFusion(
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
 
+  // Skip fusion for GPU backend
+  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return nullptr;
+  }
+
   // Only handle standalone Gemm nodes (not QDQ-wrapped)
   if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
     return nullptr;
@@ -676,6 +682,11 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
+
+  // Skip fusion for GPU backend
+  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return nullptr;
+  }
 
   // Only handle Gemm nodes (MatMul+Add gets fused to Gemm)
   if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -143,121 +143,76 @@ const OrtNodeUnit* GetOutputReshape2NodeUnit(
                                   node_to_node_unit, node_unit_to_qnn_node_group);
 }
 
-Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& reshape_node_unit,
-                                  const OrtNodeUnit& gemm_node_unit, const Ort::Logger& logger, bool validate) {
-  assert(reshape_node_unit.OpType() == "Reshape" && gemm_node_unit.OpType() == "Gemm");
-  const auto& node_name = utils::UniqueNameGenerator().New(gemm_node_unit);
-  const OrtNodeUnitIODef& input_def = reshape_node_unit.Inputs()[0];
-  const OrtNodeUnitIODef& weight_def = gemm_node_unit.Inputs()[1];
-  const OrtNodeUnitIODef* bias_def_ptr = nullptr;
-  bool has_bias = gemm_node_unit.Inputs().size() == 3;
-  if (has_bias) {
-    bias_def_ptr = &gemm_node_unit.Inputs()[2];
-  }
-  const OrtNodeUnitIODef& output_def = gemm_node_unit.Outputs()[0];
-
-  QnnTensorWrapper input_tensor;
-  QnnTensorWrapper bias_tensor;
-  QnnTensorWrapper output_tensor;
-
-  // Create input tensor wrapper
-  RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(input_def, input_tensor));
-
-  // Process weight tensor
-  std::vector<uint32_t> weight_shape;
-  std::vector<uint8_t> unpacked_tensor;
-  std::string weight_tensor_name = weight_def.name;
-
-  // Get weight shape and validate
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(weight_def.shape, weight_shape), "Failed to get weight shape");
-
-  // Get tensor type for weight
-  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
-  Qnn_DataType_t data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(false, weight_def.type, data_type));
-
-  // Get weight tensor proto and perform 2D transpose
-  const auto* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
-  // Transpose the weight tensor (2D matrix transpose)
-  RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper, weight_shape, weight_tensor_proto, unpacked_tensor, logger, validate));
-  QnnTensorWrapper weight_tensor(weight_tensor_name, tensor_type, data_type, QnnQuantParamsWrapper(),
-                                 std::move(weight_shape), std::move(unpacked_tensor));
-  if (has_bias) {
-    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(*bias_def_ptr, bias_tensor));
+// Common validation for Gemm node in fusion patterns.
+// Returns true if the Gemm node is valid for fusion, false otherwise.
+// Checks: GPU backend skip, standalone Gemm, no transpose, constant non-quantized weight.
+bool IsValidGemmForFusion(const QnnModelWrapper& qnn_model_wrapper,
+                          const OrtNodeUnit& gemm_node_unit,
+                          bool check_quantized_weight = true) {
+  // Skip fusion for GPU backend
+  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return false;
   }
 
-  // Create output tensor wrapper
-  RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(output_def, output_tensor));
-
-  if (validate) {
-    std::vector<Qnn_Tensor_t> input_tensors = {input_tensor.GetQnnTensor(), weight_tensor.GetQnnTensor()};
-    if (has_bias) {
-      input_tensors.emplace_back(bias_tensor.GetQnnTensor());
-    }
-
-    // Validate the QNN node
-    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                      QNN_OP_FULLY_CONNECTED, std::move(input_tensors),
-                                                      {output_tensor.GetQnnTensor()}, {}));
-  } else {
-    // For creation, add all tensor wrappers to the model
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor)), "Failed to add weight");
-
-    // Add bias tensor if it exists
-    if (has_bias) {
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensor)), "Failed to add bias");
-    }
-
-    // Add output tensor
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add output");
-
-    // Create input names vector
-    std::vector<std::string> input_names = {input_def.name, weight_tensor_name};
-    if (has_bias) {
-      input_names.emplace_back(bias_def_ptr->name);
-    }
-
-    // Create the QNN node for fully connected operation
-    RETURN_IF_NOT(
-        qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
-                                        std::move(input_names), {output_def.name}, {}, validate),
-        "Failed to add fused Gemm node.");
+  // Only handle standalone Gemm nodes (not QDQ-wrapped)
+  if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return false;
   }
 
-  return Ort::Status();
+  // Check transA and transB - we only handle the default case (no transpose)
+  OrtNodeAttrHelper attr_helper(gemm_node_unit);
+  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
+  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
+  if (transA != 0 || transB != 0) {
+    return false;
+  }
+
+  // Weight must be constant
+  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
+  if (!qnn_model_wrapper.IsConstantInput(weight_input.name)) {
+    return false;
+  }
+
+  // Optionally check that weight is not quantized (pattern is from MatMul->Add fusion)
+  if (check_quantized_weight && weight_input.quant_param.has_value()) {
+    return false;
+  }
+
+  return true;
 }
 
-// For ReshapeGemmReshapeReshapeFusion
-Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
-                                       const OrtNodeUnit& input_reshape_node_unit,
-                                       const OrtNodeUnit& fc_node_unit,
-                                       const OrtNodeUnit& output_reshape1_node_unit,
-                                       const OrtNodeUnit& output_reshape2_node_unit,
-                                       const Ort::Logger& logger,
-                                       bool validate) {
-  ORT_UNUSED_PARAMETER(logger);
-  ORT_UNUSED_PARAMETER(output_reshape1_node_unit);
-
-  const auto& fc_node_name = utils::UniqueNameGenerator().New(fc_node_unit);
-  const auto& reshape_node_name = utils::UniqueNameGenerator().New(output_reshape2_node_unit);
+// Common implementation for CreateOrValidateOnQnn with optional output reshape.
+// When output_reshape_node_unit is nullptr, creates FC node only (2-node fusion).
+// When output_reshape_node_unit is provided, creates FC + Reshape nodes (3-node and 4-node fusion).
+Ort::Status CreateOrValidateFusedFCOnQnn(QnnModelWrapper& qnn_model_wrapper,
+                                         const OrtNodeUnit& input_reshape_node_unit,
+                                         const OrtNodeUnit& gemm_node_unit,
+                                         const OrtNodeUnit* output_reshape_node_unit,
+                                         const Ort::Logger& logger,
+                                         bool validate) {
+  const auto& fc_node_name = utils::UniqueNameGenerator().New(gemm_node_unit);
 
   // Get input from the input reshape's input (original ND tensor)
   const OrtNodeUnitIODef& input_def = input_reshape_node_unit.Inputs()[0];
-  // Get weight from FC's input[1]
-  const OrtNodeUnitIODef& weight_def = fc_node_unit.Inputs()[1];
-  // Check for bias
+  const OrtNodeUnitIODef& weight_def = gemm_node_unit.Inputs()[1];
   const OrtNodeUnitIODef* bias_def_ptr = nullptr;
-  bool has_bias = fc_node_unit.Inputs().size() > 2;
+  bool has_bias = gemm_node_unit.Inputs().size() > 2;
   if (has_bias) {
-    bias_def_ptr = &fc_node_unit.Inputs()[2];
+    bias_def_ptr = &gemm_node_unit.Inputs()[2];
   }
-  // FC output: use Gemm's 2D output shape (QNN FC requires 2D output)
-  const OrtNodeUnitIODef& fc_output_def = fc_node_unit.Outputs()[0];
-  const std::string fc_output_name = fc_node_name + "_fc_out";
+  // FC output definition (from Gemm node)
+  const OrtNodeUnitIODef& fc_output_def = gemm_node_unit.Outputs()[0];
 
-  // Reshape2 output: final output from reshape2
-  const OrtNodeUnitIODef& final_output_def = output_reshape2_node_unit.Outputs()[0];
+  // Determine if we have an output reshape
+  const bool has_output_reshape = (output_reshape_node_unit != nullptr);
+
+  // FC output name: intermediate if we have reshape, final otherwise
+  const std::string fc_output_name = has_output_reshape ? (fc_node_name + "_fc_out") : fc_output_def.name;
+
+  // Final output: from reshape if present, otherwise from FC
+  const OrtNodeUnitIODef& final_output_def = has_output_reshape
+                                                 ? output_reshape_node_unit->Outputs()[0]
+                                                 : fc_output_def;
   const std::string& final_output_name = final_output_def.name;
 
   // Create input tensor wrapper
@@ -304,26 +259,41 @@ Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
   QnnQuantParamsWrapper fc_output_quant_param;
   RETURN_IF_ERROR(fc_output_quant_param.Init(qnn_model_wrapper, fc_output_def));
 
-  QnnTensorWrapper fc_output_tensor(fc_output_name, QNN_TENSOR_TYPE_NATIVE, fc_output_data_type,
+  // FC output tensor type: native if intermediate, check graph output if final
+  Qnn_TensorType_t fc_output_tensor_type = QNN_TENSOR_TYPE_NATIVE;
+  if (!has_output_reshape) {
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(fc_output_name);
+    fc_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+  }
+
+  QnnTensorWrapper fc_output_tensor(fc_output_name, fc_output_tensor_type, fc_output_data_type,
                                     std::move(fc_output_quant_param), std::move(fc_output_shape),
                                     std::vector<uint8_t>());
 
-  // Create Reshape2 output tensor (final output)
-  std::vector<uint32_t> final_output_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(final_output_def.shape, final_output_shape), "Failed to get final output shape");
+  // Create final output tensor (reshape output) if we have output reshape
+  QnnTensorWrapper final_output_tensor;
+  std::string reshape_node_name;
+  if (has_output_reshape) {
+    reshape_node_name = utils::UniqueNameGenerator().New(*output_reshape_node_unit);
 
-  Qnn_DataType_t final_output_data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(final_output_def.quant_param.has_value(), final_output_def.type, final_output_data_type));
+    std::vector<uint32_t> final_output_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(final_output_def.shape, final_output_shape),
+                  "Failed to get final output shape");
 
-  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
-  Qnn_TensorType_t final_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+    Qnn_DataType_t final_output_data_type = QNN_DATATYPE_FLOAT_32;
+    RETURN_IF_ERROR(utils::GetQnnDataType(final_output_def.quant_param.has_value(), final_output_def.type,
+                                          final_output_data_type));
 
-  QnnQuantParamsWrapper final_output_quant_param;
-  RETURN_IF_ERROR(final_output_quant_param.Init(qnn_model_wrapper, final_output_def));
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
+    Qnn_TensorType_t final_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-  QnnTensorWrapper final_output_tensor(final_output_name, final_output_tensor_type, final_output_data_type,
-                                       std::move(final_output_quant_param), std::move(final_output_shape),
-                                       std::vector<uint8_t>());
+    QnnQuantParamsWrapper final_output_quant_param;
+    RETURN_IF_ERROR(final_output_quant_param.Init(qnn_model_wrapper, final_output_def));
+
+    final_output_tensor = QnnTensorWrapper(final_output_name, final_output_tensor_type, final_output_data_type,
+                                           std::move(final_output_quant_param), std::move(final_output_shape),
+                                           std::vector<uint8_t>());
+  }
 
   if (validate) {
     // Validate FC node
@@ -335,10 +305,12 @@ Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
                                                       QNN_OP_FULLY_CONNECTED, std::move(fc_input_tensors),
                                                       {fc_output_tensor.GetQnnTensor()}, {}));
 
-    // Validate Reshape node
-    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                      QNN_OP_RESHAPE, {fc_output_tensor.GetQnnTensor()},
-                                                      {final_output_tensor.GetQnnTensor()}, {}));
+    // Validate Reshape node if present
+    if (has_output_reshape) {
+      RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                        QNN_OP_RESHAPE, {fc_output_tensor.GetQnnTensor()},
+                                                        {final_output_tensor.GetQnnTensor()}, {}));
+    }
   } else {
     // Add tensors to model
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
@@ -347,7 +319,9 @@ Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensor)), "Failed to add bias");
     }
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_output_tensor)), "Failed to add FC output");
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)), "Failed to add final output");
+    if (has_output_reshape) {
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)), "Failed to add final output");
+    }
 
     // Create FC input names
     std::vector<std::string> fc_input_names = {input_def.name, weight_tensor_name};
@@ -355,165 +329,59 @@ Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
       fc_input_names.emplace_back(bias_def_ptr->name);
     }
 
-    // Create the QNN FullyConnected node (ND input -> 2D output)
+    // Create the QNN FullyConnected node
     RETURN_IF_NOT(
         qnn_model_wrapper.CreateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
                                         std::move(fc_input_names), {fc_output_name},
                                         {}, validate),
         "Failed to create FullyConnected node.");
 
-    // Create the QNN Reshape node (2D -> final shape)
-    RETURN_IF_NOT(
-        qnn_model_wrapper.CreateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
-                                        {fc_output_name}, {final_output_name},
-                                        {}, validate),
-        "Failed to create Reshape node.");
+    // Create the QNN Reshape node if present
+    if (has_output_reshape) {
+      RETURN_IF_NOT(
+          qnn_model_wrapper.CreateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
+                                          {fc_output_name}, {final_output_name},
+                                          {}, validate),
+          "Failed to create Reshape node.");
+    }
   }
 
   return Ort::Status();
 }
 
-// For ReshapeGemmReshapeFusion
+// For ReshapeGemmFusion (2-node: Reshape -> Gemm)
+Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
+                                  const OrtNodeUnit& reshape_node_unit,
+                                  const OrtNodeUnit& gemm_node_unit,
+                                  const Ort::Logger& logger,
+                                  bool validate) {
+  return CreateOrValidateFusedFCOnQnn(qnn_model_wrapper, reshape_node_unit, gemm_node_unit,
+                                      nullptr, logger, validate);
+}
+
+// For ReshapeGemmReshapeFusion (3-node: Reshape -> Gemm -> Reshape)
 Ort::Status CreateOrValidateOnQnn3Node(QnnModelWrapper& qnn_model_wrapper,
                                        const OrtNodeUnit& input_reshape_node_unit,
-                                       const OrtNodeUnit& fc_node_unit,
+                                       const OrtNodeUnit& gemm_node_unit,
                                        const OrtNodeUnit& output_reshape_node_unit,
                                        const Ort::Logger& logger,
                                        bool validate) {
-  ORT_UNUSED_PARAMETER(logger);
+  return CreateOrValidateFusedFCOnQnn(qnn_model_wrapper, input_reshape_node_unit, gemm_node_unit,
+                                      &output_reshape_node_unit, logger, validate);
+}
 
-  const auto& fc_node_name = utils::UniqueNameGenerator().New(fc_node_unit);
-  const auto& reshape_node_name = utils::UniqueNameGenerator().New(output_reshape_node_unit);
-
-  // Get input from the input reshape's input (original ND tensor)
-  const OrtNodeUnitIODef& input_def = input_reshape_node_unit.Inputs()[0];
-  // Get weight from FC's input[1]
-  const OrtNodeUnitIODef& weight_def = fc_node_unit.Inputs()[1];
-  // Check for bias
-  const OrtNodeUnitIODef* bias_def_ptr = nullptr;
-  bool has_bias = fc_node_unit.Inputs().size() > 2;
-  if (has_bias) {
-    bias_def_ptr = &fc_node_unit.Inputs()[2];
-  }
-  // FC output: intermediate 2D output
-  const OrtNodeUnitIODef& fc_output_def = fc_node_unit.Outputs()[0];
-  const std::string fc_output_name = fc_node_name + "_fc_out";
-
-  // Reshape output: final output from output_reshape
-  const OrtNodeUnitIODef& final_output_def = output_reshape_node_unit.Outputs()[0];
-  const std::string& final_output_name = final_output_def.name;
-
-  // Create input tensor wrapper
-  QnnTensorWrapper input_tensor;
-  RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(input_def, input_tensor));
-
-  // Process weight tensor - need to transpose for FullyConnected
-  std::vector<uint32_t> weight_shape;
-  std::vector<uint8_t> unpacked_tensor;
-  std::string weight_tensor_name = weight_def.name;
-
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(weight_def.shape, weight_shape), "Failed to get weight shape");
-
-  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
-  Qnn_DataType_t weight_data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(weight_def.quant_param.has_value(), weight_def.type, weight_data_type));
-
-  // Get weight tensor and transpose (Gemm weight is [K, N], FC expects [N, K])
-  const auto* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
-  RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper, weight_shape, weight_tensor_proto,
-                                               unpacked_tensor, logger, validate));
-
-  QnnQuantParamsWrapper weight_quant_param;
-  RETURN_IF_ERROR(weight_quant_param.Init(qnn_model_wrapper, weight_def));
-  RETURN_IF_ERROR(weight_quant_param.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
-
-  QnnTensorWrapper weight_tensor(weight_tensor_name, tensor_type, weight_data_type,
-                                 std::move(weight_quant_param), std::move(weight_shape),
-                                 std::move(unpacked_tensor));
-
-  // Process bias if present
-  QnnTensorWrapper bias_tensor;
-  if (has_bias) {
-    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(*bias_def_ptr, bias_tensor));
-  }
-
-  // Create FC output tensor (2D intermediate)
-  std::vector<uint32_t> fc_output_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(fc_output_def.shape, fc_output_shape), "Failed to get FC output shape");
-
-  Qnn_DataType_t fc_output_data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(fc_output_def.quant_param.has_value(), fc_output_def.type, fc_output_data_type));
-
-  QnnQuantParamsWrapper fc_output_quant_param;
-  RETURN_IF_ERROR(fc_output_quant_param.Init(qnn_model_wrapper, fc_output_def));
-
-  QnnTensorWrapper fc_output_tensor(fc_output_name, QNN_TENSOR_TYPE_NATIVE, fc_output_data_type,
-                                    std::move(fc_output_quant_param), std::move(fc_output_shape),
-                                    std::vector<uint8_t>());
-
-  // Create Reshape output tensor (final output)
-  std::vector<uint32_t> final_output_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(final_output_def.shape, final_output_shape), "Failed to get final output shape");
-
-  Qnn_DataType_t final_output_data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(final_output_def.quant_param.has_value(), final_output_def.type, final_output_data_type));
-
-  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
-  Qnn_TensorType_t final_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-
-  QnnQuantParamsWrapper final_output_quant_param;
-  RETURN_IF_ERROR(final_output_quant_param.Init(qnn_model_wrapper, final_output_def));
-
-  QnnTensorWrapper final_output_tensor(final_output_name, final_output_tensor_type, final_output_data_type,
-                                       std::move(final_output_quant_param), std::move(final_output_shape),
-                                       std::vector<uint8_t>());
-
-  if (validate) {
-    // Validate FC node
-    std::vector<Qnn_Tensor_t> fc_input_tensors = {input_tensor.GetQnnTensor(), weight_tensor.GetQnnTensor()};
-    if (has_bias) {
-      fc_input_tensors.emplace_back(bias_tensor.GetQnnTensor());
-    }
-    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                      QNN_OP_FULLY_CONNECTED, std::move(fc_input_tensors),
-                                                      {fc_output_tensor.GetQnnTensor()}, {}));
-
-    // Validate Reshape node
-    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                      QNN_OP_RESHAPE, {fc_output_tensor.GetQnnTensor()},
-                                                      {final_output_tensor.GetQnnTensor()}, {}));
-  } else {
-    // Add tensors to model
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor)), "Failed to add weight");
-    if (has_bias) {
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensor)), "Failed to add bias");
-    }
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_output_tensor)), "Failed to add FC output");
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)), "Failed to add final output");
-
-    // Create FC input names
-    std::vector<std::string> fc_input_names = {input_def.name, weight_tensor_name};
-    if (has_bias) {
-      fc_input_names.emplace_back(bias_def_ptr->name);
-    }
-
-    // Create the QNN FullyConnected node (ND input -> 2D output)
-    RETURN_IF_NOT(
-        qnn_model_wrapper.CreateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
-                                        std::move(fc_input_names), {fc_output_name},
-                                        {}, validate),
-        "Failed to create FullyConnected node.");
-
-    // Create the QNN Reshape node (2D -> final shape)
-    RETURN_IF_NOT(
-        qnn_model_wrapper.CreateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
-                                        {fc_output_name}, {final_output_name},
-                                        {}, validate),
-        "Failed to create Reshape node.");
-  }
-
-  return Ort::Status();
+// For ReshapeGemmReshapeReshapeFusion (4-node: Reshape -> Gemm -> Reshape1 -> Reshape2)
+// Note: Reshape1 is skipped; we fuse directly to Reshape2's output shape
+Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& input_reshape_node_unit,
+                                       const OrtNodeUnit& gemm_node_unit,
+                                       const OrtNodeUnit& output_reshape1_node_unit,
+                                       const OrtNodeUnit& output_reshape2_node_unit,
+                                       const Ort::Logger& logger,
+                                       bool validate) {
+  ORT_UNUSED_PARAMETER(output_reshape1_node_unit);
+  return CreateOrValidateFusedFCOnQnn(qnn_model_wrapper, input_reshape_node_unit, gemm_node_unit,
+                                      &output_reshape2_node_unit, logger, validate);
 }
 
 }  // namespace
@@ -528,27 +396,7 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusion::TryFusion(
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
 
-  // Skip fusion for GPU backend
-  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
-    return nullptr;
-  }
-
-  // Only handle standalone Gemm nodes (not QDQ-wrapped)
-  if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
-    return nullptr;
-  }
-
-  // Check transA and transB - we only handle the default case (no transpose)
-  OrtNodeAttrHelper attr_helper(gemm_node_unit);
-  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
-  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
-  if (transA != 0 || transB != 0) {
-    return nullptr;
-  }
-
-  // Weight must be constant and not quantized (pattern is from MatMul->Add fusion)
-  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
-  if (!qnn_model_wrapper.IsConstantInput(weight_input.name) || weight_input.quant_param.has_value()) {
+  if (!IsValidGemmForFusion(qnn_model_wrapper, gemm_node_unit)) {
     return nullptr;
   }
 
@@ -560,6 +408,7 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusion::TryFusion(
   }
 
   // Get weight's input channel (K dimension)
+  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
   int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
   if (weight_k <= 0) {
     return nullptr;
@@ -605,27 +454,7 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeFusion::TryFusion(
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
 
-  // Skip fusion for GPU backend
-  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
-    return nullptr;
-  }
-
-  // Only handle standalone Gemm nodes (not QDQ-wrapped)
-  if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
-    return nullptr;
-  }
-
-  // Check transA and transB - we only handle the default case (no transpose)
-  OrtNodeAttrHelper attr_helper(gemm_node_unit);
-  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
-  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
-  if (transA != 0 || transB != 0) {
-    return nullptr;
-  }
-
-  // Weight must be constant
-  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
-  if (!qnn_model_wrapper.IsConstantInput(weight_input.name)) {
+  if (!IsValidGemmForFusion(qnn_model_wrapper, gemm_node_unit)) {
     return nullptr;
   }
 
@@ -642,15 +471,19 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeFusion::TryFusion(
   if (!output_reshape) {
     return nullptr;
   }
+
   // Get weight's input channel (K dimension)
+  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
   int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
   if (weight_k <= 0) {
     return nullptr;
   }
+
   // Validate input reshape pattern (ND -> 2D with last dim = weight's K)
   if (!CheckShape(qnn_model_wrapper, input_reshape->GetNode(), weight_k)) {
     return nullptr;
   }
+
   return std::make_unique<ReshapeGemmReshapeFusion>(*input_reshape, gemm_node_unit, *output_reshape);
 }
 
@@ -688,27 +521,7 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
 
-  // Skip fusion for GPU backend
-  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
-    return nullptr;
-  }
-
-  // Only handle Gemm nodes (MatMul+Add gets fused to Gemm)
-  if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
-    return nullptr;
-  }
-
-  // Check transA and transB - we only handle the default case (no transpose)
-  OrtNodeAttrHelper attr_helper(gemm_node_unit);
-  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
-  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
-  if (transA != 0 || transB != 0) {
-    return nullptr;
-  }
-
-  // Weight must be constant
-  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
-  if (!qnn_model_wrapper.IsConstantInput(weight_input.name)) {
+  if (!IsValidGemmForFusion(qnn_model_wrapper, gemm_node_unit)) {
     return nullptr;
   }
 
@@ -726,6 +539,12 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
     return nullptr;
   }
 
+  // Reshape1's output must not be a graph output (we need Reshape2 to consume it)
+  const OrtNodeUnitIODef& reshape1_output = output_reshape1->Outputs()[0];
+  if (qnn_model_wrapper.IsGraphOutput(reshape1_output.name)) {
+    return nullptr;
+  }
+
   // Find output Reshape2 (after Reshape1)
   const OrtNodeUnit* output_reshape2 = GetOutputReshape2NodeUnit(
       qnn_model_wrapper, *output_reshape1, node_to_node_unit, node_unit_to_qnn_node_group);
@@ -734,6 +553,7 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
   }
 
   // Get weight's input channel (K dimension)
+  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
   int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
   if (weight_k <= 0) {
     return nullptr;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -128,9 +128,8 @@ const OrtNodeUnit* GetOutputReshapeNodeUnit(
     const OrtNodeUnit& gemm_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
-  const std::array<std::string_view, 1> reshape_types = {"Reshape"};
-  return GetOnlyChildOfType(qnn_model_wrapper, gemm_node_unit, reshape_types,
-                            node_to_node_unit, node_unit_to_qnn_node_group);
+  return GetChildNodeUnitAllowQdq(qnn_model_wrapper, gemm_node_unit, "Reshape",
+                                  node_to_node_unit, node_unit_to_qnn_node_group);
 }
 
 // Get the second output Reshape node unit that consumes reshape1's output (reshape2)
@@ -139,9 +138,8 @@ const OrtNodeUnit* GetOutputReshape2NodeUnit(
     const OrtNodeUnit& reshape1_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
-  const std::array<std::string_view, 1> reshape_types = {"Reshape"};
-  return GetOnlyChildOfType(qnn_model_wrapper, reshape1_node_unit, reshape_types,
-                            node_to_node_unit, node_unit_to_qnn_node_group);
+  return GetChildNodeUnitAllowQdq(qnn_model_wrapper, reshape1_node_unit, "Reshape",
+                                  node_to_node_unit, node_unit_to_qnn_node_group);
 }
 
 Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& reshape_node_unit,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -9,6 +9,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/qnn_def.h"
@@ -167,6 +168,13 @@ bool IsValidGemmForFusion(const QnnModelWrapper& qnn_model_wrapper,
     return false;
   }
 
+  // Only fuse when alpha == 1.0 and beta == 1.0
+  float alpha = attr_helper.Get("alpha", 1.0f);
+  float beta = attr_helper.Get("beta", 1.0f);
+  if (alpha != 1.0f || beta != 1.0f) {
+    return false;
+  }
+
   // Weight must be constant
   const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
   if (!qnn_model_wrapper.IsConstantInput(weight_input.name)) {
@@ -181,38 +189,28 @@ bool IsValidGemmForFusion(const QnnModelWrapper& qnn_model_wrapper,
   return true;
 }
 
-// Common implementation for CreateOrValidateOnQnn with optional output reshape.
-// When output_reshape_node_unit is nullptr, creates FC node only (2-node fusion).
-// When output_reshape_node_unit is provided, creates FC + Reshape nodes (3-node and 4-node fusion).
+// Common implementation for creating/validating fused FC on QNN.
+// Handles 2-node (no output reshape), 3-node (one output reshape), and 4-node (skip reshape1, use reshape2).
 Ort::Status CreateOrValidateFusedFCOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& input_reshape_node_unit,
                                          const OrtNodeUnit& gemm_node_unit,
                                          const OrtNodeUnit* output_reshape_node_unit,
                                          const Ort::Logger& logger,
                                          bool validate) {
-  const auto& fc_node_name = utils::UniqueNameGenerator().New(gemm_node_unit);
+  const bool has_output_reshape = output_reshape_node_unit != nullptr;
 
-  // Get input from the input reshape's input (original ND tensor)
+  // Get input/output definitions
   const OrtNodeUnitIODef& input_def = input_reshape_node_unit.Inputs()[0];
   const OrtNodeUnitIODef& weight_def = gemm_node_unit.Inputs()[1];
-  const OrtNodeUnitIODef* bias_def_ptr = nullptr;
-  bool has_bias = gemm_node_unit.Inputs().size() > 2;
-  if (has_bias) {
-    bias_def_ptr = &gemm_node_unit.Inputs()[2];
-  }
-  // FC output definition (from Gemm node)
+  const OrtNodeUnitIODef* bias_def_ptr = gemm_node_unit.Inputs().size() > 2 ? &gemm_node_unit.Inputs()[2] : nullptr;
+  const bool has_bias = bias_def_ptr != nullptr;
+
+  // FC output is Gemm's output; final output is reshape's output if present
   const OrtNodeUnitIODef& fc_output_def = gemm_node_unit.Outputs()[0];
+  const OrtNodeUnitIODef& final_output_def = has_output_reshape ? output_reshape_node_unit->Outputs()[0] : fc_output_def;
 
-  // Determine if we have an output reshape
-  const bool has_output_reshape = (output_reshape_node_unit != nullptr);
-
-  // FC output name: intermediate if we have reshape, final otherwise
-  const std::string fc_output_name = has_output_reshape ? (fc_node_name + "_fc_out") : fc_output_def.name;
-
-  // Final output: from reshape if present, otherwise from FC
-  const OrtNodeUnitIODef& final_output_def = has_output_reshape
-                                                 ? output_reshape_node_unit->Outputs()[0]
-                                                 : fc_output_def;
+  const std::string fc_node_name = utils::UniqueNameGenerator().New(gemm_node_unit);
+  const std::string& fc_output_name = has_output_reshape ? fc_node_name + "_fc_out" : fc_output_def.name;
   const std::string& final_output_name = final_output_def.name;
 
   // Create input tensor wrapper
@@ -226,22 +224,18 @@ Ort::Status CreateOrValidateFusedFCOnQnn(QnnModelWrapper& qnn_model_wrapper,
 
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(weight_def.shape, weight_shape), "Failed to get weight shape");
 
-  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+  // Get tensor type for weight
+  Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
   Qnn_DataType_t weight_data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(weight_def.quant_param.has_value(), weight_def.type, weight_data_type));
+  RETURN_IF_ERROR(utils::GetQnnDataType(false, weight_def.type, weight_data_type));
 
-  // Get weight tensor and transpose (Gemm weight is [K, N], FC expects [N, K])
+  // Get weight tensor proto and perform 2D transpose
   const auto* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
   RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper, weight_shape, weight_tensor_proto,
                                                unpacked_tensor, logger, validate));
 
-  QnnQuantParamsWrapper weight_quant_param;
-  RETURN_IF_ERROR(weight_quant_param.Init(qnn_model_wrapper, weight_def));
-  RETURN_IF_ERROR(weight_quant_param.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
-
-  QnnTensorWrapper weight_tensor(weight_tensor_name, tensor_type, weight_data_type,
-                                 std::move(weight_quant_param), std::move(weight_shape),
-                                 std::move(unpacked_tensor));
+  QnnTensorWrapper weight_tensor(weight_tensor_name, weight_tensor_type, weight_data_type, QnnQuantParamsWrapper(),
+                                 std::move(weight_shape), std::move(unpacked_tensor));
 
   // Process bias if present
   QnnTensorWrapper bias_tensor;
@@ -250,25 +244,25 @@ Ort::Status CreateOrValidateFusedFCOnQnn(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // Create FC output tensor
-  std::vector<uint32_t> fc_output_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(fc_output_def.shape, fc_output_shape), "Failed to get FC output shape");
-
-  Qnn_DataType_t fc_output_data_type = QNN_DATATYPE_FLOAT_32;
-  RETURN_IF_ERROR(utils::GetQnnDataType(fc_output_def.quant_param.has_value(), fc_output_def.type, fc_output_data_type));
-
-  QnnQuantParamsWrapper fc_output_quant_param;
-  RETURN_IF_ERROR(fc_output_quant_param.Init(qnn_model_wrapper, fc_output_def));
-
-  // FC output tensor type: native if intermediate, check graph output if final
-  Qnn_TensorType_t fc_output_tensor_type = QNN_TENSOR_TYPE_NATIVE;
+  QnnTensorWrapper fc_output_tensor;
   if (!has_output_reshape) {
-    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(fc_output_name);
-    fc_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-  }
+    // For 2-node case, use MakeTensorWrapper for output
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(fc_output_def, fc_output_tensor));
+  } else {
+    // For 3/4-node case, create intermediate tensor
+    std::vector<uint32_t> fc_output_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(fc_output_def.shape, fc_output_shape), "Failed to get FC output shape");
 
-  QnnTensorWrapper fc_output_tensor(fc_output_name, fc_output_tensor_type, fc_output_data_type,
-                                    std::move(fc_output_quant_param), std::move(fc_output_shape),
-                                    std::vector<uint8_t>());
+    Qnn_DataType_t fc_output_data_type = QNN_DATATYPE_FLOAT_32;
+    RETURN_IF_ERROR(utils::GetQnnDataType(fc_output_def.quant_param.has_value(), fc_output_def.type, fc_output_data_type));
+
+    QnnQuantParamsWrapper fc_output_quant_param;
+    RETURN_IF_ERROR(fc_output_quant_param.Init(qnn_model_wrapper, fc_output_def));
+
+    fc_output_tensor = QnnTensorWrapper(fc_output_name, QNN_TENSOR_TYPE_NATIVE, fc_output_data_type,
+                                        std::move(fc_output_quant_param), std::move(fc_output_shape),
+                                        std::vector<uint8_t>());
+  }
 
   // Create final output tensor (reshape output) if we have output reshape
   QnnTensorWrapper final_output_tensor;
@@ -349,47 +343,52 @@ Ort::Status CreateOrValidateFusedFCOnQnn(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// For ReshapeGemmFusion (2-node: Reshape -> Gemm)
-Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
-                                  const OrtNodeUnit& reshape_node_unit,
-                                  const OrtNodeUnit& gemm_node_unit,
-                                  const Ort::Logger& logger,
-                                  bool validate) {
-  return CreateOrValidateFusedFCOnQnn(qnn_model_wrapper, reshape_node_unit, gemm_node_unit,
-                                      nullptr, logger, validate);
-}
-
-// For ReshapeGemmReshapeFusion (3-node: Reshape -> Gemm -> Reshape)
-Ort::Status CreateOrValidateOnQnn3Node(QnnModelWrapper& qnn_model_wrapper,
-                                       const OrtNodeUnit& input_reshape_node_unit,
-                                       const OrtNodeUnit& gemm_node_unit,
-                                       const OrtNodeUnit& output_reshape_node_unit,
-                                       const Ort::Logger& logger,
-                                       bool validate) {
-  return CreateOrValidateFusedFCOnQnn(qnn_model_wrapper, input_reshape_node_unit, gemm_node_unit,
-                                      &output_reshape_node_unit, logger, validate);
-}
-
-// For ReshapeGemmReshapeReshapeFusion (4-node: Reshape -> Gemm -> Reshape1 -> Reshape2)
-// Note: Reshape1 is skipped; we fuse directly to Reshape2's output shape
-Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
-                                       const OrtNodeUnit& input_reshape_node_unit,
-                                       const OrtNodeUnit& gemm_node_unit,
-                                       const OrtNodeUnit& output_reshape1_node_unit,
-                                       const OrtNodeUnit& output_reshape2_node_unit,
-                                       const Ort::Logger& logger,
-                                       bool validate) {
-  ORT_UNUSED_PARAMETER(output_reshape1_node_unit);
-  return CreateOrValidateFusedFCOnQnn(qnn_model_wrapper, input_reshape_node_unit, gemm_node_unit,
-                                      &output_reshape2_node_unit, logger, validate);
-}
-
 }  // namespace
 
 // ============================================================================
-// ReshapeGemmReshapeFusion: 2-node fusion (Reshape -> Gemm)
+// ReshapeGemmFusionGroup implementation
 // ============================================================================
-std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusion::TryFusion(
+
+ReshapeGemmFusionGroup::ReshapeGemmFusionGroup(std::vector<const OrtNodeUnit*> node_units)
+    : node_units_(std::move(node_units)) {
+}
+
+Ort::Status ReshapeGemmFusionGroup::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn(qmw, logger, true);
+}
+
+Ort::Status ReshapeGemmFusionGroup::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn(qmw, logger, false);
+}
+
+gsl::span<const OrtNodeUnit* const> ReshapeGemmFusionGroup::GetNodeUnits() const {
+  return node_units_;
+}
+
+const OrtNodeUnit* ReshapeGemmFusionGroup::GetTargetNodeUnit() const {
+  return node_units_[1];  // The Gemm node is always at index 1
+}
+
+Ort::Status ReshapeGemmFusionGroup::CreateOrValidateOnQnn(QnnModelWrapper& qmw, const Ort::Logger& logger,
+                                                          bool validate) const {
+  const OrtNodeUnit* input_reshape = node_units_[0];
+  const OrtNodeUnit* gemm = node_units_[1];
+
+  // Determine output reshape node based on fusion size
+  const OrtNodeUnit* output_reshape = nullptr;
+  if (node_units_.size() == 3) {
+    // 3-node: use the output reshape directly
+    output_reshape = node_units_[2];
+  } else if (node_units_.size() == 4) {
+    // 4-node: skip reshape1 (index 2), use reshape2 (index 3)
+    output_reshape = node_units_[3];
+  }
+
+  return CreateOrValidateFusedFCOnQnn(qmw, *input_reshape, *gemm, output_reshape, logger, validate);
+}
+
+// 2-node fusion: Reshape -> Gemm
+std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion2(
     QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
@@ -419,36 +418,13 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusion::TryFusion(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmFusion>(*input_reshape, gemm_node_unit);
+  return std::make_unique<ReshapeGemmFusionGroup>(
+      std::vector<const OrtNodeUnit*>{input_reshape, &gemm_node_unit});
 }
 
-ReshapeGemmFusion::ReshapeGemmFusion(const OrtNodeUnit& reshape_node_unit, const OrtNodeUnit& gemm_node_unit)
-    : node_units_{&reshape_node_unit, &gemm_node_unit} {
-}
-
-Ort::Status ReshapeGemmFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
-  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], logger, true);
-}
-
-Ort::Status ReshapeGemmFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
-  return CreateOrValidateOnQnn(qmw, *node_units_[0], *node_units_[1], logger, false);
-}
-
-gsl::span<const OrtNodeUnit* const> ReshapeGemmFusion::GetNodeUnits() const {
-  return node_units_;
-}
-
-const OrtNodeUnit* ReshapeGemmFusion::GetTargetNodeUnit() const {
-  return node_units_[1];
-}
-
-// ============================================================================
-// ReshapeGemmReshapeFusion: 3-node fusion (Reshape -> Gemm -> Reshape)
-// ============================================================================
-
-std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeFusion::TryFusion(
-    QnnModelWrapper& qnn_model_wrapper,
-    const OrtNodeUnit& gemm_node_unit,
+// 3-node fusion: Reshape -> Gemm -> Reshape
+std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion3(
+    QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
@@ -484,38 +460,13 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeFusion::TryFusion(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmReshapeFusion>(*input_reshape, gemm_node_unit, *output_reshape);
+  return std::make_unique<ReshapeGemmFusionGroup>(
+      std::vector<const OrtNodeUnit*>{input_reshape, &gemm_node_unit, output_reshape});
 }
 
-ReshapeGemmReshapeFusion::ReshapeGemmReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
-                                                   const OrtNodeUnit& gemm_node_unit,
-                                                   const OrtNodeUnit& output_reshape_node_unit)
-    : node_units_{&input_reshape_node_unit, &gemm_node_unit, &output_reshape_node_unit} {
-}
-
-Ort::Status ReshapeGemmReshapeFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
-  return CreateOrValidateOnQnn3Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], logger, true);
-}
-
-Ort::Status ReshapeGemmReshapeFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
-  return CreateOrValidateOnQnn3Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], logger, false);
-}
-
-gsl::span<const OrtNodeUnit* const> ReshapeGemmReshapeFusion::GetNodeUnits() const {
-  return node_units_;
-}
-
-const OrtNodeUnit* ReshapeGemmReshapeFusion::GetTargetNodeUnit() const {
-  return node_units_[1];  // The Gemm node is the target
-}
-
-// ============================================================================
-// ReshapeGemmReshapeReshapeFusion: 4-node fusion (Reshape -> Gemm -> Reshape -> Reshape)
-// ============================================================================
-
-std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
-    QnnModelWrapper& qnn_model_wrapper,
-    const OrtNodeUnit& gemm_node_unit,
+// 4-node fusion: Reshape -> Gemm -> Reshape -> Reshape
+std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion4(
+    QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
@@ -564,30 +515,8 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmReshapeReshapeFusion>(*input_reshape, gemm_node_unit, *output_reshape1, *output_reshape2);
-}
-
-ReshapeGemmReshapeReshapeFusion::ReshapeGemmReshapeReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
-                                                                 const OrtNodeUnit& gemm_node_unit,
-                                                                 const OrtNodeUnit& output_reshape1_node_unit,
-                                                                 const OrtNodeUnit& output_reshape2_node_unit)
-    : node_units_{&input_reshape_node_unit, &gemm_node_unit, &output_reshape1_node_unit, &output_reshape2_node_unit} {
-}
-
-Ort::Status ReshapeGemmReshapeReshapeFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
-  return CreateOrValidateOnQnn4Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], logger, true);
-}
-
-Ort::Status ReshapeGemmReshapeReshapeFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
-  return CreateOrValidateOnQnn4Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], logger, false);
-}
-
-gsl::span<const OrtNodeUnit* const> ReshapeGemmReshapeReshapeFusion::GetNodeUnits() const {
-  return node_units_;
-}
-
-const OrtNodeUnit* ReshapeGemmReshapeReshapeFusion::GetTargetNodeUnit() const {
-  return node_units_[1];  // The Gemm node is the target
+  return std::make_unique<ReshapeGemmFusionGroup>(
+      std::vector<const OrtNodeUnit*>{input_reshape, &gemm_node_unit, output_reshape1, output_reshape2});
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -528,6 +528,11 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusion::TryFusion(
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
 
+  // Skip fusion for GPU backend
+  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return nullptr;
+  }
+
   // Only handle standalone Gemm nodes (not QDQ-wrapped)
   if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
     return nullptr;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -21,77 +21,24 @@ namespace qnn {
 
 namespace {
 
-const OrtNodeUnit* GetReshapeNodeUnit(
-    const QnnModelWrapper& qnn_model_wrapper,
-    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
-    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
-    const OrtNode& gemm_node) {
-  if (Ort::ConstNode(&gemm_node).GetOperatorType() != "Gemm") {
-    return nullptr;
+// Get the weight's input channel (K dimension) from Gemm weight shape [K, N]
+int64_t GetWeightInputChannel(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight_def) {
+  std::vector<uint32_t> weight_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(weight_def.shape, weight_shape)) {
+    return -1;
   }
-
-  // Get gemm node inputs
-  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
-  size_t num_inputs = 0;
-  RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetNumInputs(&gemm_node, &num_inputs), ort_api, nullptr);
-  if (num_inputs < 1) {
-    return nullptr;
+  if (weight_shape.size() != 2) {
+    return -1;
   }
-  std::vector<const OrtValueInfo*> inputs(num_inputs);
-  RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetInputs(&gemm_node, inputs.data(), inputs.size()), ort_api, nullptr);
-
-  // Get the first input (index 0)
-  const OrtValueInfo* input_value_info = inputs[0];
-
-  // Get the producer of this input
-  const OrtNode* reshape_node = nullptr;
-  RETURN_DEFAULT_IF_API_FAIL(ort_api.ValueInfo_GetValueProducer(input_value_info, &reshape_node, nullptr),
-                             ort_api,
-                             nullptr);
-
-  // Check if it's a Reshape node
-  if (reshape_node != nullptr && Ort::ConstNode(reshape_node).GetOperatorType() == "Reshape") {
-    // Check if reshape node produces graph output
-    size_t num_outputs = 0;
-    if (num_outputs != 1) {
-      return nullptr;
-    }
-    RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetNumOutputs(reshape_node, &num_outputs), ort_api, nullptr);
-    std::vector<const OrtValueInfo*> reshape_outputs(num_outputs);
-    RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetOutputs(reshape_node, reshape_outputs.data(), reshape_outputs.size()),
-                               ort_api,
-                               nullptr);
-
-    const OrtValueInfo* output_info = reshape_outputs[0];
-
-    bool is_graph_output = false;
-    RETURN_DEFAULT_IF_API_FAIL(ort_api.ValueInfo_IsGraphOutput(output_info, &is_graph_output), ort_api, nullptr);
-
-    if (!is_graph_output) {
-      size_t num_consumers;
-      RETURN_DEFAULT_IF_API_FAIL(ort_api.ValueInfo_GetValueNumConsumers(output_info, &num_consumers),
-                                 ort_api,
-                                 nullptr);
-      if (num_consumers == 1) {
-        const auto it = node_to_node_unit.find(reshape_node);
-        if (it != node_to_node_unit.end()) {
-          const OrtNodeUnit* reshape_node_unit = it->second;
-          if (reshape_node_unit && node_unit_to_qnn_node_group.count(reshape_node_unit) == 0 &&
-              reshape_node_unit->UnitType() == OrtNodeUnit::Type::SingleNode) {
-            return reshape_node_unit;
-          }
-        }
-      }
-    }
-  }
-  return nullptr;
+  return static_cast<int64_t>(weight_shape[0]);
 }
 
-bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape_node) {
+// Check if reshape input is reshapable to [batch, n] where n is Gemm's input channel (weight's K dim).
+// QNN FullyConnected requires: input shape [n] or Rank >= 2 reshapable to [batch, n].
+bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape_node, int64_t weight_input_channel) {
   const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
 
   // Get reshape node inputs and outputs
-
   size_t num_inputs = 0;
   size_t num_outputs = 0;
   RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetNumInputs(&reshape_node, &num_inputs), ort_api, false);
@@ -131,6 +78,7 @@ bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape
   RETURN_DEFAULT_IF_API_FAIL(ort_api.GetDimensionsCount(input_tensor_info, &input_dims_count), ort_api, false);
   RETURN_DEFAULT_IF_API_FAIL(ort_api.GetDimensionsCount(output_tensor_info, &output_dims_count), ort_api, false);
 
+  // Output must be 2D [batch, n]
   if (output_dims_count != 2) {
     return false;
   }
@@ -145,18 +93,55 @@ bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape
                              ort_api,
                              false);
 
-  // Check if the reshape is from [x0, x1, ..., xn, k] to [x0 * x1 * ... * xn, k]
-  int64_t input_product = 1;
-  for (size_t i = 0; i < input_dims_count - 1; ++i) {
+  // Check output's last dim (n) matches weight's input channel
+  if (output_dims[1] != weight_input_channel) {
+    return false;
+  }
+
+  // Check input is reshapable to [batch, n]: total elements must equal batch * n
+  int64_t total_input = 1;
+  for (size_t i = 0; i < input_dims_count; ++i) {
     if (input_dims[i] <= 0) {
       return false;
     }
-    input_product *= input_dims[i];
+    total_input *= input_dims[i];
   }
 
-  bool result = (input_product == output_dims[0] && input_dims[input_dims_count - 1] == output_dims[1]);
+  int64_t total_output = output_dims[0] * output_dims[1];
+  return total_input == total_output;
+}
 
-  return result;
+// Get the input Reshape node unit that feeds into the Gemm node
+const OrtNodeUnit* GetInputReshapeNodeUnit(
+    const QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& gemm_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  const std::array<std::string_view, 1> reshape_types = {"Reshape"};
+  return GetParentOfType(qnn_model_wrapper, gemm_node_unit, reshape_types,
+                         node_to_node_unit, node_unit_to_qnn_node_group);
+}
+
+// Get the output Reshape node unit that consumes the Gemm output
+const OrtNodeUnit* GetOutputReshapeNodeUnit(
+    const QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& gemm_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  const std::array<std::string_view, 1> reshape_types = {"Reshape"};
+  return GetOnlyChildOfType(qnn_model_wrapper, gemm_node_unit, reshape_types,
+                            node_to_node_unit, node_unit_to_qnn_node_group);
+}
+
+// Get the second output Reshape node unit that consumes reshape1's output (reshape2)
+const OrtNodeUnit* GetOutputReshape2NodeUnit(
+    const QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& reshape1_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  const std::array<std::string_view, 1> reshape_types = {"Reshape"};
+  return GetOnlyChildOfType(qnn_model_wrapper, reshape1_node_unit, reshape_types,
+                            node_to_node_unit, node_unit_to_qnn_node_group);
 }
 
 Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& reshape_node_unit,
@@ -244,49 +229,344 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper, const OrtN
   return Ort::Status();
 }
 
+// For ReshapeGemmReshapeReshapeFusion
+Ort::Status CreateOrValidateOnQnn4Node(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& input_reshape_node_unit,
+                                       const OrtNodeUnit& fc_node_unit,
+                                       const OrtNodeUnit& output_reshape1_node_unit,
+                                       const OrtNodeUnit& output_reshape2_node_unit,
+                                       const Ort::Logger& logger,
+                                       bool validate) {
+  ORT_UNUSED_PARAMETER(logger);
+  ORT_UNUSED_PARAMETER(output_reshape1_node_unit);
+
+  const auto& fc_node_name = utils::UniqueNameGenerator().New(fc_node_unit);
+  const auto& reshape_node_name = utils::UniqueNameGenerator().New(output_reshape2_node_unit);
+
+  // Get input from the input reshape's input (original ND tensor)
+  const OrtNodeUnitIODef& input_def = input_reshape_node_unit.Inputs()[0];
+  // Get weight from FC's input[1]
+  const OrtNodeUnitIODef& weight_def = fc_node_unit.Inputs()[1];
+  // Check for bias
+  const OrtNodeUnitIODef* bias_def_ptr = nullptr;
+  bool has_bias = fc_node_unit.Inputs().size() > 2;
+  if (has_bias) {
+    bias_def_ptr = &fc_node_unit.Inputs()[2];
+  }
+  // FC output: use Gemm's 2D output shape (QNN FC requires 2D output)
+  const OrtNodeUnitIODef& fc_output_def = fc_node_unit.Outputs()[0];
+  const std::string fc_output_name = fc_node_name + "_fc_out";
+
+  // Reshape2 output: final output from reshape2
+  const OrtNodeUnitIODef& final_output_def = output_reshape2_node_unit.Outputs()[0];
+  const std::string& final_output_name = final_output_def.name;
+
+  // Create input tensor wrapper
+  QnnTensorWrapper input_tensor;
+  RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(input_def, input_tensor));
+
+  // Process weight tensor - need to transpose for FullyConnected
+  std::vector<uint32_t> weight_shape;
+  std::vector<uint8_t> unpacked_tensor;
+  std::string weight_tensor_name = weight_def.name;
+
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(weight_def.shape, weight_shape), "Failed to get weight shape");
+
+  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+  Qnn_DataType_t weight_data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(weight_def.quant_param.has_value(), weight_def.type, weight_data_type));
+
+  // Get weight tensor and transpose (Gemm weight is [K, N], FC expects [N, K])
+  const auto* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+  RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper, weight_shape, weight_tensor_proto,
+                                               unpacked_tensor, logger, validate));
+
+  QnnQuantParamsWrapper weight_quant_param;
+  RETURN_IF_ERROR(weight_quant_param.Init(qnn_model_wrapper, weight_def));
+  RETURN_IF_ERROR(weight_quant_param.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
+
+  QnnTensorWrapper weight_tensor(weight_tensor_name, tensor_type, weight_data_type,
+                                 std::move(weight_quant_param), std::move(weight_shape),
+                                 std::move(unpacked_tensor));
+
+  // Process bias if present
+  QnnTensorWrapper bias_tensor;
+  if (has_bias) {
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(*bias_def_ptr, bias_tensor));
+  }
+
+  // Create FC output tensor
+  std::vector<uint32_t> fc_output_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(fc_output_def.shape, fc_output_shape), "Failed to get FC output shape");
+
+  Qnn_DataType_t fc_output_data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(fc_output_def.quant_param.has_value(), fc_output_def.type, fc_output_data_type));
+
+  QnnQuantParamsWrapper fc_output_quant_param;
+  RETURN_IF_ERROR(fc_output_quant_param.Init(qnn_model_wrapper, fc_output_def));
+
+  QnnTensorWrapper fc_output_tensor(fc_output_name, QNN_TENSOR_TYPE_NATIVE, fc_output_data_type,
+                                    std::move(fc_output_quant_param), std::move(fc_output_shape),
+                                    std::vector<uint8_t>());
+
+  // Create Reshape2 output tensor (final output)
+  std::vector<uint32_t> final_output_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(final_output_def.shape, final_output_shape), "Failed to get final output shape");
+
+  Qnn_DataType_t final_output_data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(final_output_def.quant_param.has_value(), final_output_def.type, final_output_data_type));
+
+  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
+  Qnn_TensorType_t final_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  QnnQuantParamsWrapper final_output_quant_param;
+  RETURN_IF_ERROR(final_output_quant_param.Init(qnn_model_wrapper, final_output_def));
+
+  QnnTensorWrapper final_output_tensor(final_output_name, final_output_tensor_type, final_output_data_type,
+                                       std::move(final_output_quant_param), std::move(final_output_shape),
+                                       std::vector<uint8_t>());
+
+  if (validate) {
+    // Validate FC node
+    std::vector<Qnn_Tensor_t> fc_input_tensors = {input_tensor.GetQnnTensor(), weight_tensor.GetQnnTensor()};
+    if (has_bias) {
+      fc_input_tensors.emplace_back(bias_tensor.GetQnnTensor());
+    }
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                      QNN_OP_FULLY_CONNECTED, std::move(fc_input_tensors),
+                                                      {fc_output_tensor.GetQnnTensor()}, {}));
+
+    // Validate Reshape node
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                      QNN_OP_RESHAPE, {fc_output_tensor.GetQnnTensor()},
+                                                      {final_output_tensor.GetQnnTensor()}, {}));
+  } else {
+    // Add tensors to model
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor)), "Failed to add weight");
+    if (has_bias) {
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensor)), "Failed to add bias");
+    }
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_output_tensor)), "Failed to add FC output");
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)), "Failed to add final output");
+
+    // Create FC input names
+    std::vector<std::string> fc_input_names = {input_def.name, weight_tensor_name};
+    if (has_bias) {
+      fc_input_names.emplace_back(bias_def_ptr->name);
+    }
+
+    // Create the QNN FullyConnected node (ND input -> 2D output)
+    RETURN_IF_NOT(
+        qnn_model_wrapper.CreateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
+                                        std::move(fc_input_names), {fc_output_name},
+                                        {}, validate),
+        "Failed to create FullyConnected node.");
+
+    // Create the QNN Reshape node (2D -> final shape)
+    RETURN_IF_NOT(
+        qnn_model_wrapper.CreateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
+                                        {fc_output_name}, {final_output_name},
+                                        {}, validate),
+        "Failed to create Reshape node.");
+  }
+
+  return Ort::Status();
+}
+
+// For ReshapeGemmReshapeFusion
+Ort::Status CreateOrValidateOnQnn3Node(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& input_reshape_node_unit,
+                                       const OrtNodeUnit& fc_node_unit,
+                                       const OrtNodeUnit& output_reshape_node_unit,
+                                       const Ort::Logger& logger,
+                                       bool validate) {
+  ORT_UNUSED_PARAMETER(logger);
+
+  const auto& fc_node_name = utils::UniqueNameGenerator().New(fc_node_unit);
+  const auto& reshape_node_name = utils::UniqueNameGenerator().New(output_reshape_node_unit);
+
+  // Get input from the input reshape's input (original ND tensor)
+  const OrtNodeUnitIODef& input_def = input_reshape_node_unit.Inputs()[0];
+  // Get weight from FC's input[1]
+  const OrtNodeUnitIODef& weight_def = fc_node_unit.Inputs()[1];
+  // Check for bias
+  const OrtNodeUnitIODef* bias_def_ptr = nullptr;
+  bool has_bias = fc_node_unit.Inputs().size() > 2;
+  if (has_bias) {
+    bias_def_ptr = &fc_node_unit.Inputs()[2];
+  }
+  // FC output: intermediate 2D output
+  const OrtNodeUnitIODef& fc_output_def = fc_node_unit.Outputs()[0];
+  const std::string fc_output_name = fc_node_name + "_fc_out";
+
+  // Reshape output: final output from output_reshape
+  const OrtNodeUnitIODef& final_output_def = output_reshape_node_unit.Outputs()[0];
+  const std::string& final_output_name = final_output_def.name;
+
+  // Create input tensor wrapper
+  QnnTensorWrapper input_tensor;
+  RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(input_def, input_tensor));
+
+  // Process weight tensor - need to transpose for FullyConnected
+  std::vector<uint32_t> weight_shape;
+  std::vector<uint8_t> unpacked_tensor;
+  std::string weight_tensor_name = weight_def.name;
+
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(weight_def.shape, weight_shape), "Failed to get weight shape");
+
+  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
+  Qnn_DataType_t weight_data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(weight_def.quant_param.has_value(), weight_def.type, weight_data_type));
+
+  // Get weight tensor and transpose (Gemm weight is [K, N], FC expects [N, K])
+  const auto* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+  RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper, weight_shape, weight_tensor_proto,
+                                               unpacked_tensor, logger, validate));
+
+  QnnQuantParamsWrapper weight_quant_param;
+  RETURN_IF_ERROR(weight_quant_param.Init(qnn_model_wrapper, weight_def));
+  RETURN_IF_ERROR(weight_quant_param.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
+
+  QnnTensorWrapper weight_tensor(weight_tensor_name, tensor_type, weight_data_type,
+                                 std::move(weight_quant_param), std::move(weight_shape),
+                                 std::move(unpacked_tensor));
+
+  // Process bias if present
+  QnnTensorWrapper bias_tensor;
+  if (has_bias) {
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(*bias_def_ptr, bias_tensor));
+  }
+
+  // Create FC output tensor (2D intermediate)
+  std::vector<uint32_t> fc_output_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(fc_output_def.shape, fc_output_shape), "Failed to get FC output shape");
+
+  Qnn_DataType_t fc_output_data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(fc_output_def.quant_param.has_value(), fc_output_def.type, fc_output_data_type));
+
+  QnnQuantParamsWrapper fc_output_quant_param;
+  RETURN_IF_ERROR(fc_output_quant_param.Init(qnn_model_wrapper, fc_output_def));
+
+  QnnTensorWrapper fc_output_tensor(fc_output_name, QNN_TENSOR_TYPE_NATIVE, fc_output_data_type,
+                                    std::move(fc_output_quant_param), std::move(fc_output_shape),
+                                    std::vector<uint8_t>());
+
+  // Create Reshape output tensor (final output)
+  std::vector<uint32_t> final_output_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(final_output_def.shape, final_output_shape), "Failed to get final output shape");
+
+  Qnn_DataType_t final_output_data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(final_output_def.quant_param.has_value(), final_output_def.type, final_output_data_type));
+
+  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
+  Qnn_TensorType_t final_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  QnnQuantParamsWrapper final_output_quant_param;
+  RETURN_IF_ERROR(final_output_quant_param.Init(qnn_model_wrapper, final_output_def));
+
+  QnnTensorWrapper final_output_tensor(final_output_name, final_output_tensor_type, final_output_data_type,
+                                       std::move(final_output_quant_param), std::move(final_output_shape),
+                                       std::vector<uint8_t>());
+
+  if (validate) {
+    // Validate FC node
+    std::vector<Qnn_Tensor_t> fc_input_tensors = {input_tensor.GetQnnTensor(), weight_tensor.GetQnnTensor()};
+    if (has_bias) {
+      fc_input_tensors.emplace_back(bias_tensor.GetQnnTensor());
+    }
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                      QNN_OP_FULLY_CONNECTED, std::move(fc_input_tensors),
+                                                      {fc_output_tensor.GetQnnTensor()}, {}));
+
+    // Validate Reshape node
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                      QNN_OP_RESHAPE, {fc_output_tensor.GetQnnTensor()},
+                                                      {final_output_tensor.GetQnnTensor()}, {}));
+  } else {
+    // Add tensors to model
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor)), "Failed to add input");
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor)), "Failed to add weight");
+    if (has_bias) {
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensor)), "Failed to add bias");
+    }
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_output_tensor)), "Failed to add FC output");
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)), "Failed to add final output");
+
+    // Create FC input names
+    std::vector<std::string> fc_input_names = {input_def.name, weight_tensor_name};
+    if (has_bias) {
+      fc_input_names.emplace_back(bias_def_ptr->name);
+    }
+
+    // Create the QNN FullyConnected node (ND input -> 2D output)
+    RETURN_IF_NOT(
+        qnn_model_wrapper.CreateQnnNode(fc_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
+                                        std::move(fc_input_names), {fc_output_name},
+                                        {}, validate),
+        "Failed to create FullyConnected node.");
+
+    // Create the QNN Reshape node (2D -> final shape)
+    RETURN_IF_NOT(
+        qnn_model_wrapper.CreateQnnNode(reshape_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
+                                        {fc_output_name}, {final_output_name},
+                                        {}, validate),
+        "Failed to create Reshape node.");
+  }
+
+  return Ort::Status();
+}
+
 }  // namespace
 
+// ============================================================================
+// ReshapeGemmReshapeFusion: 2-node fusion (Reshape -> Gemm)
+// ============================================================================
 std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusion::TryFusion(
     QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
   ORT_UNUSED_PARAMETER(logger);
+
+  // Only handle standalone Gemm nodes (not QDQ-wrapped)
   if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
     return nullptr;
   }
 
-  const OrtNode& gemm_node = gemm_node_unit.GetNode();
-
-  // Check transA and transB attributes
+  // Check transA and transB - we only handle the default case (no transpose)
   OrtNodeAttrHelper attr_helper(gemm_node_unit);
-  float transA = attr_helper.Get("transA", 0.0f);
-  float transB = attr_helper.Get("transB", 0.0f);
-
-  // The pattern is from MatMul->Add, so the transA and transB should be false
-  if (transA != 0.0f || transB != 0.0f) {
+  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
+  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
+  if (transA != 0 || transB != 0) {
     return nullptr;
   }
 
-  // Check if weight is constant
+  // Weight must be constant and not quantized (pattern is from MatMul->Add fusion)
   const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
-  // The pattern is from MatMul->Add, so the transA and transB should be false, and weight should be initializer.
-  // Currently we don't handle quantized weight.
   if (!qnn_model_wrapper.IsConstantInput(weight_input.name) || weight_input.quant_param.has_value()) {
     return nullptr;
   }
 
-  // Find the reshape node unit
-  const OrtNodeUnit* reshape_node_unit = GetReshapeNodeUnit(qnn_model_wrapper, node_to_node_unit, node_unit_to_qnn_node_group, gemm_node);
-  if (!reshape_node_unit) {
+  // Find input Reshape
+  const OrtNodeUnit* input_reshape = GetInputReshapeNodeUnit(
+      qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!input_reshape) {
     return nullptr;
   }
 
-  if (!CheckShape(qnn_model_wrapper, reshape_node_unit->GetNode())) {
+  // Get weight's input channel (K dimension)
+  int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
+  if (weight_k <= 0) {
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmFusion>(*reshape_node_unit, gemm_node_unit);
+  // Validate input reshape pattern (ND -> 2D with last dim = weight's K)
+  if (!CheckShape(qnn_model_wrapper, input_reshape->GetNode(), weight_k)) {
+    return nullptr;
+  }
+
+  return std::make_unique<ReshapeGemmFusion>(*input_reshape, gemm_node_unit);
 }
 
 ReshapeGemmFusion::ReshapeGemmFusion(const OrtNodeUnit& reshape_node_unit, const OrtNodeUnit& gemm_node_unit)
@@ -307,6 +587,173 @@ gsl::span<const OrtNodeUnit* const> ReshapeGemmFusion::GetNodeUnits() const {
 
 const OrtNodeUnit* ReshapeGemmFusion::GetTargetNodeUnit() const {
   return node_units_[1];
+}
+
+// ============================================================================
+// ReshapeGemmReshapeFusion: 3-node fusion (Reshape -> Gemm -> Reshape)
+// ============================================================================
+
+std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& gemm_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  ORT_UNUSED_PARAMETER(logger);
+
+  // Only handle standalone Gemm nodes (not QDQ-wrapped)
+  if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return nullptr;
+  }
+
+  // Check transA and transB - we only handle the default case (no transpose)
+  OrtNodeAttrHelper attr_helper(gemm_node_unit);
+  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
+  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
+  if (transA != 0 || transB != 0) {
+    return nullptr;
+  }
+
+  // Weight must be constant
+  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
+  if (!qnn_model_wrapper.IsConstantInput(weight_input.name)) {
+    return nullptr;
+  }
+
+  // Find input Reshape
+  const OrtNodeUnit* input_reshape = GetInputReshapeNodeUnit(
+      qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!input_reshape) {
+    return nullptr;
+  }
+
+  // Find output Reshape (after Gemm)
+  const OrtNodeUnit* output_reshape = GetOutputReshapeNodeUnit(
+      qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!output_reshape) {
+    return nullptr;
+  }
+  // Get weight's input channel (K dimension)
+  int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
+  if (weight_k <= 0) {
+    return nullptr;
+  }
+  // Validate input reshape pattern (ND -> 2D with last dim = weight's K)
+  if (!CheckShape(qnn_model_wrapper, input_reshape->GetNode(), weight_k)) {
+    return nullptr;
+  }
+  return std::make_unique<ReshapeGemmReshapeFusion>(*input_reshape, gemm_node_unit, *output_reshape);
+}
+
+ReshapeGemmReshapeFusion::ReshapeGemmReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
+                                                   const OrtNodeUnit& gemm_node_unit,
+                                                   const OrtNodeUnit& output_reshape_node_unit)
+    : node_units_{&input_reshape_node_unit, &gemm_node_unit, &output_reshape_node_unit} {
+}
+
+Ort::Status ReshapeGemmReshapeFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn3Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], logger, true);
+}
+
+Ort::Status ReshapeGemmReshapeFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn3Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], logger, false);
+}
+
+gsl::span<const OrtNodeUnit* const> ReshapeGemmReshapeFusion::GetNodeUnits() const {
+  return node_units_;
+}
+
+const OrtNodeUnit* ReshapeGemmReshapeFusion::GetTargetNodeUnit() const {
+  return node_units_[1];  // The Gemm node is the target
+}
+
+// ============================================================================
+// ReshapeGemmReshapeReshapeFusion: 4-node fusion (Reshape -> Gemm -> Reshape -> Reshape)
+// ============================================================================
+
+std::unique_ptr<IQnnNodeGroup> ReshapeGemmReshapeReshapeFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& gemm_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  ORT_UNUSED_PARAMETER(logger);
+
+  // Only handle Gemm nodes (MatMul+Add gets fused to Gemm)
+  if (gemm_node_unit.OpType() != "Gemm" || gemm_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return nullptr;
+  }
+
+  // Check transA and transB - we only handle the default case (no transpose)
+  OrtNodeAttrHelper attr_helper(gemm_node_unit);
+  int64_t transA = attr_helper.Get("transA", static_cast<int64_t>(0));
+  int64_t transB = attr_helper.Get("transB", static_cast<int64_t>(0));
+  if (transA != 0 || transB != 0) {
+    return nullptr;
+  }
+
+  // Weight must be constant
+  const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
+  if (!qnn_model_wrapper.IsConstantInput(weight_input.name)) {
+    return nullptr;
+  }
+
+  // Find input Reshape
+  const OrtNodeUnit* input_reshape = GetInputReshapeNodeUnit(
+      qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!input_reshape) {
+    return nullptr;
+  }
+
+  // Find output Reshape1 (after Gemm)
+  const OrtNodeUnit* output_reshape1 = GetOutputReshapeNodeUnit(
+      qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!output_reshape1) {
+    return nullptr;
+  }
+
+  // Find output Reshape2 (after Reshape1)
+  const OrtNodeUnit* output_reshape2 = GetOutputReshape2NodeUnit(
+      qnn_model_wrapper, *output_reshape1, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!output_reshape2) {
+    return nullptr;
+  }
+
+  // Get weight's input channel (K dimension)
+  int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
+  if (weight_k <= 0) {
+    return nullptr;
+  }
+
+  // Validate input reshape pattern (ND -> 2D with last dim = weight's K)
+  if (!CheckShape(qnn_model_wrapper, input_reshape->GetNode(), weight_k)) {
+    return nullptr;
+  }
+
+  return std::make_unique<ReshapeGemmReshapeReshapeFusion>(*input_reshape, gemm_node_unit, *output_reshape1, *output_reshape2);
+}
+
+ReshapeGemmReshapeReshapeFusion::ReshapeGemmReshapeReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
+                                                                 const OrtNodeUnit& gemm_node_unit,
+                                                                 const OrtNodeUnit& output_reshape1_node_unit,
+                                                                 const OrtNodeUnit& output_reshape2_node_unit)
+    : node_units_{&input_reshape_node_unit, &gemm_node_unit, &output_reshape1_node_unit, &output_reshape2_node_unit} {
+}
+
+Ort::Status ReshapeGemmReshapeReshapeFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn4Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], logger, true);
+}
+
+Ort::Status ReshapeGemmReshapeReshapeFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn4Node(qmw, *node_units_[0], *node_units_[1], *node_units_[2], *node_units_[3], logger, false);
+}
+
+gsl::span<const OrtNodeUnit* const> ReshapeGemmReshapeReshapeFusion::GetNodeUnits() const {
+  return node_units_;
+}
+
+const OrtNodeUnit* ReshapeGemmReshapeReshapeFusion::GetTargetNodeUnit() const {
+  return node_units_[1];  // The Gemm node is the target
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -40,6 +41,63 @@ class ReshapeGemmFusion : public IQnnNodeGroup {
 
  private:
   std::array<const OrtNodeUnit*, 2> node_units_;
+};
+
+/// <summary>
+/// Represents a fusion of a Reshape->Gemm->Reshape sequence.
+/// Fuses to FullyConnected + Reshape (FC takes ND input, outputs 2D, then Reshape restores ND).
+/// </summary>
+class ReshapeGemmReshapeFusion : public IQnnNodeGroup {
+ public:
+  ReshapeGemmReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
+                           const OrtNodeUnit& gemm_node_unit,
+                           const OrtNodeUnit& output_reshape_node_unit);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmReshapeFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override;
+  std::string_view Type() const override { return "ReshapeGemmReshapeFusion"; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::array<const OrtNodeUnit*, 3> node_units_;
+};
+
+/// <summary>
+/// Represents a fusion of Reshape->Gemm->Reshape->Reshape into FC->Reshape.
+/// Pattern: ND input -> Reshape0 (ND->2D) -> Gemm (2D->2D) -> Reshape1 -> Reshape2 -> output
+/// Fused:   ND input -> FullyConnected (ND->2D) -> Reshape2 -> output
+/// All 4 nodes are claimed.
+/// </summary>
+class ReshapeGemmReshapeReshapeFusion : public IQnnNodeGroup {
+ public:
+  ReshapeGemmReshapeReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
+                                  const OrtNodeUnit& gemm_node_unit,
+                                  const OrtNodeUnit& output_reshape1_node_unit,
+                                  const OrtNodeUnit& output_reshape2_node_unit);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmReshapeReshapeFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override;
+  std::string_view Type() const override { return "ReshapeGemmReshapeReshapeFusion"; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::array<const OrtNodeUnit*, 4> node_units_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <array>
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -17,88 +17,55 @@ namespace qnn {
 class QnnModelWrapper;
 
 /// <summary>
-/// Represents a fusion of a Reshape->Gemm sequence to a single Gemm node.
-/// Ideally Reshape->Gemm->Reshape should be fused to a single Gemm node with keep_dims set to True,
-/// but on some devices the OpConfig validation will fail when keep_dims to True (it says expected value is 0),
-/// so we still need to keep the 2nd Reshape node.
+/// Unified fusion class for Reshape-Gemm patterns:
+/// - 2-node: Reshape -> Gemm
+/// - 3-node: Reshape -> Gemm -> Reshape
+/// - 4-node: Reshape -> Gemm -> Reshape -> Reshape
+///
+/// All patterns fuse to QNN FullyConnected (+ optional output Reshape).
 /// </summary>
-class ReshapeGemmFusion : public IQnnNodeGroup {
+class ReshapeGemmFusionGroup : public IQnnNodeGroup {
  public:
-  ReshapeGemmFusion(const OrtNodeUnit& reshape_node_unit, const OrtNodeUnit& gemm_node_unit);
-  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmFusion);
+  explicit ReshapeGemmFusionGroup(std::vector<const OrtNodeUnit*> node_units);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmFusionGroup);
 
   Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
   Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
   gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
   const OrtNodeUnit* GetTargetNodeUnit() const override;
-  std::string_view Type() const override { return "ReshapeGemmFusion"; }
+  std::string_view Type() const override { return "ReshapeGemmFusionGroup"; }
 
-  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+  // 2-node fusion: Reshape -> Gemm
+  static std::unique_ptr<IQnnNodeGroup> TryFusion2(
+      QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+  // 3-node fusion: Reshape -> Gemm -> Reshape
+  static std::unique_ptr<IQnnNodeGroup> TryFusion3(
+      QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+  // 4-node fusion: Reshape -> Gemm -> Reshape -> Reshape
+  static std::unique_ptr<IQnnNodeGroup> TryFusion4(
       QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
       const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
       const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
       const Ort::Logger& logger);
 
  private:
-  std::array<const OrtNodeUnit*, 2> node_units_;
+  Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qmw, const Ort::Logger& logger, bool validate) const;
+
+  std::vector<const OrtNodeUnit*> node_units_;
 };
 
-/// <summary>
-/// Represents a fusion of a Reshape->Gemm->Reshape sequence.
-/// Fuses to FullyConnected + Reshape (FC takes ND input, outputs 2D, then Reshape restores ND).
-/// </summary>
-class ReshapeGemmReshapeFusion : public IQnnNodeGroup {
- public:
-  ReshapeGemmReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
-                           const OrtNodeUnit& gemm_node_unit,
-                           const OrtNodeUnit& output_reshape_node_unit);
-  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmReshapeFusion);
-
-  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
-  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
-  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
-  const OrtNodeUnit* GetTargetNodeUnit() const override;
-  std::string_view Type() const override { return "ReshapeGemmReshapeFusion"; }
-
-  static std::unique_ptr<IQnnNodeGroup> TryFusion(
-      QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
-      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
-      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
-      const Ort::Logger& logger);
-
- private:
-  std::array<const OrtNodeUnit*, 3> node_units_;
-};
-
-/// <summary>
-/// Represents a fusion of Reshape->Gemm->Reshape->Reshape into FC->Reshape.
-/// Pattern: ND input -> Reshape0 (ND->2D) -> Gemm (2D->2D) -> Reshape1 -> Reshape2 -> output
-/// Fused:   ND input -> FullyConnected (ND->2D) -> Reshape2 -> output
-/// All 4 nodes are claimed.
-/// </summary>
-class ReshapeGemmReshapeReshapeFusion : public IQnnNodeGroup {
- public:
-  ReshapeGemmReshapeReshapeFusion(const OrtNodeUnit& input_reshape_node_unit,
-                                  const OrtNodeUnit& gemm_node_unit,
-                                  const OrtNodeUnit& output_reshape1_node_unit,
-                                  const OrtNodeUnit& output_reshape2_node_unit);
-  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmReshapeReshapeFusion);
-
-  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
-  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
-  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
-  const OrtNodeUnit* GetTargetNodeUnit() const override;
-  std::string_view Type() const override { return "ReshapeGemmReshapeReshapeFusion"; }
-
-  static std::unique_ptr<IQnnNodeGroup> TryFusion(
-      QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& gemm_node_unit,
-      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
-      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
-      const Ort::Logger& logger);
-
- private:
-  std::array<const OrtNodeUnit*, 4> node_units_;
-};
+// Backward-compatible aliases for existing registration code
+using ReshapeGemmFusion = ReshapeGemmFusionGroup;
+using ReshapeGemmReshapeFusion = ReshapeGemmFusionGroup;
+using ReshapeGemmReshapeReshapeFusion = ReshapeGemmFusionGroup;
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #if !defined(ORT_MINIMAL_BUILD)
 

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
@@ -324,6 +324,301 @@ TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_Transformer) {
   AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
 }
 
+// ============================================================================
+// Negative Tests - Fusion should NOT happen
+// ============================================================================
+
+// Build a test case where Gemm has transA=1 (fusion should not happen)
+GetTestModelFn BuildReshapeGemmWithTransATestCase(const std::vector<int64_t>& input_shape,
+                                                  int64_t hidden_size,
+                                                  int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_transA_graph");
+
+    // Input tensor - transposed shape for transA=1
+    std::vector<int64_t> transposed_input_shape = input_shape;
+    std::swap(transposed_input_shape[transposed_input_shape.size() - 1],
+              transposed_input_shape[transposed_input_shape.size() - 2]);
+    auto input_def = TestInputDef<float>(transposed_input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Calculate flattened batch size
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    // Reshape to 2D (transposed)
+    builder.Make1DInitializer<int64_t>("reshape_shape", {hidden_size, batch_size});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // Gemm weight: [hidden, output]
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<float>("weight", weight_shape, -0.5f, 0.5f);
+
+    // Gemm bias
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm with transA=1: [hidden, batch*seq]^T x [hidden, output] -> [batch*seq, output]
+    builder.AddNode("gemm", "Gemm", {"reshape_out", "weight", "bias"}, {"output"}, kOnnxDomain,
+                    {builder.MakeScalarAttribute("transA", static_cast<int64_t>(1))});
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a test case where Gemm has transB=1 (fusion should not happen)
+GetTestModelFn BuildReshapeGemmWithTransBTestCase(const std::vector<int64_t>& input_shape,
+                                                  int64_t hidden_size,
+                                                  int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_transB_graph");
+
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    builder.Make1DInitializer<int64_t>("reshape_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // Gemm weight: [output, hidden] (transposed for transB=1)
+    std::vector<int64_t> weight_shape = {output_size, hidden_size};
+    builder.MakeInitializer<float>("weight", weight_shape, -0.5f, 0.5f);
+
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm with transB=1
+    builder.AddNode("gemm", "Gemm", {"reshape_out", "weight", "bias"}, {"output"}, kOnnxDomain,
+                    {builder.MakeScalarAttribute("transB", static_cast<int64_t>(1))});
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a test case where Gemm weight is not constant (fusion should not happen)
+GetTestModelFn BuildReshapeGemmDynamicWeightTestCase(const std::vector<int64_t>& input_shape,
+                                                     int64_t hidden_size,
+                                                     int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_dynamic_weight_graph");
+
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    builder.Make1DInitializer<int64_t>("reshape_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // Dynamic weight (not initializer)
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    auto weight_def = TestInputDef<float>(weight_shape, false, -0.5f, 0.5f);
+    MakeTestInput<float>(builder, "weight", weight_def);
+
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    builder.AddNode("gemm", "Gemm", {"reshape_out", "weight", "bias"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a test case with non-default alpha (fusion should not happen for Gemm)
+GetTestModelFn BuildReshapeGemmNonDefaultAlphaTestCase(const std::vector<int64_t>& input_shape,
+                                                       int64_t hidden_size,
+                                                       int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_alpha_graph");
+
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    builder.Make1DInitializer<int64_t>("reshape_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<float>("weight", weight_shape, -0.5f, 0.5f);
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm with non-default alpha
+    builder.AddNode("gemm", "Gemm", {"reshape_out", "weight", "bias"}, {"output"}, kOnnxDomain,
+                    {builder.MakeScalarAttribute("alpha", 0.5f)});
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Test: Fusion should NOT happen when transA=1
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_TransA) {
+  ProviderOptions provider_options = GetProviderOptions();
+
+  // Model should still run, but fusion won't happen (Gemm handled separately)
+  RunQnnModelTest(BuildReshapeGemmWithTransATestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// Test: Fusion should NOT happen when transB=1
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_TransB) {
+  ProviderOptions provider_options = GetProviderOptions();
+
+  RunQnnModelTest(BuildReshapeGemmWithTransBTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// Test: Fusion should NOT happen when weight is dynamic
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_DynamicWeight) {
+  ProviderOptions provider_options = GetProviderOptions();
+
+  RunQnnModelTest(BuildReshapeGemmDynamicWeightTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// ============================================================================
+// QDQ Tests - Fusion should NOT happen for QDQ-wrapped Gemm
+// ============================================================================
+
+// Build a QDQ test case: Reshape -> Q -> DQ -> Gemm -> Q -> DQ
+// Fusion should NOT happen because Gemm is QDQ-wrapped
+GetTestModelFn BuildQDQReshapeGemmTestCase(const std::vector<int64_t>& input_shape,
+                                           int64_t hidden_size,
+                                           int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("qdq_reshape_gemm_graph");
+
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    // Reshape
+    builder.Make1DInitializer<int64_t>("reshape_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // Q -> DQ on reshape output
+    float scale = 0.01f;
+    uint8_t zp = 128;
+    builder.AddQuantizeLinearNode<uint8_t>("q1", "reshape_out", scale, zp, "q1_out", false);
+    builder.AddDequantizeLinearNode<uint8_t>("dq1", "q1_out", scale, zp, "dq1_out", false);
+
+    // Pre-quantized weight (uint8 initializer with DQ only - no Q node needed for initializers)
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<uint8_t>("weight_q", weight_shape, static_cast<uint8_t>(64), static_cast<uint8_t>(192));
+    builder.AddDequantizeLinearNode<uint8_t>("dq_weight", "weight_q", 0.01f, static_cast<uint8_t>(128), "dq_weight_out", false);
+
+    // Bias (not quantized for Gemm)
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm (QDQ-wrapped input and weight)
+    builder.AddNode("gemm", "Gemm", {"dq1_out", "dq_weight_out", "bias"}, {"gemm_out"}, kOnnxDomain);
+
+    // Q -> DQ on output
+    builder.AddQuantizeLinearNode<uint8_t>("q2", "gemm_out", scale, zp, "q2_out", false);
+    builder.AddDequantizeLinearNode<uint8_t>("dq2", "q2_out", scale, zp, "output", false);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a QDQ test case: Reshape -> Q -> DQ -> Gemm -> Q -> DQ -> Reshape
+GetTestModelFn BuildQDQReshapeGemmReshapeTestCase(const std::vector<int64_t>& input_shape,
+                                                  int64_t hidden_size,
+                                                  int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("qdq_reshape_gemm_reshape_graph");
+
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    // Input Reshape
+    builder.Make1DInitializer<int64_t>("reshape1_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape1", "Reshape", {"input", "reshape1_shape"}, {"reshape1_out"}, kOnnxDomain);
+
+    // Q -> DQ
+    float scale = 0.01f;
+    uint8_t zp = 128;
+    builder.AddQuantizeLinearNode<uint8_t>("q1", "reshape1_out", scale, zp, "q1_out", false);
+    builder.AddDequantizeLinearNode<uint8_t>("dq1", "q1_out", scale, zp, "dq1_out", false);
+
+    // Pre-quantized weight (uint8 initializer with DQ only - no Q node needed for initializers)
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<uint8_t>("weight_q", weight_shape, static_cast<uint8_t>(64), static_cast<uint8_t>(192));
+    builder.AddDequantizeLinearNode<uint8_t>("dq_weight", "weight_q", 0.01f, static_cast<uint8_t>(128), "dq_weight_out", false);
+
+    // Bias
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm
+    builder.AddNode("gemm", "Gemm", {"dq1_out", "dq_weight_out", "bias"}, {"gemm_out"}, kOnnxDomain);
+
+    // Q -> DQ on Gemm output
+    builder.AddQuantizeLinearNode<uint8_t>("q2", "gemm_out", scale, zp, "q2_out", false);
+    builder.AddDequantizeLinearNode<uint8_t>("dq2", "q2_out", scale, zp, "dq2_out", false);
+
+    // Output Reshape
+    std::vector<int64_t> output_shape_vec = input_shape;
+    output_shape_vec.back() = output_size;
+    builder.Make1DInitializer<int64_t>("reshape2_shape", output_shape_vec);
+    builder.AddNode("reshape2", "Reshape", {"dq2_out", "reshape2_shape"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Test: QDQ Reshape -> Gemm (fusion should NOT happen, QDQ Gemm handled differently)
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_QDQ_NoFusion) {
+  ProviderOptions provider_options = GetProviderOptions();
+
+  // QDQ model should run but ReshapeGemmFusion should not apply
+  // (QDQ Gemm is handled by different code path)
+  // Use ExpectedEPNodeAssignment::Some since not all nodes may be assigned to QNN EP
+  RunQnnModelTest(BuildQDQReshapeGemmTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
+                  /*fp32_abs_err=*/0.5f);  // Higher tolerance for quantized
+}
+
+// Test: QDQ Reshape -> Gemm -> Reshape (fusion should NOT happen)
+TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_QDQ_NoFusion) {
+  ProviderOptions provider_options = GetProviderOptions();
+
+  // Use ExpectedEPNodeAssignment::Some since not all nodes may be assigned to QNN EP
+  RunQnnModelTest(BuildQDQReshapeGemmReshapeTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
+                  /*fp32_abs_err=*/0.5f);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
@@ -1,0 +1,332 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <gsl/util>
+#include "gtest/gtest.h"
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+namespace {
+
+// Build a 2-node fusion test case: Reshape -> Gemm
+// Input: [batch, seq, hidden] -> Reshape to [batch*seq, hidden] -> Gemm -> [batch*seq, out]
+GetTestModelFn BuildReshapeGemmTestCase(const std::vector<int64_t>& input_shape,
+                                        int64_t hidden_size,
+                                        int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_graph");
+
+    // Input tensor
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Calculate flattened batch size (all dims except last)
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    // Reshape: [batch, seq, hidden] -> [batch*seq, hidden]
+    builder.Make1DInitializer<int64_t>("reshape_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // Gemm weight: [hidden, output] (transB=0)
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<float>("weight", weight_shape, -0.5f, 0.5f);
+
+    // Gemm bias
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm: [batch*seq, hidden] x [hidden, output] -> [batch*seq, output]
+    builder.AddNode("gemm", "Gemm", {"reshape_out", "weight", "bias"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a 3-node fusion test case: Reshape -> Gemm -> Reshape
+// Input: [batch, seq, hidden] -> Reshape -> Gemm -> Reshape -> [batch, seq, out]
+GetTestModelFn BuildReshapeGemmReshapeTestCase(const std::vector<int64_t>& input_shape,
+                                               int64_t hidden_size,
+                                               int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_reshape_graph");
+
+    // Input tensor
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Calculate flattened batch size (all dims except last)
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    // Reshape: [batch, seq, hidden] -> [batch*seq, hidden]
+    builder.Make1DInitializer<int64_t>("reshape1_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape1", "Reshape", {"input", "reshape1_shape"}, {"reshape1_out"}, kOnnxDomain);
+
+    // Gemm weight: [hidden, output]
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<float>("weight", weight_shape, -0.5f, 0.5f);
+
+    // Gemm bias
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm: [batch*seq, hidden] x [hidden, output] -> [batch*seq, output]
+    builder.AddNode("gemm", "Gemm", {"reshape1_out", "weight", "bias"}, {"gemm_out"}, kOnnxDomain);
+
+    // Build output shape: same as input but with last dim = output_size
+    std::vector<int64_t> output_shape_vec = input_shape;
+    output_shape_vec.back() = output_size;
+
+    // Reshape: [batch*seq, output] -> [batch, seq, output]
+    builder.Make1DInitializer<int64_t>("reshape2_shape", output_shape_vec);
+    builder.AddNode("reshape2", "Reshape", {"gemm_out", "reshape2_shape"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a 4-node fusion test case: Reshape -> Gemm -> Reshape -> Reshape
+// Input: [batch, seq, hidden] -> Reshape -> Gemm -> Reshape -> Reshape -> [1, batch*seq, out]
+GetTestModelFn BuildReshapeGemmReshapeReshapeTestCase(const std::vector<int64_t>& input_shape,
+                                                      int64_t hidden_size,
+                                                      int64_t output_size) {
+  return [input_shape, hidden_size, output_size](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_reshape_reshape_graph");
+
+    // Input tensor
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Calculate flattened batch size (all dims except last)
+    int64_t batch_size = 1;
+    for (size_t i = 0; i < input_shape.size() - 1; ++i) {
+      batch_size *= input_shape[i];
+    }
+
+    // Reshape: [batch, seq, hidden] -> [batch*seq, hidden]
+    builder.Make1DInitializer<int64_t>("reshape1_shape", {batch_size, hidden_size});
+    builder.AddNode("reshape1", "Reshape", {"input", "reshape1_shape"}, {"reshape1_out"}, kOnnxDomain);
+
+    // Gemm weight: [hidden, output]
+    std::vector<int64_t> weight_shape = {hidden_size, output_size};
+    builder.MakeInitializer<float>("weight", weight_shape, -0.5f, 0.5f);
+
+    // Gemm bias
+    builder.MakeInitializer<float>("bias", {output_size}, -0.1f, 0.1f);
+
+    // Gemm: [batch*seq, hidden] x [hidden, output] -> [batch*seq, output]
+    builder.AddNode("gemm", "Gemm", {"reshape1_out", "weight", "bias"}, {"gemm_out"}, kOnnxDomain);
+
+    // Build intermediate shape: same as input but with last dim = output_size
+    std::vector<int64_t> intermediate_shape_vec = input_shape;
+    intermediate_shape_vec.back() = output_size;
+
+    // Reshape2: [batch*seq, output] -> [batch, seq, output]
+    builder.Make1DInitializer<int64_t>("reshape2_shape", intermediate_shape_vec);
+    builder.AddNode("reshape2", "Reshape", {"gemm_out", "reshape2_shape"}, {"reshape2_out"}, kOnnxDomain);
+
+    // Reshape3: [batch, seq, output] -> [1, batch*seq, output]
+    builder.Make1DInitializer<int64_t>("reshape3_shape", {1, batch_size, output_size});
+    builder.AddNode("reshape3", "Reshape", {"reshape2_out", "reshape3_shape"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Build a test case with pattern: keep first dim, flatten last dims
+// Input: [16, 1, 4, 8] -> Reshape to [16, 32] -> Gemm -> [16, 32] -> Reshape -> [16, 1, 32]
+// (Smaller version of ViT attention output pattern)
+GetTestModelFn BuildReshapeGemmReshapeKeepFirstDimTestCase() {
+  return [](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_reshape_keep_first_graph");
+
+    // Input: [16, 1, 4, 8] - smaller ViT-like attention output shape
+    auto input_def = TestInputDef<float>({16, 1, 4, 8}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Reshape: [16, 1, 4, 8] -> [16, 32] (keep first dim, flatten last dims)
+    builder.Make1DInitializer<int64_t>("reshape1_shape", {16, 32});
+    builder.AddNode("reshape1", "Reshape", {"input", "reshape1_shape"}, {"reshape1_out"}, kOnnxDomain);
+
+    // Gemm weight: [32, 32]
+    builder.MakeInitializer<float>("weight", {32, 32}, -0.5f, 0.5f);
+
+    // Gemm bias
+    builder.MakeInitializer<float>("bias", {32}, -0.1f, 0.1f);
+
+    // Gemm: [16, 32] x [32, 32] -> [16, 32]
+    builder.AddNode("gemm", "Gemm", {"reshape1_out", "weight", "bias"}, {"gemm_out"}, kOnnxDomain);
+
+    // Reshape: [16, 32] -> [16, 1, 32]
+    builder.Make1DInitializer<int64_t>("reshape2_shape", {16, 1, 32});
+    builder.AddNode("reshape2", "Reshape", {"gemm_out", "reshape2_shape"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return provider_options;
+}
+
+}  // namespace
+
+// Test 2-node fusion: Reshape -> Gemm (3D input)
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_3D) {
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmFusion_3D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildReshapeGemmTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify FullyConnected is in the graph (fusion happened)
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+}
+
+// Test 3-node fusion: Reshape -> Gemm -> Reshape (3D input)
+TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_3D) {
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmReshapeFusion_3D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildReshapeGemmReshapeTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify FullyConnected and one Reshape (output reshape kept)
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
+}
+
+// Test 3-node fusion: Reshape -> Gemm -> Reshape (4D input)
+TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_4D) {
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmReshapeFusion_4D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildReshapeGemmReshapeTestCase({2, 4, 8, 32}, 32, 64),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify FullyConnected and one Reshape
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
+}
+
+// Test 4-node fusion: Reshape -> Gemm -> Reshape -> Reshape
+TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeReshapeFusion_3D) {
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmReshapeReshapeFusion_3D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildReshapeGemmReshapeReshapeTestCase({1, 32, 64}, 64, 128),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify FullyConnected and one Reshape (only final reshape kept)
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
+}
+
+// Test 3-node fusion with ViT-like pattern: keep first dim, flatten last dims
+// [197, 1, 12, 64] -> [197, 768] -> Gemm -> [197, 768] -> [197, 1, 768]
+TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_ViTPattern) {
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmReshapeFusion_ViTPattern";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildReshapeGemmReshapeKeepFirstDimTestCase(),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify FullyConnected and one Reshape
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
+}
+
+// Test with transformer-like shape (smaller for unit test)
+TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_Transformer) {
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmReshapeFusion_Transformer";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  // Smaller transformer-like shape: [batch, seq, hidden] with hidden=64
+  RunQnnModelTest(BuildReshapeGemmReshapeTestCase({1, 16, 64}, 64, 64),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify FullyConnected and one Reshape
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add 2 QNN group node fusion to reshape_gemm_fusion:
1. Reshape - Gemm - Reshape
The ONNX pattern:
`Nd -> matmul  -> add -> Nd `
ORT-core optimize to
`Nd -> reshape_in -> 2d -> GEMM -> 2d -> reshape_out -> Nd`
optimize to QNN pattern:
`Nd -> FC  -> 2d -> reshape_out`

2. Reshape - Gemm - Reshape - Reshape
The ONNX pattern:
`Nd -> matmul  -> add -> Nd -> reshape_original`
ORT-core optimize to
`Nd -> reshape_in -> 2d -> GEMM  -2d -> reshape_out -> Nd -> reshape_original`
optimize to QNN pattern:
`Nd -> FC  -> 2d -> reshape_original`

The reshape - gemm - reshape is a very common pattern when ORT-core optimizes matmul-add, and since ort requires gemm to have 2d input and output, ort-core will add reshape before and after gemm. However fc in QNN is more flexable, it accepts any input rank/shape as long as it can be reshaped to [batch_size. N] where N in fc's weight input dim.

Adding reshape - gemm - reshape - reshape pattern as well because matmul - add - reshape is another popular pattern in attention models.

Another reason for this change, we observed HTP compiler has a long chain optimization for attention modules, and it relies on certain pattern matching to hit the optimization. I have belief from previous experiments that the long chain attention pattern expects a `Nd -> FC -> 2d` pattern. That's why we observed 44x perf imrpovement.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

With this change, this model's performance can be improved from 800 ms to 28ms
834 ms job w/o fusion: https://dev.aihub.qualcomm.com/jobs/jgjz34085 (w/ qairt2.43)
829 ms job w/o fusion: https://dev.aihub.qualcomm.com/jobs/jpyj37z0p/ (w/ qairt2.45)
28 ms job w/ with fusion: https://dev.aihub.qualcomm.com/jobs/jgokq134p (w/ qairt 2.45)

Other experimental jobs:
904ms job with `ReshapeGemmReshapeReshapeFusion` disabled: https://dev.aihub.qualcomm.com/jobs/jpr23n6k5/ (w/ qairt 2.45)

