### PR TITLE
QnnNodeGroupFusion: Add Gelu pattern3 to fuse ERF

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -69,7 +70,7 @@ static const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_u
                           ctx.node_unit_to_qnn_node_group);
 }
 
-static bool TryMatchPattern1(
+static bool TryMatchGeluMulPattern1(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
@@ -110,7 +111,7 @@ static bool TryMatchPattern1(
   return false;
 }
 
-static bool TryMatchPattern2(
+static bool TryMatchGeluMulPattern2(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
@@ -149,7 +150,7 @@ static bool TryMatchPattern2(
   return true;
 }
 
-static bool TryMatchPattern3(
+static bool TryMatchGeluMulPattern3(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
@@ -192,30 +193,30 @@ static bool TryMatchPattern3(
   return true;
 }
 
-static bool TryMatchGeluPattern(const OrtNodeUnit* div_node_unit,
-                                const OrtNodeUnit& erf_node_unit,
-                                const OrtNodeUnit* add_node_unit,
-                                const OrtNodeUnit* mul_after_add_node_unit,
-                                const GeluPatternMatchContext& ctx,
-                                GeluPatternMatchResult& result) {
-  return TryMatchPattern1(div_node_unit,
-                          erf_node_unit,
-                          add_node_unit,
-                          mul_after_add_node_unit,
-                          ctx,
-                          result) ||
-         TryMatchPattern2(div_node_unit,
-                          erf_node_unit,
-                          add_node_unit,
-                          mul_after_add_node_unit,
-                          ctx,
-                          result) ||
-         TryMatchPattern3(div_node_unit,
-                          erf_node_unit,
-                          add_node_unit,
-                          mul_after_add_node_unit,
-                          ctx,
-                          result);
+static bool TryMatchGeluMulPattern(const OrtNodeUnit* div_node_unit,
+                                   const OrtNodeUnit& erf_node_unit,
+                                   const OrtNodeUnit* add_node_unit,
+                                   const OrtNodeUnit* mul_after_add_node_unit,
+                                   const GeluPatternMatchContext& ctx,
+                                   GeluPatternMatchResult& result) {
+  return TryMatchGeluMulPattern1(div_node_unit,
+                                 erf_node_unit,
+                                 add_node_unit,
+                                 mul_after_add_node_unit,
+                                 ctx,
+                                 result) ||
+         TryMatchGeluMulPattern2(div_node_unit,
+                                 erf_node_unit,
+                                 add_node_unit,
+                                 mul_after_add_node_unit,
+                                 ctx,
+                                 result) ||
+         TryMatchGeluMulPattern3(div_node_unit,
+                                 erf_node_unit,
+                                 add_node_unit,
+                                 mul_after_add_node_unit,
+                                 ctx,
+                                 result);
 }
 
 }  // namespace
@@ -308,12 +309,12 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
                                           root_input_name};
 
   GeluPatternMatchResult pattern_match;
-  const bool is_match = TryMatchGeluPattern(div_node_unit,
-                                            erf_node_unit,
-                                            add_node_unit,
-                                            mul_node_unit,
-                                            match_ctx,
-                                            pattern_match);
+  const bool is_match = TryMatchGeluMulPattern(div_node_unit,
+                                               erf_node_unit,
+                                               add_node_unit,
+                                               mul_node_unit,
+                                               match_ctx,
+                                               pattern_match);
 
   if (!is_match) {
     return nullptr;
@@ -331,7 +332,7 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     return nullptr;
   }
 
-  return std::unique_ptr<IQnnNodeGroup>(new GeluFusion(std::move(pattern_match.node_units), &erf_node_unit));
+  return std::make_unique<GeluFusion>(std::move(pattern_match.node_units), &erf_node_unit);
 }
 
 GeluFusion::GeluFusion(std::vector<const OrtNodeUnit*>&& node_units, const OrtNodeUnit* target_node_unit)

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -70,14 +70,14 @@ static const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_u
                           ctx.node_unit_to_qnn_node_group);
 }
 
-static bool TryMatchGeluMulPattern1(
+static bool TryMatchErfAddPattern1(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
     const OrtNodeUnit* mul_after_add_node_unit,
     const GeluPatternMatchContext& ctx,
     GeluPatternMatchResult& result) {
-  // Pattern 1:
+  // ErfAdd Pattern 1:
   //               +-------Mul(0.5)---------------------+
   //               |                                    |
   //               |                                    v
@@ -85,7 +85,7 @@ static bool TryMatchGeluMulPattern1(
   //                      (B=1.4142...)        (1)
   //
   // At this stage: "mul_after_add_node_unit" is the final Mul after Add.
-  // We now verify its non-Add input comes from Mul(root, const).
+  // We now verify its non-Add input comes from Mul(root, const=0.5).
   const auto& mul_inputs = mul_after_add_node_unit->Inputs();
   if (mul_inputs.size() < 2) {
     return false;
@@ -111,14 +111,14 @@ static bool TryMatchGeluMulPattern1(
   return false;
 }
 
-static bool TryMatchGeluMulPattern2(
+static bool TryMatchErfAddPattern2(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
     const OrtNodeUnit* mul_after_add_node_unit,
     const GeluPatternMatchContext& ctx,
     GeluPatternMatchResult& result) {
-  // Pattern 2:
+  // ErfAdd Pattern 2:
   //               +------------------------------------+
   //               |                                    |
   //               |                                    v
@@ -150,73 +150,95 @@ static bool TryMatchGeluMulPattern2(
   return true;
 }
 
-static bool TryMatchGeluMulPattern3(
+static bool TryMatchErfMulPattern(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
-    const OrtNodeUnit* add_node_unit,
-    const OrtNodeUnit* mul_after_add_node_unit,
     const GeluPatternMatchContext& ctx,
     GeluPatternMatchResult& result) {
-  // Pattern 3:
-  //               +---------------------------------------------+
-  //               |                                             |
-  //               |                                             v
-  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
-  //                      (B=1.4142...)        (1)     (0.5)
-  //
-  // At this stage: "mul_after_add_node_unit" is Mul(Add, 0.5) and does NOT consume root.
-  // Its child Mul must consume both root and this intermediate output.
-  if (HasInputWithName(*mul_after_add_node_unit, ctx.root_input_name)) {
+  // ErfMul Pattern (Pattern 3):
+  //               +-------------------------------------------+
+  //               |                                           |
+  //               |                                           v
+  //            [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
+  //                      (B=1.4142...)      (0.5)   (0.5)
+  const auto& erf_outputs = erf_node_unit.Outputs();
+  if (erf_outputs.empty()) {
     return false;
   }
 
-  const auto& mul_outputs = mul_after_add_node_unit->Outputs();
+  // Erf should have a Mul child
+  const OrtNodeUnit* mul_after_erf_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                                    erf_node_unit,
+                                                                    erf_outputs[0],
+                                                                    ctx.node_to_node_unit,
+                                                                    ctx.node_unit_to_qnn_node_group);
+  if (mul_after_erf_node_unit == nullptr || mul_after_erf_node_unit->OpType() != "Mul") {
+    return false;
+  }
+
+  // This Mul should NOT consume root (it multiplies by constant 0.5)
+  if (HasInputWithName(*mul_after_erf_node_unit, ctx.root_input_name)) {
+    return false;
+  }
+
+  // Mul must have an Add child
+  const auto& mul_outputs = mul_after_erf_node_unit->Outputs();
   if (mul_outputs.empty()) {
     return false;
   }
 
+  const OrtNodeUnit* add_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                          *mul_after_erf_node_unit,
+                                                          mul_outputs[0],
+                                                          ctx.node_to_node_unit,
+                                                          ctx.node_unit_to_qnn_node_group);
+  if (add_node_unit == nullptr || add_node_unit->OpType() != "Add") {
+    return false;
+  }
+
+  // Add must have a Mul child (final node)
+  const auto& add_outputs = add_node_unit->Outputs();
+  if (add_outputs.empty()) {
+    return false;
+  }
+
   const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
-                                                                *mul_after_add_node_unit,
-                                                                mul_outputs[0],
+                                                                *add_node_unit,
+                                                                add_outputs[0],
                                                                 ctx.node_to_node_unit,
                                                                 ctx.node_unit_to_qnn_node_group);
   if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
     return false;
   }
 
+  // Final Mul must consume root (skip connection)
   if (!HasInputWithName(*final_mul_node_unit, ctx.root_input_name)) {
     return false;
   }
 
-  result.node_units = {div_node_unit, &erf_node_unit, add_node_unit, mul_after_add_node_unit, final_mul_node_unit};
+  result.node_units = {div_node_unit, &erf_node_unit, mul_after_erf_node_unit, add_node_unit, final_mul_node_unit};
   result.final_mul_node_unit = final_mul_node_unit;
   return true;
 }
 
-static bool TryMatchGeluMulPattern(const OrtNodeUnit* div_node_unit,
+static bool TryMatchErfAddPatterns(const OrtNodeUnit* div_node_unit,
                                    const OrtNodeUnit& erf_node_unit,
                                    const OrtNodeUnit* add_node_unit,
                                    const OrtNodeUnit* mul_after_add_node_unit,
                                    const GeluPatternMatchContext& ctx,
                                    GeluPatternMatchResult& result) {
-  return TryMatchGeluMulPattern1(div_node_unit,
-                                 erf_node_unit,
-                                 add_node_unit,
-                                 mul_after_add_node_unit,
-                                 ctx,
-                                 result) ||
-         TryMatchGeluMulPattern2(div_node_unit,
-                                 erf_node_unit,
-                                 add_node_unit,
-                                 mul_after_add_node_unit,
-                                 ctx,
-                                 result) ||
-         TryMatchGeluMulPattern3(div_node_unit,
-                                 erf_node_unit,
-                                 add_node_unit,
-                                 mul_after_add_node_unit,
-                                 ctx,
-                                 result);
+  return TryMatchErfAddPattern1(div_node_unit,
+                                erf_node_unit,
+                                add_node_unit,
+                                mul_after_add_node_unit,
+                                ctx,
+                                result) ||
+         TryMatchErfAddPattern2(div_node_unit,
+                                erf_node_unit,
+                                add_node_unit,
+                                mul_after_add_node_unit,
+                                ctx,
+                                result);
 }
 
 }  // namespace
@@ -249,59 +271,18 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     return nullptr;
   }
 
-  // Erf must have an Add child consuming its output
+  // Determine which GELU pattern variant by checking Erf's child node type
   const auto& erf_outputs = erf_node_unit.Outputs();
   if (erf_outputs.empty()) {
     return nullptr;
   }
 
-  const OrtNodeUnit* add_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper, erf_node_unit, erf_outputs[0],
-                                                          node_to_node_unit, node_unit_to_qnn_node_group);
-  if (add_node_unit == nullptr || add_node_unit->OpType() != "Add") {
+  const OrtNodeUnit* erf_child_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper, erf_node_unit, erf_outputs[0],
+                                                                node_to_node_unit, node_unit_to_qnn_node_group);
+  if (erf_child_node_unit == nullptr) {
     return nullptr;
   }
 
-  // Add must have 2 inputs
-  const auto& add_inputs = add_node_unit->Inputs();
-  if (add_inputs.size() < 2) {
-    return nullptr;
-  }
-
-  // Add must have a Mul child consuming its output.
-  // Stage 1 graph shape validated:
-  // [root] -> Div -> Erf -> Add -> Mul
-  const auto& add_outputs = add_node_unit->Outputs();
-  if (add_outputs.empty()) {
-    return nullptr;
-  }
-
-  const OrtNodeUnit* mul_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper, *add_node_unit, add_outputs[0],
-                                                          node_to_node_unit, node_unit_to_qnn_node_group);
-  if (mul_node_unit == nullptr || mul_node_unit->OpType() != "Mul") {
-    return nullptr;
-  }
-
-  // Stage 2: match one of the supported complete GELU patterns.
-  // We use explicit case matching in order: Pattern 1, Pattern 2, Pattern 3.
-  //
-  // Pattern 1:
-  //               +-------Mul(0.5)---------------------+
-  //               |                                    |
-  //               |                                    v
-  //            [root] --> Div -----> Erf  --> Add --> Mul ==>
-  //
-  // Pattern 2:
-  //               +------------------------------------+
-  //               |                                    |
-  //               |                                    v
-  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
-  //                      (B=1.4142...)        (1)             (0.5)
-  // Pattern 3:
-  //               +---------------------------------------------+
-  //               |                                             |
-  //               |                                             v
-  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
-  //                                                  (0.5)
   const std::string& root_input_name = div_inputs[0].name;
   const GeluPatternMatchContext match_ctx{qnn_model_wrapper,
                                           node_to_node_unit,
@@ -309,12 +290,43 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
                                           root_input_name};
 
   GeluPatternMatchResult pattern_match;
-  const bool is_match = TryMatchGeluMulPattern(div_node_unit,
-                                               erf_node_unit,
-                                               add_node_unit,
-                                               mul_node_unit,
-                                               match_ctx,
-                                               pattern_match);
+  bool is_match = false;
+
+  if (erf_child_node_unit->OpType() == "Mul") {
+    // ErfMul Pattern3: Erf -> Mul -> Add -> Mul
+    // Structure: x * (Erf(x / sqrt2) * 0.5 + 0.5)
+    is_match = TryMatchErfMulPattern(div_node_unit,
+                                     erf_node_unit,
+                                     match_ctx,
+                                     pattern_match);
+  } else if (erf_child_node_unit->OpType() == "Add") {
+    // ErfAdd Patterns 1 or 2: Erf -> Add -> Mul [-> Mul]
+    // Structure: x * 0.5 * (Erf(x / sqrt2) + 1) [with variations in Mul ordering]
+    const OrtNodeUnit* add_node_unit = erf_child_node_unit;
+
+    const auto& add_inputs = add_node_unit->Inputs();
+    if (add_inputs.size() < 2) {
+      return nullptr;
+    }
+
+    const auto& add_outputs = add_node_unit->Outputs();
+    if (add_outputs.empty()) {
+      return nullptr;
+    }
+
+    const OrtNodeUnit* mul_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper, *add_node_unit, add_outputs[0],
+                                                            node_to_node_unit, node_unit_to_qnn_node_group);
+    if (mul_node_unit == nullptr || mul_node_unit->OpType() != "Mul") {
+      return nullptr;
+    }
+
+    is_match = TryMatchErfAddPatterns(div_node_unit,
+                                      erf_node_unit,
+                                      add_node_unit,
+                                      mul_node_unit,
+                                      match_ctx,
+                                      pattern_match);
+  }
 
   if (!is_match) {
     return nullptr;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -10,6 +10,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "core/providers/qnn/ort_api.h"
@@ -48,16 +49,16 @@ struct GeluPatternMatchContext {
 };
 
 /* Checks if the given NodeUnit has an input tensor with the specified name. */
-static bool HasInputWithName(const OrtNodeUnit& node_unit, const std::string& input_name) {
+bool HasInputWithName(const OrtNodeUnit& node_unit, std::string_view input_name) {
   const auto& inputs = node_unit.Inputs();
-  return std::any_of(inputs.begin(), inputs.end(), [input_name](const OrtNodeUnitIODef& input) {
+  return std::any_of(inputs.begin(), inputs.end(), [&input_name](const OrtNodeUnitIODef& input) {
     return input.name == input_name;
   });
 }
 
-static const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_unit,
-                                              size_t input_index,
-                                              const GeluPatternMatchContext& ctx) {
+const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_unit,
+                                       size_t input_index,
+                                       const GeluPatternMatchContext& ctx) {
   const auto& inputs = consumer_node_unit.Inputs();
   if (input_index >= inputs.size()) {
     return nullptr;
@@ -70,7 +71,7 @@ static const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_u
                           ctx.node_unit_to_qnn_node_group);
 }
 
-static bool TryMatchErfAddPattern1(
+bool TryMatchErfAddPattern1(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
@@ -111,7 +112,7 @@ static bool TryMatchErfAddPattern1(
   return false;
 }
 
-static bool TryMatchErfAddPattern2(
+bool TryMatchErfAddPattern2(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const OrtNodeUnit* add_node_unit,
@@ -150,7 +151,7 @@ static bool TryMatchErfAddPattern2(
   return true;
 }
 
-static bool TryMatchErfMulPattern(
+bool TryMatchErfMulPattern(
     const OrtNodeUnit* div_node_unit,
     const OrtNodeUnit& erf_node_unit,
     const GeluPatternMatchContext& ctx,
@@ -221,12 +222,12 @@ static bool TryMatchErfMulPattern(
   return true;
 }
 
-static bool TryMatchErfAddPatterns(const OrtNodeUnit* div_node_unit,
-                                   const OrtNodeUnit& erf_node_unit,
-                                   const OrtNodeUnit* add_node_unit,
-                                   const OrtNodeUnit* mul_after_add_node_unit,
-                                   const GeluPatternMatchContext& ctx,
-                                   GeluPatternMatchResult& result) {
+bool TryMatchErfAddPatterns(const OrtNodeUnit* div_node_unit,
+                            const OrtNodeUnit& erf_node_unit,
+                            const OrtNodeUnit* add_node_unit,
+                            const OrtNodeUnit* mul_after_add_node_unit,
+                            const GeluPatternMatchContext& ctx,
+                            GeluPatternMatchResult& result) {
   return TryMatchErfAddPattern1(div_node_unit,
                                 erf_node_unit,
                                 add_node_unit,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -8,7 +8,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
-#include <optional>
+#include <string>
 #include <utility>
 
 #include "core/providers/qnn/ort_api.h"
@@ -31,6 +31,194 @@ static Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnitIODef& root_input,
                                          const OrtNodeUnitIODef& final_output,
                                          bool validate);
+
+namespace {
+
+struct GeluPatternMatchResult {
+  std::vector<const OrtNodeUnit*> node_units;
+  const OrtNodeUnit* final_mul_node_unit = nullptr;  // traces location of MUL with skip connection with root.
+};
+
+struct GeluPatternMatchContext {
+  QnnModelWrapper& qnn_model_wrapper;
+  const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit;
+  const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group;
+  const std::string& root_input_name;
+};
+
+/* Checks if the given NodeUnit has an input tensor with the specified name. */
+static bool HasInputWithName(const OrtNodeUnit& node_unit, const std::string& input_name) {
+  const auto& inputs = node_unit.Inputs();
+  return std::any_of(inputs.begin(), inputs.end(), [input_name](const OrtNodeUnitIODef& input) {
+    return input.name == input_name;
+  });
+}
+
+static const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_unit,
+                                              size_t input_index,
+                                              const GeluPatternMatchContext& ctx) {
+  const auto& inputs = consumer_node_unit.Inputs();
+  if (input_index >= inputs.size()) {
+    return nullptr;
+  }
+
+  return GetParentOfInput(ctx.qnn_model_wrapper,
+                          consumer_node_unit,
+                          inputs[input_index],
+                          ctx.node_to_node_unit,
+                          ctx.node_unit_to_qnn_node_group);
+}
+
+static bool TryMatchPattern1(
+    const OrtNodeUnit* div_node_unit,
+    const OrtNodeUnit& erf_node_unit,
+    const OrtNodeUnit* add_node_unit,
+    const OrtNodeUnit* mul_after_add_node_unit,
+    const GeluPatternMatchContext& ctx,
+    GeluPatternMatchResult& result) {
+  // Pattern 1:
+  //               +-------Mul(0.5)---------------------+
+  //               |                                    |
+  //               |                                    v
+  //            [root] --> Div -----> Erf  --> Add --> Mul ==>
+  //                      (B=1.4142...)        (1)
+  //
+  // At this stage: "mul_after_add_node_unit" is the final Mul after Add.
+  // We now verify its non-Add input comes from Mul(root, const).
+  const auto& mul_inputs = mul_after_add_node_unit->Inputs();
+  if (mul_inputs.size() < 2) {
+    return false;
+  }
+
+  for (size_t i = 0; i < mul_inputs.size(); ++i) {
+    const OrtNodeUnit* producer = GetProducerForInput(*mul_after_add_node_unit,
+                                                      i,
+                                                      ctx);
+    if (producer == nullptr || producer->OpType() != "Mul") {
+      continue;
+    }
+
+    if (!HasInputWithName(*producer, ctx.root_input_name)) {
+      continue;
+    }
+
+    result.node_units = {div_node_unit, &erf_node_unit, add_node_unit, producer, mul_after_add_node_unit};
+    result.final_mul_node_unit = mul_after_add_node_unit;
+    return true;
+  }
+
+  return false;
+}
+
+static bool TryMatchPattern2(
+    const OrtNodeUnit* div_node_unit,
+    const OrtNodeUnit& erf_node_unit,
+    const OrtNodeUnit* add_node_unit,
+    const OrtNodeUnit* mul_after_add_node_unit,
+    const GeluPatternMatchContext& ctx,
+    GeluPatternMatchResult& result) {
+  // Pattern 2:
+  //               +------------------------------------+
+  //               |                                    |
+  //               |                                    v
+  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
+  //                      (B=1.4142...)        (1)            (0.5)
+  //
+  // At this stage: "mul_after_add_node_unit" is the first Mul after Add, and it must
+  // already consume root. Then its child Mul is the final output node.
+  if (!HasInputWithName(*mul_after_add_node_unit, ctx.root_input_name)) {
+    return false;
+  }
+
+  const auto& mul_outputs = mul_after_add_node_unit->Outputs();
+  if (mul_outputs.empty()) {
+    return false;
+  }
+
+  const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                                *mul_after_add_node_unit,
+                                                                mul_outputs[0],
+                                                                ctx.node_to_node_unit,
+                                                                ctx.node_unit_to_qnn_node_group);
+  if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
+    return false;
+  }
+
+  result.node_units = {div_node_unit, &erf_node_unit, add_node_unit, mul_after_add_node_unit, final_mul_node_unit};
+  result.final_mul_node_unit = final_mul_node_unit;
+  return true;
+}
+
+static bool TryMatchPattern3(
+    const OrtNodeUnit* div_node_unit,
+    const OrtNodeUnit& erf_node_unit,
+    const OrtNodeUnit* add_node_unit,
+    const OrtNodeUnit* mul_after_add_node_unit,
+    const GeluPatternMatchContext& ctx,
+    GeluPatternMatchResult& result) {
+  // Pattern 3:
+  //               +---------------------------------------------+
+  //               |                                             |
+  //               |                                             v
+  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
+  //                      (B=1.4142...)        (1)     (0.5)
+  //
+  // At this stage: "mul_after_add_node_unit" is Mul(Add, 0.5) and does NOT consume root.
+  // Its child Mul must consume both root and this intermediate output.
+  if (HasInputWithName(*mul_after_add_node_unit, ctx.root_input_name)) {
+    return false;
+  }
+
+  const auto& mul_outputs = mul_after_add_node_unit->Outputs();
+  if (mul_outputs.empty()) {
+    return false;
+  }
+
+  const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                                *mul_after_add_node_unit,
+                                                                mul_outputs[0],
+                                                                ctx.node_to_node_unit,
+                                                                ctx.node_unit_to_qnn_node_group);
+  if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
+    return false;
+  }
+
+  if (!HasInputWithName(*final_mul_node_unit, ctx.root_input_name)) {
+    return false;
+  }
+
+  result.node_units = {div_node_unit, &erf_node_unit, add_node_unit, mul_after_add_node_unit, final_mul_node_unit};
+  result.final_mul_node_unit = final_mul_node_unit;
+  return true;
+}
+
+static bool TryMatchGeluPattern(const OrtNodeUnit* div_node_unit,
+                                const OrtNodeUnit& erf_node_unit,
+                                const OrtNodeUnit* add_node_unit,
+                                const OrtNodeUnit* mul_after_add_node_unit,
+                                const GeluPatternMatchContext& ctx,
+                                GeluPatternMatchResult& result) {
+  return TryMatchPattern1(div_node_unit,
+                          erf_node_unit,
+                          add_node_unit,
+                          mul_after_add_node_unit,
+                          ctx,
+                          result) ||
+         TryMatchPattern2(div_node_unit,
+                          erf_node_unit,
+                          add_node_unit,
+                          mul_after_add_node_unit,
+                          ctx,
+                          result) ||
+         TryMatchPattern3(div_node_unit,
+                          erf_node_unit,
+                          add_node_unit,
+                          mul_after_add_node_unit,
+                          ctx,
+                          result);
+}
+
+}  // namespace
 
 std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     QnnModelWrapper& qnn_model_wrapper,
@@ -55,8 +243,6 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
   if (div_node_unit == nullptr || div_node_unit->OpType() != "Div") {
     return nullptr;
   }
-
-  // Div must have 2 inputs
   const auto& div_inputs = div_node_unit->Inputs();
   if (div_inputs.size() < 2) {
     return nullptr;
@@ -80,7 +266,9 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     return nullptr;
   }
 
-  // Add must have a Mul child consuming its output
+  // Add must have a Mul child consuming its output.
+  // Stage 1 graph shape validated:
+  // [root] -> Div -> Erf -> Add -> Mul
   const auto& add_outputs = add_node_unit->Outputs();
   if (add_outputs.empty()) {
     return nullptr;
@@ -92,114 +280,58 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     return nullptr;
   }
 
-  // Now check which pattern we have
-  const auto& root_input_name = div_inputs[0].name;
-  const auto& mul_inputs = mul_node_unit->Inputs();
+  // Stage 2: match one of the supported complete GELU patterns.
+  // We use explicit case matching in order: Pattern 1, Pattern 2, Pattern 3.
+  //
+  // Pattern 1:
+  //               +-------Mul(0.5)---------------------+
+  //               |                                    |
+  //               |                                    v
+  //            [root] --> Div -----> Erf  --> Add --> Mul ==>
+  //
+  // Pattern 2:
+  //               +------------------------------------+
+  //               |                                    |
+  //               |                                    v
+  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
+  //                      (B=1.4142...)        (1)             (0.5)
+  // Pattern 3:
+  //               +---------------------------------------------+
+  //               |                                             |
+  //               |                                             v
+  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
+  //                                                  (0.5)
+  const std::string& root_input_name = div_inputs[0].name;
+  const GeluPatternMatchContext match_ctx{qnn_model_wrapper,
+                                          node_to_node_unit,
+                                          node_unit_to_qnn_node_group,
+                                          root_input_name};
 
-  if (mul_inputs.size() < 2) {
+  GeluPatternMatchResult pattern_match;
+  const bool is_match = TryMatchGeluPattern(div_node_unit,
+                                            erf_node_unit,
+                                            add_node_unit,
+                                            mul_node_unit,
+                                            match_ctx,
+                                            pattern_match);
+
+  if (!is_match) {
     return nullptr;
-  }
-
-  // Try to match Pattern 1: root -> Mul -> ... -> Mul
-  // In this case, one input to the final Mul should be from a Mul node
-  const OrtNodeUnit* mul2_node_unit = nullptr;
-
-  // Check if either input to mul_node_unit comes from a Mul node
-  for (size_t i = 0; i < 2; ++i) {
-    const auto& mul_input_name = mul_inputs[i].name;
-
-    // Find the node that produces this input by iterating through all nodes in QNN-ABI
-    const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
-
-    for (const auto& [node, node_unit] : node_to_node_unit) {
-      if (node == nullptr) continue;
-
-      // Get outputs of this node and check if any matches our input
-      size_t num_outputs = 0;
-      RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetNumOutputs(node, &num_outputs), ort_api, nullptr);
-
-      std::vector<const OrtValueInfo*> outputs(num_outputs);
-      RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetOutputs(node, outputs.data(), outputs.size()), ort_api, nullptr);
-
-      // Check if this node's output matches our input
-      for (const auto* output_info : outputs) {
-        const char* output_name = nullptr;
-        RETURN_DEFAULT_IF_API_FAIL(ort_api.GetValueInfoName(output_info, &output_name), ort_api, nullptr);
-
-        if (output_name && output_name == mul_input_name) {
-          // Found the producer node, check if it's a Mul
-          const OrtNodeUnit* producer_unit = node_unit;
-          if (producer_unit->OpType() == "Mul" &&
-              node_unit_to_qnn_node_group.find(producer_unit) == node_unit_to_qnn_node_group.end()) {
-            // Check if this Mul has root as one input (no longer checking for constant 0.5)
-            const auto& mul2_inputs = producer_unit->Inputs();
-            if (mul2_inputs.size() >= 2) {
-              bool has_root_input = (mul2_inputs[0].name == root_input_name ||
-                                     mul2_inputs[1].name == root_input_name);
-
-              if (has_root_input) {
-                mul2_node_unit = producer_unit;
-                break;
-              }
-            }
-          }
-        }
-      }
-      if (mul2_node_unit != nullptr) break;
-    }
-    if (mul2_node_unit != nullptr) break;
-  }
-
-  std::vector<const OrtNodeUnit*> node_units;
-  const OrtNodeUnit* final_mul_node_unit = nullptr;
-
-  if (mul2_node_unit != nullptr) {
-    // Pattern 1: root -> Mul -> ... -> Mul
-    node_units = {div_node_unit, &erf_node_unit, add_node_unit, mul2_node_unit, mul_node_unit};
-    final_mul_node_unit = mul_node_unit;
-  } else {
-    // Try Pattern 2: root -> ... -> Mul -> Mul
-    // Check if one input to mul_node_unit is root
-    bool has_root_input = (mul_inputs[0].name == root_input_name ||
-                           mul_inputs[1].name == root_input_name);
-
-    if (!has_root_input) {
-      return nullptr;
-    }
-
-    // mul_node_unit must have a Mul child consuming its output
-    const auto& mul_outputs = mul_node_unit->Outputs();
-    if (mul_outputs.empty()) {
-      return nullptr;
-    }
-
-    const OrtNodeUnit* mul2_node_unit_pattern2 = GetOnlyChildOfOutput(qnn_model_wrapper, *mul_node_unit, mul_outputs[0],
-                                                                      node_to_node_unit, node_unit_to_qnn_node_group);
-    if (mul2_node_unit_pattern2 == nullptr || mul2_node_unit_pattern2->OpType() != "Mul") {
-      return nullptr;
-    }
-
-    // Verify this final Mul has 2 inputs
-    const auto& mul2_inputs = mul2_node_unit_pattern2->Inputs();
-    if (mul2_inputs.size() < 2) {
-      return nullptr;
-    }
-
-    // Pattern 2
-    node_units = {div_node_unit, &erf_node_unit, add_node_unit, mul_node_unit, mul2_node_unit_pattern2};
-    final_mul_node_unit = mul2_node_unit_pattern2;
   }
 
   // Validate on QNN
   const OrtNodeUnitIODef& root_input = div_inputs[0];
-  const OrtNodeUnitIODef& final_output = final_mul_node_unit->Outputs()[0];
+  if (pattern_match.final_mul_node_unit == nullptr || pattern_match.final_mul_node_unit->Outputs().empty()) {
+    return nullptr;
+  }
+  const OrtNodeUnitIODef& final_output = pattern_match.final_mul_node_unit->Outputs()[0];
 
-  if (auto status = ValidateOnQnn(qnn_model_wrapper, node_units, root_input, final_output);
-      !status.IsOK()) {
+  Ort::Status status = ValidateOnQnn(qnn_model_wrapper, pattern_match.node_units, root_input, final_output);
+  if (!status.IsOK()) {
     return nullptr;
   }
 
-  return std::make_unique<GeluFusion>(std::move(node_units), &erf_node_unit);
+  return std::unique_ptr<IQnnNodeGroup>(new GeluFusion(std::move(pattern_match.node_units), &erf_node_unit));
 }
 
 GeluFusion::GeluFusion(std::vector<const OrtNodeUnit*>&& node_units, const OrtNodeUnit* target_node_unit)
@@ -221,7 +353,7 @@ Ort::Status GeluFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logge
 }
 
 gsl::span<const OrtNodeUnit* const> GeluFusion::GetNodeUnits() const {
-  return gsl::span<const OrtNodeUnit* const>(node_units_.data(), node_units_.size());
+  return gsl::make_span(node_units_);
 }
 
 const OrtNodeUnit* GeluFusion::GetTargetNodeUnit() const {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
@@ -18,7 +18,9 @@ class QnnModelWrapper;
 
 /// <summary>
 /// Represents a fusion of the Gelu pattern expanded into ONNX operators.
-/// This fusion handles two patterns:
+/// This fusion handles three pattern variants categorized by Erf's child node type:
+///
+/// ErfAdd Patterns (Erf -> Add):
 ///   Pattern 1:
 ///                +-------Mul(0.5)---------------------+
 ///                |                                    |
@@ -33,12 +35,13 @@ class QnnModelWrapper;
 ///             [root] --> Div -----> Erf  --> Add --> Mul -->Mul ==>
 ///                       (B=1.4142...)        (1)            (0.5)
 ///
+/// ErfMul Pattern (Erf -> Mul):
 ///   Pattern 3:
-///                +---------------------------------------------+
-///                |                                             |
-///                |                                             v
-///             [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
-///                       (B=1.4142...)        (1)     (0.5)
+///                +-------------------------------------------+
+///                |                                           |
+///                |                                           v
+///             [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
+///                       (B=1.4142...)      (0.5)   (0.5)
 ///
 /// All patterns are translated into a QNN Gelu operator.
 /// The contained NodeUnits can be of type SingleNode or QDQGroup (with Q-DQ nodes).

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -32,7 +33,14 @@ class QnnModelWrapper;
 ///             [root] --> Div -----> Erf  --> Add --> Mul -->Mul ==>
 ///                       (B=1.4142...)        (1)            (0.5)
 ///
-/// Both patterns are translated into a QNN Gelu operator.
+///   Pattern 3:
+///                +---------------------------------------------+
+///                |                                             |
+///                |                                             v
+///             [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
+///                       (B=1.4142...)        (1)     (0.5)
+///
+/// All patterns are translated into a QNN Gelu operator.
 /// The contained NodeUnits can be of type SingleNode or QDQGroup (with Q-DQ nodes).
 /// The second inputs to Div, Add, and Mul Node Units should be constant.
 /// </summary>

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -139,18 +139,17 @@ GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def) {
   };
 }
 
-// Helper function to build GELU Pattern 3: Mul(0.5) on Add output, then skip Mul with root
+// Helper function to build GELU Pattern 3 (ErfMul Pattern)
 // Pattern 3:
-//                   +---------------------------------------------+
-//                   |                                             |
-//                   |                                             v
-//                [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
-//                          (B=1.4142...)        (1)     (0.5)
+//                   +-------------------------------------------+
+//                   |                                           |
+//                   |                                           v
+//                [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
+//                          (B=1.4142...)      (0.5)   (0.5)
 GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def) {
   return [input_def](ModelTestBuilder& builder) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
     constexpr float half = 0.5f;
-    constexpr float one = 1.0f;
 
     builder.graph_->set_name("gelu_pattern3_graph");
 
@@ -172,26 +171,26 @@ GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def) {
                     {"erf_out"},
                     kOnnxDomain);
 
-    // erf_out -> Add(1.0) -> add_out
-    builder.MakeScalarInitializer<float>("one", one);
-    builder.AddNode("Add_one",
-                    "Add",
-                    {"erf_out", "one"},
-                    {"add_out"},
-                    kOnnxDomain);
-
-    // add_out * 0.5 -> mul_half_out
+    // erf_out * 0.5 -> mul_out
     builder.MakeScalarInitializer<float>("half", half);
     builder.AddNode("Mul_half",
                     "Mul",
-                    {"add_out", "half"},
-                    {"mul_half_out"},
+                    {"erf_out", "half"},
+                    {"mul_out"},
                     kOnnxDomain);
 
-    // input * mul_half_out -> output
+    // mul_out + 0.5 -> add_out
+    builder.MakeScalarInitializer<float>("half2", half);
+    builder.AddNode("Add_half",
+                    "Add",
+                    {"mul_out", "half2"},
+                    {"add_out"},
+                    kOnnxDomain);
+
+    // input * add_out -> output
     builder.AddNode("Mul_out",
                     "Mul",
-                    {"input", "mul_half_out"},
+                    {"input", "add_out"},
                     {"output"},
                     kOnnxDomain);
 
@@ -364,13 +363,12 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<flo
   };
 }
 
-// Helper function to build QDQ GELU Pattern 3
+// Helper function to build QDQ GELU Pattern 3 (ErfMul Pattern)
 template <typename QuantType>
 GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<float>& input_def) {
   return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
     constexpr float half = 0.5f;
-    constexpr float one = 1.0f;
 
     builder.graph_->set_name("qdq_gelu_pattern3_graph");
 
@@ -381,17 +379,17 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<flo
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
     builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-    builder.MakeScalarInitializer<float>("one", one);
     builder.MakeScalarInitializer<float>("half", half);
+    builder.MakeScalarInitializer<float>("half2", half);
 
     const std::string sqrt2_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
-    const std::string one_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
     const std::string half_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
+    const std::string half2_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_half2", "half2", input_qparams.scale, input_qparams.zero_point);
 
-    // input -> Div(sqrt2) -> Erf -> Add(one)
+    // input -> Div(sqrt2) -> Erf -> Mul(0.5) -> Add(0.5)
     builder.AddNode("Div_sqrt2",
                     "Div",
                     {input_qdq, sqrt2_qdq},
@@ -410,29 +408,28 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<flo
     const std::string erf_out_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_erf_out", "erf_out", input_qparams.scale, input_qparams.zero_point);
 
-    builder.AddNode("Add_one",
+    // ErfMul Pattern: Mul(erf_out, 0.5) -> Add(0.5) -> Mul(input)
+    builder.AddNode("Mul_half",
+                    "Mul",
+                    {erf_out_qdq, half_qdq},
+                    {"mul_out"},
+                    kOnnxDomain);
+
+    const std::string mul_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_mul_out", "mul_out", input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Add_half",
                     "Add",
-                    {erf_out_qdq, one_qdq},
+                    {mul_out_qdq, half2_qdq},
                     {"add_out"},
                     kOnnxDomain);
 
     const std::string add_out_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_add_out", "add_out", input_qparams.scale, input_qparams.zero_point);
 
-    // Pattern 3: Mul(add_out, half) then Mul(root, previous)
-    builder.AddNode("Mul_half",
-                    "Mul",
-                    {add_out_qdq, half_qdq},
-                    {"mul_half_out"},
-                    kOnnxDomain);
-
-    const std::string mul_half_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_mul_half_out", "mul_half_out",
-                                  input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Mul_out",
                     "Mul",
-                    {input_qdq, mul_half_out_qdq},
+                    {input_qdq, add_out_qdq},
                     {"Y"},
                     kOnnxDomain);
 
@@ -495,7 +492,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_Float32) {
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
 
-// Test GELU Pattern 3 with float32 model (for fp16-derived graph topology)
+// Test GELU Pattern 3 (ErfMul Pattern) with float32 model
 TEST_F(QnnHTPBackendTests, GeluFusionPattern3_Float32) {
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_Float32";
   std::filesystem::remove_all(json_qnn_graph_dir);

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -139,6 +139,66 @@ GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def) {
   };
 }
 
+// Helper function to build GELU Pattern 3: Mul(0.5) on Add output, then skip Mul with root
+// Pattern 3:
+//                   +---------------------------------------------+
+//                   |                                             |
+//                   |                                             v
+//                [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
+//                          (B=1.4142...)        (1)     (0.5)
+GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) -> void {
+    constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float half = 0.5f;
+    constexpr float one = 1.0f;
+
+    builder.graph_->set_name("gelu_pattern3_graph");
+
+    // input
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // input -> Div(sqrt2) -> div_out
+    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+    builder.AddNode("Div_sqrt2",
+                    "Div",
+                    {"input", "sqrt2"},
+                    {"div_out"},
+                    kOnnxDomain);
+
+    // div_out -> Erf -> erf_out
+    builder.AddNode("Erf",
+                    "Erf",
+                    {"div_out"},
+                    {"erf_out"},
+                    kOnnxDomain);
+
+    // erf_out -> Add(1.0) -> add_out
+    builder.MakeScalarInitializer<float>("one", one);
+    builder.AddNode("Add_one",
+                    "Add",
+                    {"erf_out", "one"},
+                    {"add_out"},
+                    kOnnxDomain);
+
+    // add_out * 0.5 -> mul_half_out
+    builder.MakeScalarInitializer<float>("half", half);
+    builder.AddNode("Mul_half",
+                    "Mul",
+                    {"add_out", "half"},
+                    {"mul_half_out"},
+                    kOnnxDomain);
+
+    // input * mul_half_out -> output
+    builder.AddNode("Mul_out",
+                    "Mul",
+                    {"input", "mul_half_out"},
+                    {"output"},
+                    kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
 // Helper function to build QDQ GELU Pattern 1
 template <typename QuantType>
 GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<float>& input_def) {
@@ -304,6 +364,83 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<flo
   };
 }
 
