### PR TITLE
[QNN EP] Generate PDB for Windows Release builds and wrap in zip

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -77,6 +77,14 @@ on:
       upload_archive:
         default: false
         type: boolean
+      build_pdb_archive:
+        description: "If true (Windows only), build an archive containing just the PDB debug symbols."
+        default: false
+        type: boolean
+      upload_pdb_archive:
+        description: "If true, upload the PDB archive as a CI artifact."
+        default: false
+        type: boolean
       build_aar:
         description: |
           If true, also build the Android AAR during the Android build.
@@ -129,6 +137,18 @@ jobs:
           ${{ inputs.build_archive == true && '--build-archive' || '' }}
           ${{ inputs.build_aar == true && '--build-aar' || '' }}
           ${{inputs.upload_test_archive == true && 'archive' || 'build'}}_ort_${{inputs.target_os}}_${{ inputs.target_arch }}
+
+      - name: Build Windows ${{ inputs.target_arch }} PDB Archive
+        if: ${{ inputs.build_pdb_archive && inputs.target_os == 'windows' }}
+        run: >
+          python.exe tools/ci_build/pkg_assets.py
+          --source_dir ${{ github.workspace }}
+          --build_dir ${{ github.workspace }}/build/${{ inputs.target_os }}-${{ inputs.target_arch }}
+          --config Release
+          --pdb_only
+          --target_arch ${{ inputs.target_arch }}
+          ${{ env.BUILD_CONFIG_DIR == 'Release' && '--use_ninja' || '' }}
+          ${{ env.ORT_VERSION_SUFFIX != '' && format('--version_suffix {0}', env.ORT_VERSION_SUFFIX) || '' }}
 
       - name: Test ${{inputs.target_os}} ${{ inputs.target_arch }} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
         if: ${{ inputs.run_tests && inputs.build_test_same_runner }}
@@ -209,6 +229,13 @@ jobs:
         with:
           name: "${{inputs.target_os}}-${{ inputs.target_arch }}-pom"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.pom"
