### PR TITLE
Support Identity op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -53,6 +53,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateReduceOpBuilder("ReduceProd", *this);
   CreateReduceOpBuilder("ReduceSum", *this);
   CreateReshapeOpBuilder("Flatten", *this);
+  CreateReshapeOpBuilder("Identity", *this);
   CreateReshapeOpBuilder("Reshape", *this);
   CreateReshapeOpBuilder("Squeeze", *this);
   CreateReshapeOpBuilder("Unsqueeze", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -28,6 +28,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateGatherNDOpBuilder("GatherND", *this);
   CreateGemmOpBuilder("Gemm", *this);
   CreateGroupNormOpBuilder("GroupNormalization", *this);
+  CreateIdentityOpBuilder("Identity", *this);
   CreateInstanceNormOpBuilder("InstanceNormalization", *this);
   CreateInverseOpBuilder("Inverse", *this);
   CreateIsNanOpBuilder("IsNaN", *this);
@@ -52,7 +53,6 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateReduceOpBuilder("ReduceMin", *this);
   CreateReduceOpBuilder("ReduceProd", *this);
   CreateReduceOpBuilder("ReduceSum", *this);
-  CreateIdentityOpBuilder("Identity", *this);
   CreateReshapeOpBuilder("Flatten", *this);
   CreateReshapeOpBuilder("Reshape", *this);
   CreateReshapeOpBuilder("Squeeze", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -52,8 +52,8 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateReduceOpBuilder("ReduceMin", *this);
   CreateReduceOpBuilder("ReduceProd", *this);
   CreateReduceOpBuilder("ReduceSum", *this);
+  CreateIdentityOpBuilder("Identity", *this);
   CreateReshapeOpBuilder("Flatten", *this);
-  CreateReshapeOpBuilder("Identity", *this);
   CreateReshapeOpBuilder("Reshape", *this);
   CreateReshapeOpBuilder("Squeeze", *this);
   CreateReshapeOpBuilder("Unsqueeze", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -67,6 +67,8 @@ void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_
 
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
+void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+
 void CreateReshapeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -168,7 +168,6 @@ class BaseOpBuilder : public IOpBuilder {
         {"GroupNormalization", QNN_OP_GROUP_NORM},
         {"HardSigmoid", QNN_OP_ELEMENT_WISE_NEURON},
         {"HardSwish", QNN_OP_HARD_SWISH},
-        {"Identity", QNN_OP_RESHAPE},
         {"InstanceNormalization", QNN_OP_INSTANCE_NORM},
         {"LRN", QNN_OP_LRN},
         {"LSTM", QNN_OP_LSTM},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -168,6 +168,7 @@ class BaseOpBuilder : public IOpBuilder {
         {"GroupNormalization", QNN_OP_GROUP_NORM},
         {"HardSigmoid", QNN_OP_ELEMENT_WISE_NEURON},
         {"HardSwish", QNN_OP_HARD_SWISH},
+        {"Identity", QNN_OP_RESHAPE},
         {"InstanceNormalization", QNN_OP_INSTANCE_NORM},
         {"LRN", QNN_OP_LRN},
         {"LSTM", QNN_OP_LSTM},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/identity_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/identity_op_builder.cc
@@ -1,0 +1,91 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Maps ONNX Identity to QNN Transpose with identity permutation [0, 1, ..., rank-1].
+// QNN has no native Identity op. Same-shape Reshape is rejected by HTP graph compose,
+// but identity-perm Transpose is a well-supported no-op pattern on all QNN backends.
+class IdentityOpBuilder : public BaseOpBuilder {
+ public:
+  IdentityOpBuilder() : BaseOpBuilder("IdentityOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(IdentityOpBuilder);
+
+ protected:
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status IdentityOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                           const OrtNodeUnit& node_unit,
+                                                           std::vector<std::string>&& input_names,
+                                                           const Ort::Logger& logger,
+                                                           bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+
+  if (input_names.size() < 1) {
+    return Ort::Status();
+  }
+
+  // Build identity permutation from input rank
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape");
+  uint32_t rank = static_cast<uint32_t>(input_shape.size());
+
+  std::vector<uint32_t> perm_data(rank);
+  for (uint32_t i = 0; i < rank; ++i) {
+    perm_data[i] = i;
+  }
+
+  std::vector<uint32_t> perm_shape{rank};
+  QnnParamWrapper perm_param(node_unit.Index(), node_unit.Name(), QNN_OP_TRANSPOSE_PARAM_PERM,
+                             std::move(perm_shape), std::move(perm_data));
+  std::vector<std::string> param_tensor_names;
+  param_tensor_names.push_back(perm_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(perm_param));
+
+  // Output tensor copies input data type and quantization
+  const auto& output_name = node_unit.Outputs()[0].name;
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
+  Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  const QnnTensorWrapper& input_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]);
+
+  QnnTensorWrapper output_tensorwrapper(output_name,
+                                        tensor_type,
+                                        input_tensor_wrapper.GetTensorDataType(),
+                                        input_tensor_wrapper.GetQnnQuantParams().Copy(),
+                                        std::vector<uint32_t>(input_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
+
+  std::vector<std::string> output_names{output_name};
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_TRANSPOSE,
+                                                std::move(input_names),
+                                                std::move(output_names),
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
+                "Failed to add node.");
+
+  return Ort::Status();
+}
+
+void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<IdentityOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/identity_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/identity_op_builder.cc
@@ -7,14 +7,13 @@
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
-#include "core/providers/qnn/ort_api.h"
 
 namespace onnxruntime {
 namespace qnn {
 
 // Maps ONNX Identity to QNN Transpose with identity permutation [0, 1, ..., rank-1].
-// QNN has no native Identity op. Same-shape Reshape is rejected by HTP graph compose,
-// but identity-perm Transpose is a well-supported no-op pattern on all QNN backends.
+// QNN has no native Identity op and rejects same-shape Reshape during HTP graph compose.
+// Identity-perm Transpose is optimized to zero cycles on HTP.
 class IdentityOpBuilder : public BaseOpBuilder {
  public:
   IdentityOpBuilder() : BaseOpBuilder("IdentityOpBuilder") {}
@@ -26,6 +25,14 @@ class IdentityOpBuilder : public BaseOpBuilder {
                                           std::vector<std::string>&& input_names,
                                           const Ort::Logger& logger,
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status OverrideOutputQuantParam(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       const Ort::Logger& logger,
+                                       const std::vector<std::string>& input_names,
+                                       size_t output_index,
+                                       Qnn_DataType_t qnn_data_type,
+                                       QnnQuantParamsWrapper& quant_param) const override ORT_MUST_USE_RESULT;
 };
 
 Ort::Status IdentityOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
@@ -33,13 +40,6 @@ Ort::Status IdentityOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
                                                            std::vector<std::string>&& input_names,
                                                            const Ort::Logger& logger,
                                                            bool do_op_validation) const {
-  ORT_UNUSED_PARAMETER(logger);
-
-  if (input_names.size() < 1) {
-    return Ort::Status();
-  }
-
-  // Build identity permutation from input rank
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape");
   uint32_t rank = static_cast<uint32_t>(input_shape.size());
@@ -49,38 +49,29 @@ Ort::Status IdentityOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
     perm_data[i] = i;
   }
 
-  std::vector<uint32_t> perm_shape{rank};
   QnnParamWrapper perm_param(node_unit.Index(), node_unit.Name(), QNN_OP_TRANSPOSE_PARAM_PERM,
-                             std::move(perm_shape), std::move(perm_data));
+                             std::vector<uint32_t>{rank}, std::move(perm_data));
   std::vector<std::string> param_tensor_names;
   param_tensor_names.push_back(perm_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(perm_param));
 
-  // Output tensor copies input data type and quantization
-  const auto& output_name = node_unit.Outputs()[0].name;
-  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
-  Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+  return ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names),
+                        std::move(param_tensor_names), logger, do_op_validation, QNN_OP_TRANSPOSE);
+}
 
-  const QnnTensorWrapper& input_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]);
+Ort::Status IdentityOpBuilder::OverrideOutputQuantParam(QnnModelWrapper& qnn_model_wrapper,
+                                                        const OrtNodeUnit& node_unit,
+                                                        const Ort::Logger& logger,
+                                                        const std::vector<std::string>& input_names,
+                                                        size_t output_index,
+                                                        Qnn_DataType_t qnn_data_type,
+                                                        QnnQuantParamsWrapper& quant_param) const {
+  if (!quant_param.IsPerTensor()) {
+    return Ort::Status();
+  }
 
-  QnnTensorWrapper output_tensorwrapper(output_name,
-                                        tensor_type,
-                                        input_tensor_wrapper.GetTensorDataType(),
-                                        input_tensor_wrapper.GetQnnQuantParams().Copy(),
-                                        std::vector<uint32_t>(input_shape));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-
-  std::vector<std::string> output_names{output_name};
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
-                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                QNN_OP_TRANSPOSE,
-                                                std::move(input_names),
-                                                std::move(output_names),
-                                                std::move(param_tensor_names),
-                                                do_op_validation),
-                "Failed to add node.");
-
-  return Ort::Status();
+  return SetOutputQParamEqualToInputIfNearlyEqual(qnn_model_wrapper, node_unit, logger, input_names,
+                                                  0, output_index, qnn_data_type, quant_param);
 }
 
 void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/test/providers/qnn/identity_test.cc
