### PR TITLE
Rename zip arguments to archive

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -71,10 +71,10 @@ on:
       upload_nuget:
         default: false
         type: boolean
-      build_zip:
+      build_archive:
         default: false
         type: boolean
-      upload_zip:
+      upload_archive:
         default: false
         type: boolean
       build_aar:
@@ -126,9 +126,9 @@ jobs:
           qcom/build_and_test.py
           --target-py-version ${{inputs.target_py_vsn}}
           ${{ inputs.build_nuget == true && '--build-nuget' || '' }}
-          ${{ inputs.build_zip == true && '--build-zip' || '' }}
+          ${{ inputs.build_archive == true && '--build-archive' || '' }}
           ${{ inputs.build_aar == true && '--build-aar' || '' }}
-          ${{ inputs.upload_test_archive == true && 'archive' || 'build' }}_ort_${{ inputs.target_os }}_${{ inputs.target_arch }}
+          ${{inputs.upload_test_archive == true && 'archive' || 'build'}}_ort_${{inputs.target_os}}_${{ inputs.target_arch }}
 
       - name: Test ${{inputs.target_os}} ${{ inputs.target_arch }} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
         if: ${{ inputs.run_tests && inputs.build_test_same_runner }}
@@ -190,7 +190,7 @@ jobs:
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/Qualcomm.ML.OnnxRuntime.QNN*.nupkg"
 
       - name: Upload Archive to Artifactory
