### PR TITLE
Support for ARM64x Zip, ARM64x NuGet, ARM64 Debug and ARM64 RelWithDebInfo builds on nightly

### DIFF
--- a/.github/actions/upload-qa-artifact/action.yml
+++ b/.github/actions/upload-qa-artifact/action.yml
@@ -2,16 +2,29 @@
 # SPDX-License-Identifier: MIT
 
 name: "Upload QA Artifact"
-description: "Upload a QA artifact to Artifactory"
+description: "Upload a QA artifact to Artifactory under a date/branch/commit hierarchy"
 
 inputs:
   src_pattern:
     description: Pattern of files to upload, relative to build/
     required: true
     type: string
-  qa_tag:
-    description: Name of the QA release
+  date:
+    description: "Date in DD_MM_YY_HH_MM_SS format (e.g. 10_04_26_02_00_05)"
     required: true
+    type: string
+  branch:
+    description: "Branch name (e.g. main)"
+    required: true
+    type: string
+  commit:
+    description: "First 10 characters of the commit SHA"
+    required: true
+    type: string
+  dest_subpath:
+    description: "Subdirectory within the QA root to upload into (e.g. wheels/windows-arm64). Leave blank to upload to the root."
+    required: false
+    default: ""
     type: string
 
 runs:
@@ -23,4 +36,7 @@ runs:
         "${{ runner.os == 'Windows' && 'python.exe' || 'python3' }}"
         qcom/scripts/artifactory/publish_qa.py
         --src-pattern "${{ inputs.src_pattern }}"
-        --tag "${{ inputs.qa_tag }}"
+        --date "${{ inputs.date }}"
+        --branch "${{ inputs.branch }}"
+        --commit "${{ inputs.commit }}"
+        --dest-subpath "${{ inputs.dest_subpath }}"

--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -25,6 +25,10 @@ on:
         description: "Build a wheel for this version of Python (3.11, 3.12, 3.13, 3.14, None)"
         default: "3.12"
         type: string
+      build_config:
+        description: "The build configuration: Release, Debug, or RelWithDebInfo."
+        type: string
+        default: "Release"
       nightly_build:
         description: "If true, include a verbose version string in wheel file names."
         type: boolean
@@ -84,7 +88,7 @@ env:
   ORT_NIGHTLY_BUILD: "${{ inputs.nightly_build == true && '1' || '0' }}"
 
   # Cross compilation on Windows adds a folder to the build directory.
-  BUILD_CONFIG_DIR: "${{ (inputs.target_os == 'windows' && ((inputs.build_runner_arch == 'X64' && inputs.target_arch != 'x86_64') || (inputs.build_runner_arch == 'ARM64' && inputs.target_arch != 'arm64'))) && 'Release/Release' || 'Release' }}"
+  BUILD_CONFIG_DIR: "${{ (inputs.target_os == 'windows' && ((inputs.build_runner_arch == 'X64' && inputs.target_arch != 'x86_64') || (inputs.build_runner_arch == 'ARM64' && inputs.target_arch != 'arm64'))) && format('{0}/{0}', inputs.build_config || 'Release') || (inputs.build_config || 'Release') }}"
 
   TEST_ARCHIVE_EXT: "${{ inputs.target_os == 'linux' && 'tar.bz2' || 'zip' }}"
 
@@ -111,6 +115,7 @@ jobs:
         run: >
           "${{ inputs.target_os == 'windows' && 'python.exe' || 'python3' }}"
           qcom/build_and_test.py
+          --config ${{ inputs.build_config || 'Release' }}
           --target-py-version ${{inputs.target_py_vsn}}
           ${{ inputs.build_nuget == true && '--build-nuget' || '' }}
           ${{ inputs.build_zip == true && '--build-zip' || '' }}
@@ -179,7 +184,7 @@ jobs:
         if: ${{ inputs.upload_zip }}
         uses: ./.github/actions/upload-ci-artifact
         with:
-          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-zip"
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-${{ inputs.build_config || 'Release' }}-py${{ inputs.target_py_vsn }}-zip"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime-qnn*.zip"
 
   test:

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -174,9 +174,9 @@ jobs:
       target_arch: arm64x
       target_py_vsn: "3.11"
       build_config: "Release"
-      build_runner_arch: "X64"
+      build_runner_arch: "ARM64"
       test_runner_arch: ARM64
-      run_tests: true
+      run_tests: false
       test_wheel: false
       upload_test_archive: true
       upload_wheel: false

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -54,6 +54,18 @@ on:
         description: "If true, build the Android AAR"
         type: boolean
         default: true
