### PR TITLE
fix: re-enable offload_graph_io_quantization tensor name overrides

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -94,6 +94,8 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name)) {
+      qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
+                                              /*external=*/node_unit.Outputs()[0].name);
       return MAKE_EP_FAIL("QNN EP is configured to not take DQ nodes that generate a graph output.");
     }
   }
@@ -106,6 +108,8 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
+      qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
+                                              /*external=*/node_unit.Inputs()[0].name);
       return MAKE_EP_FAIL("QNN EP is configured to not take Q nodes that consume a graph input.");
     }
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -171,6 +171,36 @@ Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
                                    std::forward_as_tuple(i, static_cast<int32_t>(elem_type), std::move(shape)));
   }
 
+  // DLC tensors may carry overridden names that differ from the fused node I/O names.
+  if (graph_info_) {
+    auto add_qnn_name_aliases = [](GraphInputOutputInfo& io_info,
+                                   const std::vector<QnnTensorWrapper>& qnn_tensors,
+                                   const std::vector<std::string>& fused_order) {
+      size_t count = std::min(qnn_tensors.size(), fused_order.size());
+      for (size_t i = 0; i < count; ++i) {
+        const std::string& qnn_name = qnn_tensors[i].GetName();
+        const std::string& fused_name = fused_order[i];
+        if (qnn_name != fused_name && io_info.indices.find(qnn_name) == io_info.indices.end()) {
+          auto idx_it = io_info.indices.find(fused_name);
+          if (idx_it != io_info.indices.end()) {
+            io_info.indices.emplace(qnn_name, idx_it->second);
+          }
+          auto tensor_it = io_info.tensors.find(fused_name);
+          if (tensor_it != io_info.tensors.end()) {
+            const OnnxTensorInfo& info = tensor_it->second;
+            io_info.tensors.emplace(std::piecewise_construct,
+                                    std::forward_as_tuple(qnn_name),
+                                    std::forward_as_tuple(info.index_, info.data_type_,
+                                                          std::vector<int64_t>(info.shape_)));
+          }
+        }
+      }
+    };
+
+    add_qnn_name_aliases(graph_inputs_, graph_info_->InputTensors(), fused_input_order);
+    add_qnn_name_aliases(graph_outputs_, graph_info_->OutputTensors(), fused_output_order);
+  }
+
   return Ort::Status();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -176,8 +176,7 @@ Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
     auto add_qnn_name_aliases = [](GraphInputOutputInfo& io_info,
                                    const std::vector<QnnTensorWrapper>& qnn_tensors,
                                    const std::vector<std::string>& fused_order) {
-      size_t count = std::min(qnn_tensors.size(), fused_order.size());
-      for (size_t i = 0; i < count; ++i) {
+      for (size_t i = 0; i < qnn_tensors.size() && i < fused_order.size(); ++i) {
         const std::string& qnn_name = qnn_tensors[i].GetName();
         const std::string& fused_name = fused_order[i];
         if (qnn_name != fused_name && io_info.indices.find(qnn_name) == io_info.indices.end()) {

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1524,9 +1524,7 @@ static GetTestModelFn QDQBuildSigmoidForTensorNameTest(const TestInputDef<float>
 }
 
 // Test that DLC I/O tensor names match original ONNX names when offload_graph_io_quantization=1.
-// Disabled: tensor_name_overrides mapping was removed to fix a crash when offload_graph_io_quantization is enabled.
-// Re-enable once tensor name override support is re-implemented.
-TEST_F(QnnHTPBackendTests, DISABLED_OffloadGraphIoQuantizationTensorNameOverrides) {
+TEST_F(QnnHTPBackendTests, OffloadGraphIoQuantizationTensorNameOverrides) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnHtp.dll";
@@ -1972,6 +1970,51 @@ TEST_F(QnnHTPBackendTests, TestMismatchedGraphInputAndTensorWrapperCount) {
                   0.008f);
 }
 
+// Compile a QDQ model to a context binary with offload_graph_io_quantization=1,
+// then load and run the context binary. Regression test for PR #234.
+TEST_F(QnnHTPBackendTests, OffloadGraphIoQuantizationContextBinaryRoundTrip) {
+  const std::string ctx_model_file = "./offload_qdq_ctx_test.onnx";
+  std::remove(ctx_model_file.c_str());
+  auto cleanup = gsl::finally([&]() { std::remove(ctx_model_file.c_str()); });
+
+  std::vector<float> input_data = GetFloatDataInRange(0.0f, 1.0f, 8);
+  TestInputDef<float> input_def({1, 2, 2, 2}, false, input_data);
+
+  std::unique_ptr<ModelAndBuilder> model;
+  CreateModelInMemory(model, QDQBuildSigmoidForTensorNameTest<uint8_t>(input_def), "sigmoid.qdq", 21);
+
+  ProviderOptions provider_options;
+#if defined(_WIN32)
+  provider_options["backend_path"] = "QnnHtp.dll";
+#else
+  provider_options["backend_path"] = "libQnnHtp.so";
+#endif
+  provider_options["offload_graph_io_quantization"] = "1";
+
+  {
+    Ort::SessionOptions so;
+    so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_model_file.c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+
+    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+    ASSERT_TRUE(std::filesystem::exists(ctx_model_file)) << "Context binary not generated";
+  }
+
+  {
+    Ort::SessionOptions so2;
+    so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_model_file.c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so2, onnxruntime::kQnnExecutionProvider, provider_options);
+
+    Ort::Session session2(*ort_env, ctx_model_file.c_str(), so2);
+  }
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if !BUILD_QNN_EP_STATIC_LIB
@@ -2171,9 +2214,7 @@ static GetTestModelFn BuildPartitionAddedInputQDQModel() {
 // Verifies the same as PartitionAddedInputRegisteredAsGraphInput but via the
 // tensor_name_overrides code path: with offload_graph_io_quantization=1,
 // QuantizeLinear stays on CPU and causes a tensor name remap (q_input <-> input).
-// Disabled: tensor_name_overrides mapping was removed to fix a crash when offload_graph_io_quantization is enabled.
-// Re-enable once tensor name override support is re-implemented.
-TEST_F(QnnCPUBackendTests, DISABLED_PartitionAddedInputRegisteredAsGraphInputOffloadGraphIoQuantization) {
+TEST_F(QnnCPUBackendTests, PartitionAddedInputRegisteredAsGraphInputOffloadGraphIoQuantization) {
   // Build model using public API
   std::unique_ptr<ModelAndBuilder> model;
   CreateModelInMemory(model, BuildPartitionAddedInputQDQModel(), "partition_added_input_qdq", 13);
@@ -2379,9 +2420,7 @@ static GetTestModelFn BuildMultiSigmoidQDQModelForIOOrderTest() {
 }
 
 // Verifies QNN graph I/O order matches ONNX declaration order with offload_graph_io_quantization=1.
-// Disabled: tensor_name_overrides mapping was removed to fix a crash when offload_graph_io_quantization is enabled.
-// Re-enable once tensor name override support is re-implemented.
-TEST_F(QnnCPUBackendTests, DISABLED_GraphInputOutputOrderMatchesOnnxOffloadGraphIoQuantization) {
+TEST_F(QnnCPUBackendTests, GraphInputOutputOrderMatchesOnnxOffloadGraphIoQuantization) {
   ProviderOptions provider_options;
 #if defined(_WIN32)
   provider_options["backend_path"] = "QnnCpu.dll";

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -2011,7 +2011,9 @@ TEST_F(QnnHTPBackendTests, OffloadGraphIoQuantizationContextBinaryRoundTrip) {
     RegisteredEpDeviceUniquePtr registered_ep_device;
     RegisterQnnEpLibrary(registered_ep_device, so2, onnxruntime::kQnnExecutionProvider, provider_options);
 
-    Ort::Session session2(*ort_env, ctx_model_file.c_str(), so2);
+    std::ifstream ifs(ctx_model_file, std::ios::binary);
+    std::string ctx_data((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    Ort::Session session2(*ort_env, ctx_data.data(), ctx_data.size(), so2);
   }
 }
 


### PR DESCRIPTION
fix: re-enable offload_graph_io_quantization tensor name overrides

The tensor name override mechanism was disabled in PR #234 to work
around a crash when loading context binaries (DLCs) compiled with
offload_graph_io_quantization=1. The root cause was that DLC tensors
carry overridden ONNX names, but CompileContextModel populates
graph I/O index maps using fused node names, causing a lookup failure
in SetupTensors.

Fix by adding QNN tensor name aliases in SetGraphInputOutputInfo when
a deserialized graph_info_ is already available, so that SetupTensors
can resolve either name. Re-enable the three disabled tests and add a
context binary round-trip regression test.