-        if: ${{ inputs.upload_zip }}
+        if: ${{ inputs.upload_archive }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-${{ inputs.target_os == 'linux' && 'tgz' || 'zip' }}"

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -50,8 +50,8 @@ on:
         description: "If true, build a NuGet package with the first ARM64 build."
         type: boolean
         default: true
-      windows_arm64_build_zip:
-        description: "If true, build a zip archive with the first ARM64 build."
+      windows_arm64_build_archive:
+        description: "If true, build an archive with the first ARM64 build."
         type: boolean
         default: true
 
@@ -101,9 +101,9 @@ jobs:
       run_tests: false
       # Upload the test archive with the first Python version we encounter
       upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
-      # Build Zip with the first Python version we encounter
-      build_zip: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
-      upload_zip: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
+      # Build Tgz with the first Python version we encounter
+      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
+      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
 
   build-linux-aarch64-oe-gcc11_2:
       if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
@@ -155,8 +155,8 @@ jobs:
       test_wheel: false
       # For each arch, upload the test archive with the first Python version we encounter
       upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
-      # On ARM64, build NuGet/Zip with the first python version we encounter
+      # On ARM64, build NuGet/Archive with the first python version we encounter
       build_nuget: ${{ inputs.windows_arm64_build_nuget && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_nuget: ${{ inputs.windows_arm64_build_nuget && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
-      build_zip: ${{ inputs.windows_arm64_build_zip && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
-      upload_zip: ${{ inputs.windows_arm64_build_zip && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+      build_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+      upload_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -48,7 +48,7 @@ jobs:
       windows_target_archs: ${{ inputs.windows_target_archs }}
       windows_target_py_vsns: ${{ inputs.windows_target_py_vsns }}
       windows_arm64_build_nuget: true
-      windows_arm64_build_zip: true
+      windows_arm64_build_archive: true
       nightly_build: ${{ inputs.nightly_build }}
       version_suffix: ${{ inputs.version_suffix }}
 

--- a/docs/execution_providers/build.md
+++ b/docs/execution_providers/build.md
@@ -258,10 +258,10 @@ Located in `build/Release/Release/nuget-local-artifacts/` (Windows):
 
 #### Archives
 
-Located in `build/`:
+Located in `build/Release/Release/dist/` (Windows) or `build/Release/dist/` (Linux):
 
-* Windows: `onnxruntime-[platform]-[arch]-[version].zip`
-* Linux: `onnxruntime-[platform]-[arch]-[version].tgz`
+* Windows: `onnxruntime-qnn-[version]-[platform]-[arch].zip`
+* Linux: `onnxruntime-qnn-[version]-[platform]-[arch].tgz`
 
 ## Advanced Usage
 

--- a/docs/execution_providers/build.md
+++ b/docs/execution_providers/build.md
@@ -45,7 +45,7 @@ The build system uses a task-based approach via `python qcom/build_and_test.py`.
 * `--ort-prebuilt PATH`: Path to pre-built ONNX Runtime SDK (optional)
 * `--target-py-version [3.10/3.11/3.12/3.13/3.14]`: Python version for wheel building (default: 3.12 on Windows, 3.10 on Linux)
 * `--build-nuget`: Enable building NuGet packages for .NET bindings
-* `--build-zip`: Enable building Zip archives
+* `--build-archive`: Enable building archives
 * `--venv-path PATH`: Virtual environment path (default: ./venv)
 * `--dry-run`: Print the build plan without executing
 * `--only`: Run only specified tasks, skipping dependencies
@@ -256,11 +256,12 @@ Located in `build/Release/Release/nuget-local-artifacts/` (Windows):
 
 * `Qualcomm.ML.OnnxRuntime.QNN.[version].nupkg`
 
-#### Zip Archives
+#### Archives
 
 Located in `build/`:
 
-* `onnxruntime-[platform]-[arch]-[version].zip`
+* Windows: `onnxruntime-[platform]-[arch]-[version].zip`
+* Linux: `onnxruntime-[platform]-[arch]-[version].tgz`
 
 ## Advanced Usage
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -169,9 +169,9 @@ Environment variables
         help="Enable building NuGet packages for .NET bindings.",
     )
     parser.add_argument(
-        "--build-zip",
+        "--build-archive",
         action="store_true",
-        help="Enable building Zip archive.",
+        help="Enable building release archive.",
     )
     parser.add_argument(
         "--build-aar",
@@ -201,7 +201,7 @@ class TaskLibrary:
         qairt_sdk_root: Path | None,
         docker_ccache_root: Path | None,
         build_nuget: bool,
-        build_zip: bool,
+        build_archive: bool,
         build_aar: bool,
     ) -> None:
         self.__python_executable = python_executable
@@ -213,7 +213,7 @@ class TaskLibrary:
         self.__qairt_sdk_root = qairt_sdk_root
         self.__docker_ccache_root = docker_ccache_root
         self.__build_nuget = build_nuget
-        self.__build_zip = build_zip
+        self.__build_archive = build_archive
         self.__build_aar = build_aar
 
     @staticmethod
@@ -267,7 +267,7 @@ class TaskLibrary:
                 "build",
                 extra_args=extra_args,
                 env=env,
-                build_zip=self.__build_zip,
+                build_archive=self.__build_archive,
             )
         )
 
@@ -471,7 +471,7 @@ class TaskLibrary:
                 self.__target_py_version,
                 self.__qairt_sdk_root,
                 self.__docker_ccache_root,
-                self.__build_zip,
+                self.__build_archive,
             ),
         )
 
@@ -542,7 +542,7 @@ class TaskLibrary:
                     "build",
                     False,
                     self.__build_nuget,
-                    self.__build_zip,
+                    self.__build_archive,
                 )
             )
 
@@ -1147,7 +1147,7 @@ def plan_from_dependencies(
     qairt_sdk_root: Path | None,
     docker_ccache_root: Path | None,
     build_nuget: bool,
-    build_zip: bool,
+    build_archive: bool,
     build_aar: bool,
 ) -> Plan:
     """
@@ -1163,7 +1163,7 @@ def plan_from_dependencies(
         qairt_sdk_root,
         docker_ccache_root,
         build_nuget,
-        build_zip,
+        build_archive,
         build_aar,
     )
     plan = Plan()
@@ -1217,7 +1217,7 @@ def plan_from_task_list(
     qairt_sdk_root: Path | None,
     docker_ccache_root: Path | None,
     build_nuget: bool,
-    build_zip: bool,
+    build_archive: bool,
     build_aar: bool,
 ) -> Plan:
     """
@@ -1233,7 +1233,7 @@ def plan_from_task_list(
         qairt_sdk_root,
         docker_ccache_root,
         build_nuget,
-        build_zip,
+        build_archive,
         build_aar,
     )
     plan = Plan()
@@ -1271,7 +1271,7 @@ def build_and_test():
             qairt_sdk_root,
             docker_ccache_root,
             args.build_nuget,
-            args.build_zip,
+            args.build_archive,
             args.build_aar,
         )
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -171,7 +171,7 @@ Environment variables
     parser.add_argument(
         "--build-archive",
         action="store_true",
-        help="Enable building release archive.",
+        help="Enable building archive.",
     )
     parser.add_argument(
         "--build-aar",

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -150,7 +150,7 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
             cmd.extend(["-BuildNuget", "1"])
 
         if build_archive:
-            cmd.extend(["-BuildZip", "1"])
+            cmd.extend(["-BuildArchive", "1"])
 
         super().__init__(group_name, [cmd], env=ort_build_env_vars())
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -38,7 +38,7 @@ class BuildEpDockerTask(CompositeTask):
         target_py_version: TargetPyVersionT | None,
         qairt_sdk_root: Path | None,
         ccache_root: Path | None,
-        build_zip: bool = False,
+        build_archive: bool = False,
     ) -> None:
         dist_rel_dir = Path("build") / f"linux-{target_arch}" / config / "dist"
 
@@ -58,7 +58,7 @@ class BuildEpDockerTask(CompositeTask):
                     venv_path=DOCKER_REPO_ROOT / "build" / "venv.build",
                     qairt_sdk_root=qairt_sdk_root,
                     ccache_root=ccache_root,
-                    build_zip=build_zip,
+                    build_archive=build_archive,
                 ),
             ],
         )
