### PR TITLE
[QNN EP] Enable static MSVC runtime for providers_qnn DLL

### DIFF
--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -134,7 +134,8 @@ $CommonArgs = `
     "--build_shared_lib", `
     "--cmake_generator", $CMakeGenerator, `
     "--config", $Config, `
-    "--parallel"
+    "--parallel", `
+    "--enable_msvc_static_runtime"
 
 $QnnArgs = "--use_qnn", "--qnn_home", "$QairtSdkRoot"
 if ($OrtPrebuiltRoot -ne "") {

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -137,6 +137,12 @@ $CommonArgs = `
     "--parallel", `
     "--enable_msvc_static_runtime"
 
+# Use static MSVC runtime for ARM64 builds to eliminate MSVCP140.dll and
+# VCRUNTIME140.dll dependencies from the shipping QNN EP DLL.
+if ($Arch -in @("aarch64", "arm64", "arm64ec")) {
+    $CommonArgs += "--enable_msvc_static_runtime"
+}
+
 $QnnArgs = "--use_qnn", "--qnn_home", "$QairtSdkRoot"
 if ($OrtPrebuiltRoot -ne "") {
     $OrtPrebuiltRoot = Resolve-Path -Path $OrtPrebuiltRoot

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -134,8 +134,7 @@ $CommonArgs = `
     "--build_shared_lib", `
     "--cmake_generator", $CMakeGenerator, `
     "--config", $Config, `
-    "--parallel", `
-    "--enable_msvc_static_runtime"
+    "--parallel"
 
 # Use static MSVC runtime for ARM64 builds to eliminate MSVCP140.dll and
 # VCRUNTIME140.dll dependencies from the shipping QNN EP DLL.


### PR DESCRIPTION
### Description

- Add --enable_msvc_static_runtime to build args, removing MSVCP140.dll and VCRUNTIME140.dll dependencies




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


