### PR TITLE
[QNN EP] Add ARM64x NuGet for Release

### DIFF
--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -217,6 +217,56 @@ jobs:
           Write-Host "Found $count NuGet package(s)"
           if ($count -ne 2) { Write-Error "Expected 2 NuGet packages (arm64 + arm64x), found $count"; exit 1 }
 
+      - name: Repackage ARM64x NuGet with distinct package ID
+        shell: powershell
+        run: |
+          # NuGet best practice: use a separate package ID for each architecture variant
+          # so NuGet treats them as distinct packages and users can install the right one.
+          #
+          # ARM64  → Qualcomm.ML.OnnxRuntime.QNN        (standard ARM64 binary)
+          # ARM64x → Qualcomm.ML.OnnxRuntime.QNN.ARM64X (merged ARM64 + ARM64EC binary)
+          #
+          # This requires modifying the .nuspec inside the .nupkg (which is a zip file).
+
+          $arm64xDistDir = "${{ github.workspace }}\build\windows-arm64x\Release\Release\dist"
+          $nupkg = Get-ChildItem -Path $arm64xDistDir -Filter "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" |
+                   Where-Object { $_.Name -notmatch "ARM64X" } |
+                   Select-Object -First 1
+          if (-not $nupkg) {
+            Write-Error "ARM64x NuGet package not found in $arm64xDistDir"
+            exit 1
+          }
+
+          $version = $nupkg.BaseName -replace "^Qualcomm\.ML\.OnnxRuntime\.QNN\.", ""
+          $newPackageId = "Qualcomm.ML.OnnxRuntime.QNN.ARM64X"
+          $newNupkgName = "$newPackageId.$version.nupkg"
+          $newNupkgPath = Join-Path $arm64xDistDir $newNupkgName
+
+          # Extract, patch .nuspec, repack
+          $extractDir = Join-Path $env:TEMP "nupkg_arm64x_repack"
+          if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
+          New-Item -ItemType Directory -Path $extractDir | Out-Null
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          [System.IO.Compression.ZipFile]::ExtractToDirectory($nupkg.FullName, $extractDir)
+
+          # Patch the .nuspec: change <id> and rename the file
+          $nuspecFile = Get-ChildItem -Path $extractDir -Filter "*.nuspec" | Select-Object -First 1
+          $nuspecContent = Get-Content $nuspecFile.FullName -Raw
+          $nuspecContent = $nuspecContent -replace '<id>Qualcomm\.ML\.OnnxRuntime\.QNN</id>', "<id>$newPackageId</id>"
+          Set-Content -Path $nuspecFile.FullName -Value $nuspecContent -NoNewline
+
+          # Rename the .nuspec file to match the new package ID
+          $newNuspecName = "$newPackageId.nuspec"
+          Rename-Item -Path $nuspecFile.FullName -NewName $newNuspecName
+
+          # Repack into a new .nupkg
+          [System.IO.Compression.ZipFile]::CreateFromDirectory($extractDir, $newNupkgPath)
+          Remove-Item $extractDir -Recurse -Force
+          Remove-Item $nupkg.FullName -Force
+
+          Write-Host "Repackaged: $($nupkg.Name) → $newNupkgName (package ID: $newPackageId)"
+
       - name: Publish ARM64 NuGet
         if: ${{ !inputs.skip_publish }}
         shell: powershell

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -51,6 +51,7 @@ jobs:
       nightly_build: ${{ inputs.nightly_build }}
       version_suffix: ${{ inputs.version_suffix }}
       build_android_aar: true
+      build_windows_arm64x: true
 
   upload-wheel-workflow:
     name: "Upload python wheel artifatcs to Artifactory"
@@ -199,19 +200,24 @@ jobs:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
-      - name: Download NuGet from Artifactory
+      - name: Download ARM64 NuGet from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-nuget
 
-      - name: Verify NuGet artifact
+      - name: Download ARM64x NuGet from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64x-py3.11-nuget
+
+      - name: Verify NuGet artifacts
         shell: powershell
         run: |
           $count = (Get-ChildItem -Path "${{ github.workspace }}\build" -Recurse -Filter "*.nupkg").Count
           Write-Host "Found $count NuGet package(s)"
-          if ($count -ne 1) { Write-Error "Expected 1 NuGet package, found $count"; exit 1 }
+          if ($count -ne 2) { Write-Error "Expected 2 NuGet packages (arm64 + arm64x), found $count"; exit 1 }
 
-      - name: Publish
+      - name: Publish ARM64 NuGet
         if: ${{ !inputs.skip_publish }}
         shell: powershell
         env:
@@ -229,6 +235,18 @@ jobs:
 
           . ".\qcom\scripts\upleveling\upload_nupkg_to_artifactory.ps1" `
             -InputDir "${{ github.workspace }}\build\windows-arm64\Release"
+
+      - name: Publish ARM64x NuGet
+        if: ${{ !inputs.skip_publish }}
+        shell: powershell
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+        run: |
+          .\uplevel_venv\Scripts\activate
+
+          . ".\qcom\scripts\upleveling\upload_nupkg_to_artifactory.ps1" `
+            -InputDir "${{ github.workspace }}\build\windows-arm64x\Release"
 
   upload-zip-workflow:
     name: "Upload zip artifatcs to Artifactory"


### PR DESCRIPTION
### Description

This change enables publishing of `ARM64x NuGet` package as part of the release pipeline


### Motivation and Context

The current CI pipeline / release flow does not support releasing `ARM64x NuGet` package. This change builds and verifies `ARM64x NuGet` package before publishing them to our internal artifactory.