+++ b/onnxruntime/test/providers/qnn/identity_test.cc
@@ -25,34 +25,34 @@ static GetTestModelFn BuildIdentityTestCase(const TestInputDef<DataType>& input_
 }
 
 template <typename QuantType>
-static GetTestQDQModelFn<QuantType> BuildQDQIdentityTestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
+static GetTestQDQModelFn<QuantType> BuildQDQIdentityTestCase(const TestInputDef<float>& input_def,
+                                                             float output_scale_perturbation = 1.0f) {
+  return [input_def, output_scale_perturbation](ModelTestBuilder& builder,
+                                                std::vector<QuantParams<QuantType>>& output_qparams) {
     ORT_UNUSED_PARAMETER(output_qparams);
-
     MakeTestInput(builder, "input", input_def);
-
     const QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
     const std::string input_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input",
                                   input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("identity", "Identity", {input_qdq}, {"Y"}, kOnnxDomain);
-
+    const float output_scale = input_qparams.scale * output_scale_perturbation;
     AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "Y",
-                                                     input_qparams.scale,
+                                                     output_scale,
                                                      input_qparams.zero_point);
   };
 }
 
 template <typename QuantType = uint8_t>
 static void RunIdentityQDQTest(const TestInputDef<float>& input_def,
-                               ExpectedEPNodeAssignment expected_ep_assignment) {
+                               ExpectedEPNodeAssignment expected_ep_assignment,
+                               float output_scale_perturbation = 1.0f) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
   TestQDQModelAccuracy(BuildIdentityTestCase<float>(input_def),
-                       BuildQDQIdentityTestCase<QuantType>(input_def),
+                       BuildQDQIdentityTestCase<QuantType>(input_def, output_scale_perturbation),
                        provider_options,
                        18,
                        expected_ep_assignment);