@@ -80,7 +80,7 @@ class BuildEpLinuxTask(BashScriptsWithVenvTask):
         mode: str,
         extra_args: Iterable[str] | None = None,
         env: Mapping[str, str] | None = None,
-        build_zip: bool = False,
+        build_archive: bool = False,
     ) -> None:
         cmd = [
             str(REPO_ROOT / "qcom" / "scripts" / "linux" / "build.sh"),
@@ -99,8 +99,8 @@ class BuildEpLinuxTask(BashScriptsWithVenvTask):
         if qairt_sdk_root is not None:
             cmd.append(f"--qairt-sdk-root={qairt_sdk_root}")
 
-        if build_zip:
-            cmd.append("--build-tgz")
+        if build_archive:
+            cmd.append("--build-archive")
 
         if extra_args is not None:
             cmd.extend(extra_args)
@@ -121,7 +121,7 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
         mode: str,
         build_as_x: bool = False,
         build_nuget: bool = False,
-        build_zip: bool = False,
+        build_archive: bool = False,
     ) -> None:
         cmd = [
             str(REPO_ROOT / "qcom" / "scripts" / "windows" / "build.ps1"),
@@ -149,7 +149,7 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
         if build_nuget:
             cmd.extend(["-BuildNuget", "1"])
 
-        if build_zip:
+        if build_archive:
             cmd.extend(["-BuildZip", "1"])
 
         super().__init__(group_name, [cmd], env=ort_build_env_vars())

--- a/qcom/ep_build/tasks/docker.py
+++ b/qcom/ep_build/tasks/docker.py
@@ -88,7 +88,7 @@ class DockerBuildAndTestTask(DockerRunTask):
         venv_path: Path | None = None,
         qairt_sdk_root: Path | None = None,
         ccache_root: Path | None = None,
-        build_zip: bool = False,
+        build_archive: bool = False,
     ) -> None:
         # deferred to avoid circular import
         from ..tools import get_package_dir, get_tools_dir  # noqa:PLC0415
@@ -100,8 +100,8 @@ class DockerBuildAndTestTask(DockerRunTask):
         ]
         if venv_path is not None:
             cmd.append(f"--venv-path={venv_path}")
-        if build_zip:
-            cmd.append("--build-zip")
+        if build_archive:
+            cmd.append("--build-archive")
         cmd.extend(tasks)
 
         volumes_with_caches = dict({} if volumes is None else volumes)

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -38,11 +38,11 @@ target_py_version=
 use_cache=1
 warnings_as_errors=1
 build_java=
-build_tgz=
+build_archive=
 for i in "$@"; do
   case $i in
-    --build-tgz)
-      build_tgz=1
+    --build-archive)
+      build_archive=1
       shift
       ;;
     --config=*)
@@ -288,9 +288,9 @@ else
     python "${REPO_ROOT}/qcom/scripts/all/fetch_cmake_deps.py"
 
     package_args=()
-    if [ -n "${build_tgz}" ]; then
-      log_info "Building tgz asset."
-      package_args+=(--build_zip_asset)
+    if [ -n "${build_archive}" ]; then
+      log_info "Building archive asset."
+      package_args+=(--build_archive_asset)
     fi
     if [ -n "${ORT_VERSION_SUFFIX:-}" ]; then
       package_args+=(--version_suffix "${ORT_VERSION_SUFFIX}")

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -16,8 +16,8 @@ param (
     [bool]$BuildNuget = $false,
 
     [Parameter(Mandatory = $false,
-               HelpMessage = "If true, build Zip archive.")]
-    [bool]$BuildZip = $false,
+               HelpMessage = "If true, build archive.")]
+    [bool]$BuildArchive = $false,
 
     [Parameter(Mandatory = $false,
                HelpMessage = "Path to ORT Prebuilt.")]
@@ -342,7 +342,7 @@ else {
                         }
                     }
                 }