+// Helper function to build QDQ GELU Pattern 3
+template <typename QuantType>
+GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) -> void {
+    constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float half = 0.5f;
+    constexpr float one = 1.0f;
+
+    builder.graph_->set_name("qdq_gelu_pattern3_graph");
+
+    // input
+    MakeTestInput(builder, "input", input_def);
+    const QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+    const std::string input_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
+
+    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+    builder.MakeScalarInitializer<float>("one", one);
+    builder.MakeScalarInitializer<float>("half", half);
+
+    const std::string sqrt2_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
+    const std::string one_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
+    const std::string half_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
+
+    // input -> Div(sqrt2) -> Erf -> Add(one)
+    builder.AddNode("Div_sqrt2",
+                    "Div",
+                    {input_qdq, sqrt2_qdq},
+                    {"div_out"},
+                    kOnnxDomain);
+
+    const std::string erf_in_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", "div_out", input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Erf",
+                    "Erf",
+                    {erf_in_qdq},
+                    {"erf_out"},
+                    kOnnxDomain);
+
+    const std::string erf_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_out", "erf_out", input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Add_one",
+                    "Add",
+                    {erf_out_qdq, one_qdq},
+                    {"add_out"},
+                    kOnnxDomain);
+
+    const std::string add_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_add_out", "add_out", input_qparams.scale, input_qparams.zero_point);
+
+    // Pattern 3: Mul(add_out, half) then Mul(root, previous)
+    builder.AddNode("Mul_half",
+                    "Mul",
+                    {add_out_qdq, half_qdq},
+                    {"mul_half_out"},
+                    kOnnxDomain);
+
+    const std::string mul_half_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_mul_half_out", "mul_half_out",
+                                  input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Mul_out",
+                    "Mul",
+                    {input_qdq, mul_half_out_qdq},
+                    {"Y"},
+                    kOnnxDomain);
+
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "Y",
+                                                     output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+}
+
 ProviderOptions GetProviderOptions() {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -350,6 +487,27 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_Float32) {
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
 
   RunQnnModelTest(BuildGeluPattern2TestCase(input_def),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+}
+
+// Test GELU Pattern 3 with float32 model (for fp16-derived graph topology)
+TEST_F(QnnHTPBackendTests, GeluFusionPattern3_Float32) {
+  const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_Float32";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
+  RunQnnModelTest(BuildGeluPattern3TestCase(input_def),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -519,6 +677,27 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
 
   TestQDQModelAccuracy(BuildGeluPattern2TestCase(input_def),
                        BuildQDQGeluPattern2TestCase<uint8_t>(input_def),
+                       provider_options,
+                       /*opset_version=*/13,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+}
+
+// Test GELU Pattern 3 with QDQ
+TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
+  const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_QDQ_U8";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
+  TestQDQModelAccuracy(BuildGeluPattern3TestCase(input_def),
+                       BuildQDQGeluPattern3TestCase<uint8_t>(input_def),
                        provider_options,
                        /*opset_version=*/13,
                        /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);


### PR DESCRIPTION
### Description
Added new GELU pattern:
<img width="555" height="145" alt="image" src="https://github.com/user-attachments/assets/5f7466ba-84af-486c-b2a0-32f699c1f3b9" />

this one got transformed into above [(Erf + 1) * 0.5 into Erf*0.5 + 0.5]:
<img width="551" height="116" alt="image" src="https://github.com/user-attachments/assets/456ffcda-0d83-4a1b-b0a0-2e35e402d065" />



### Motivation and Context
- Fixes many of the failing models have above Gelu pattern
- Restructured implementation for better readability 