+
+      - name: Upload PDB Archive to Artifactory
+        if: ${{ inputs.upload_pdb_archive && inputs.target_os == 'windows' }}
+        uses: ./.github/actions/upload-ci-artifact
+        with:
+          name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-pdb-zip"
+          src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime-qnn-*-win-*-pdb.zip"
 
   test:
     name: "test-${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}"

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -160,3 +160,6 @@ jobs:
       upload_nuget: ${{ inputs.windows_arm64_build_nuget && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       build_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+      # For each arch, build and upload a PDB archive with the first python version we encounter
+      build_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+      upload_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -271,6 +271,21 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
+      - name: Download Windows ARM64 PDB Archive from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.11-pdb-zip
+
+      - name: Download Windows ARM64EC PDB Archive from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.11-pdb-zip
+
+      - name: Download Windows x86_64 PDB Archive from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.11-pdb-zip
+
       - name: Merge AMD Wheels
         run: |
           # Collect the ARM64ec and x86_64 wheels into known locations
@@ -313,9 +328,10 @@ jobs:
 
       - name: Verify Zip artifact
         run: |
+          # 4 test archives + 1 windows zip + 3 PDB archives = 8 zips
           count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
           echo "Found $count Zip archive(s)"
-          [ "$count" -eq 5 ] || { echo "ERROR: Expected 5 Zip archives, found $count"; exit 1; }
+          [ "$count" -eq 8 ] || { echo "ERROR: Expected 8 Zip archives, found $count"; exit 1; }
 
       - name: Verify TGZ artifact
         run: |

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   workflow_call:
-    inputs: &common_inputs
+    inputs:
       nightly_build:
         description: "If true, include a verbose version string in file names."
         type: boolean
@@ -31,8 +31,6 @@ on:
         description: "If true, skip publishing artifacts (dry run)."
         type: boolean
         default: false
-  workflow_dispatch:
-    inputs: *common_inputs
 
 env:
   BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
@@ -283,11 +281,27 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
+      - name: Download Windows ARM64 PDB Archive from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.11-pdb-zip
+
+      - name: Download Windows ARM64EC PDB Archive from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.11-pdb-zip
+
+      - name: Download Windows x86_64 PDB Archive from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.11-pdb-zip
+
       - name: Verify Zip artifacts
         run: |
+          # 1 windows zip + 3 PDB archives = 4 zips
           count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
           echo "Found $count Zip archive(s)"
-          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 Zip archive, found $count"; exit 1; }
+          [ "$count" -eq 4 ] || { echo "ERROR: Expected 4 Zip archive, found $count"; exit 1; }
 
       - name: Verify TGZ artifact
         run: |
@@ -310,7 +324,7 @@ jobs:
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
 
-          # Upload Windows ARM64 zip
+          # Upload Windows ARM64 archive and PDB archive
           ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
             "${{ github.workspace }}/build/windows-arm64/Release/dist" \
             "$NETRC_FILE"
@@ -318,6 +332,16 @@ jobs:
           # Upload Linux aarch64 manylinux_2_34 zip
           ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
             "${{ github.workspace }}/build/linux-aarch64_manylinux_2_34/Release/dist" \
+            "$NETRC_FILE"
+
+          # Upload Windows ARM64EC PDB archive
+          ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
+            "${{ github.workspace }}/build/windows-arm64ec/Release/Release/dist" \
+            "$NETRC_FILE"
+
+          # Upload Windows x86_64 PDB archive
+          ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
+            "${{ github.workspace }}/build/windows-x86_64/Release/dist" \
             "$NETRC_FILE"
 
           # Clean up the temporary .netrc file

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -79,6 +79,14 @@
   elseif(WIN32)
     set_property(TARGET onnxruntime_providers_qnn APPEND_STRING PROPERTY LINK_FLAGS
                   "-DEF:${ONNXRUNTIME_ROOT}/core/providers/qnn/symbols.def")
+    # Generate PDB for Release builds.
+    # /DEBUG tells the linker to emit a .pdb; /OPT:REF and /OPT:ICF re-enable
+    # linker optimizations that /DEBUG implicitly turns off via /OPT:NOREF /OPT:NOICF.
+    # Note: When developers use this PDB for crash analysis,
+    # please be aware that ICF may cause symbol aliasing.
+    target_link_options(onnxruntime_providers_qnn PRIVATE
+      "$<$<CONFIG:Release>:/DEBUG;/OPT:REF;/OPT:ICF>"
+    )
   else()
     message(FATAL_ERROR "onnxruntime_providers_qnn unknown platform, need to specify shared library exports for it")
   endif()

--- a/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
+++ b/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
@@ -5,6 +5,9 @@
 # Script to upload zip and tgz files to Artifactory using netrc authentication
 # Usage: upload_zip_to_artifactory.sh <input_dir> <netrc_file>
 
+# Files ending in pdb.zip are uploaded to .../onnxruntime-qnn/<version>-pdb/<file>;
+# all other .zip/.tgz files are uploaded to .../onnxruntime-qnn/<version>/<file>.
+
 set -euo pipefail
 
 if [ "$#" -ne 2 ]; then
@@ -34,12 +37,18 @@ find "$INPUT_DIR" \( -name "*.zip" -o -name "*.tgz" \) -type f -print0 | while I
     filename_no_ext="${file_basename%.*}"
     version=$(echo "$filename_no_ext" | cut -d'-' -f3)
 
+    if [[ "$file_basename" == *pdb.zip ]]; then
+        TARGET_SUFFIX="-pdb"
+    else
+        TARGET_SUFFIX=""
+    fi
+
     echo "Uploading $file_basename (version: $version)..."
 
     curl -T "$file" \
         --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
         --netrc-file "$NETRC_FILE" \
-        https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"$version"/"$file_basename"
+        https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename"
 
     echo "Successfully uploaded $file_basename"
 done

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -170,7 +170,7 @@ else {
     $FakeClCcacheDir = $BuildDir.Replace("\", "/")
     $CommonArgs += `
         "--cmake_extra_defines", "CMAKE_VS_GLOBALS=CLToolExe=cl.exe;CLToolPath=$FakeClCcacheDir;UseMultiToolTask=true", `
-        "--cmake_extra_defines", 'CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$"<"$"<"CONFIG:Debug,RelWithDebInfo">":Embedded">"'
+        "--cmake_extra_defines", 'CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=$"<"$"<"CONFIG:Debug,Release,RelWithDebInfo">":Embedded">"'
 }
 
 $TargetPyExe = $null

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -424,7 +424,7 @@ def generate_build_tree(
                 add_default_definition(
                     cmake_extra_defines,
                     "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT",
-                    "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>",
+                    "$<$<CONFIG:Debug,Release,RelWithDebInfo>:Embedded>",
                 )
             else:
                 # Always enable debug info even in release build. The debug information is in separated *.pdb files that

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1109,6 +1109,17 @@ def main():
                 args.archive_name_suffix,
                 args.version_suffix,
                 use_ninja=(args.cmake_generator == "Ninja"),
+                target_arch=(
+                    "arm64ec"
+                    if getattr(args, "arm64ec", False)
+                    else "arm64"
+                    if getattr(args, "arm64", False)
+                    else "arm"
+                    if getattr(args, "arm", False)
+                    else "x86"
+                    if getattr(args, "x86", False)
+                    else None
+                ),
             )
 
     if args.gen_doc:

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -46,7 +46,7 @@ def parse_version_number(source_dir):
 
 def get_qnn_asset_file_list():
     """
-    Returns the list of QNN asset files to include in the zip package.
+    Returns the list of QNN asset files to include in the archive package.
 
     Args:
         is_windows_platform: If None, auto-detect from platform.system()
@@ -105,6 +105,47 @@ def get_qnn_asset_file_list():
     return qnn_assets["windows"] if is_windows() else qnn_assets["others"]
 
 
+def _compute_archive_name(source_dir, version_suffix, archive_name_suffix, archive_ext, target_arch=None):
+    """
+    Build the archive filename using the shared naming rules.
+
+    Format: onnxruntime-qnn[-<version>][<version_suffix>][-<archive_name_suffix>]-<platform>-<arch><ext>
+
+    Args:
+        source_dir: Path to source directory
+        version_suffix: Optional version suffix for archive filename
+        archive_name_suffix: Optional suffix for archive filename
+        archive_ext: String for archive extension
+        target_arch: Optional explicit target architecture. When set, overrides
+            platform.machine() — needed for cross-compile builds where the build
+            host arch differs from the target arch (e.g. arm64ec on an x64 host).
+    """
+    sys_name = platform.system().lower()
+    platform_name = "win" if sys_name == "windows" else sys_name
+    arch = (target_arch or platform.machine()).lower()
+    arch = {"amd64": "x64", "x86_64": "x64"}.get(arch, arch)
+
+    version = parse_version_number(source_dir)
+
+    name = "onnxruntime-qnn"
+    if version:
+        name += f"-{version}"
+    if version_suffix:
+        name += f"{version_suffix}"
+    if archive_name_suffix:
+        name += f"-{archive_name_suffix}"
+    name += f"-{platform_name}-{arch}{archive_ext}"
+    return name
+
+
+def _resolve_config_cwd(build_dir, config, use_ninja):
+    """Resolve the per-config working directory for asset packaging."""
+    config_build_dir = os.path.join(build_dir, config)
+    if is_windows() and not use_ninja:
+        return os.path.join(config_build_dir, config)
+    return config_build_dir
+
+
 def build_archive_asset(
     source_dir,
     build_dir,
@@ -112,6 +153,7 @@ def build_archive_asset(
     archive_name_suffix=None,
     version_suffix="",
     use_ninja=False,
+    target_arch=None,
 ):
     """
     Build archive asset packages containing QNN EP and dependencies.
@@ -123,6 +165,9 @@ def build_archive_asset(
         archive_name_suffix: Optional suffix for archive filename
         version_suffix: Optional version suffix for archive filename
         use_ninja: Whether Ninja generator was used
+        target_arch: Override for platform.machine() in the archive filename.
+            Required for cross-compile builds (e.g. arm64ec on x64) where the
+            build host arch differs from the target arch.
 
     Returns:
         list[Path]: List of created archive file paths
@@ -132,13 +177,7 @@ def build_archive_asset(
     for config in configs:
         log.info(f"Building archive asset for {config} configuration")
 
-        # Determine working directory (matching build_python_wheel logic)
-        config_build_dir = os.path.join(build_dir, config)
-        if is_windows() and not use_ninja:
-            cwd = os.path.join(config_build_dir, config)
-        else:
-            cwd = config_build_dir
-
+        cwd = _resolve_config_cwd(build_dir, config, use_ninja)
         if not os.path.exists(cwd):
             raise FileNotFoundError(f"Build directory not found: {cwd}")
 
@@ -146,31 +185,10 @@ def build_archive_asset(
         dist_dir = os.path.join(cwd, "dist")
         os.makedirs(dist_dir, exist_ok=True)
 
-        # Generate archive filename
-        platform_name = platform.system().lower()
-        platform_abbr = {"windows": "win"}
-        if platform_name in platform_abbr:
-            platform_name = platform_abbr[platform_name]
-        arch = platform.machine().lower()
-        if arch == "amd64":
-            arch = "x64"
-        elif arch == "x86_64":
-            arch = "x64"
-
-        # Parse version from VERSION_NUMBER file
-        version = parse_version_number(source_dir)
-
         archive_ext = ".zip" if is_windows() else ".tgz"
-
-        archive_name = "onnxruntime-qnn"
-        if version:
-            archive_name += f"-{version}"
-        if version_suffix:
-            archive_name += f"{version_suffix}"
-        if archive_name_suffix:
-            archive_name += f"-{archive_name_suffix}"
-        archive_name += f"-{platform_name}-{arch}{archive_ext}"
-
+        archive_name = _compute_archive_name(
+            source_dir, version_suffix, archive_name_suffix, archive_ext, target_arch=target_arch
+        )
         archive_path = Path(dist_dir) / archive_name
 
         # Get list of files to include
@@ -220,7 +238,7 @@ def build_archive_asset(
                 file_path = os.path.join(cwd, filename)
 
             if os.path.exists(file_path):
-                found_files.append((filename, file_path))
+                found_files.append(file_path)
                 log.debug(f"Found asset file: {file_path}")
             else:
                 missing_files.append(filename)
@@ -240,18 +258,86 @@ def build_archive_asset(
         log.info(f"Creating archive: {archive_path}")
         if is_windows():
             with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-                for _filename, file_path in found_files:
+                for file_path in found_files:
                     arcname = os.path.relpath(file_path, cwd)
                     zipf.write(file_path, arcname)
                     log.debug(f"Added to zip: {arcname}")
         else:
             with tarfile.open(archive_path, "w:gz") as tgzf:
-                for _filename, file_path in found_files:
+                for file_path in found_files:
                     arcname = os.path.relpath(file_path, cwd)
                     tgzf.add(file_path, arcname)
                     log.debug(f"Added to tgz: {arcname}")
 
         log.info(f"Created archive: {archive_path} ({len(found_files)} files)")
+        created_archives.append(archive_path)
+
+    return created_archives
+
+
+def build_pdb_archive_asset(
+    source_dir,
+    build_dir,
+    configs,
+    version_suffix="",
+    use_ninja=False,
+    target_arch=None,
+):
+    """
+    Build a Windows-only archive containing PDB debug symbol files.
+
+    The resulting archive is a sibling of the main asset archive and uses the same
+    naming convention with a trailing "-pdb" suffix, e.g.:
+        onnxruntime-qnn-<version>[<version_suffix>]-win-<arch>-pdb.zip
+
+    Args:
+        source_dir: Path to source directory
+        build_dir: Path to build directory
+        configs: List of build configurations (e.g., ['RelWithDebInfo'])
+        version_suffix: Optional version suffix for archive filename
+        use_ninja: Whether Ninja generator was used
+        target_arch: Override for platform.machine() in the archive filename.
+            Required for cross-compile builds (e.g. arm64ec on x64) where the
+            build host arch differs from the target arch.
+
+    Returns:
+        list[Path]: List of created archive file paths (empty on non-Windows).
+    """
+    if not is_windows():
+        log.info("Skipping PDB archive: not on Windows")
+        return []
+
+    pdb_files = ["onnxruntime_providers_qnn.pdb"]
+    created_archives = []
+
+    for config in configs:
+        log.info(f"Building PDB archive asset for {config} configuration")
+
+        cwd = _resolve_config_cwd(build_dir, config, use_ninja)
+        if not os.path.exists(cwd):
+            raise FileNotFoundError(f"Build directory not found: {cwd}")
+
+        dist_dir = os.path.join(cwd, "dist")
+        os.makedirs(dist_dir, exist_ok=True)
+
+        base_name = _compute_archive_name(source_dir, version_suffix, None, "", target_arch=target_arch)
+        archive_path = Path(dist_dir) / f"{base_name}-pdb.zip"
+
+        found_files = []
+        for filename in pdb_files:
+            file_path = os.path.join(cwd, filename)
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Required PDB file missing: {file_path}")
+            found_files.append(file_path)
+
+        log.info(f"Creating PDB archive: {archive_path}")
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for file_path in found_files:
+                arcname = os.path.relpath(file_path, cwd)
+                zipf.write(file_path, arcname)
+                log.debug(f"Added to PDB archive: {arcname}")
+
+        log.info(f"Created PDB archive: {archive_path} ({len(found_files)} files)")
         created_archives.append(archive_path)
 
     return created_archives
@@ -288,6 +374,20 @@ Examples:
 
     parser.add_argument("--use_ninja", action="store_true", help="Whether Ninja generator was used for build")
 
+    parser.add_argument(
+        "--pdb_only",
+        action="store_true",
+        help="Build a Windows PDB-only archive (onnxruntime-qnn-<version>-win-<arch>-pdb.zip) instead of the main asset archive.",
+    )
+
+    parser.add_argument(
+        "--target_arch",
+        type=str,
+        default=None,
+        help="Target architecture for the archive filename (overrides platform.machine()). "
+        "Required for cross-compile builds such as arm64ec on an x64 host.",
+    )
+
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
 
     args = parser.parse_args()
@@ -301,14 +401,25 @@ Examples:
         args.config = ["RelWithDebInfo"]
 
     try:
-        created_archives = build_archive_asset(
-            source_dir=args.source_dir,
-            build_dir=args.build_dir,
-            configs=args.config,
-            archive_name_suffix=args.suffix,
-            version_suffix=args.version_suffix,
-            use_ninja=args.use_ninja,
-        )
+        if args.pdb_only:
+            created_archives = build_pdb_archive_asset(
+                source_dir=args.source_dir,
+                build_dir=args.build_dir,
+                configs=args.config,
+                version_suffix=args.version_suffix,
+                use_ninja=args.use_ninja,
+                target_arch=args.target_arch,
+            )
+        else:
+            created_archives = build_archive_asset(
+                source_dir=args.source_dir,
+                build_dir=args.build_dir,
+                configs=args.config,
+                archive_name_suffix=args.suffix,
+                version_suffix=args.version_suffix,
+                use_ninja=args.use_ninja,
+                target_arch=args.target_arch,
+            )
 
         print(f"Successfully created {len(created_archives)} archive package(s):")
         for archive_path in created_archives:

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -197,6 +197,16 @@ def build_archive_asset(
         asset_files.extend(doc_md_files)
         asset_files.extend(doc_png_files)
 
+        necessary_files_dict = {
+            "windows": [
+                "onnxruntime_providers_qnn.dll",
+            ],
+            "others": [
+                "libonnxruntime_providers_qnn.so",
+            ],
+        }
+        necessary_files = necessary_files_dict["windows"] if is_windows() else necessary_files_dict["others"]
+
         # Collect and verify files exist
         missing_files = []
         found_files = []
@@ -218,6 +228,8 @@ def build_archive_asset(
         if missing_files:
             log.warning(f"Missing asset files in {cwd}:")
             for missing in missing_files:
+                if missing in necessary_files:
+                    raise FileNotFoundError(f"Required file missing: {missing}")
                 log.warning(f"  - {missing}")
             log.warning("Continuing with available files...")
 


### PR DESCRIPTION
### Description
Enable debug symbol generation for Release config on Windows, wrap the PDB in a zip archive, and upload the pdb zip to internal artifactory.

### Motivation and Context
There is a request to generate the .pdb with Release config.