@@ -73,13 +73,15 @@ static void RunIdentityNonQDQOnHTP(const TestInputDef<DataType>& input_def,
 }
 
 TEST_F(QnnHTPBackendTests, IdentityU8) {
+  // Use slightly different output scale (1.0001x) to exercise
+  // SetOutputQParamEqualToInputIfNearlyEqual snapping output qparams to input.
   RunIdentityQDQTest(TestInputDef<float>({1, 3, 4, 4}, false, 0.0f, 1.0f),
-                     ExpectedEPNodeAssignment::All);
+                     ExpectedEPNodeAssignment::All, /*output_scale_perturbation=*/1.0001f);
 }
 
 TEST_F(QnnHTPBackendTests, IdentityF32) {
   RunIdentityNonQDQOnHTP<float>(TestInputDef<float>({1, 3, 4, 4}, false, 0.0f, 10.0f),
-                                ExpectedEPNodeAssignment::All, 5e-3f);
+                                ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, IdentityI32) {
@@ -89,7 +91,7 @@ TEST_F(QnnHTPBackendTests, IdentityI32) {
 
 TEST_F(QnnHTPBackendTests, IdentityRank1F32) {
   RunIdentityNonQDQOnHTP<float>(TestInputDef<float>({16}, false, 0.0f, 10.0f),
-                                ExpectedEPNodeAssignment::All, 5e-3f);
+                                ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/identity_test.cc
+++ b/onnxruntime/test/providers/qnn/identity_test.cc
@@ -1,0 +1,100 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+
+#include "core/graph/graph.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+template <typename DataType>
+static GetTestModelFn BuildIdentityTestCase(const TestInputDef<DataType>& input_def) {
+  return [input_def](ModelTestBuilder& builder) {
+    MakeTestInput<DataType>(builder, "input", input_def);
+    builder.MakeOutput("Y");
+    builder.AddNode("identity", "Identity", {"input"}, {"Y"}, kOnnxDomain);
+  };
+}
+
+template <typename QuantType>
+static GetTestQDQModelFn<QuantType> BuildQDQIdentityTestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
+    ORT_UNUSED_PARAMETER(output_qparams);
+
+    MakeTestInput(builder, "input", input_def);
+
+    const QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+    const std::string input_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_in", "input",
+                                  input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("identity", "Identity", {input_qdq}, {"Y"}, kOnnxDomain);
+
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "Y",
+                                                     input_qparams.scale,
+                                                     input_qparams.zero_point);
+  };
+}
+
+template <typename QuantType = uint8_t>
+static void RunIdentityQDQTest(const TestInputDef<float>& input_def,
+                               ExpectedEPNodeAssignment expected_ep_assignment) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildIdentityTestCase<float>(input_def),
+                       BuildQDQIdentityTestCase<QuantType>(input_def),
+                       provider_options,
+                       18,
+                       expected_ep_assignment);
+}
+
+template <typename DataType>
+static void RunIdentityNonQDQOnHTP(const TestInputDef<DataType>& input_def,
+                                   ExpectedEPNodeAssignment expected_ep_assignment,
+                                   float fp32_abs_err = 1e-5f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  RunQnnModelTest(BuildIdentityTestCase<DataType>(input_def),
+                  provider_options,
+                  13,
+                  expected_ep_assignment,
+                  fp32_abs_err);
+}
+
+TEST_F(QnnHTPBackendTests, IdentityU8) {
+  RunIdentityQDQTest(TestInputDef<float>({1, 3, 4, 4}, false, 0.0f, 1.0f),
+                     ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, IdentityF32) {
+  RunIdentityNonQDQOnHTP<float>(TestInputDef<float>({1, 3, 4, 4}, false, 0.0f, 10.0f),
+                                ExpectedEPNodeAssignment::All, 5e-3f);
+}
+
+TEST_F(QnnHTPBackendTests, IdentityI32) {
+  RunIdentityNonQDQOnHTP<int32_t>(TestInputDef<int32_t>({1, 3, 4, 4}, false, -100, 100),
+                                  ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, IdentityRank1F32) {
+  RunIdentityNonQDQOnHTP<float>(TestInputDef<float>({16}, false, 0.0f, 10.0f),
+                                ExpectedEPNodeAssignment::All, 5e-3f);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif


### PR DESCRIPTION
Identity op usually get cleaned up, however, when `Identity` op is graph output, no elimination pass can handle this case (level 1 optimizer pass will be skipped). 

Without QNN EP support, they fall to CPUExecutionProvider and split the graph into multiple subgraphs, failing compilation. After this change, Identity nodes run on NPU with 0 cycles and 0 execution time. HTP optimizes them away completely, so no actual cost. 