### PR TITLE
Disable FP16 UT for Linux Arm64 V68 platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Core runtime sources live in `onnxruntime/` (provider code, session/runtime internals, shared APIs).
+- QNN-specific build/test orchestration and helper tooling live in `qcom/`:
+  - `qcom/build_and_test.py`: primary entrypoint for build, test, and lint tasks.
+  - `qcom/ep_build/`: task graph and build task implementations.
+  - `qcom/model_test/` and `qcom/samples/`: model validation and usage samples.
+- Tests are mainly under `onnxruntime/test/`, including `onnxruntime/test/providers/qnn/` for QNN provider coverage.
+- Docs and contributor references are in `docs/` and `docs/execution_providers/`.
+
+## Build, Test, and Development Commands
+- List available tasks: `python qcom/build_and_test.py list`
+- Build for host platform: `python qcom/build_and_test.py build`
+- Run host tests: `python qcom/build_and_test.py test`
+- Run QNN-focused provider tests directly: `./onnxruntime_provider_test --gtest_filter=Qnn*`
+- Apply lint/format fixes used by CI: `python qcom/build_and_test.py lint_and_fix`
+- Optional dry-run for task planning: `python qcom/build_and_test.py --dry-run build`
+
+## Coding Style & Naming Conventions
+- C/C++ style is Google-based with project overrides (`.clang-format`); target max line length is 120.
+- Python style follows Black/PEP8 with 120-char line length (`pyproject.toml`).
+- Use descriptive, scope-prefixed names when useful (e.g., commit prefixes like `[QNN EP]`, `[ABI]`).
+- Run local formatting/lint before opening a PR via `lint_and_fix` or pre-commit.
+
+## Testing Guidelines
+- Add or update unit tests for every behavior change; this is a hard requirement in contribution docs.
+- Prefer focused test runs while iterating (e.g., `--gtest_filter=Qnn*`), then run broader `test` tasks.
+- Python tests generally use `unittest` and are executed with `pytest` where applicable.
+- Test names should communicate behavior, e.g., `test_<unit>_<expected_behavior>_when_<condition>`.
+
+## Commit & Pull Request Guidelines
+- Commit messages are typically imperative and concise, often with optional tags like `[QNN EP]` and an issue/PR reference `( #123 )` style.
+- Keep PRs small and reviewable; separate cosmetic-only changes from functional changes.
+- PRs must explain motivation, include test evidence, and resolve review comments.
+- For non-trivial changes or new APIs, open/discuss an issue before implementation.
+
+## Security & Configuration Tips
+- Report security issues privately to `secure@microsoft.com` (do not open public issues).
+- Use environment variables such as `QAIRT_SDK_ROOT` and `ORT_PREBUILT_ROOT` for reproducible local builds.

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -422,11 +422,9 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_U16S16S32) {
 
 // Test FP16 BatchNormalization on the HTP backend.
 TEST_F(QnnHTPBackendTests, BatchNorm_FP16) {
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
   constexpr int64_t num_channels = 2;
   std::vector<float> input_data = {-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 1.1f, 3.3f, 8.0f,
                                    -7.0f, -5.0f, -3.0f, -1.0f, 0.0f, 2.1f, 4.3f, 7.0f};
@@ -442,11 +440,9 @@ TEST_F(QnnHTPBackendTests, BatchNorm_FP16) {
 TEST_F(QnnHTPBackendTests, BatchNorm_FP32_as_FP16) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -104,11 +104,9 @@ static void RunCastOpTest(const std::vector<int64_t>& shape, ONNX_NAMESPACE::Ten
                           const std::string& backend_name = "cpu",
                           bool enable_fp16_precision = true) {
   if (backend_name == "htp" && enable_fp16_precision) {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
   }
 
   RunQnnModelTest(BuildCastTestCase<InputType>(shape, dst_type),
@@ -120,11 +118,9 @@ static void RunCastOpTest(const std::vector<int64_t>& shape, ONNX_NAMESPACE::Ten
 static void RunCastFP64OpTest(const std::vector<int64_t>& shape,
                               ExpectedEPNodeAssignment expected_ep_assignment,
                               const std::string& backend_name = "cpu") {
-#if defined(_WIN32)
   if (backend_name == "htp" && QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 
   RunQnnModelTest(BuildCastFP64TestCase(shape),
                   GetProviderOption(backend_name, true),
@@ -136,11 +132,9 @@ static void RunCastFP64OpTest(const std::vector<int64_t>& shape,
 static void RunCastFP16HTPTest(const std::vector<int64_t>& shape,
                                ONNX_NAMESPACE::TensorProto_DataType dst_type,
                                ExpectedEPNodeAssignment expected_ep_assignment) {
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnHtp.dll";

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -375,11 +375,9 @@ TEST_F(QnnHTPBackendTests, Clip_U8_QuantizedMinMax) {
 
 // Test FP16 Clip with min (FP16)
 TEST_F(QnnHTPBackendTests, Clip_FP16) {
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
 

--- a/onnxruntime/test/providers/qnn/fusedmatmul_test.cc
+++ b/onnxruntime/test/providers/qnn/fusedmatmul_test.cc
@@ -28,11 +28,9 @@ static void RunFusedMatMulTest(const TestInputDef<DataType>& input_a_def,
   provider_options["backend_type"] = backend_name;
 
   if (backend_name == "htp") {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/leakyrelu_test.cc
+++ b/onnxruntime/test/providers/qnn/leakyrelu_test.cc
@@ -56,11 +56,9 @@ TEST_F(QnnHTPBackendTests, LeakyReluOpSet16) {
 
 // Test Leaky Relu where input is FP16 and alpha is FP32
 TEST_F(QnnHTPBackendTests, LeakyReluFP16OpSet16) {
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -196,11 +196,9 @@ static void RunQDQPerChannelMatMulOpTest(
   provider_options["offload_graph_io_quantization"] = "0";
 
   if (enable_fp16_precision) {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/pad_test.cc
+++ b/onnxruntime/test/providers/qnn/pad_test.cc
@@ -135,11 +135,9 @@ static void RunPadOpTest(const TestInputDef<T>& data_def,
   provider_options["offload_graph_io_quantization"] = "0";
 
   if (enable_fp16_precision) {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1165,11 +1165,9 @@ TEST_F(QnnHTPBackendTests, ProfilingTest) {
 
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -1200,11 +1198,9 @@ TEST_F(QnnHTPBackendTests, OptraceTest) {
 
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -1290,11 +1286,9 @@ TEST_F(QnnHTPBackendTests, Float32ModelWithFP16PrecisionTest) {
 #else
   provider_options["backend_path"] = "libQnnHtp.so";
 #endif
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -1361,11 +1355,9 @@ TEST_F(QnnHTPBackendTests, EPRejectsDynamicShapesF32) {
   provider_options["backend_path"] = "libQnnHtp.so";
 #endif
   provider_options["offload_graph_io_quantization"] = "0";
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -2527,7 +2519,7 @@ TEST_F(QnnCPUBackendTests, GetUniqueNameResetBetweenCompilations) {
 }
 
 // Test extended UDMA mode on supported hardware (should run successfully)
-#if defined(_WIN32)
+#if defined(_WIN32) || (defined(__linux__) && defined(__aarch64__))
 TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V79)) {
     GTEST_SKIP() << "Test requires HTP arch >= V81 for extended UDMA support.";
@@ -2550,7 +2542,7 @@ TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
                   ExpectedEPNodeAssignment::All,
                   0.008f);
 }
-#endif  // defined(_WIN32)
+#endif  // defined(_WIN32) || (defined(__linux__) && defined(__aarch64__))
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -628,7 +628,7 @@ void QnnIRBackendTests::SetUp() {
   }
 }
 
-#if defined(_WIN32)
+#if defined(_WIN32) || (defined(__linux__) && defined(__aarch64__))
 // TODO: Remove or set to SUPPORTED once HTP emulation is supported on win arm64.
 BackendSupport QnnHTPBackendTests::cached_htp_support_ = BackendSupport::SUPPORT_UNKNOWN;
 

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1586,8 +1586,12 @@ class QnnHTPBackendTests : public ::testing::Test {
 
   // Returns true if the test should be skipped because HTP architecture is less than or equal to the provided arch.
   // Example: if (QnnHTPBackendTests::ShouldSkipIfHTPArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) { GTEST_SKIP() << "..."; }
-  static bool ShouldSkipIfHtpArchIsLessThanOrEqualTo(QnnHtpDevice_Arch_t arch) {
+  static bool ShouldSkipIfHtpArchIsLessThanOrEqualTo([[maybe_unused]] QnnHtpDevice_Arch_t arch) {
+#if defined(_WIN32) || (defined(__linux__) && defined(__aarch64__))
     return HasPlatformAttributes() && GetPlatformAttributes().htp_arch <= arch;
+#else
+    return false;
+#endif
   }
 
   // Query QNN platform attributes by directly calling QNN APIs
@@ -1595,20 +1599,14 @@ class QnnHTPBackendTests : public ::testing::Test {
 
   // Returns true if the test should be skipped because HTP FP16 is not supported on this platform.
   static bool ShouldSkipIfHtpFp16Unsupported() {
-#if defined(_WIN32)  // On Windows ARM64, FP16 is not supported if the HTP architecture is v68.
+    // On ARM64 platforms, FP16 is not supported if the HTP architecture is v68 or below.
     return ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68);
-#else
-    return false;
-#endif
   }
 
   // Returns true if the test should be skipped because AutoEP is not supported on this platform.
   static bool ShouldSkipIfAutoEpNpuUnsupported() {
-#if defined(_WIN32)  // V68 device (Makena) on win-arm64 doesn't support NPU device discovery with dxcore.dll.
+    // V68 device (Makena) on ARM64 platforms doesn't support NPU device discovery.
     return ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68);
-#else
-    return false;
-#endif
   }
 
   static std::optional<QnnHTPBackendTests::QnnPlatformAttributes> cached_platform_attrs_;  // Set by the first test using this fixture.

--- a/onnxruntime/test/providers/qnn/quickgelu_test.cc
+++ b/onnxruntime/test/providers/qnn/quickgelu_test.cc
@@ -24,11 +24,9 @@ static void RunQuickGeluTest(const TestInputDef<DataType>& input_def,
   provider_options["backend_type"] = backend_name;
 
   if (backend_name == "htp") {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -92,11 +92,9 @@ static void RunReduceTest(const std::string& op_type,
   provider_options["offload_graph_io_quantization"] = "0";
   if (enable_fp16) {
     provider_options["backend_type"] = "htp";
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/rope_op_test.cc
+++ b/onnxruntime/test/providers/qnn/rope_op_test.cc
@@ -56,12 +56,10 @@ static void RunRopeOpTest(const TestInputDef<DataType>& input_def,
 
 // Basic test with FP16 data type (QNN EP only supports FP16 for RotaryEmbedding)
 TEST_F(QnnHTPBackendTests, RotaryEmbedding_Basic) {
-#if defined(_WIN32)
-  // Skip test on Windows if HTP FP16 is not supported (V68 and below)
+  // Skip test if HTP FP16 is not supported (V68 and below)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 
   constexpr int64_t batch_size = 1;
   constexpr int64_t num_heads = 2;

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -222,11 +222,9 @@ static void RunOpTest(const std::string& op_type,
   provider_options["backend_type"] = "htp";
 
   if (enable_htp_fp16_precision) {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = soc_model.has_value() ? *soc_model : std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -257,11 +255,9 @@ static void RunOpTest(const std::string& op_type,
   provider_options["backend_type"] = "htp";
 
   if (enable_htp_fp16_precision) {
-#if defined(_WIN32)
     if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
       GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
     }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
     provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -1045,11 +1041,9 @@ TEST_F(QnnHTPBackendTests, BinaryOp_Add4D_FP64) {
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -1999,11 +1993,9 @@ TEST_F(QnnHTPBackendTests, HardSigmoidFusedIntoHardSwish_FP32_as_FP16) {
   ProviderOptions provider_options;
 
   provider_options["backend_type"] = "htp";
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
@@ -2026,11 +2018,9 @@ TEST_F(QnnHTPBackendTests, HardSigmoidFusedIntoHardSwish_FP32_as_FP16) {
 
 // Test FP16 fusion of HardSigmoid into HardSwish on the HTP backend.
 TEST_F(QnnHTPBackendTests, HardSigmoidFusedIntoHardSwish_FP16) {
-#if defined(_WIN32)
   if (QnnHTPBackendTests::ShouldSkipIfHtpArchIsLessThanOrEqualTo(QNN_HTP_DEVICE_ARCH_V68)) {
     GTEST_SKIP() << "Test requires HTP FP16 support (arch > V68).";
   }
-#endif
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Move platform check to ShouldSkipIfHtpArchIsLessThanOrEqualTo


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Disable FP16 UT for Linux Arm64 V68 platform