+      build_windows_arm64x:
+        description: "If true, build Windows ARM64x (Release) with NuGet and test archive."
+        type: boolean
+        default: false
+      build_windows_arm64_debug:
+        description: "If true, build Windows ARM64 Debug with zip archive."
+        type: boolean
+        default: false
+      build_windows_arm64_relwithdebinfo:
+        description: "If true, build Windows ARM64 RelWithDebInfo with zip archive."
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs: *common_inputs
@@ -150,6 +162,70 @@ jobs:
       upload_nuget: ${{ inputs.windows_arm64_build_nuget && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       build_zip: ${{ inputs.windows_arm64_build_zip && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_zip: ${{ inputs.windows_arm64_build_zip && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+
+  build-windows-arm64x:
+    if: ${{ inputs.build_windows_arm64x }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: arm64x
+      target_py_vsn: "3.11"
+      build_config: "Release"
+      build_runner_arch: "X64"
+      test_runner_arch: ARM64
+      run_tests: true
+      test_wheel: false
+      upload_test_archive: true
+      upload_wheel: false
+      build_nuget: true
+      upload_nuget: true
+      build_zip: false
+      upload_zip: false
+
+  build-windows-arm64-debug:
+    if: ${{ inputs.build_windows_arm64_debug }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: arm64
+      target_py_vsn: "3.11"
+      build_config: "Debug"
+      build_runner_arch: "ARM64"
+      run_tests: false
+      test_wheel: false
+      upload_test_archive: false
+      upload_wheel: false
+      build_nuget: false
+      upload_nuget: false
+      build_zip: true
+      upload_zip: true
+
+  build-windows-arm64-relwithdebinfo:
+    if: ${{ inputs.build_windows_arm64_relwithdebinfo }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: arm64
+      target_py_vsn: "3.11"
+      build_config: "RelWithDebInfo"
+      build_runner_arch: "ARM64"
+      run_tests: false
+      test_wheel: false
+      upload_test_archive: false
+      upload_wheel: false
+      build_nuget: false
+      upload_nuget: false
+      build_zip: true
+      upload_zip: true
 
   build-android-aarch64-aar:
     if: ${{ inputs.build_android_aar }}

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -175,6 +175,7 @@ jobs:
       target_py_vsn: "3.11"
       build_config: "Release"
       build_runner_arch: "X64"
+      build_test_same_runner: false
       test_runner_arch: ARM64
       run_tests: true
       test_wheel: false

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -176,7 +176,7 @@ jobs:
       build_config: "Release"
       build_runner_arch: "ARM64"
       test_runner_arch: ARM64
-      run_tests: false
+      run_tests: true
       test_wheel: false
       upload_test_archive: true
       upload_wheel: false

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -175,7 +175,6 @@ jobs:
       target_py_vsn: "3.11"
       build_config: "Release"
       build_runner_arch: "X64"
-      build_test_same_runner: false
       test_runner_arch: ARM64
       run_tests: true
       test_wheel: false

--- a/.github/workflows/qualcomm-internal-release-nightly.yml
+++ b/.github/workflows/qualcomm-internal-release-nightly.yml
@@ -21,3 +21,6 @@ jobs:
       nightly_build: true
       skip_publish_qa: false
       skip_publish_wheel: false
+      skip_arm64x: true
+      skip_arm64_debug: true
+      skip_arm64_relwithdebinfo: true

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -364,9 +364,10 @@ jobs:
             mv "$f" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-${suffix}"
           done
 
-          # Rename AAR
+          # Rename AAR (into android/ subfolder so it uploads separately from test_archives)
+          mkdir -p "${{ github.workspace }}/build/android"
           mv "${{ github.workspace }}/build/android-aarch64/Release/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.aar" \
-             "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-android.aar"
+             "${{ github.workspace }}/build/android/onnxruntime_qnn-${VERSION}-android.aar"
 
           # Rename Debug zip (from build/windows-arm64/Debug/dist/)
           if [ "${{ inputs.skip_arm64_debug }}" == "false" ]; then
@@ -426,7 +427,7 @@ jobs:
           date: ${{ env.QA_DATE }}
           branch: ${{ env.QA_BRANCH }}
           commit: ${{ env.QA_COMMIT }}
-          dest_subpath: "nuget"
+          dest_subpath: "nuget/arm64"
 
       - name: Upload ARM64x NuGet to QA Artifactory
         if: ${{ !inputs.skip_publish_qa && !inputs.skip_arm64x }}
@@ -436,7 +437,7 @@ jobs:
           date: ${{ env.QA_DATE }}
           branch: ${{ env.QA_BRANCH }}
           commit: ${{ env.QA_COMMIT }}
-          dest_subpath: "nuget"
+          dest_subpath: "nuget/arm64x"
 
       - name: Upload Release Zip to QA Artifactory
         if: ${{ !inputs.skip_publish_qa }}
@@ -447,6 +448,16 @@ jobs:
           branch: ${{ env.QA_BRANCH }}
           commit: ${{ env.QA_COMMIT }}
           dest_subpath: "zip"
+
+      - name: Upload Android AAR to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "android/onnxruntime_qnn-*"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "android"
 
       - name: Upload Test Archives to QA Artifactory
         if: ${{ !inputs.skip_publish_qa }}

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -384,6 +384,19 @@ jobs:
               mv "$RWDI_ZIP" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-windows-arm64-relwithdebinfo.zip"
             fi
           fi
+          ARM64_NUGET=$(find "${{ github.workspace }}/build/windows-arm64/Release/dist" -name "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" | head -1)
+          if [ -n "$ARM64_NUGET" ]; then
+            NUGET_VER=$(basename "$ARM64_NUGET" | sed 's/Qualcomm\.ML\.OnnxRuntime\.QNN\.\(.*\)\.nupkg/\1/')
+            mv "$ARM64_NUGET" "$(dirname "$ARM64_NUGET")/Qualcomm.ML.OnnxRuntime.QNN.arm64.${NUGET_VER}.nupkg"
+          fi
+
+          if [ "${{ inputs.skip_arm64x }}" == "false" ]; then
+            ARM64X_NUGET=$(find "${{ github.workspace }}/build/windows-arm64x/Release/Release/dist" -name "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" | head -1)
+            if [ -n "$ARM64X_NUGET" ]; then
+              NUGET_VER=$(basename "$ARM64X_NUGET" | sed 's/Qualcomm\.ML\.OnnxRuntime\.QNN\.\(.*\)\.nupkg/\1/')
+              mv "$ARM64X_NUGET" "$(dirname "$ARM64X_NUGET")/Qualcomm.ML.OnnxRuntime.QNN.arm64_arm64x.${NUGET_VER}.nupkg"
+            fi
+          fi
 
       # --------------------------------
       # Upload to QA Artifactory

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -350,53 +350,12 @@ jobs:
 
       - name: Rename artifacts for QA
         run: |
-          # Read version from VERSION_NUMBER file
-          VERSION=$(cat "${{ github.workspace }}/VERSION_NUMBER")
-          echo "Version: ${VERSION}"
-          echo "QA_VERSION=${VERSION}" >> ${GITHUB_ENV}
-
-          # Rename test archives: onnxruntime-tests-{os}-{arch}.ext → onnxruntime_qnn-{ver}-{os}-{arch}.ext
-          # e.g. onnxruntime-tests-windows-arm64.zip → onnxruntime_qnn-2.2.0-windows-arm64.zip
-          for f in "${{ github.workspace }}/build"/onnxruntime-tests-*; do
-            [ -f "$f" ] || continue
-            filename=$(basename "$f")
-            suffix="${filename#onnxruntime-tests-}"
-            mv "$f" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-${suffix}"
-          done
-
-          # Rename AAR (into android/ subfolder so it uploads separately from test_archives)
-          mkdir -p "${{ github.workspace }}/build/android"
-          mv "${{ github.workspace }}/build/android-aarch64/Release/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.aar" \
-             "${{ github.workspace }}/build/android/onnxruntime_qnn-${VERSION}-android.aar"
-
-          # Rename Debug zip (from build/windows-arm64/Debug/dist/)
-          if [ "${{ inputs.skip_arm64_debug }}" == "false" ]; then
-            DEBUG_ZIP=$(find "${{ github.workspace }}/build/windows-arm64/Debug/dist" -name "onnxruntime-qnn*.zip" | head -1)
-            if [ -n "$DEBUG_ZIP" ]; then
-              mv "$DEBUG_ZIP" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-windows-arm64-debug.zip"
-            fi
-          fi
-
-          # Rename RelWithDebInfo zip (from build/windows-arm64/RelWithDebInfo/dist/)
-          if [ "${{ inputs.skip_arm64_relwithdebinfo }}" == "false" ]; then
-            RWDI_ZIP=$(find "${{ github.workspace }}/build/windows-arm64/RelWithDebInfo/dist" -name "onnxruntime-qnn*.zip" | head -1)
-            if [ -n "$RWDI_ZIP" ]; then
-              mv "$RWDI_ZIP" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-windows-arm64-relwithdebinfo.zip"
-            fi
-          fi
-          ARM64_NUGET=$(find "${{ github.workspace }}/build/windows-arm64/Release/dist" -name "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" | head -1)
-          if [ -n "$ARM64_NUGET" ]; then
-            NUGET_VER=$(basename "$ARM64_NUGET" | sed 's/Qualcomm\.ML\.OnnxRuntime\.QNN\.\(.*\)\.nupkg/\1/')
-            mv "$ARM64_NUGET" "$(dirname "$ARM64_NUGET")/Qualcomm.ML.OnnxRuntime.QNN.arm64.${NUGET_VER}.nupkg"
-          fi
-
-          if [ "${{ inputs.skip_arm64x }}" == "false" ]; then
-            ARM64X_NUGET=$(find "${{ github.workspace }}/build/windows-arm64x/Release/Release/dist" -name "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" | head -1)
-            if [ -n "$ARM64X_NUGET" ]; then
-              NUGET_VER=$(basename "$ARM64X_NUGET" | sed 's/Qualcomm\.ML\.OnnxRuntime\.QNN\.\(.*\)\.nupkg/\1/')
-              mv "$ARM64X_NUGET" "$(dirname "$ARM64X_NUGET")/Qualcomm.ML.OnnxRuntime.QNN.arm64_arm64x.${NUGET_VER}.nupkg"
-            fi
-          fi
+          bash qcom/scripts/artifactory/rename_qa_artifacts.sh \
+            "${{ github.workspace }}/build" \
+            "${{ github.workspace }}/VERSION_NUMBER" \
+            "${{ inputs.skip_arm64_debug }}" \
+            "${{ inputs.skip_arm64_relwithdebinfo }}" \
+            "${{ inputs.skip_arm64x }}"
 
       # --------------------------------
       # Upload to QA Artifactory

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -24,9 +24,21 @@ on:
         type: boolean
         default: true
       qa_tag:
-        description: "Name of the build for QA purposes; leave blank to generate one based on today's date."
+        description: "Name of the build for QA purposes; leave blank to generate one based on today's date (DD_MM_YY_HH_MM_SS)."
         type: string
         default: ''
+      skip_arm64x:
+        description: "If true, don't build ARM64x NuGet and test archive."
+        type: boolean
+        default: true
+      skip_arm64_debug:
+        description: "If true, don't build ARM64 Debug zip."
+        type: boolean
+        default: true
+      skip_arm64_relwithdebinfo:
+        description: "If true, don't build ARM64 RelWithDebInfo zip."
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs: *common_inputs
 
@@ -44,7 +56,12 @@ jobs:
       linux_aarch64_manylinux_2_34_target_py_vsns: "[]"
       windows_target_archs: "['arm64', 'arm64ec', 'x86_64']"
       windows_target_py_vsns: "['3.11','3.12','3.13','3.14']"
+      windows_arm64_build_nuget: true
+      windows_arm64_build_zip: true
       build_android_aar: true
+      build_windows_arm64x: ${{ !inputs.skip_arm64x }}
+      build_windows_arm64_debug: ${{ !inputs.skip_arm64_debug }}
+      build_windows_arm64_relwithdebinfo: ${{ !inputs.skip_arm64_relwithdebinfo }}
 
   publish-wheel-workflow:
     name: "Publish distribution to PyPI"
@@ -217,6 +234,12 @@ jobs:
         with:
           name: windows-x86_64-py3.11-tests
 
+      - name: Download arm64x Windows Tests from Artifactory
+        if: ${{ !inputs.skip_arm64x }}
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64x-py3.11-tests
+
       # -----------------------------
       # Download other distributables
       # -----------------------------
@@ -231,10 +254,28 @@ jobs:
         with:
           name: windows-arm64-py3.11-nuget
 
-      - name: Download ARM64 Windows Zip Package
+      - name: Download ARM64x Windows NuGet Package from Artifactory
+        if: ${{ !inputs.skip_arm64x }}
         uses: ./.github/actions/download-ci-artifact
         with:
-          name: windows-arm64-py3.11-zip
+          name: windows-arm64x-py3.11-nuget
+
+      - name: Download ARM64 Windows Release Zip Package
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-Release-py3.11-zip
+
+      - name: Download ARM64 Windows Debug Zip from Artifactory
+        if: ${{ !inputs.skip_arm64_debug }}
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-Debug-py3.11-zip
+
+      - name: Download ARM64 Windows RelWithDebInfo Zip from Artifactory
+        if: ${{ !inputs.skip_arm64_relwithdebinfo }}
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-RelWithDebInfo-py3.11-zip
 
       - name: Merge AMD Wheels
         run: |
@@ -264,11 +305,13 @@ jobs:
           echo "Found $count wheel(s)"
           [ "$count" -eq 9 ] || { echo "ERROR: Expected 9 wheels, found $count"; exit 1; }
 
-      - name: Verify NuGet artifact
+      - name: Verify NuGet artifacts
         run: |
+          EXPECTED_NUGET=1
+          if [ "${{ inputs.skip_arm64x }}" == "false" ]; then EXPECTED_NUGET=2; fi
           count=$(find "${{ github.workspace }}/build" -name "*.nupkg" | wc -l)
-          echo "Found $count NuGet package(s)"
-          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 NuGet package, found $count"; exit 1; }
+          echo "Found $count NuGet package(s) (expected ${EXPECTED_NUGET})"
+          [ "$count" -eq "$EXPECTED_NUGET" ] || { echo "ERROR: Expected ${EXPECTED_NUGET} NuGet package(s), found $count"; exit 1; }
 
       - name: Verify tarball artifacts
         run: |
@@ -276,11 +319,16 @@ jobs:
           echo "Found $count .tar.bz2 archive(s)"
           [ "$count" -eq 2 ] || { echo "ERROR: Expected 2 .tar.bz2 archives, found $count"; exit 1; }
 
-      - name: Verify Zip artifact
+      - name: Verify Zip artifacts
         run: |
+          # Base: android test + windows-arm64 test + windows-arm64ec test + windows-x86_64 test + Release zip = 5
+          EXPECTED_ZIP=5
+          if [ "${{ inputs.skip_arm64x }}" == "false" ]; then EXPECTED_ZIP=$((EXPECTED_ZIP + 1)); fi
+          if [ "${{ inputs.skip_arm64_debug }}" == "false" ]; then EXPECTED_ZIP=$((EXPECTED_ZIP + 1)); fi
+          if [ "${{ inputs.skip_arm64_relwithdebinfo }}" == "false" ]; then EXPECTED_ZIP=$((EXPECTED_ZIP + 1)); fi
           count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
-          echo "Found $count Zip archive(s)"
-          [ "$count" -eq 5 ] || { echo "ERROR: Expected 5 Zip archives, found $count"; exit 1; }
+          echo "Found $count Zip archive(s) (expected ${EXPECTED_ZIP})"
+          [ "$count" -eq "$EXPECTED_ZIP" ] || { echo "ERROR: Expected ${EXPECTED_ZIP} Zip archives, found $count"; exit 1; }
 
       - name: Verify AAR artifact
         run: |
@@ -288,17 +336,124 @@ jobs:
           echo "Found $count AAR package(s)"
           [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 AAR package, found $count"; exit 1; }
 
-      - name: Set QA Build Tag
+      - name: Set QA Build Info
         run: |
           if [ -z "${{ inputs.qa_tag }}" ]; then
-            echo "QA_TAG=nightly-$(date --rfc-3339=date)-${GITHUB_SHA:0:10}" >> ${GITHUB_ENV}
+            echo "QA_DATE=$(date +%d_%m_%y_%H_%M_%S)" >> ${GITHUB_ENV}
           else
-            echo "QA_TAG=${{ inputs.qa_tag }}" >> ${GITHUB_ENV}
+            echo "QA_DATE=${{ inputs.qa_tag }}" >> ${GITHUB_ENV}
+          fi
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          BRANCH="${BRANCH//\//-}"
+          echo "QA_BRANCH=${BRANCH}" >> ${GITHUB_ENV}
+          echo "QA_COMMIT=${GITHUB_SHA:0:10}" >> ${GITHUB_ENV}
+
+      - name: Rename artifacts for QA
+        run: |
+          # Read version from VERSION_NUMBER file
+          VERSION=$(cat "${{ github.workspace }}/VERSION_NUMBER")
+          echo "Version: ${VERSION}"
+          echo "QA_VERSION=${VERSION}" >> ${GITHUB_ENV}
+
+          # Rename test archives: onnxruntime-tests-{os}-{arch}.ext → onnxruntime_qnn-{ver}-{os}-{arch}.ext
+          # e.g. onnxruntime-tests-windows-arm64.zip → onnxruntime_qnn-2.2.0-windows-arm64.zip
+          for f in "${{ github.workspace }}/build"/onnxruntime-tests-*; do
+            [ -f "$f" ] || continue
+            filename=$(basename "$f")
+            suffix="${filename#onnxruntime-tests-}"
+            mv "$f" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-${suffix}"
+          done
+
+          # Rename AAR
+          mv "${{ github.workspace }}/build/android-aarch64/Release/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.aar" \
+             "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-android.aar"
+
+          # Rename Debug zip (from build/windows-arm64/Debug/dist/)
+          if [ "${{ inputs.skip_arm64_debug }}" == "false" ]; then
+            DEBUG_ZIP=$(find "${{ github.workspace }}/build/windows-arm64/Debug/dist" -name "onnxruntime-qnn*.zip" | head -1)
+            if [ -n "$DEBUG_ZIP" ]; then
+              mv "$DEBUG_ZIP" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-windows-arm64-debug.zip"
+            fi
           fi
 
-      - name: Upload Artifacts to QA Artifactory
+          # Rename RelWithDebInfo zip (from build/windows-arm64/RelWithDebInfo/dist/)
+          if [ "${{ inputs.skip_arm64_relwithdebinfo }}" == "false" ]; then
+            RWDI_ZIP=$(find "${{ github.workspace }}/build/windows-arm64/RelWithDebInfo/dist" -name "onnxruntime-qnn*.zip" | head -1)
+            if [ -n "$RWDI_ZIP" ]; then
+              mv "$RWDI_ZIP" "${{ github.workspace }}/build/onnxruntime_qnn-${VERSION}-windows-arm64-relwithdebinfo.zip"
+            fi
+          fi
+
+      # --------------------------------
+      # Upload to QA Artifactory
+      # --------------------------------
+
+      - name: Upload Windows ARM64 Wheels to QA Artifactory
         if: ${{ !inputs.skip_publish_qa }}
         uses: ./.github/actions/upload-qa-artifact
         with:
-          src_pattern: "*.*"
-          qa_tag: ${{ env.QA_TAG }}
+          src_pattern: "windows-arm64/Release/dist/*.whl"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "wheels/windows-arm64"
+
+      - name: Upload Windows x86 Wheels to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "dist/*.whl"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "wheels/windows-x86"
+
+      - name: Upload Linux x86_64 Wheels to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "linux-x86_64/Release/dist/*.whl"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "wheels/linux-x86"
+
+      - name: Upload ARM64 NuGet to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "windows-arm64/Release/dist/*.nupkg"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "nuget"
+
+      - name: Upload ARM64x NuGet to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa && !inputs.skip_arm64x }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "windows-arm64x/Release/Release/dist/*.nupkg"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "nuget"
+
+      - name: Upload Release Zip to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "windows-arm64/Release/dist/*.zip"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "zip"
+
+      - name: Upload Test Archives to QA Artifactory
+        if: ${{ !inputs.skip_publish_qa }}
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "onnxruntime_qnn-*"
+          date: ${{ env.QA_DATE }}
+          branch: ${{ env.QA_BRANCH }}
+          commit: ${{ env.QA_COMMIT }}
+          dest_subpath: "test_archives"

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -623,6 +623,7 @@ class TaskLibrary:
                             self.__qairt_sdk_root,
                             "build",
                             build_as_x=True,
+                            build_nuget=self.__build_nuget,
                         ),
                     ],
                 )

--- a/qcom/scripts/artifactory/aql/expired_qa_artifacts.json
+++ b/qcom/scripts/artifactory/aql/expired_qa_artifacts.json
@@ -7,7 +7,7 @@
                     "$and": [
                         {
                             "created": { "$before": "30d" },
-                            "path": { "$match": "qa/*" }
+                            "path": { "$match": "qa/**" }
                         }
                     ]
                 }

--- a/qcom/scripts/artifactory/artifactory.py
+++ b/qcom/scripts/artifactory/artifactory.py
@@ -72,7 +72,7 @@ class CiArtifactory(Artifactory):
 class QaArtifactory(Artifactory):
     def __init__(self, date: str, branch: str, commit: str) -> None:
         super().__init__()
-        self.__date = date      # MM_DD_YY format
+        self.__date = date  # MM_DD_YY format
         self.__branch = branch  # branch name (e.g. "main")
         self.__commit = commit  # first 10 chars of SHA
 

--- a/qcom/scripts/artifactory/artifactory.py
+++ b/qcom/scripts/artifactory/artifactory.py
@@ -70,13 +70,15 @@ class CiArtifactory(Artifactory):
 
 
 class QaArtifactory(Artifactory):
-    def __init__(self, tag: str) -> None:
+    def __init__(self, date: str, branch: str, commit: str) -> None:
         super().__init__()
-        self.__tag = tag
+        self.__date = date      # MM_DD_YY format
+        self.__branch = branch  # branch name (e.g. "main")
+        self.__commit = commit  # first 10 chars of SHA
 
     @property
     def artifact_root(self) -> str:
-        return f"{super().repo_path}/qa/{self.__tag}"
+        return f"{super().repo_path}/qa/{self.__date}/{self.__branch}/{self.__commit}"
 
 
 def initialize_logging(name: str) -> None:

--- a/qcom/scripts/artifactory/publish_qa.py
+++ b/qcom/scripts/artifactory/publish_qa.py
@@ -5,19 +5,30 @@
 import argparse
 from pathlib import Path
 
-from artifactory import QaArtifactory, initialize_logging, valid_artifact_name
+from artifactory import QaArtifactory, initialize_logging
 
 REPO_ROOT = Path(__file__).parent.parent.parent.parent.absolute()
 
 
 class PublishQaArtifact:
-    def __init__(self, tag: str, build_dir: Path, src_pattern: str) -> None:
+    def __init__(
+        self,
+        date: str,
+        branch: str,
+        commit: str,
+        build_dir: Path,
+        src_pattern: str,
+        dest_subpath: str = "",
+    ) -> None:
         self.__build_dir = build_dir
         self.__src_pattern = src_pattern
-        self.__client = QaArtifactory(tag)
+        self.__dest_subpath = dest_subpath
+        self.__client = QaArtifactory(date, branch, commit)
 
     @property
     def destination(self) -> str:
+        if self.__dest_subpath:
+            return f"{self.__client.artifact_root}/{self.__dest_subpath}/"
         return f"{self.__client.artifact_root}/"
 
     def run(self) -> None:
@@ -28,14 +39,25 @@ if __name__ == "__main__":
     initialize_logging("publish_qa.py")
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--tag", type=valid_artifact_name, required=True, help="QA tag")
+    parser.add_argument("--date", type=str, required=True, help="Date in DD_MM_YY_HH_MM_SS format")
+    parser.add_argument("--branch", type=str, required=True, help="Branch name (e.g. main)")
+    parser.add_argument("--commit", type=str, required=True, help="First 10 characters of commit SHA")
     parser.add_argument("--src-root", type=Path, default=REPO_ROOT / "build", help="Root directory of artifacts")
     parser.add_argument("--src-pattern", type=str, required=True, help="Artifact file pattern, relative to SRC_ROOT.")
+    parser.add_argument(
+        "--dest-subpath",
+        type=str,
+        default="",
+        help="Subdirectory within the QA root to upload into (e.g. wheels/windows-arm64).",
+    )
 
     args = parser.parse_args()
 
     PublishQaArtifact(
-        args.tag,
+        args.date,
+        args.branch,
+        args.commit,
         args.src_root,
         args.src_pattern,
+        args.dest_subpath,
     ).run()

--- a/qcom/scripts/artifactory/rename_qa_artifacts.sh
+++ b/qcom/scripts/artifactory/rename_qa_artifacts.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Renames build artifacts into the canonical QA naming convention before
+# uploading to QA Artifactory.
+#
+# Usage:
+#   rename_qa_artifacts.sh <build_dir> <version_number_file> \
+#       <skip_arm64_debug> <skip_arm64_relwithdebinfo> <skip_arm64x>
+#
+# Arguments:
+#   build_dir              Path to the build/ directory (e.g. $GITHUB_WORKSPACE/build)
+#   version_number_file    Path to the VERSION_NUMBER file
+#   skip_arm64_debug       "true" or "false"
+#   skip_arm64_relwithdebinfo  "true" or "false"
+#   skip_arm64x            "true" or "false"
+
+set -euo pipefail
+
+BUILD_DIR="${1:?build_dir is required}"
+VERSION_NUMBER_FILE="${2:?version_number_file is required}"
+SKIP_ARM64_DEBUG="${3:?skip_arm64_debug is required}"
+SKIP_ARM64_RELWITHDEBINFO="${4:?skip_arm64_relwithdebinfo is required}"
+SKIP_ARM64X="${5:?skip_arm64x is required}"
+
+# Read version
+VERSION=$(cat "$VERSION_NUMBER_FILE")
+echo "Version: ${VERSION}"
+
+# Export for the caller (GitHub Actions) to pick up
+echo "QA_VERSION=${VERSION}" >> "${GITHUB_ENV:-/dev/null}"
+
+# ---------------------------------------------------------------------------
+# Rename test archives: onnxruntime-tests-{os}-{arch}.ext
+#                     → onnxruntime_qnn-{ver}-{os}-{arch}.ext
+# e.g. onnxruntime-tests-windows-arm64.zip → onnxruntime_qnn-2.2.0-windows-arm64.zip
+# ---------------------------------------------------------------------------
+for f in "${BUILD_DIR}"/onnxruntime-tests-*; do
+    [ -f "$f" ] || continue
+    filename=$(basename "$f")
+    suffix="${filename#onnxruntime-tests-}"
+    mv "$f" "${BUILD_DIR}/onnxruntime_qnn-${VERSION}-${suffix}"
+    echo "Renamed: ${filename} → onnxruntime_qnn-${VERSION}-${suffix}"
+done
+
+# ---------------------------------------------------------------------------
+# Rename AAR into android/ subfolder so it uploads separately from test_archives
+# ---------------------------------------------------------------------------
+mkdir -p "${BUILD_DIR}/android"
+AAR_SRC="${BUILD_DIR}/android-aarch64/Release/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.aar"
+AAR_DST="${BUILD_DIR}/android/onnxruntime_qnn-${VERSION}-android.aar"
+mv "$AAR_SRC" "$AAR_DST"
+echo "Renamed AAR: $(basename "$AAR_SRC") → $(basename "$AAR_DST")"
+
+# ---------------------------------------------------------------------------
+# Rename Debug zip
+# ---------------------------------------------------------------------------
+if [ "${SKIP_ARM64_DEBUG}" == "false" ]; then
+    DEBUG_ZIP=$(find "${BUILD_DIR}/windows-arm64/Debug/dist" -name "onnxruntime-qnn*.zip" 2>/dev/null | head -1)
+    if [ -n "$DEBUG_ZIP" ]; then
+        mv "$DEBUG_ZIP" "${BUILD_DIR}/onnxruntime_qnn-${VERSION}-windows-arm64-debug.zip"
+        echo "Renamed Debug zip → onnxruntime_qnn-${VERSION}-windows-arm64-debug.zip"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Rename RelWithDebInfo zip
+# ---------------------------------------------------------------------------
+if [ "${SKIP_ARM64_RELWITHDEBINFO}" == "false" ]; then
+    RWDI_ZIP=$(find "${BUILD_DIR}/windows-arm64/RelWithDebInfo/dist" -name "onnxruntime-qnn*.zip" 2>/dev/null | head -1)
+    if [ -n "$RWDI_ZIP" ]; then
+        mv "$RWDI_ZIP" "${BUILD_DIR}/onnxruntime_qnn-${VERSION}-windows-arm64-relwithdebinfo.zip"
+        echo "Renamed RelWithDebInfo zip → onnxruntime_qnn-${VERSION}-windows-arm64-relwithdebinfo.zip"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Rename ARM64 NuGet:
+#   Qualcomm.ML.OnnxRuntime.QNN.{ver}.nupkg → Qualcomm.ML.OnnxRuntime.QNN.{ver}.nupkg
+# ---------------------------------------------------------------------------
+ARM64_NUGET=$(find "${BUILD_DIR}/windows-arm64/Release/dist" -name "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" 2>/dev/null | head -1)
+if [ -n "$ARM64_NUGET" ]; then
+    NUGET_VER=$(basename "$ARM64_NUGET" | sed 's/Qualcomm\.ML\.OnnxRuntime\.QNN\.\(.*\)\.nupkg/\1/')
+    NEW_NAME="$(dirname "$ARM64_NUGET")/Qualcomm.ML.OnnxRuntime.QNN.arm64.${NUGET_VER}.nupkg"
+    mv "$ARM64_NUGET" "$NEW_NAME"
+    echo "Renamed ARM64 NuGet → Qualcomm.ML.OnnxRuntime.QNN.${NUGET_VER}.nupkg"
+fi
+
+# ---------------------------------------------------------------------------
+# Rename ARM64x NuGet:
+#   Qualcomm.ML.OnnxRuntime.QNN.{ver}.nupkg → Qualcomm.ML.OnnxRuntime.QNN.ARM64x.{ver}.nupkg
+# ---------------------------------------------------------------------------
+if [ "${SKIP_ARM64X}" == "false" ]; then
+    ARM64X_NUGET=$(find "${BUILD_DIR}/windows-arm64x/Release/Release/dist" -name "Qualcomm.ML.OnnxRuntime.QNN.*.nupkg" 2>/dev/null | head -1)
+    if [ -n "$ARM64X_NUGET" ]; then
+        NUGET_VER=$(basename "$ARM64X_NUGET" | sed 's/Qualcomm\.ML\.OnnxRuntime\.QNN\.\(.*\)\.nupkg/\1/')
+        NEW_NAME="$(dirname "$ARM64X_NUGET")/Qualcomm.ML.OnnxRuntime.QNN.ARM64x.${NUGET_VER}.nupkg"
+        mv "$ARM64X_NUGET" "$NEW_NAME"
+        echo "Renamed ARM64x NuGet → Qualcomm.ML.OnnxRuntime.QNN.ARM64x.${NUGET_VER}.nupkg"
+    fi
+fi

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -370,12 +370,6 @@ def generate_files(line_list, args):
             files_list.append(
                 "<file src=" + '"' + os.path.join(args.native_build_path, "QnnHtpPrepare.dll") + runtimes + " />"
             )
-            files_list.append(
-                "<file src=" + '"' + os.path.join(args.native_build_path, "QnnHtpNetRunExtensions.dll") + runtimes + " />"
-            )
-            files_list.append(
-                "<file src=" + '"' + os.path.join(args.native_build_path, "Genie.dll") + runtimes + " />"
-            )
             for htp_arch in [73, 81]:
                 files_list.append(
                     "<file src="

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -370,6 +370,12 @@ def generate_files(line_list, args):
             files_list.append(
                 "<file src=" + '"' + os.path.join(args.native_build_path, "QnnHtpPrepare.dll") + runtimes + " />"
             )
+            files_list.append(
+                "<file src=" + '"' + os.path.join(args.native_build_path, "QnnHtpNetRunExtensions.dll") + runtimes + " />"
+            )
+            files_list.append(
+                "<file src=" + '"' + os.path.join(args.native_build_path, "Genie.dll") + runtimes + " />"
+            )
             for htp_arch in [73, 81]:
                 files_list.append(
                     "<file src="


### PR DESCRIPTION
### Description

This change adds support for the following

- Add support to build `ARM 64 (ARM64x) Zip`, `ARM64 (ARM64x) NuGet`, `ARM64 Debug`, `ARM64 RelWithDebInfo` builds. These are disabled by default on each nightly, can be triggered when needed.
- Change internal artifactory structure to a nested structure

### Motivation and Context

- The current CI pipeline doesnt support building ARM64x packages for testing. This change enables building and testing `ARM64 (ARM64x) Zip`, `ARM64 (ARM64x) NuGet`, `ARM64 Debug`, `ARM64 RelWithDebInfo` builds.
- The previous QA Artifactory layout used a flat tag-based path. This made it difficult to correlate artifacts with their source branch and commit. This change creates a nested structure allowing us to map and get the required files as needed.