-                if ($BuildZip) {
+                if ($BuildArchive) {
                     Use-PyVenv -PyVenv $BuildVEnv {
                         Use-WorkingDir -Path $BuildOutputDir {
                             $PkgAssetsArgs = @(
@@ -354,7 +354,7 @@ else {
                             if ($CMakeGenerator -eq "Ninja") {
                                 $PkgAssetsArgs += "--use_ninja"
                             }
-                            Assert-Success -ErrorMessage "Failed to build zip" {
+                            Assert-Success -ErrorMessage "Failed to build archive" {
                                 python.exe (Join-Path $RepoRoot "tools\ci_build\pkg_assets.py") @PkgAssetsArgs $VersionSuffixArg
                             }
                         }

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -17,7 +17,7 @@ REPO_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", ".."))
 
 sys.path.insert(0, os.path.join(REPO_DIR, "tools", "python"))
 from build_args import parse_arguments  # noqa: E402
-from pkg_assets import build_zip_asset  # noqa: E402
+from pkg_assets import build_archive_asset  # noqa: E402
 from util import (  # noqa: E402
     generate_android_triplets,
     generate_linux_triplets,
@@ -1101,12 +1101,12 @@ def main():
                 use_ninja=(args.cmake_generator == "Ninja"),
             )
 
-        if args.build_zip_asset:
-            build_zip_asset(
+        if args.build_archive_asset:
+            build_archive_asset(
                 source_dir,
                 build_dir,
                 configs,
-                args.zip_asset_name_suffix,
+                args.archive_name_suffix,
                 args.version_suffix,
                 use_ninja=(args.cmake_generator == "Ninja"),
             )

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -386,11 +386,11 @@ def add_csharp_binding_args(parser: argparse.ArgumentParser) -> None:
 def add_packaging_args(parser: argparse.ArgumentParser) -> None:
     """Adds arguments for packaging and distribution."""
     parser.add_argument(
-        "--build_zip_asset", action="store_true", help="Build zip asset package containing QNN EP and dependencies."
+        "--build_archive_asset", action="store_true", help="Build archive asset package containing QNN EP and dependencies."
     )
     parser.add_argument(
-        "--zip_asset_name_suffix",
-        help="Suffix for zip asset name (used for nightly builds).",
+        "--archive_name_suffix",
+        help="Suffix for archive asset name (used for nightly builds).",
     )
 
 

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -386,7 +386,9 @@ def add_csharp_binding_args(parser: argparse.ArgumentParser) -> None:
 def add_packaging_args(parser: argparse.ArgumentParser) -> None:
     """Adds arguments for packaging and distribution."""
     parser.add_argument(
-        "--build_archive_asset", action="store_true", help="Build archive asset package containing QNN EP and dependencies."
+        "--build_archive_asset",
+        action="store_true",
+        help="Build archive asset package containing QNN EP and dependencies.",
     )
     parser.add_argument(
         "--archive_name_suffix",

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -250,7 +250,7 @@ def main():
     Main entry point for standalone execution of pkg_assets.py
     """
     parser = argparse.ArgumentParser(
-        description="Build QNN asset packages",
+        description="Build QNN asset archive packages",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -105,32 +105,32 @@ def get_qnn_asset_file_list():
     return qnn_assets["windows"] if is_windows() else qnn_assets["others"]
 
 
-def build_zip_asset(
+def build_archive_asset(
     source_dir,
     build_dir,
     configs,
-    zip_name_suffix=None,
+    archive_name_suffix=None,
     version_suffix="",
     use_ninja=False,
 ):
     """
-    Build zip asset packages containing QNN EP and dependencies.
+    Build archive asset packages containing QNN EP and dependencies.
 
     Args:
         source_dir: Path to source directory
         build_dir: Path to build directory
         configs: List of build configurations (e.g., ['RelWithDebInfo'])
-        zip_name_suffix: Optional suffix for zip filename
-        version_suffix: Optional version suffix for zip filename
+        archive_name_suffix: Optional suffix for archive filename
+        version_suffix: Optional version suffix for archive filename
         use_ninja: Whether Ninja generator was used
 
     Returns:
-        list[Path]: List of created zip file paths
+        list[Path]: List of created archive file paths
     """
-    created_zips = []
+    created_archives = []
 
     for config in configs:
-        log.info(f"Building zip asset for {config} configuration")
+        log.info(f"Building archive asset for {config} configuration")
 
         # Determine working directory (matching build_python_wheel logic)
         config_build_dir = os.path.join(build_dir, config)
@@ -146,7 +146,7 @@ def build_zip_asset(
         dist_dir = os.path.join(cwd, "dist")
         os.makedirs(dist_dir, exist_ok=True)
 
-        # Generate zip filename
+        # Generate archive filename
         platform_name = platform.system().lower()
         platform_abbr = {"windows": "win"}
         if platform_name in platform_abbr:
@@ -162,16 +162,16 @@ def build_zip_asset(
 
         archive_ext = ".zip" if is_windows() else ".tgz"
 
-        zip_name = "onnxruntime-qnn"
+        archive_name = "onnxruntime-qnn"
         if version:
-            zip_name += f"-{version}"
+            archive_name += f"-{version}"
         if version_suffix:
-            zip_name += f"{version_suffix}"
-        if zip_name_suffix:
-            zip_name += f"-{zip_name_suffix}"
-        zip_name += f"-{platform_name}-{arch}{archive_ext}"
+            archive_name += f"{version_suffix}"
+        if archive_name_suffix:
+            archive_name += f"-{archive_name_suffix}"
+        archive_name += f"-{platform_name}-{arch}{archive_ext}"
 
-        zip_path = Path(dist_dir) / zip_name
+        archive_path = Path(dist_dir) / archive_name
 
         # Get list of files to include
         asset_files = get_qnn_asset_file_list()
@@ -225,24 +225,24 @@ def build_zip_asset(
             raise FileNotFoundError(f"No asset files found in {cwd}. Expected files: {asset_files}")
 
         # Create archive file
-        log.info(f"Creating archive: {zip_path}")
+        log.info(f"Creating archive: {archive_path}")
         if is_windows():
-            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zipf:
                 for _filename, file_path in found_files:
                     arcname = os.path.relpath(file_path, cwd)
                     zipf.write(file_path, arcname)
                     log.debug(f"Added to zip: {arcname}")
         else:
-            with tarfile.open(zip_path, "w:gz") as tgzf:
+            with tarfile.open(archive_path, "w:gz") as tgzf:
                 for _filename, file_path in found_files:
                     arcname = os.path.relpath(file_path, cwd)
                     tgzf.add(file_path, arcname)
                     log.debug(f"Added to tgz: {arcname}")
 
-        log.info(f"Created archive: {zip_path} ({len(found_files)} files)")
-        created_zips.append(zip_path)
+        log.info(f"Created archive: {archive_path} ({len(found_files)} files)")
+        created_archives.append(archive_path)
 
-    return created_zips
+    return created_archives
 
 
 def main():
@@ -250,7 +250,7 @@ def main():
     Main entry point for standalone execution of pkg_assets.py
     """
     parser = argparse.ArgumentParser(
-        description="Build QNN asset zip packages",
+        description="Build QNN asset packages",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -270,9 +270,9 @@ Examples:
         help="Build configuration(s) to package (e.g., RelWithDebInfo, Debug). Can be specified multiple times.",
     )
 
-    parser.add_argument("--suffix", help="Optional suffix for zip filename")
+    parser.add_argument("--suffix", help="Optional suffix for archive filename")
 
-    parser.add_argument("--version_suffix", type=str, default="", help="Optional version suffix for zip filename")
+    parser.add_argument("--version_suffix", type=str, default="", help="Optional version suffix for archive filename")
 
     parser.add_argument("--use_ninja", action="store_true", help="Whether Ninja generator was used for build")
 
@@ -289,21 +289,21 @@ Examples:
         args.config = ["RelWithDebInfo"]
 
     try:
-        created_zips = build_zip_asset(
+        created_archives = build_archive_asset(
             source_dir=args.source_dir,
             build_dir=args.build_dir,
             configs=args.config,
-            zip_name_suffix=args.suffix,
+            archive_name_suffix=args.suffix,
             version_suffix=args.version_suffix,
             use_ninja=args.use_ninja,
         )
 
-        print(f"Successfully created {len(created_zips)} zip package(s):")
-        for zip_path in created_zips:
-            print(f"  {zip_path}")
+        print(f"Successfully created {len(created_archives)} archive package(s):")
+        for archive_path in created_archives:
+            print(f"  {archive_path}")
 
     except Exception as e:
-        log.error(f"Failed to create zip packages: {e}")
+        log.error(f"Failed to create archive packages: {e}")
         sys.exit(1)
 
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Rename zip arguments to archive throughout the codebase


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Rename all zip-specific parameter names, flags, and identifiers to the more generic "archive" term, since the format is now platform-dependent (.zip on Windows, .tgz on Linux):


