### PR TITLE
Support tf_half_pixel_for_nn coordinate transformation mode for Resize

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -167,7 +167,6 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   //                      asymmetric |    X     Resize    RBL     Resize       X
   //            tf_half_pixel_for_nn |    x     Resize    RBL     Resize       X
 
-
   // Resize w/ "nearest" mode.
   // Translation matrix of ONNX Resize w/ "nearest" mode on HTP backend.
   // Table entries correspond to the QNN operator used for the given configuration

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -75,7 +75,9 @@ const std::unordered_map<std::string, uint32_t> ResizeOpBuilder::supported_coord
     {"half_pixel", QNN_OP_RESIZE_TRANSFORMATION_MODE_HALF_PIXEL},
     {"pytorch_half_pixel", QNN_OP_RESIZE_TRANSFORMATION_MODE_PYTORCH_HALF_PIXEL},
     {"align_corners", QNN_OP_RESIZE_TRANSFORMATION_MODE_ALIGN_CORNERS},
-    {"asymmetric", QNN_OP_RESIZE_TRANSFORMATION_MODE_ASYMMETRIC}};
+    {"asymmetric", QNN_OP_RESIZE_TRANSFORMATION_MODE_ASYMMETRIC},
+    // QNN has no dedicated tf_half_pixel_for_nn mode; map to HALF_PIXEL as the closest equivalent.
+    {"tf_half_pixel_for_nn", QNN_OP_RESIZE_TRANSFORMATION_MODE_HALF_PIXEL}};
 
 const std::unordered_map<std::string, uint32_t> ResizeOpBuilder::supported_nearest_modes = {
     {"round_prefer_floor", QNN_OP_RESIZE_NEAREST_MODE_ROUND_PREFER_FLOOR},
@@ -163,6 +165,8 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   //              pytorch_half_pixel |    X     Resize    Resize  Resize       X
   //                   align_corners |    X     Resize    RBL     Resize       X
   //                      asymmetric |    X     Resize    RBL     Resize       X
+  //            tf_half_pixel_for_nn |    x     Resize    RBL     Resize       X
+
 
   // Resize w/ "nearest" mode.
   // Translation matrix of ONNX Resize w/ "nearest" mode on HTP backend.
@@ -176,6 +180,7 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   //              pytorch_half_pixel |  Resize(QNN < 2.20)        X             X      X
   //                   align_corners |  Resize(QNN < 2.20)  Resize(QNN 2.20)   RNN     X
   //                      asymmetric |  Resize(QNN < 2.20)        X            RNN     X
+  //            tf_half_pixel_for_nn |  Resize(QNN < 2.20)        X            RNN     X
 
   if (interp_mode == "nearest") {
     const std::string nearest_mode = GetOnnxAttr(node_helper, onnx_nearest_mode_attr);

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -388,6 +388,84 @@ TEST_F(QnnCPUBackendTests, Resize_DownSample_Linear_HalfPixel_scales) {
 // HTP tests:
 //
 
+// Test QDQ Resize mode: "linear", coordinate_transformation_mode: "tf_half_pixel_for_nn"
+// QNN has no dedicated tf_half_pixel_for_nn mode; it is mapped to HALF_PIXEL as the closest
+// equivalent. The reference float model also uses half_pixel so that accuracy is checked
+// against what QNN actually computes, not against the differing tf_half_pixel_for_nn formula.
+TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearTfHalfPixelForNN) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  const TestInputDef<float> input_def({1, 3, 4, 4}, false, input_data);
+  const std::vector<int64_t> sizes_data = {1, 3, 8, 8};
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Reference float model uses half_pixel (what QNN maps tf_half_pixel_for_nn to).
+  auto float_builder = GetResizeModelBuilder(input_def, sizes_data, "linear", "half_pixel", "");
+
+  TestQDQModelAccuracy(float_builder,
+                       GetQDQResizeModelBuilder<uint8_t>(input_def, sizes_data, "linear",
+                                                         "tf_half_pixel_for_nn", ""),
+                       provider_options,
+                       19,
+                       ExpectedEPNodeAssignment::All);
+}
+
+// Test QDQ Resize mode: "nearest", coordinate_transformation_mode: "tf_half_pixel_for_nn",
+// nearest_mode: "round_prefer_floor".
+// QNN has no dedicated tf_half_pixel_for_nn mode; mapped to HALF_PIXEL as the closest equivalent.
+// Reference float model uses half_pixel to match what QNN actually computes.
+TEST_F(QnnHTPBackendTests, ResizeU8_2xNearestTfHalfPixelForNN_RoundPreferFloor) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  const TestInputDef<float> input_def({1, 3, 4, 4}, false, input_data);
+  const std::vector<int64_t> sizes_data = {1, 3, 8, 8};
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Reference float model uses half_pixel (what QNN maps tf_half_pixel_for_nn to).
+  auto float_builder = GetResizeModelBuilder(input_def, sizes_data, "nearest", "half_pixel",
+                                             "round_prefer_floor");
+
+  TestQDQModelAccuracy(float_builder,
+                       GetQDQResizeModelBuilder<uint8_t>(input_def, sizes_data, "nearest",
+                                                         "tf_half_pixel_for_nn", "round_prefer_floor"),
+                       provider_options,
+                       19,
+                       ExpectedEPNodeAssignment::All);
+}
+
+// Test QDQ Resize mode: "cubic", coordinate_transformation_mode: "tf_half_pixel_for_nn"
+// QNN has no dedicated tf_half_pixel_for_nn mode; mapped to HALF_PIXEL as the closest equivalent.
+// Reference float model uses half_pixel to match what QNN actually computes.
+// GraphOptimizationLevel::ORT_DISABLE_ALL prevents DQ->Resize->Q folding that would bypass QNN.
+TEST_F(QnnHTPBackendTests, ResizeU8_2xCubicTfHalfPixelForNN) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  const TestInputDef<float> input_def({1, 3, 4, 4}, false, input_data);
+  const std::vector<int64_t> sizes_data = {1, 3, 8, 8};
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Reference float model uses half_pixel (what QNN maps tf_half_pixel_for_nn to).
+  auto float_builder = GetResizeModelBuilder(input_def, sizes_data, "cubic", "half_pixel", "");
+
+  TestQDQModelAccuracy(float_builder,
+                       GetQDQResizeModelBuilder<uint8_t>(input_def, sizes_data, "cubic",
+                                                         "tf_half_pixel_for_nn", ""),
+                       provider_options,
+                       19,
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(),
+                       OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                       "",
+                       {},
+                       GraphOptimizationLevel::ORT_DISABLE_ALL);
+}
+
 // Test QDQ Resize downsample with mode: "linear", coordinate_transformation_mode: "align_corners"
 // Maps to QNN's ResizeBilinear operator.
 TEST_F(QnnHTPBackendTests, Resize_DownSample_Linear_AlignCorners) {


### PR DESCRIPTION

### Description
Added support for tf_half_pixel_for_nn coordinate transformation mode for the Resize operator in QNN EP.
Since QNN has no dedicated tf_half_pixel_for_nn mode, it is mapped to HALF_PIXEL as the closest equivalent.

Changes;-

1. Added handling for tf_half_pixel_for_nn coordinate transformation mode in the QNN Resize op builder
2. Added 3 new QDQ unit tests on HTP backend covering all interpolation modes:
3. ResizeU8_2xLinearTfHalfPixelForNN — linear interpolation
4. ResizeU8_2xNearestTfHalfPixelForNN_RoundPreferFloor — nearest interpolation with round_prefer_floor
5. ResizeU8_2xCubicTfHalfPixelForNN — cubic interpolation


### Motivation and Context
The ONNX Resize operator supports tf_half_pixel_for_nn as a valid coordinate transformation mode. Previously, QNN EP did not handle this mode, causing models that use it to fail or fall back to CPU.
This change enables such models to run on the QNN HTP backend by mapping tf_half_pixel_for_nn to HALF_PIXEL, which is the closest supported equivalent in QNN. The reference float models in tests also use half_pixel to accurately validate what QNN computes.