### PR TITLE
[QNN EP] Include Genie and QnnHtpNetRunExtensions as part of NuGet

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -370,6 +370,14 @@ def generate_files(line_list, args):
             files_list.append(
                 "<file src=" + '"' + os.path.join(args.native_build_path, "QnnHtpPrepare.dll") + runtimes + " />"
             )
+            files_list.append(
+                "<file src="
+                + '"'
+                + os.path.join(args.native_build_path, "QnnHtpNetRunExtensions.dll")
+                + runtimes
+                + " />"
+            )
+            files_list.append("<file src=" + '"' + os.path.join(args.native_build_path, "Genie.dll") + runtimes + " />")
             for htp_arch in [73, 81]:
                 files_list.append(
                     "<file src="


### PR DESCRIPTION
### Description

This change adds `Genie.dll` and `QnnHtpNetRunExtensions.dll` as part of the NuGet package.

### Motivation and Context

The current NuGet package shipped doesnt include `Genie.dll` and `QnnHtpNetRunExtensions.dll`.


