### PR TITLE
[OpBuilder] GRU Op Enablement

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -28,6 +28,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateGatherNDOpBuilder("GatherND", *this);
   CreateGemmOpBuilder("Gemm", *this);
   CreateGroupNormalizationOpBuilder("GroupNormalization", *this);
+  CreateGRUOpBuilder("GRU", *this);
   CreateIdentityOpBuilder("Identity", *this);
   CreateInstanceNormalizationOpBuilder("InstanceNormalization", *this);
   CreateInverseOpBuilder("Inverse", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -71,6 +71,7 @@ void CreateGatherOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateGatherNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateGroupNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateGRUOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateHardSigmoidOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateInstanceNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -132,6 +132,8 @@ Ort::Status GRUOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   }
 
   OrtNodeAttrHelper node_helper(node_unit);
+  RETURN_IF(node_helper.Get("layout", static_cast<int64_t>(0)) != 0,
+            "QNN EP doesn't support layout=1 for GRU (ORT CPU EP cannot provide a reference for accuracy validation).");
   RETURN_IF(node_helper.HasAttr("clip"), "QNN EP doesn't support clip for GRU.");
   const std::vector<std::string> activations = node_helper.Get("activations", std::vector<std::string>{});
   RETURN_IF((activations.size() >= 2 && (activations[0] != "sigmoid" || activations[1] != "tanh")) ||
@@ -208,6 +210,9 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(linear_before_reset),
                                          QNN_OP_GRU_PARAM_LINEAR_BEFORE_RESET, param_names));
+  // TODO: Once the QNN CPU backend accuracy issue with time_major=true is resolved, remove the CPU
+  // workaround below and the associated Transpose nodes (X pre-transpose, per-step Y-to-h transpose,
+  // and post-concat transpose), then let CPU use time_major=true uniformly with layout=0.
   // time_major: on CPU, always use false to work around its batch dimension bug with time_major=true.
   // On other backends (HTP), follow the ONNX layout attribute: layout=0 -> true, layout=1 -> false.
   const bool is_cpu_backend = qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::CPU;
@@ -330,7 +335,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   // so that per-step slicing produces [batch, 1, input] directly without per-step Reshapes.
   std::string x_source = input_names[0];                               // [seq, batch, input] for HTP, [batch, seq, input] for CPU
   std::vector<uint32_t> x_source_shape = input_tensor_infos[0].shape;  // [seq, batch, input]
-  if (!time_major) {
+  if (is_cpu_backend) {
     std::string x_transposed = utils::UniqueNameGenerator().New(input_names[0], "_transposed_" + direction);
     RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
         node_unit.Index(), input_names[0], x_transposed,
@@ -410,7 +415,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     // Derive next step's initial_h.
     // QNN CPU's Y_h (out[1]) is unreliable, so on CPU we derive h from Y (out[0]) via Transpose.
     // On HTP (time_major=true), Y_h (out[1]) is already [1, batch, hidden] and can be used directly.
-    if (time_major) {
+    if (!is_cpu_backend) {
       // HTP: use Y_h directly as next step's initial_h
       prev_h_name = yh_name;
     } else {
@@ -454,7 +459,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
 
   // For CPU (time_major=false), Transpose [batch, seq, hidden] -> [seq, batch, hidden].
   std::string y_all;
-  if (!time_major) {
+  if (is_cpu_backend) {
     y_all = utils::UniqueNameGenerator().New(node_unit, "_Y_all_" + direction);
     RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
         node_unit.Index(), y_concat, y_all,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -171,9 +171,9 @@ Ort::Status GRUOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// Manually unrolls the GRU across time steps and batch elements.
-// Each QNN GRU node processes a single (time_step, batch_element) with batch_size=1, seq_length=1.
-// This works around QNN CPU/HTP backend bugs where batch_size > 1 produces incorrect results.
+// Manually unrolls the GRU across time steps only (time_major=true).
+// Each QNN GRU node processes a single time step with input shape [1, batch, input] (seq=1, time_major=true).
+// The full batch is processed together in each step, avoiding the batch-element loop entirely.
 Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                              const OrtNodeUnit& node_unit,
                                              const std::string& direction,
@@ -211,15 +211,21 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   const uint32_t seq_length = input_tensor_infos[0].shape[0];
   const int32_t direction_idx = input_tensor_infos[1].shape[0] < 2 || direction == "forward" ? 0 : 1;
 
-  // GRU parameters - shared by all unrolled cells
+  // GRU parameters - shared by all unrolled time-step cells.
+  // Use the actual ONNX direction so QNN sees the correct gate ordering.
+  // Time step ordering for reverse is handled by the unrolling loop (iterating t from seq-1 down to 0).
   std::vector<std::string> param_names;
-  // Always use forward direction for individual cells; time step ordering handled by unrolling loop
+  const uint32_t qnn_direction = (direction == "reverse") ? QNN_OP_GRU_DIRECTION_REVERSE : QNN_OP_GRU_DIRECTION_FORWARD;
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_" + direction,
-                                         QNN_OP_GRU_DIRECTION_FORWARD, QNN_OP_GRU_PARAM_DIRECTION, param_names));
+                                         qnn_direction, QNN_OP_GRU_PARAM_DIRECTION, param_names));
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(linear_before_reset),
                                          QNN_OP_GRU_PARAM_LINEAR_BEFORE_RESET, param_names));
-  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
+  // QNN CPU has a batch bug with time_major=true; QNN HTP has a batch bug with time_major=false.
+  // Pick time_major based on the backend to avoid the respective batch dimension bugs.
+  const bool is_npu_backend = qnn_model_wrapper.GetQnnBackendType() != QnnBackendType::CPU;
+  const bool time_major = is_npu_backend;  // true for HTP, false for CPU
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), time_major,
                                      QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));
 
   // Null tensor for optional inputs
@@ -301,6 +307,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     }
   }
   // initial_h: ONNX in[5] [num_directions, batch_size, hidden_size] -> [1, batch_size, hidden_size]
+  // Shape [1, batch, hidden] matches time_major=true initial_h for seq=1 GRU nodes.
   std::string initial_h_name;
   {
     std::vector<uint32_t> h_shape = {1, batch_size, hidden_size};
@@ -322,90 +329,97 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     }
   }
 
-  // Split initial_h [1, batch, hidden] -> per-batch [hidden_size] tensors
-  std::vector<std::string> prev_h_names(batch_size);
-  for (uint32_t b = 0; b < batch_size; b++) {
-    prev_h_names[b] = utils::UniqueNameGenerator().New(node_unit, "_h_init_b" + std::to_string(b) + "_" + direction);
-    RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, initial_h_name, prev_h_names[b],
-                                             {1, batch_size, hidden_size}, {hidden_size},
-                                             {{0, 1, 1}, {SafeInt<int32_t>(b), SafeInt<int32_t>(b + 1), 1}, {0, hidden_size_sign, 1}},
-                                             0, 0, 0b011U, 0, input_tensor_infos[0].qnn_data_type,
-                                             output_tensor_infos[1].quant_param, do_op_validation, false, false));
-  }
-
-  // Unroll across time steps and batch elements
-  std::vector<std::string> qnn_all_hidden_state_names(seq_length);
+  // Unroll across time steps only.
+  // Each step feeds the full batch with seq=1.
+  // time_major=true:  input [1, batch, input], output Y [1, batch, hidden]
+  // time_major=false: input [batch, 1, input], output Y [batch, 1, hidden]
+  std::vector<std::string> qnn_all_step_hidden_names(seq_length);  // [batch, hidden] per step, ordered by t
+  std::string prev_h_name = initial_h_name;                        // [1, batch, hidden]
 
   for (uint32_t step = 0; step < seq_length; step++) {
-    uint32_t t = direction == "forward" ? step : seq_length - step - 1;
-    std::vector<std::string> per_batch_h(batch_size);
+    // For reverse direction iterate from the last time step to the first.
+    const uint32_t t = (direction == "reverse") ? (seq_length - step - 1) : step;
+    const std::string sfx = "_t" + std::to_string(t) + "_" + direction;
 
-    for (uint32_t b = 0; b < batch_size; b++) {
-      std::vector<std::string> cell_inputs = qnn_gru_input_names;
-      const std::string sfx = "_t" + std::to_string(t) + "_b" + std::to_string(b) + "_" + direction;
+    std::vector<std::string> cell_inputs = qnn_gru_input_names;
 
-      // Slice X[t, b, :] -> [input_size], reshape to [1, 1, input_size]
-      std::string x_flat = utils::UniqueNameGenerator().New(input_names[0], "_xf" + sfx);
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[0], x_flat,
-                                               input_tensor_infos[0].shape, {input_size},
-                                               {{SafeInt<int32_t>(t), SafeInt<int32_t>(t + 1), 1},
-                                                {SafeInt<int32_t>(b), SafeInt<int32_t>(b + 1), 1},
-                                                {0, SafeInt<int32_t>(input_size), 1}},
-                                               0, 0, 0b011U, 0, input_tensor_infos[0].qnn_data_type,
-                                               input_tensor_infos[0].quant_param, do_op_validation, false, false));
-      std::string x_3d = utils::UniqueNameGenerator().New(input_names[0], "_x3d" + sfx);
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(x_flat, x_3d, {input_size}, {1, 1, input_size},
-                                                       input_tensor_infos[0].qnn_data_type,
-                                                       input_tensor_infos[0].quant_param, do_op_validation, false, false));
-      cell_inputs[0] = x_3d;
+    // Slice X[t, :, :] -> [batch, input], reshape to 3D for QNN GRU.
+    std::string x_2d = utils::UniqueNameGenerator().New(input_names[0], "_x2d" + sfx);
+    RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[0], x_2d,
+                                             input_tensor_infos[0].shape, {batch_size, input_size},
+                                             {{SafeInt<int32_t>(t), SafeInt<int32_t>(t + 1), 1},
+                                              {0, SafeInt<int32_t>(batch_size), 1},
+                                              {0, SafeInt<int32_t>(input_size), 1}},
+                                             0, 0, 0b001U, 0, input_tensor_infos[0].qnn_data_type,
+                                             input_tensor_infos[0].quant_param, do_op_validation, false, false));
+    std::string x_3d = utils::UniqueNameGenerator().New(input_names[0], "_x3d" + sfx);
+    const std::vector<uint32_t> x_3d_shape = time_major ? std::vector<uint32_t>{1, batch_size, input_size}
+                                                        : std::vector<uint32_t>{batch_size, 1, input_size};
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(x_2d, x_3d, {batch_size, input_size}, x_3d_shape,
+                                                     input_tensor_infos[0].qnn_data_type,
+                                                     input_tensor_infos[0].quant_param, do_op_validation, false, false));
+    cell_inputs[0] = x_3d;
 
-      // Reshape prev_h [hidden_size] -> [1, 1, hidden_size] for initial_h
-      std::string h_3d = utils::UniqueNameGenerator().New(node_unit, "_h3d" + sfx);
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_names[b], h_3d, {hidden_size}, {1, 1, hidden_size},
-                                                       input_tensor_infos[0].qnn_data_type,
-                                                       output_tensor_infos[1].quant_param, do_op_validation, false, false));
-      cell_inputs[13] = h_3d;
+    // initial_h for this step: prev_h_name is [1, batch, hidden].
+    // Use a no-op Reshape to give it a unique name for this step's cell.
+    std::string h_in = utils::UniqueNameGenerator().New(node_unit, "_h_in" + sfx);
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_name, h_in,
+                                                     {1, batch_size, hidden_size}, {1, batch_size, hidden_size},
+                                                     input_tensor_infos[0].qnn_data_type,
+                                                     output_tensor_infos[1].quant_param, do_op_validation, false, false));
+    cell_inputs[13] = h_in;
 
-      // GRU outputs: Y [1, 1, hidden], Y_h [1, 1, hidden]
-      std::string y_name = utils::UniqueNameGenerator().New(node_unit, "_Y" + sfx);
-      std::string yh_name = utils::UniqueNameGenerator().New(node_unit, "_Yh" + sfx);
-      for (const auto& [name, idx] : std::vector<std::pair<std::string, size_t>>{{y_name, 0}, {yh_name, 1}}) {
-        QnnTensorWrapper tw(name, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[idx].qnn_data_type,
-                            output_tensor_infos[idx].quant_param.Copy(), std::vector<uint32_t>{1, 1, hidden_size});
-        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add GRU output tensor.");
-      }
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::UniqueNameGenerator().New(node_unit, "_cell" + sfx),
-                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_GRU,
-                        std::move(cell_inputs), {y_name, yh_name},
-                        std::vector<std::string>(param_names), do_op_validation),
-                    "Failed to create GRU node.");
+    // GRU outputs:
+    // time_major=true:  Y [1, batch, hidden], Y_h [1, batch, hidden]
+    // time_major=false: Y [batch, 1, hidden], Y_h [1, batch, hidden]
+    const std::vector<uint32_t> y_shape = time_major ? std::vector<uint32_t>{1, batch_size, hidden_size}
+                                                     : std::vector<uint32_t>{batch_size, 1, hidden_size};
+    std::string y_name = utils::UniqueNameGenerator().New(node_unit, "_Y" + sfx);
+    std::string yh_name = utils::UniqueNameGenerator().New(node_unit, "_Yh" + sfx);
+    {
+      QnnTensorWrapper y_tw(y_name, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
+                            output_tensor_infos[0].quant_param.Copy(), std::vector<uint32_t>(y_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(y_tw)), "Failed to add GRU Y output.");
+      QnnTensorWrapper yh_tw(yh_name, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[1].qnn_data_type,
+                             output_tensor_infos[1].quant_param.Copy(), std::vector<uint32_t>{1, batch_size, hidden_size});
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(yh_tw)), "Failed to add GRU Y_h output.");
+    }
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(node_unit, "_cell" + sfx),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_GRU,
+                      std::move(cell_inputs), {y_name, yh_name},
+                      std::vector<std::string>(param_names), do_op_validation),
+                  "Failed to create GRU node.");
 
-      // Reshape Y [1, 1, hidden] -> [hidden_size]
-      std::string h_flat = utils::UniqueNameGenerator().New(node_unit, "_hf" + sfx);
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_name, h_flat, {1, 1, hidden_size}, {hidden_size},
+    // Derive next step's initial_h from Y (out[0]) - Y_h (out[1]) is unreliable on QNN CPU.
+    // Need [1, batch, hidden] for initial_h.
+    std::string y_as_h = utils::UniqueNameGenerator().New(node_unit, "_Y_as_h" + sfx);
+    if (time_major) {
+      // Y is already [1, batch, hidden] - just use a no-op Reshape
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_name, y_as_h,
+                                                       y_shape, {1, batch_size, hidden_size},
                                                        output_tensor_infos[0].qnn_data_type,
                                                        output_tensor_infos[0].quant_param, do_op_validation, false, false));
-      per_batch_h[b] = h_flat;
-      prev_h_names[b] = h_flat;
+    } else {
+      // Y is [batch, 1, hidden] - Transpose to [1, batch, hidden]
+      RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
+          node_unit.Index(), y_name, y_as_h,
+          y_shape, {1, 0, 2}, {1, batch_size, hidden_size},
+          output_tensor_infos[0].qnn_data_type, output_tensor_infos[0].quant_param,
+          do_op_validation, false, false));
     }
+    prev_h_name = y_as_h;
 
-    // Pack per-batch [hidden] -> [batch, hidden]
-    std::string packed = utils::UniqueNameGenerator().New(node_unit, "_pk_t" + std::to_string(t) + "_" + direction);
-    {
-      std::vector<std::string> pp;
-      RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), packed, 0, QNN_OP_PACK_PARAM_AXIS, pp));
-      QnnTensorWrapper tw(packed, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
-                          output_tensor_infos[0].quant_param.Copy(), {batch_size, hidden_size});
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Pack output.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(packed, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
-                                                    std::move(per_batch_h), {packed}, std::move(pp), do_op_validation),
-                    "Failed to create Pack node.");
-    }
-    qnn_all_hidden_state_names[t] = packed;
+    // Reshape Y -> [batch, hidden] for packing across time steps.
+    std::string y_2d = utils::UniqueNameGenerator().New(node_unit, "_Y2d" + sfx);
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_name, y_2d, y_shape, {batch_size, hidden_size},
+                                                     output_tensor_infos[0].qnn_data_type,
+                                                     output_tensor_infos[0].quant_param, do_op_validation, false, false));
+    qnn_all_step_hidden_names[t] = y_2d;
   }
 
-  // Pack time steps [batch, hidden] * seq -> [seq, batch, hidden]
+  // Pack all per-step [batch, hidden] -> [seq, batch, hidden] using QNN_OP_PACK axis=0.
+  // qnn_all_step_hidden_names is indexed by t (0..seq-1) so forward order is naturally correct.
   const std::string y_all = utils::UniqueNameGenerator().New(node_unit, "_Y_all_" + direction);
   {
     std::vector<std::string> pp;
@@ -414,34 +428,30 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                         output_tensor_infos[0].quant_param.Copy(), {seq_length, batch_size, hidden_size});
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Y Pack output.");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(y_all, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
-                                                  std::move(qnn_all_hidden_state_names), {y_all}, std::move(pp), do_op_validation),
+                                                  std::move(qnn_all_step_hidden_names), {y_all}, std::move(pp), do_op_validation),
                   "Failed to create Y Pack node.");
   }
 
-  // Pack final hidden states [hidden] * batch -> [batch, hidden]
-  const std::string y_h_packed = utils::UniqueNameGenerator().New(node_unit, "_Yh_pk_" + direction);
-  {
-    std::vector<std::string> pp;
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), y_h_packed, 0, QNN_OP_PACK_PARAM_AXIS, pp));
-    QnnTensorWrapper tw(y_h_packed, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[1].qnn_data_type,
-                        output_tensor_infos[1].quant_param.Copy(), {batch_size, hidden_size});
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Y_h Pack output.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(y_h_packed, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
-                                                  std::vector<std::string>(prev_h_names), {y_h_packed}, std::move(pp), do_op_validation),
-                  "Failed to create Y_h Pack node.");
-  }
+  // Final Y_h: last step's Y is already [1, batch, hidden] - use prev_h_name directly.
+  // Give it a stable name via a no-op Reshape so it can be referenced as Y_h.
+  const std::string y_h_final = utils::UniqueNameGenerator().New(node_unit, "_Yh_final_" + direction);
+  RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_name, y_h_final,
+                                                   {1, batch_size, hidden_size}, {1, batch_size, hidden_size},
+                                                   output_tensor_infos[1].qnn_data_type,
+                                                   output_tensor_infos[1].quant_param, do_op_validation, false, false));
 
-  // Map to ONNX output shapes
+  // Map to ONNX output shapes:
+  //   Y:   [seq, batch, hidden] -> ONNX [seq, 1, batch, hidden]  (Reshape)
+  //   Y_h: [1, batch, hidden]   -> ONNX [1, batch, hidden]       (no-op Reshape)
   std::vector<std::vector<uint32_t>> onnx_shapes = {{seq_length, 1, batch_size, hidden_size}, {1, batch_size, hidden_size}};
+  const std::string* srcs[2] = {&y_all, &y_h_final};
+  std::vector<std::vector<uint32_t>> src_shapes = {{seq_length, batch_size, hidden_size}, {1, batch_size, hidden_size}};
   for (size_t i = 0; i < 2; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
       const std::string out_name = is_bidirection
-                                       ? utils::UniqueNameGenerator().New(y_all, "_unsqueeze_" + direction)
+                                       ? utils::UniqueNameGenerator().New(*srcs[i], "_unsqueeze_" + direction)
                                        : onnx_outputs[i].name;
-      const std::string& src = (i == 0) ? y_all : y_h_packed;
-      const std::vector<uint32_t> src_shape = (i == 0) ? std::vector<uint32_t>{seq_length, batch_size, hidden_size}
-                                                       : std::vector<uint32_t>{batch_size, hidden_size};
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(src, out_name, src_shape, onnx_shapes[i],
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(*srcs[i], out_name, src_shapes[i], onnx_shapes[i],
                                                        output_tensor_infos[i].qnn_data_type,
                                                        output_tensor_infos[i].quant_param, do_op_validation, false,
                                                        qnn_model_wrapper.IsGraphOutput(out_name)));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -41,39 +41,39 @@ class GRUOpBuilder : public BaseOpBuilder {
                                  const bool& is_bidirection,
                                  std::vector<std::string>& uni_gru_output_names) const;
   Ort::Status AddStridedSlice(QnnModelWrapper& qnn_model_wrapper,
-                                       const OrtNodeUnit& node_unit,
-                                       const std::string& input_name,
-                                       const std::string& output_name,
-                                       const std::vector<uint32_t>& input_shape,
-                                       const std::vector<uint32_t>& output_shape,
-                                       const std::vector<std::vector<int32_t>>& ranges,
-                                       const uint32_t& begin_mask,
-                                       const uint32_t& end_mask,
-                                       const uint32_t& shrink_axes,
-                                       const uint32_t& new_axes_mask,
-                                       const Qnn_DataType_t& tensor_data_type,
-                                       const QnnQuantParamsWrapper& quantize_param,
-                                       bool do_op_validation,
-                                       bool is_for_input,
-                                       bool is_for_output) const;
+                              const OrtNodeUnit& node_unit,
+                              const std::string& input_name,
+                              const std::string& output_name,
+                              const std::vector<uint32_t>& input_shape,
+                              const std::vector<uint32_t>& output_shape,
+                              const std::vector<std::vector<int32_t>>& ranges,
+                              const uint32_t& begin_mask,
+                              const uint32_t& end_mask,
+                              const uint32_t& shrink_axes,
+                              const uint32_t& new_axes_mask,
+                              const Qnn_DataType_t& tensor_data_type,
+                              const QnnQuantParamsWrapper& quantize_param,
+                              bool do_op_validation,
+                              bool is_for_input,
+                              bool is_for_output) const;
 };
 
 Ort::Status GRUOpBuilder::AddStridedSlice(QnnModelWrapper& qnn_model_wrapper,
-                                                   const OrtNodeUnit& node_unit,
-                                                   const std::string& input_name,
-                                                   const std::string& output_name,
-                                                   const std::vector<uint32_t>& input_shape,
-                                                   const std::vector<uint32_t>& output_shape,
-                                                   const std::vector<std::vector<int32_t>>& ranges,
-                                                   const uint32_t& begin_mask,
-                                                   const uint32_t& end_mask,
-                                                   const uint32_t& shrink_axes,
-                                                   const uint32_t& new_axes_mask,
-                                                   const Qnn_DataType_t& tensor_data_type,
-                                                   const QnnQuantParamsWrapper& quantize_param,
-                                                   bool do_op_validation,
-                                                   bool is_for_input,
-                                                   bool is_for_output) const {
+                                          const OrtNodeUnit& node_unit,
+                                          const std::string& input_name,
+                                          const std::string& output_name,
+                                          const std::vector<uint32_t>& input_shape,
+                                          const std::vector<uint32_t>& output_shape,
+                                          const std::vector<std::vector<int32_t>>& ranges,
+                                          const uint32_t& begin_mask,
+                                          const uint32_t& end_mask,
+                                          const uint32_t& shrink_axes,
+                                          const uint32_t& new_axes_mask,
+                                          const Qnn_DataType_t& tensor_data_type,
+                                          const QnnQuantParamsWrapper& quantize_param,
+                                          bool do_op_validation,
+                                          bool is_for_input,
+                                          bool is_for_output) const {
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(output_name)) {
     return Ort::Status();
   }
@@ -85,32 +85,32 @@ Ort::Status GRUOpBuilder::AddStridedSlice(QnnModelWrapper& qnn_model_wrapper,
 
   const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_STRIDED_SLICE);
   std::vector<uint32_t> ranges_data;
-    for (size_t i = 0; i < ranges.size(); i++) {
-      for (size_t j = 0; j < 3; j++) {
-        ranges_data.emplace_back(SafeInt<uint32_t>(ranges[i][j]));
-      }
+  for (size_t i = 0; i < ranges.size(); i++) {
+    for (size_t j = 0; j < 3; j++) {
+      ranges_data.emplace_back(SafeInt<uint32_t>(ranges[i][j]));
     }
-    QnnParamWrapper ranges_param_wrapper(node_unit.Index(), node_name, QNN_OP_STRIDED_SLICE_PARAM_RANGES,
-                                         {static_cast<uint32_t>(ranges.size()), 3}, std::move(ranges_data), true);
-    std::vector<std::string> param_names = {ranges_param_wrapper.GetParamTensorName()};
-    qnn_model_wrapper.AddParamWrapper(std::move(ranges_param_wrapper));
+  }
+  QnnParamWrapper ranges_param_wrapper(node_unit.Index(), node_name, QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                                       {static_cast<uint32_t>(ranges.size()), 3}, std::move(ranges_data), true);
+  std::vector<std::string> param_names = {ranges_param_wrapper.GetParamTensorName()};
+  qnn_model_wrapper.AddParamWrapper(std::move(ranges_param_wrapper));
 
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, begin_mask,
-                                           QNN_OP_STRIDED_SLICE_PARAM_BEGIN_MASK, param_names));
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, end_mask,
-                                           QNN_OP_STRIDED_SLICE_PARAM_END_MASK, param_names));
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, shrink_axes,
-                                           QNN_OP_STRIDED_SLICE_PARAM_SHRINK_AXES, param_names));
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, new_axes_mask,
-                                           QNN_OP_STRIDED_SLICE_PARAM_NEW_AXES_MASK, param_names));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, begin_mask,
+                                         QNN_OP_STRIDED_SLICE_PARAM_BEGIN_MASK, param_names));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, end_mask,
+                                         QNN_OP_STRIDED_SLICE_PARAM_END_MASK, param_names));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, shrink_axes,
+                                         QNN_OP_STRIDED_SLICE_PARAM_SHRINK_AXES, param_names));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, new_axes_mask,
+                                         QNN_OP_STRIDED_SLICE_PARAM_NEW_AXES_MASK, param_names));
 
-    QnnTensorWrapper output_tensorwrapper(output_name, is_for_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
-                                          tensor_data_type, quantize_param.Copy(), std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
-                  "Failed to add output tensor for inserted StridedSlice.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE,
-                                                  {input_name}, {output_name}, std::move(param_names), do_op_validation),
-                  "Failed to create manually inserted Qnn StridedSlice node.");
+  QnnTensorWrapper output_tensorwrapper(output_name, is_for_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
+                                        tensor_data_type, quantize_param.Copy(), std::vector<uint32_t>(output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                "Failed to add output tensor for inserted StridedSlice.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE,
+                                                {input_name}, {output_name}, std::move(param_names), do_op_validation),
+                "Failed to create manually inserted Qnn StridedSlice node.");
   return Ort::Status();
 }
 
@@ -235,12 +235,12 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
         utils::UniqueNameGenerator().New(input_names[1], "_input_to_new_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
       RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[1], names[i],
-                                               input_tensor_infos[1].shape, {hidden_size, input_size},
-                                               {{direction_idx, direction_idx + 1, 1},
-                                                {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
-                                                {0, SafeInt<int32_t>(input_size), 1}},
-                                               0, 0, 0b001U, 0, input_tensor_infos[1].qnn_data_type,
-                                               input_tensor_infos[1].quant_param, do_op_validation, false, false));
+                                      input_tensor_infos[1].shape, {hidden_size, input_size},
+                                      {{direction_idx, direction_idx + 1, 1},
+                                       {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
+                                       {0, SafeInt<int32_t>(input_size), 1}},
+                                      0, 0, 0b001U, 0, input_tensor_infos[1].qnn_data_type,
+                                      input_tensor_infos[1].quant_param, do_op_validation, false, false));
       qnn_gru_input_names[qnn_idx[i]] = names[i];
     }
   }
@@ -254,12 +254,12 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
         utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_new_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
       RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[2], names[i],
-                                               input_tensor_infos[2].shape, {hidden_size, hidden_size},
-                                               {{direction_idx, direction_idx + 1, 1},
-                                                {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
-                                                {0, hidden_size_sign, 1}},
-                                               0, 0, 0b001U, 0, input_tensor_infos[2].qnn_data_type,
-                                               input_tensor_infos[2].quant_param, do_op_validation, false, false));
+                                      input_tensor_infos[2].shape, {hidden_size, hidden_size},
+                                      {{direction_idx, direction_idx + 1, 1},
+                                       {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
+                                       {0, hidden_size_sign, 1}},
+                                      0, 0, 0b001U, 0, input_tensor_infos[2].qnn_data_type,
+                                      input_tensor_infos[2].quant_param, do_op_validation, false, false));
       qnn_gru_input_names[qnn_idx[i]] = names[i];
     }
   }
@@ -277,11 +277,11 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
           utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_new_gate_bias_" + direction)};
       for (size_t i = 0; i < 6; i++) {
         RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[3], names[i],
-                                                 input_tensor_infos[3].shape, {hidden_size},
-                                                 {{direction_idx, direction_idx + 1, 1},
-                                                  {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}},
-                                                 0, 0, 0b01U, 0, input_tensor_infos[3].qnn_data_type,
-                                                 input_tensor_infos[3].quant_param, do_op_validation, false, false));
+                                        input_tensor_infos[3].shape, {hidden_size},
+                                        {{direction_idx, direction_idx + 1, 1},
+                                         {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}},
+                                        0, 0, 0b01U, 0, input_tensor_infos[3].qnn_data_type,
+                                        input_tensor_infos[3].quant_param, do_op_validation, false, false));
         qnn_gru_input_names[qnn_idx[i]] = names[i];
       }
     } else {
@@ -328,7 +328,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
 
   // For CPU (time_major=false), transpose X upfront from [seq, batch, input] to [batch, seq, input]
   // so that per-step slicing produces [batch, 1, input] directly without per-step Reshapes.
-  std::string x_source = input_names[0];  // [seq, batch, input] for HTP, [batch, seq, input] for CPU
+  std::string x_source = input_names[0];                               // [seq, batch, input] for HTP, [batch, seq, input] for CPU
   std::vector<uint32_t> x_source_shape = input_tensor_infos[0].shape;  // [seq, batch, input]
   if (!time_major) {
     std::string x_transposed = utils::UniqueNameGenerator().New(input_names[0], "_transposed_" + direction);
@@ -365,9 +365,9 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
 
     std::string x_step = utils::UniqueNameGenerator().New(input_names[0], "_xs" + sfx);
     RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, x_source, x_step,
-                                             x_source_shape, x_step_shape, x_ranges,
-                                             0, 0, 0, 0, input_tensor_infos[0].qnn_data_type,
-                                             input_tensor_infos[0].quant_param, do_op_validation, false, false));
+                                    x_source_shape, x_step_shape, x_ranges,
+                                    0, 0, 0, 0, input_tensor_infos[0].qnn_data_type,
+                                    input_tensor_infos[0].quant_param, do_op_validation, false, false));
     cell_inputs[0] = x_step;
 
     // initial_h for this step

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -341,10 +341,16 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     x_source_shape = {batch_size, seq_length, input_size};
   }
 
-  std::vector<std::string> qnn_all_step_hidden_names(seq_length);  // [batch, hidden] per step, ordered by t
+  std::vector<std::string> qnn_all_step_hidden_names(seq_length);  // Y tensors, indexed by t
   std::string prev_h_name = initial_h_name;                        // [1, batch, hidden]
 
+  // If Y_h is a direct graph output for unidirectional, the last step can write it directly.
+  const bool needs_y_h_output = !is_bidirection && onnx_outputs.size() > 1 && onnx_outputs[1].Exists();
+  const std::string y_h_out_name = needs_y_h_output ? onnx_outputs[1].name : "";
+  const bool y_h_is_graph_output = needs_y_h_output && qnn_model_wrapper.IsGraphOutput(y_h_out_name);
+
   for (uint32_t step = 0; step < seq_length; step++) {
+    const bool is_last_step = (step == seq_length - 1);
     // For reverse direction iterate from the last time step to the first.
     const uint32_t t = (direction == "reverse") ? (seq_length - step - 1) : step;
     const std::string sfx = "_t" + std::to_string(t) + "_" + direction;
@@ -379,12 +385,18 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     const std::vector<uint32_t> y_shape = time_major ? std::vector<uint32_t>{1, batch_size, hidden_size}
                                                      : std::vector<uint32_t>{batch_size, 1, hidden_size};
     std::string y_name = utils::UniqueNameGenerator().New(node_unit, "_Y" + sfx);
-    std::string yh_name = utils::UniqueNameGenerator().New(node_unit, "_Yh" + sfx);
+
+    // For the last step on HTP: name Y_h after the ONNX output directly.
+    // CPU derives h from Y via Transpose instead (Y_h is unreliable on CPU).
+    const bool write_yh_directly = is_last_step && needs_y_h_output && time_major;
+    std::string yh_name = write_yh_directly ? y_h_out_name
+                                            : utils::UniqueNameGenerator().New(node_unit, "_Yh" + sfx);
     {
       QnnTensorWrapper y_tw(y_name, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
                             output_tensor_infos[0].quant_param.Copy(), std::vector<uint32_t>(y_shape));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(y_tw)), "Failed to add GRU Y output.");
-      QnnTensorWrapper yh_tw(yh_name, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[1].qnn_data_type,
+      Qnn_TensorType_t yh_type = (write_yh_directly && y_h_is_graph_output) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+      QnnTensorWrapper yh_tw(yh_name, yh_type, output_tensor_infos[1].qnn_data_type,
                              output_tensor_infos[1].quant_param.Copy(), std::vector<uint32_t>{1, batch_size, hidden_size});
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(yh_tw)), "Failed to add GRU Y_h output.");
     }
@@ -402,13 +414,16 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
       // HTP: use Y_h directly as next step's initial_h
       prev_h_name = yh_name;
     } else {
-      // CPU: Y is [batch, 1, hidden] - Transpose to [1, batch, hidden]
-      std::string y_as_h = utils::UniqueNameGenerator().New(node_unit, "_Y_as_h" + sfx);
+      // CPU: Y is [batch, 1, hidden] - Transpose to [1, batch, hidden].
+      // On the last step for unidirectional, write directly to the ONNX output (is_for_output=true).
+      const bool write_as_output = is_last_step && needs_y_h_output;
+      const std::string y_as_h = write_as_output ? y_h_out_name
+                                                 : utils::UniqueNameGenerator().New(node_unit, "_Y_as_h" + sfx);
       RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
           node_unit.Index(), y_name, y_as_h,
           y_shape, {1, 0, 2}, {1, batch_size, hidden_size},
           output_tensor_infos[0].qnn_data_type, output_tensor_infos[0].quant_param,
-          do_op_validation, false, false));
+          do_op_validation, false, write_as_output && y_h_is_graph_output));
       prev_h_name = y_as_h;
     }
 
@@ -424,8 +439,8 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   const std::string y_concat = utils::UniqueNameGenerator().New(node_unit, "_Y_concat_" + direction);
   {
     std::vector<uint32_t> concat_out_shape = time_major
-                                                        ? std::vector<uint32_t>{seq_length, batch_size, hidden_size}
-                                                        : std::vector<uint32_t>{batch_size, seq_length, hidden_size};
+                                                 ? std::vector<uint32_t>{seq_length, batch_size, hidden_size}
+                                                 : std::vector<uint32_t>{batch_size, seq_length, hidden_size};
     std::vector<std::string> cp;
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), y_concat,
                                            concat_axis, QNN_OP_CONCAT_PARAM_AXIS, cp));
@@ -468,16 +483,9 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                                          qnn_model_wrapper.IsGraphOutput(out_name)));
         uni_gru_output_names.emplace_back(out_name);
       } else {
-        // Y_h: prev_h_name is already [1, batch, hidden] from the last step.
+        // Y_h: already written under onnx_outputs[1].name in the last step (APP_READ or NATIVE).
         if (!is_bidirection) {
-          // Unidirectional: surface under the ONNX output name via Reshape (registers as APP_READ).
-          RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_name, onnx_outputs[i].name,
-                                                           {1, batch_size, hidden_size},
-                                                           {1, batch_size, hidden_size},
-                                                           output_tensor_infos[1].qnn_data_type,
-                                                           output_tensor_infos[1].quant_param, do_op_validation, false,
-                                                           qnn_model_wrapper.IsGraphOutput(onnx_outputs[i].name)));
-          uni_gru_output_names.emplace_back(onnx_outputs[i].name);
+          uni_gru_output_names.emplace_back(y_h_out_name);
         } else {
           // Bidirectional: pass directly to Concat.
           uni_gru_output_names.emplace_back(prev_h_name);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -412,26 +412,42 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
       prev_h_name = y_as_h;
     }
 
-    // Reshape Y -> [batch, hidden] for packing across time steps.
-    std::string y_2d = utils::UniqueNameGenerator().New(node_unit, "_Y2d" + sfx);
-    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_name, y_2d, y_shape, {batch_size, hidden_size},
-                                                     output_tensor_infos[0].qnn_data_type,
-                                                     output_tensor_infos[0].quant_param, do_op_validation, false, false));
-    qnn_all_step_hidden_names[t] = y_2d;
+    // Collect Y for Concat (no per-step Reshape needed).
+    qnn_all_step_hidden_names[t] = y_name;
   }
 
-  // Pack all per-step [batch, hidden] -> [seq, batch, hidden] using QNN_OP_PACK axis=0.
-  // qnn_all_step_hidden_names is indexed by t (0..seq-1) so forward order is naturally correct.
-  const std::string y_all = utils::UniqueNameGenerator().New(node_unit, "_Y_all_" + direction);
+  // Concat all per-step Y tensors into [seq, batch, hidden].
+  // HTP (time_major=true):  Y [1,batch,hidden] * seq, Concat axis=0 -> [seq, batch, hidden]
+  // CPU (time_major=false): Y [batch,1,hidden] * seq, Concat axis=1 -> [batch, seq, hidden]
+  //                         then Transpose -> [seq, batch, hidden]
+  const uint32_t concat_axis = time_major ? 0 : 1;
+  const std::string y_concat = utils::UniqueNameGenerator().New(node_unit, "_Y_concat_" + direction);
   {
-    std::vector<std::string> pp;
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), y_all, 0, QNN_OP_PACK_PARAM_AXIS, pp));
-    QnnTensorWrapper tw(y_all, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
-                        output_tensor_infos[0].quant_param.Copy(), {seq_length, batch_size, hidden_size});
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Y Pack output.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(y_all, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
-                                                  std::move(qnn_all_step_hidden_names), {y_all}, std::move(pp), do_op_validation),
-                  "Failed to create Y Pack node.");
+    std::vector<uint32_t> concat_out_shape = time_major
+                                                        ? std::vector<uint32_t>{seq_length, batch_size, hidden_size}
+                                                        : std::vector<uint32_t>{batch_size, seq_length, hidden_size};
+    std::vector<std::string> cp;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), y_concat,
+                                           concat_axis, QNN_OP_CONCAT_PARAM_AXIS, cp));
+    QnnTensorWrapper tw(y_concat, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
+                        output_tensor_infos[0].quant_param.Copy(), std::move(concat_out_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Y Concat output.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(y_concat, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CONCAT,
+                                                  std::move(qnn_all_step_hidden_names), {y_concat}, std::move(cp), do_op_validation),
+                  "Failed to create Y Concat node.");
+  }
+
+  // For CPU (time_major=false), Transpose [batch, seq, hidden] -> [seq, batch, hidden].
+  std::string y_all;
+  if (!time_major) {
+    y_all = utils::UniqueNameGenerator().New(node_unit, "_Y_all_" + direction);
+    RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
+        node_unit.Index(), y_concat, y_all,
+        {batch_size, seq_length, hidden_size}, {1, 0, 2}, {seq_length, batch_size, hidden_size},
+        output_tensor_infos[0].qnn_data_type, output_tensor_infos[0].quant_param,
+        do_op_validation, false, false));
+  } else {
+    y_all = y_concat;
   }
 
   // Map to ONNX output shapes:

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -132,15 +132,11 @@ Ort::Status GRUOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   }
 
   OrtNodeAttrHelper node_helper(node_unit);
-  const float clip = node_helper.Get("clip", (float)0.0);
-  RETURN_IF(clip != 0, "QNN EP doesn't support non-default clip for GRU.");
+  RETURN_IF(node_helper.HasAttr("clip"), "QNN EP doesn't support clip for GRU.");
   const std::vector<std::string> activations = node_helper.Get("activations", std::vector<std::string>{});
   RETURN_IF((activations.size() >= 2 && (activations[0] != "sigmoid" || activations[1] != "tanh")) ||
                 (activations.size() == 4 && (activations[2] != "sigmoid" || activations[3] != "tanh")),
             "QNN EP doesn't support non-default activations for GRU.");
-  const int64_t layout = node_helper.Get("layout", static_cast<int64_t>(0));
-  RETURN_IF_NOT(layout == 0,
-                ("QNN EP: Unsupport layout mode" + std::to_string(layout) + " for " + node_unit.Name()).c_str());
   return Ort::Status();
 }
 
@@ -195,10 +191,11 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   const int32_t hidden_size_sign = SafeInt<int32_t>(hidden_size);
   RETURN_IF_NOT(hidden_size > 0, "hidden size is not set for GRU");
   const int64_t linear_before_reset = node_helper.Get("linear_before_reset", static_cast<int64_t>(0));
+  const int64_t layout = node_helper.Get("layout", static_cast<int64_t>(0));
 
   const uint32_t input_size = input_tensor_infos[0].shape[2];
-  const uint32_t batch_size = input_tensor_infos[0].shape[1];
-  const uint32_t seq_length = input_tensor_infos[0].shape[0];
+  const uint32_t batch_size = layout == 0 ? input_tensor_infos[0].shape[1] : input_tensor_infos[0].shape[0];
+  const uint32_t seq_length = layout == 0 ? input_tensor_infos[0].shape[0] : input_tensor_infos[0].shape[1];
   const int32_t direction_idx = input_tensor_infos[1].shape[0] < 2 || direction == "forward" ? 0 : 1;
 
   // GRU parameters - shared by all unrolled time-step cells.
@@ -211,10 +208,10 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(linear_before_reset),
                                          QNN_OP_GRU_PARAM_LINEAR_BEFORE_RESET, param_names));
-  // QNN CPU has a batch bug with time_major=true; QNN HTP has a batch bug with time_major=false.
-  // Pick time_major based on the backend to avoid the respective batch dimension bugs.
-  const bool is_npu_backend = qnn_model_wrapper.GetQnnBackendType() != QnnBackendType::CPU;
-  const bool time_major = is_npu_backend;  // true for HTP, false for CPU
+  // time_major: on CPU, always use false to work around its batch dimension bug with time_major=true.
+  // On other backends (HTP), follow the ONNX layout attribute: layout=0 -> true, layout=1 -> false.
+  const bool is_cpu_backend = qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::CPU;
+  const bool time_major = is_cpu_backend ? false : (layout == 0);
   RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), time_major,
                                      QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -1,0 +1,700 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class GRUOpBuilder : public BaseOpBuilder {
+ public:
+  GRUOpBuilder() : BaseOpBuilder("GRUOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GRUOpBuilder);
+
+ protected:
+  /*
+  ONNX GRU inputs:
+  in[0]: X [seq_length, batch_size, input_size]
+  in[1]: W [num_directions, 3*hidden_size, input_size], gate order: z (update), r (reset), h (new)
+  in[2]: R [num_directions, 3*hidden_size, hidden_size], gate order: z (update), r (reset), h (new)
+
+  ONNX GRU optional inputs:
+  in[3]: B [num_directions, 6*hidden_size], order: [Wb[zrh], Rb[zrh]]
+  in[4]: sequence_lens  ---> not supported
+  in[5]: initial_h [num_directions, batch_size, hidden_size]
+
+  ONNX GRU Parameters:
+  - activations      ---> not supported by QNN
+  - activation_alpha ---> not supported by QNN
+  - activation_beta  ---> not supported by QNN
+  - clip             ---> not supported by QNN
+  - direction
+  - hidden_size
+  - linear_before_reset
+  - layout: The shape format of inputs X, initial_h and outputs Y, Y_h.
+            If 0, the following shapes are expected:
+                X.shape = [seq_length, batch_size, input_size],
+                Y.shape = [seq_length, num_directions, batch_size, hidden_size],
+                initial_h.shape = Y_h.shape = [num_directions, batch_size, hidden_size].
+            If 1, the following shapes are expected:
+                X.shape = [batch_size, seq_length, input_size],
+                Y.shape = [batch_size, seq_length, num_directions, hidden_size],
+                initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].
+
+  ONNX GRU optional outputs:
+  out[0]: Y [seq_length, num_directions, batch_size, hidden_size]
+  out[1]: Y_h [num_directions, batch_size, hidden_size]
+
+  QNN GRU inputs:
+  in[0]: x_t: 3D of shape [seq_length, batch_size, input_size] if time_major
+                           [batch_size, seq_length, input_size] else
+  in[1]: W_xz: input-to-update weights [hidden_size, input_size]   = ONNX in[1][direction, 0*hidden_size:1*hidden_size, :]
+  in[2]: W_xr: input-to-reset weights [hidden_size, input_size]    = ONNX in[1][direction, 1*hidden_size:2*hidden_size, :]
+  in[3]: W_xn: input-to-new weights [hidden_size, input_size]      = ONNX in[1][direction, 2*hidden_size:3*hidden_size, :]
+  in[4]: W_hz: recurrent-to-update weights [hidden_size, hidden_size] = ONNX in[2][direction, 0*hidden_size:1*hidden_size, :]
+  in[5]: W_hr: recurrent-to-reset weights [hidden_size, hidden_size]  = ONNX in[2][direction, 1*hidden_size:2*hidden_size, :]
+  in[6]: W_hn: recurrent-to-new weights [hidden_size, hidden_size]    = ONNX in[2][direction, 2*hidden_size:3*hidden_size, :]
+
+  # optional inputs
+  in[7]:  b_xz: input-to-update gate bias [hidden_size]     = ONNX in[3][direction, 0*hidden_size:1*hidden_size]
+  in[8]:  b_xr: input-to-reset gate bias [hidden_size]      = ONNX in[3][direction, 1*hidden_size:2*hidden_size]
+  in[9]:  b_xn: input-to-new gate bias [hidden_size]        = ONNX in[3][direction, 2*hidden_size:3*hidden_size]
+  in[10]: b_hz: recurrent-to-update gate bias [hidden_size] = ONNX in[3][direction, 3*hidden_size:4*hidden_size]
+  in[11]: b_hr: recurrent-to-reset gate bias [hidden_size]  = ONNX in[3][direction, 4*hidden_size:5*hidden_size]
+  in[12]: b_hn: recurrent-to-new gate bias [hidden_size]    = ONNX in[3][direction, 5*hidden_size:6*hidden_size]
+  in[13]: initial_h [1, batch_size, hidden_size]             = ONNX in[5][direction:direction+1, :, :] as [1, batch_size, hidden_size]
+  in[14]: reset ---> not used
+
+  QNN GRU Parameters:
+  - direction
+  - linear_before_reset
+  - time_major
+
+  QNN GRU outputs:
+  out[0]: Y 3D of shape [seq_length, batch_size, hidden_size] if time_major
+                        [batch_size, seq_length, hidden_size] else
+  out[1]: Y_h [1, batch_size, hidden_size]
+  */
+
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+ private:
+  Ort::Status AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
+                                 const OrtNodeUnit& node_unit,
+                                 const std::string& direction,
+                                 const std::vector<std::string>& input_names,
+                                 const Ort::Logger& logger,
+                                 const bool& do_op_validation,
+                                 const bool& is_bidirection,
+                                 std::vector<std::string>& uni_gru_output_names) const;
+  Ort::Status AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       const std::string& input_name,
+                                       const std::string& output_name,
+                                       const std::vector<uint32_t>& input_shape,
+                                       const std::vector<uint32_t>& output_shape,
+                                       const std::vector<std::vector<int32_t>>& ranges,
+                                       const uint32_t& begin_mask,
+                                       const uint32_t& end_mask,
+                                       const uint32_t& shrink_axes,
+                                       const uint32_t& new_axes_mask,
+                                       const Qnn_DataType_t& tensor_data_type,
+                                       const QnnQuantParamsWrapper& quantize_param,
+                                       bool do_op_validation,
+                                       bool is_for_input,
+                                       bool is_for_output) const;
+};
+
+Ort::Status GRUOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wrapper,
+                                                   const OrtNodeUnit& node_unit,
+                                                   const std::string& input_name,
+                                                   const std::string& output_name,
+                                                   const std::vector<uint32_t>& input_shape,
+                                                   const std::vector<uint32_t>& output_shape,
+                                                   const std::vector<std::vector<int32_t>>& ranges,
+                                                   const uint32_t& begin_mask,
+                                                   const uint32_t& end_mask,
+                                                   const uint32_t& shrink_axes,
+                                                   const uint32_t& new_axes_mask,
+                                                   const Qnn_DataType_t& tensor_data_type,
+                                                   const QnnQuantParamsWrapper& quantize_param,
+                                                   bool do_op_validation,
+                                                   bool is_for_input,
+                                                   bool is_for_output) const {
+  if (qnn_model_wrapper.IsQnnTensorWrapperExist(output_name)) {
+    return Ort::Status();
+  }
+  // add strided_slice or reshape
+  // this is not general condition, only limited to caller in this builder
+  size_t minSize = std::min(input_shape.size(), output_shape.size());
+  if (input_shape[0] == 1 && std::equal(output_shape.rbegin(), output_shape.rbegin() + minSize, input_shape.rbegin())) {
+    // add Reshape
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(input_name,
+                                                     output_name,
+                                                     input_shape,
+                                                     output_shape,
+                                                     tensor_data_type,
+                                                     quantize_param.Copy(),
+                                                     quantize_param.Copy(),
+                                                     do_op_validation,
+                                                     is_for_input,
+                                                     is_for_output));
+  } else {
+    // add StridedSlice
+    // inputs
+    QnnTensorWrapper input_tensorwrapper(input_name, is_for_input ? QNN_TENSOR_TYPE_APP_WRITE : QNN_TENSOR_TYPE_NATIVE,
+                                         tensor_data_type, quantize_param.Copy(),
+                                         std::vector<uint32_t>(input_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)),
+                  "Failed to add input tensor for inserted StridedSlice or Reshape.");
+
+    // params
+    const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_STRIDED_SLICE);
+
+    // ranges
+    std::vector<uint32_t> ranges_data;
+    for (size_t i = 0; i < ranges.size(); i++) {
+      for (size_t j = 0; j < 3; j++) {
+        ranges_data.emplace_back(SafeInt<uint32_t>(ranges[i][j]));
+      }
+    }
+    QnnParamWrapper ranges_param_wrapper(node_unit.Index(), node_name, QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                                         {static_cast<uint32_t>(ranges.size()), 3}, std::move(ranges_data), true);
+    std::vector<std::string> param_names = {
+        ranges_param_wrapper.GetParamTensorName(),
+    };
+    qnn_model_wrapper.AddParamWrapper(std::move(ranges_param_wrapper));
+
+    // begin_mask
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, begin_mask,
+                                           QNN_OP_STRIDED_SLICE_PARAM_BEGIN_MASK, param_names));
+
+    // end_mask
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, end_mask,
+                                           QNN_OP_STRIDED_SLICE_PARAM_END_MASK, param_names));
+
+    // shrink_axes
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, shrink_axes,
+                                           QNN_OP_STRIDED_SLICE_PARAM_SHRINK_AXES, param_names));
+
+    // new_axes_mask
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, new_axes_mask,
+                                           QNN_OP_STRIDED_SLICE_PARAM_NEW_AXES_MASK, param_names));
+
+    // outputs
+    QnnTensorWrapper output_tensorwrapper(output_name,
+                                          is_for_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
+                                          tensor_data_type,
+                                          quantize_param.Copy(),
+                                          std::vector<uint32_t>(output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                  "Failed to add output tensor for inserted StridedSlice.");
+    // addNode
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE, {input_name},
+                                                  {output_name}, std::move(param_names), do_op_validation),
+                  "Failed to create manually inserted Qnn StridedSlice node.");
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status GRUOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                                        const OrtNodeUnit& node_unit,
+                                        const Ort::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  if (node_unit.Inputs().size() > 4 && node_unit.Inputs()[4].Exists()) {
+    TensorInfo tensor_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[4], tensor_info));
+
+    RETURN_IF_NOT(tensor_info.is_initializer, "QNN EP: dynamic sequence_length is not supported.");
+
+    std::vector<uint8_t> sequence_lens_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(tensor_info.initializer_tensor, sequence_lens_bytes));
+    const size_t num_elems = sequence_lens_bytes.size() / sizeof(int32_t);
+    gsl::span<const int32_t> sequence_lens{reinterpret_cast<const int32_t*>(sequence_lens_bytes.data()), num_elems};
+    RETURN_IF(std::any_of(sequence_lens.begin(),
+                          sequence_lens.end(),
+                          [sequence_lens](int i) { return i != sequence_lens[0]; }),
+              "QNN EP: Only support GRU with same sequence length.");
+  }
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  const float clip = node_helper.Get("clip", (float)0.0);
+  RETURN_IF(clip != 0,
+            "QNN EP doesn't support non-default clip for GRU.");
+  const std::vector<std::string> activations = node_helper.Get("activations", std::vector<std::string>{});
+  RETURN_IF((activations.size() >= 2 && (activations[0] != "sigmoid" || activations[1] != "tanh")) ||
+                (activations.size() == 4 && (activations[2] != "sigmoid" || activations[3] != "tanh")),
+            "QNN EP doesn't support non-default activations for GRU.");
+  // TODO: Add support for layout==1
+  const int64_t layout = node_helper.Get("layout", static_cast<int64_t>(0));
+  RETURN_IF_NOT(layout == 0,
+                ("QNN EP: Unsupport layout mode" + std::to_string(layout) + " for " + node_unit.Name()).c_str());
+  return Ort::Status();
+}
+
+Ort::Status GRUOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                        const OrtNodeUnit& node_unit,
+                                        const Ort::Logger& logger,
+                                        std::vector<std::string>& input_names,
+                                        bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(do_op_validation);
+  const auto& onnx_inputs = node_unit.Inputs();
+  for (size_t i = 0; i < onnx_inputs.size(); i++) {
+    if (onnx_inputs[i].Exists()) {
+      RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, onnx_inputs[i], logger, input_names));
+    } else {
+      input_names.emplace_back("");
+    }
+  }
+  return Ort::Status();
+}
+
+Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
+                                             const OrtNodeUnit& node_unit,
+                                             const std::string& direction,
+                                             const std::vector<std::string>& input_names,
+                                             const Ort::Logger& logger,
+                                             const bool& do_op_validation,
+                                             const bool& is_bidirection,
+                                             std::vector<std::string>& uni_gru_output_names) const {
+  ORT_UNUSED_PARAMETER(logger);
+  const auto& onnx_inputs = node_unit.Inputs();
+  const auto& onnx_outputs = node_unit.Outputs();
+  std::vector<TensorInfo> input_tensor_infos(onnx_inputs.size());
+  for (size_t i = 0; i < onnx_inputs.size(); i++) {
+    if (onnx_inputs[i].Exists()) {
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(onnx_inputs[i], input_tensor_infos[i]));
+    }
+  }
+  // QNN GRU has 2 mandatory outputs
+  std::vector<TensorInfo> output_tensor_infos(2);
+  for (size_t i = 0; i < 2; i++) {
+    if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(onnx_outputs[i], output_tensor_infos[i]));
+    } else {
+      output_tensor_infos[i].qnn_data_type = input_tensor_infos[0].qnn_data_type;
+    }
+  }
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  const uint32_t hidden_size = node_helper.Get("hidden_size", 0);
+  const int32_t hidden_size_sign = SafeInt<int32_t>(hidden_size);
+  RETURN_IF_NOT(hidden_size > 0, "hidden size is not set for GRU");
+  const int64_t linear_before_reset = node_helper.Get("linear_before_reset", static_cast<int64_t>(0));
+
+  const uint32_t input_size = input_tensor_infos[0].shape[2];
+  const uint32_t batch_size = input_tensor_infos[0].shape[1];
+  const uint32_t seq_length = input_tensor_infos[0].shape[0];
+  const int32_t direction_idx = input_tensor_infos[1].shape[0] < 2 || direction == "forward" ? 0 : 1;
+
+  // params
+  std::vector<std::string> param_names;
+
+  // direction
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_" + direction,
+                                         direction == "forward" ? QNN_OP_GRU_DIRECTION_FORWARD : QNN_OP_GRU_DIRECTION_REVERSE,
+                                         QNN_OP_GRU_PARAM_DIRECTION, param_names));
+
+  // linear_before_reset
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(linear_before_reset),
+                                         QNN_OP_GRU_PARAM_LINEAR_BEFORE_RESET, param_names));
+
+  // time_major: set to true since current builder only supports time major GRU (layout=0)
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), true,
+                                     QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));
+
+  // Common null tensor for optional inputs
+  const std::string null_tensor_name = "null_tensor";
+  QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_FLOAT_32,
+                                       QnnQuantParamsWrapper(), std::vector<uint32_t>{0});
+  qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
+
+  std::vector<std::string> qnn_gru_input_names(15, null_tensor_name);
+  qnn_gru_input_names[0] = input_names[0];
+
+  // input W: ONNX in[1] [num_directions, 3*hidden_size, input_size], gate order: z, r, h
+  {
+    // QNN in[1] (W_xz) = ONNX in[1][direction, 0*hidden_size:1*hidden_size, :]
+    // QNN in[2] (W_xr) = ONNX in[1][direction, 1*hidden_size:2*hidden_size, :]
+    // QNN in[3] (W_xn) = ONNX in[1][direction, 2*hidden_size:3*hidden_size, :]
+    uint32_t begin_mask = 0b000U;
+    uint32_t end_mask = 0b000U;
+    uint32_t shrink_axes = 0b001U;
+    uint32_t new_axes_mask = 0b000U;
+    std::vector<uint32_t> qnn_input_indices = {1, 2, 3};
+    std::vector<int32_t> begins = {0, 1, 2};
+    std::vector<std::string> qnn_gru_weight_name = {
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_update_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_reset_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_new_gate_weight_" + direction),
+    };
+    for (size_t i = 0; i < 3; i++) {
+      std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
+                                                  {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
+                                                  {0, SafeInt<int32_t>(input_size), 1}};
+      std::vector<uint32_t> output_shape = {hidden_size, input_size};
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
+                                               /*node_unit=*/node_unit,
+                                               /*input_name=*/input_names[1],
+                                               /*output_name=*/qnn_gru_weight_name[i],
+                                               /*input_shape=*/input_tensor_infos[1].shape,
+                                               /*output_shape=*/output_shape,
+                                               /*ranges=*/ranges,
+                                               /*begin_mask=*/begin_mask,
+                                               /*end_mask=*/end_mask,
+                                               /*shrink_axes=*/shrink_axes,
+                                               /*new_axes_mask=*/new_axes_mask,
+                                               /*tensor_data_type=*/input_tensor_infos[1].qnn_data_type,
+                                               /*QnnQuantParamsWrapper=*/input_tensor_infos[1].quant_param,
+                                               /*do_op_validation=*/do_op_validation,
+                                               /*is_for_input=*/false,
+                                               /*is_for_output=*/false));
+      qnn_gru_input_names[qnn_input_indices[i]] = qnn_gru_weight_name[i];
+    }
+  }
+
+  // input R: ONNX in[2] [num_directions, 3*hidden_size, hidden_size], gate order: z, r, h
+  {
+    // QNN in[4] (W_hz) = ONNX in[2][direction, 0*hidden_size:1*hidden_size, :]
+    // QNN in[5] (W_hr) = ONNX in[2][direction, 1*hidden_size:2*hidden_size, :]
+    // QNN in[6] (W_hn) = ONNX in[2][direction, 2*hidden_size:3*hidden_size, :]
+    uint32_t begin_mask = 0b000U;
+    uint32_t end_mask = 0b000U;
+    uint32_t shrink_axes = 0b001U;
+    uint32_t new_axes_mask = 0b000U;
+    std::vector<uint32_t> qnn_input_indices = {4, 5, 6};
+    std::vector<int32_t> begins = {0, 1, 2};
+    std::vector<std::string> qnn_gru_weight_name = {
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_update_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_reset_gate_weight_" + direction),
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_new_gate_weight_" + direction),
+    };
+    for (size_t i = 0; i < 3; i++) {
+      std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
+                                                  {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
+                                                  {0, hidden_size_sign, 1}};
+      std::vector<uint32_t> output_shape = {hidden_size, hidden_size};
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
+                                               /*node_unit=*/node_unit,
+                                               /*input_name=*/input_names[2],
+                                               /*output_name=*/qnn_gru_weight_name[i],
+                                               /*input_shape=*/input_tensor_infos[2].shape,
+                                               /*output_shape=*/output_shape,
+                                               /*ranges=*/ranges,
+                                               /*begin_mask=*/begin_mask,
+                                               /*end_mask=*/end_mask,
+                                               /*shrink_axes=*/shrink_axes,
+                                               /*new_axes_mask=*/new_axes_mask,
+                                               /*tensor_data_type=*/input_tensor_infos[2].qnn_data_type,
+                                               /*QnnQuantParamsWrapper=*/input_tensor_infos[2].quant_param,
+                                               /*do_op_validation=*/do_op_validation,
+                                               /*is_for_input=*/false,
+                                               /*is_for_output=*/false));
+      qnn_gru_input_names[qnn_input_indices[i]] = qnn_gru_weight_name[i];
+    }
+  }
+
+  // input B: ONNX in[3] [num_directions, 6*hidden_size], order: [Wb[zrh], Rb[zrh]]
+  {
+    // QNN in[7]  (b_xz) = ONNX in[3][direction, 0*hidden_size:1*hidden_size]
+    // QNN in[8]  (b_xr) = ONNX in[3][direction, 1*hidden_size:2*hidden_size]
+    // QNN in[9]  (b_xn) = ONNX in[3][direction, 2*hidden_size:3*hidden_size]
+    // QNN in[10] (b_hz) = ONNX in[3][direction, 3*hidden_size:4*hidden_size]
+    // QNN in[11] (b_hr) = ONNX in[3][direction, 4*hidden_size:5*hidden_size]
+    // QNN in[12] (b_hn) = ONNX in[3][direction, 5*hidden_size:6*hidden_size]
+    uint32_t begin_mask = 0b00U;
+    uint32_t end_mask = 0b00U;
+    uint32_t shrink_axes = 0b01U;
+    uint32_t new_axes_mask = 0b00U;
+    std::vector<uint32_t> output_shape = {hidden_size};
+    std::vector<uint32_t> qnn_input_indices = {7, 8, 9, 10, 11, 12};
+    if (onnx_inputs.size() > 3 && onnx_inputs[3].Exists()) {
+      std::vector<int32_t> begins = {0, 1, 2, 3, 4, 5};
+      std::vector<std::string> qnn_gru_bias_name = {
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_update_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_reset_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_input_to_new_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_update_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_reset_gate_bias_" + direction),
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_new_gate_bias_" + direction),
+      };
+      for (size_t i = 0; i < 6; i++) {
+        std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
+                                                    {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}};
+        RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
+                                                 /*node_unit=*/node_unit,
+                                                 /*input_name=*/input_names[3],
+                                                 /*output_name=*/qnn_gru_bias_name[i],
+                                                 /*input_shape=*/input_tensor_infos[3].shape,
+                                                 /*output_shape=*/output_shape,
+                                                 /*ranges=*/ranges,
+                                                 /*begin_mask=*/begin_mask,
+                                                 /*end_mask=*/end_mask,
+                                                 /*shrink_axes=*/shrink_axes,
+                                                 /*new_axes_mask=*/new_axes_mask,
+                                                 /*tensor_data_type=*/input_tensor_infos[3].qnn_data_type,
+                                                 /*QnnQuantParamsWrapper=*/input_tensor_infos[3].quant_param,
+                                                 /*do_op_validation=*/do_op_validation,
+                                                 /*is_for_input=*/false,
+                                                 /*is_for_output=*/false));
+        qnn_gru_input_names[qnn_input_indices[i]] = qnn_gru_bias_name[i];
+      }
+    } else {
+      // prepare zero bias
+      std::string zero_bias_name = utils::UniqueNameGenerator().New(node_unit, "_zero_bias");
+      QnnTensorWrapper zero_bias_tensor_wrapper(zero_bias_name,
+                                                QNN_TENSOR_TYPE_STATIC,
+                                                input_tensor_infos[0].qnn_data_type,
+                                                QnnQuantParamsWrapper(),
+                                                std::vector<uint32_t>(output_shape),
+                                                std::vector<uint8_t>(
+                                                    utils::GetElementSizeByType(input_tensor_infos[0].qnn_data_type) * hidden_size,
+                                                    0));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zero_bias_tensor_wrapper)),
+                    "Failed to add additional zero bias for QNN GRU node.");
+      for (size_t i = 0; i < 6; i++) {
+        qnn_gru_input_names[qnn_input_indices[i]] = zero_bias_name;
+      }
+    }
+  }
+
+  // input initial_h: ONNX in[5] [num_directions, batch_size, hidden_size]
+  {
+    // QNN in[13] = ONNX in[5][direction_idx:direction_idx+1, :, :] as [1, batch_size, hidden_size]
+    // shrink_axes must be 0 so the direction dim is kept as 1 (not squeezed), matching QNN in[13]'s
+    // expected shape [1, batch_size, hidden_size]. For unidirectional (num_directions=1), the
+    // Reshape path is taken instead since input already has shape [1, batch, hidden].
+    uint32_t begin_mask = 0b000U;
+    uint32_t end_mask = 0b000U;
+    uint32_t shrink_axes = 0b000U;
+    uint32_t new_axes_mask = 0b000U;
+    std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
+                                                {0, SafeInt<int32_t>(batch_size), 1},
+                                                {0, hidden_size_sign, 1}};
+    std::vector<uint32_t> output_shape = {1, batch_size, hidden_size};
+    if (onnx_inputs.size() > 5 && onnx_inputs[5].Exists()) {
+      const std::string qnn_gru_initial_h_name = utils::UniqueNameGenerator().New(input_names[5], direction);
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
+                                               /*node_unit=*/node_unit,
+                                               /*input_name=*/input_names[5],
+                                               /*output_name=*/qnn_gru_initial_h_name,
+                                               /*input_shape=*/input_tensor_infos[5].shape,
+                                               /*output_shape=*/output_shape,
+                                               /*ranges=*/ranges,
+                                               /*begin_mask=*/begin_mask,
+                                               /*end_mask=*/end_mask,
+                                               /*shrink_axes=*/shrink_axes,
+                                               /*new_axes_mask=*/new_axes_mask,
+                                               /*tensor_data_type=*/input_tensor_infos[5].qnn_data_type,
+                                               /*QnnQuantParamsWrapper=*/input_tensor_infos[5].quant_param,
+                                               /*do_op_validation=*/do_op_validation,
+                                               /*is_for_input=*/false,
+                                               /*is_for_output=*/false));
+      qnn_gru_input_names[13] = qnn_gru_initial_h_name;
+    } else {
+      // prepare zero initial_h
+      const std::string& node_name = node_unit.Name();
+      std::string zero_initial_h_name = utils::UniqueNameGenerator().New(node_name, "_GRU_initial_h");
+      QnnTensorWrapper zero_initial_h_wrapper(zero_initial_h_name,
+                                              QNN_TENSOR_TYPE_STATIC,
+                                              input_tensor_infos[0].qnn_data_type,
+                                              QnnQuantParamsWrapper(),
+                                              std::vector<uint32_t>(output_shape),
+                                              std::vector<uint8_t>(
+                                                  utils::GetElementSizeByType(input_tensor_infos[0].qnn_data_type) * batch_size * hidden_size,
+                                                  0));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zero_initial_h_wrapper)),
+                    "Failed to add initial hidden state for QNN GRU node.");
+      qnn_gru_input_names[13] = zero_initial_h_name;
+    }
+  }
+
+  // outputs
+  // QNN out[0]: Y [seq_length, batch_size, hidden_size]
+  // QNN out[1]: Y_h [1, batch_size, hidden_size] - QNN CPU may not give the correct final hidden
+  //              state in out[1], so we derive Y_h from the appropriate time step of out[0] instead.
+  std::vector<std::vector<uint32_t>> qnn_gru_output_shapes = {
+      {seq_length, batch_size, hidden_size},
+      {1, batch_size, hidden_size}};
+
+  std::vector<std::string> qnn_gru_output_names = {
+      utils::UniqueNameGenerator().New(node_unit, "_QNN_GRU_output_all_hidden_state_" + direction),
+      utils::UniqueNameGenerator().New(node_unit, "_QNN_GRU_output_last_hidden_state_" + direction)};
+
+  for (size_t j = 0; j < qnn_gru_output_names.size(); j++) {
+    QnnTensorWrapper output_tensorwrapper(qnn_gru_output_names[j],
+                                          QNN_TENSOR_TYPE_NATIVE,
+                                          output_tensor_infos[j].qnn_data_type,
+                                          output_tensor_infos[j].quant_param.Copy(),
+                                          std::vector<uint32_t>(qnn_gru_output_shapes[j]));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                  ("QNN EP: Failed to add " + std::to_string(j) + "th output tensor for QNN GRU.").c_str());
+  }
+  const std::string gru_node_name = utils::UniqueNameGenerator().New(node_unit, "_" + direction);
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(gru_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_GRU,
+                                                std::move(qnn_gru_input_names), std::vector<std::string>(qnn_gru_output_names),
+                                                std::vector<std::string>(param_names), do_op_validation),
+                "QNN EP: Failed to create Qnn GRU node.");
+
+  // Map QNN outputs to ONNX outputs with appropriate reshapes/slices.
+  //
+  // QNN out[0]: Y [seq_length, batch_size, hidden_size]
+  //   -> ONNX out[0]: Y [seq_length, 1, batch_size, hidden_size] (add num_directions dim via Reshape)
+  //
+  // QNN out[1] is unreliable on some backends (may return first-step state instead of final state).
+  // Instead, derive Y_h by slicing the correct time step from out[0]:
+  //   - forward:  Y[seq_length-1, :, :] = final hidden state
+  //   - reverse:  Y[0, :, :] = final hidden state (last processed in reverse order)
+  // Then reshape [batch_size, hidden_size] -> [1, batch_size, hidden_size] for ONNX Y_h.
+  std::vector<std::vector<uint32_t>> onnx_gru_output_shapes = {
+      {seq_length, 1, batch_size, hidden_size},
+      {1, batch_size, hidden_size}};
+
+  for (size_t i = 0; i < 2; i++) {
+    if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
+      // For bidirectional: use a unique intermediate name that will be consumed by a Concat op.
+      // For unidirectional: use the ONNX output name directly.
+      const std::string reshape_output_name = is_bidirection
+                                                  ? utils::UniqueNameGenerator().New(qnn_gru_output_names[i], "_unsqueeze_" + direction)
+                                                  : onnx_outputs[i].name;
+
+      if (i == 0) {
+        // Y: Reshape [seq, batch, hidden] -> [seq, 1, batch, hidden]
+        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/qnn_gru_output_names[0],
+                                                         /*output_name=*/reshape_output_name,
+                                                         /*input_shape=*/qnn_gru_output_shapes[0],
+                                                         /*output_shape=*/onnx_gru_output_shapes[0],
+                                                         /*tensor_data_type=*/output_tensor_infos[0].qnn_data_type,
+                                                         /*quantize_param=*/output_tensor_infos[0].quant_param,
+                                                         /*do_op_validation=*/do_op_validation,
+                                                         /*is_for_input=*/false,
+                                                         /*is_for_output=*/qnn_model_wrapper.IsGraphOutput(reshape_output_name)));
+      } else {
+        // Y_h: slice the final hidden state from Y (out[0]) and reshape to [1, batch, hidden].
+        // For forward direction: take Y[seq_length-1, :, :] (last time step).
+        // For reverse direction: take Y[0, :, :] (first index = last processed in reverse).
+        const int32_t y_h_t = (direction == "forward") ? SafeInt<int32_t>(seq_length) - 1 : 0;
+        const std::string y_h_slice_name = utils::UniqueNameGenerator().New(
+            qnn_gru_output_names[0], "_y_h_slice_" + direction);
+        std::vector<std::vector<int32_t>> y_h_ranges = {{y_h_t, y_h_t + 1, 1},
+                                                         {0, SafeInt<int32_t>(batch_size), 1},
+                                                         {0, hidden_size_sign, 1}};
+        std::vector<uint32_t> y_h_slice_shape = {batch_size, hidden_size};
+        RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
+                                                 /*node_unit=*/node_unit,
+                                                 /*input_name=*/qnn_gru_output_names[0],
+                                                 /*output_name=*/y_h_slice_name,
+                                                 /*input_shape=*/qnn_gru_output_shapes[0],
+                                                 /*output_shape=*/y_h_slice_shape,
+                                                 /*ranges=*/y_h_ranges,
+                                                 /*begin_mask=*/0b000U,
+                                                 /*end_mask=*/0b000U,
+                                                 /*shrink_axes=*/0b001U,
+                                                 /*new_axes_mask=*/0b000U,
+                                                 /*tensor_data_type=*/output_tensor_infos[1].qnn_data_type,
+                                                 /*QnnQuantParamsWrapper=*/output_tensor_infos[1].quant_param,
+                                                 /*do_op_validation=*/do_op_validation,
+                                                 /*is_for_input=*/false,
+                                                 /*is_for_output=*/false));
+        // Reshape [batch, hidden] -> [1, batch, hidden] for ONNX Y_h format.
+        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/y_h_slice_name,
+                                                         /*output_name=*/reshape_output_name,
+                                                         /*input_shape=*/y_h_slice_shape,
+                                                         /*output_shape=*/onnx_gru_output_shapes[1],
+                                                         /*tensor_data_type=*/output_tensor_infos[1].qnn_data_type,
+                                                         /*quantize_param=*/output_tensor_infos[1].quant_param,
+                                                         /*do_op_validation=*/do_op_validation,
+                                                         /*is_for_input=*/false,
+                                                         /*is_for_output=*/qnn_model_wrapper.IsGraphOutput(reshape_output_name)));
+      }
+      uni_gru_output_names.emplace_back(reshape_output_name);
+    } else {
+      uni_gru_output_names.emplace_back("");
+    }
+  }
+  return Ort::Status();
+}
+
+Ort::Status GRUOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                      const OrtNodeUnit& node_unit,
+                                                      std::vector<std::string>&& input_names,
+                                                      const Ort::Logger& logger,
+                                                      bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  std::string direction = node_helper.Get("direction", "forward");
+  RETURN_IF_NOT(inputs.size() >= 3 && inputs.size() <= 6, "GRU should receive inputs ranging from 3 to 6!");
+
+  if (direction == "bidirectional") {
+    std::vector<std::string> uni_gru_output_names_forward, uni_gru_output_names_reverse;
+    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, "forward", input_names, logger, do_op_validation, true,
+                                       uni_gru_output_names_forward));
+    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, "reverse", input_names, logger, do_op_validation, true,
+                                       uni_gru_output_names_reverse));
+
+    // Concat forward and reverse output along the num_directions axis
+    for (size_t i = 0; i < 2; i++) {
+      TensorInfo output_info = {};
+      if (node_unit.Outputs().size() > i && node_unit.Outputs()[i].Exists()) {
+        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[i], output_info));
+        std::string onnx_output_name = node_unit.Outputs()[i].name;
+
+        // param
+        std::vector<std::string> concat_param_names;
+        RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), onnx_output_name,
+                                               static_cast<uint32_t>(output_info.shape.size() - 3),
+                                               QNN_OP_CONCAT_PARAM_AXIS, concat_param_names));
+
+        // create tensor and add op
+        Qnn_TensorType_t output_tensor_type = qnn_model_wrapper.IsGraphOutput(onnx_output_name) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+        QnnTensorWrapper concat_output_tensorwrapper(onnx_output_name,
+                                                     output_tensor_type,
+                                                     output_info.qnn_data_type,
+                                                     output_info.quant_param.Copy(),
+                                                     std::vector<uint32_t>(output_info.shape));
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(concat_output_tensorwrapper)),
+                      "QNN EP: Failed to add output tensor for QNN Concat.");
+        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_CONCAT),
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                      QNN_OP_CONCAT,
+                                                      {uni_gru_output_names_forward[i], uni_gru_output_names_reverse[i]},
+                                                      {onnx_output_name},
+                                                      std::move(concat_param_names), do_op_validation),
+                      "QNN EP: Failed to create Qnn Concat node.");
+      }
+    }
+  } else {
+    // not used, just a placeholder
+    std::vector<std::string> uni_gru_output_names;
+    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, direction, input_names, logger, do_op_validation, false,
+                                       uni_gru_output_names));
+  }
+  return Ort::Status();
+}
+
+void CreateGRUOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<GRUOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -328,7 +328,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                        QnnQuantParamsWrapper(), std::vector<uint32_t>{0});
   qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
 
-  std::vector<std::string> qnn_gru_input_names(15, null_tensor_name);
+  std::vector<std::string> qnn_gru_input_names(14, null_tensor_name);
   qnn_gru_input_names[0] = input_names[0];
 
   // input W: ONNX in[1] [num_directions, 3*hidden_size, input_size], gate order: z, r, h
@@ -527,6 +527,22 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
       qnn_gru_input_names[13] = zero_initial_h_name;
     }
   }
+
+  // {
+  //   // QNN in[14]
+  //   // prepare reset
+  //   const std::string& node_name = node_unit.Name();
+  //   std::string reset_name = utils::UniqueNameGenerator().New(node_name, "_GRU_reset");
+  //   QnnTensorWrapper reset_wrapper(reset_name,
+  //                                  QNN_TENSOR_TYPE_STATIC,
+  //                                  QNN_DATATYPE_BOOL_8,
+  //                                  QnnQuantParamsWrapper(),
+  //                                  std::vector<uint32_t>({}),
+  //                                  std::vector<uint8_t>({1}));
+  //   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reset_wrapper)),
+  //                 "Failed to add reset for QNN GRU node.");
+  //   qnn_gru_input_names[13] = reset_name;
+  // }
 
   // outputs
   // QNN out[0]: Y [seq_length, batch_size, hidden_size]

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -309,7 +309,8 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
       RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[5], initial_h_name,
                                                input_tensor_infos[5].shape, h_shape,
                                                {{direction_idx, direction_idx + 1, 1},
-                                                {0, SafeInt<int32_t>(batch_size), 1}, {0, hidden_size_sign, 1}},
+                                                {0, SafeInt<int32_t>(batch_size), 1},
+                                                {0, hidden_size_sign, 1}},
                                                0, 0, 0, 0, input_tensor_infos[5].qnn_data_type,
                                                input_tensor_infos[5].quant_param, do_op_validation, false, false));
     } else {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -40,7 +40,7 @@ class GRUOpBuilder : public BaseOpBuilder {
                                  const bool& do_op_validation,
                                  const bool& is_bidirection,
                                  std::vector<std::string>& uni_gru_output_names) const;
-  Ort::Status AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wrapper,
+  Ort::Status AddStridedSlice(QnnModelWrapper& qnn_model_wrapper,
                                        const OrtNodeUnit& node_unit,
                                        const std::string& input_name,
                                        const std::string& output_name,
@@ -58,7 +58,7 @@ class GRUOpBuilder : public BaseOpBuilder {
                                        bool is_for_output) const;
 };
 
-Ort::Status GRUOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wrapper,
+Ort::Status GRUOpBuilder::AddStridedSlice(QnnModelWrapper& qnn_model_wrapper,
                                                    const OrtNodeUnit& node_unit,
                                                    const std::string& input_name,
                                                    const std::string& output_name,
@@ -77,23 +77,14 @@ Ort::Status GRUOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wr
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(output_name)) {
     return Ort::Status();
   }
-  size_t minSize = std::min(input_shape.size(), output_shape.size());
-  uint32_t in_elems = 1, out_elems = 1;
-  for (auto s : input_shape) in_elems *= s;
-  for (auto s : output_shape) out_elems *= s;
-  if (in_elems == out_elems && input_shape[0] == 1 &&
-      std::equal(output_shape.rbegin(), output_shape.rbegin() + minSize, input_shape.rbegin())) {
-    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(input_name, output_name, input_shape, output_shape,
-                                                     tensor_data_type, quantize_param.Copy(), quantize_param.Copy(),
-                                                     do_op_validation, is_for_input, is_for_output));
-  } else {
-    QnnTensorWrapper input_tensorwrapper(input_name, is_for_input ? QNN_TENSOR_TYPE_APP_WRITE : QNN_TENSOR_TYPE_NATIVE,
-                                         tensor_data_type, quantize_param.Copy(), std::vector<uint32_t>(input_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)),
-                  "Failed to add input tensor for inserted StridedSlice or Reshape.");
 
-    const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_STRIDED_SLICE);
-    std::vector<uint32_t> ranges_data;
+  QnnTensorWrapper input_tensorwrapper(input_name, is_for_input ? QNN_TENSOR_TYPE_APP_WRITE : QNN_TENSOR_TYPE_NATIVE,
+                                       tensor_data_type, quantize_param.Copy(), std::vector<uint32_t>(input_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)),
+                "Failed to add input tensor for inserted StridedSlice.");
+
+  const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_STRIDED_SLICE);
+  std::vector<uint32_t> ranges_data;
     for (size_t i = 0; i < ranges.size(); i++) {
       for (size_t j = 0; j < 3; j++) {
         ranges_data.emplace_back(SafeInt<uint32_t>(ranges[i][j]));
@@ -120,7 +111,6 @@ Ort::Status GRUOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wr
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE,
                                                   {input_name}, {output_name}, std::move(param_names), do_op_validation),
                   "Failed to create manually inserted Qnn StridedSlice node.");
-  }
   return Ort::Status();
 }
 
@@ -247,7 +237,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
         utils::UniqueNameGenerator().New(input_names[1], "_input_to_reset_gate_weight_" + direction),
         utils::UniqueNameGenerator().New(input_names[1], "_input_to_new_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[1], names[i],
+      RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[1], names[i],
                                                input_tensor_infos[1].shape, {hidden_size, input_size},
                                                {{direction_idx, direction_idx + 1, 1},
                                                 {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
@@ -266,7 +256,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
         utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_reset_gate_weight_" + direction),
         utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_new_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[2], names[i],
+      RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[2], names[i],
                                                input_tensor_infos[2].shape, {hidden_size, hidden_size},
                                                {{direction_idx, direction_idx + 1, 1},
                                                 {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
@@ -289,7 +279,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
           utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_reset_gate_bias_" + direction),
           utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_new_gate_bias_" + direction)};
       for (size_t i = 0; i < 6; i++) {
-        RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[3], names[i],
+        RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[3], names[i],
                                                  input_tensor_infos[3].shape, {hidden_size},
                                                  {{direction_idx, direction_idx + 1, 1},
                                                   {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}},
@@ -307,19 +297,24 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     }
   }
   // initial_h: ONNX in[5] [num_directions, batch_size, hidden_size] -> [1, batch_size, hidden_size]
-  // Shape [1, batch, hidden] matches time_major=true initial_h for seq=1 GRU nodes.
   std::string initial_h_name;
   {
     std::vector<uint32_t> h_shape = {1, batch_size, hidden_size};
     if (onnx_inputs.size() > 5 && onnx_inputs[5].Exists()) {
-      initial_h_name = utils::UniqueNameGenerator().New(input_names[5], direction);
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[5], initial_h_name,
-                                               input_tensor_infos[5].shape, h_shape,
-                                               {{direction_idx, direction_idx + 1, 1},
-                                                {0, SafeInt<int32_t>(batch_size), 1},
-                                                {0, hidden_size_sign, 1}},
-                                               0, 0, 0, 0, input_tensor_infos[5].qnn_data_type,
-                                               input_tensor_infos[5].quant_param, do_op_validation, false, false));
+      if (input_tensor_infos[5].shape == h_shape) {
+        // num_directions=1: already [1, batch, hidden], use directly
+        initial_h_name = input_names[5];
+      } else {
+        // num_directions=2 (bidirectional): slice one direction
+        initial_h_name = utils::UniqueNameGenerator().New(input_names[5], direction);
+        RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, input_names[5], initial_h_name,
+                                        input_tensor_infos[5].shape, h_shape,
+                                        {{direction_idx, direction_idx + 1, 1},
+                                         {0, SafeInt<int32_t>(batch_size), 1},
+                                         {0, hidden_size_sign, 1}},
+                                        0, 0, 0, 0, input_tensor_infos[5].qnn_data_type,
+                                        input_tensor_infos[5].quant_param, do_op_validation, false, false));
+      }
     } else {
       initial_h_name = utils::UniqueNameGenerator().New(node_unit.Name(), "_GRU_initial_h");
       QnnTensorWrapper zero_h(initial_h_name, QNN_TENSOR_TYPE_STATIC, input_tensor_infos[0].qnn_data_type,
@@ -372,7 +367,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
     x_ranges[2] = {0, SafeInt<int32_t>(input_size), 1};
 
     std::string x_step = utils::UniqueNameGenerator().New(input_names[0], "_xs" + sfx);
-    RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, x_source, x_step,
+    RETURN_IF_ERROR(AddStridedSlice(qnn_model_wrapper, node_unit, x_source, x_step,
                                              x_source_shape, x_step_shape, x_ranges,
                                              0, 0, 0, 0, input_tensor_infos[0].qnn_data_type,
                                              input_tensor_infos[0].quant_param, do_op_validation, false, false));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -333,6 +333,22 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   // Each step feeds the full batch with seq=1.
   // time_major=true:  input [1, batch, input], output Y [1, batch, hidden]
   // time_major=false: input [batch, 1, input], output Y [batch, 1, hidden]
+
+  // For CPU (time_major=false), transpose X upfront from [seq, batch, input] to [batch, seq, input]
+  // so that per-step slicing produces [batch, 1, input] directly without per-step Reshapes.
+  std::string x_source = input_names[0];  // [seq, batch, input] for HTP, [batch, seq, input] for CPU
+  std::vector<uint32_t> x_source_shape = input_tensor_infos[0].shape;  // [seq, batch, input]
+  if (!time_major) {
+    std::string x_transposed = utils::UniqueNameGenerator().New(input_names[0], "_transposed_" + direction);
+    RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
+        node_unit.Index(), input_names[0], x_transposed,
+        input_tensor_infos[0].shape, {1, 0, 2}, {batch_size, seq_length, input_size},
+        input_tensor_infos[0].qnn_data_type, input_tensor_infos[0].quant_param,
+        do_op_validation, false, false));
+    x_source = x_transposed;
+    x_source_shape = {batch_size, seq_length, input_size};
+  }
+
   std::vector<std::string> qnn_all_step_hidden_names(seq_length);  // [batch, hidden] per step, ordered by t
   std::string prev_h_name = initial_h_name;                        // [1, batch, hidden]
 
@@ -343,31 +359,27 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
 
     std::vector<std::string> cell_inputs = qnn_gru_input_names;
 
-    // Slice X[t, :, :] -> [batch, input], reshape to 3D for QNN GRU.
-    std::string x_2d = utils::UniqueNameGenerator().New(input_names[0], "_x2d" + sfx);
-    RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[0], x_2d,
-                                             input_tensor_infos[0].shape, {batch_size, input_size},
-                                             {{SafeInt<int32_t>(t), SafeInt<int32_t>(t + 1), 1},
-                                              {0, SafeInt<int32_t>(batch_size), 1},
-                                              {0, SafeInt<int32_t>(input_size), 1}},
-                                             0, 0, 0b001U, 0, input_tensor_infos[0].qnn_data_type,
-                                             input_tensor_infos[0].quant_param, do_op_validation, false, false));
-    std::string x_3d = utils::UniqueNameGenerator().New(input_names[0], "_x3d" + sfx);
-    const std::vector<uint32_t> x_3d_shape = time_major ? std::vector<uint32_t>{1, batch_size, input_size}
-                                                        : std::vector<uint32_t>{batch_size, 1, input_size};
-    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(x_2d, x_3d, {batch_size, input_size}, x_3d_shape,
-                                                     input_tensor_infos[0].qnn_data_type,
-                                                     input_tensor_infos[0].quant_param, do_op_validation, false, false));
-    cell_inputs[0] = x_3d;
+    // Slice one time step from x_source:
+    // time_major=true:  x_source[t:t+1, :, :] from [seq, batch, input] -> [1, batch, input]
+    // time_major=false: x_source[:, t:t+1, :] from [batch, seq, input] -> [batch, 1, input]
+    const std::vector<uint32_t> x_step_shape = time_major ? std::vector<uint32_t>{1, batch_size, input_size}
+                                                          : std::vector<uint32_t>{batch_size, 1, input_size};
+    const int32_t seq_dim = time_major ? 0 : 1;
+    const int32_t batch_dim = time_major ? 1 : 0;
+    std::vector<std::vector<int32_t>> x_ranges(3);
+    x_ranges[seq_dim] = {SafeInt<int32_t>(t), SafeInt<int32_t>(t + 1), 1};
+    x_ranges[batch_dim] = {0, SafeInt<int32_t>(batch_size), 1};
+    x_ranges[2] = {0, SafeInt<int32_t>(input_size), 1};
 
-    // initial_h for this step: prev_h_name is [1, batch, hidden].
-    // Use a no-op Reshape to give it a unique name for this step's cell.
-    std::string h_in = utils::UniqueNameGenerator().New(node_unit, "_h_in" + sfx);
-    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_name, h_in,
-                                                     {1, batch_size, hidden_size}, {1, batch_size, hidden_size},
-                                                     input_tensor_infos[0].qnn_data_type,
-                                                     output_tensor_infos[1].quant_param, do_op_validation, false, false));
-    cell_inputs[13] = h_in;
+    std::string x_step = utils::UniqueNameGenerator().New(input_names[0], "_xs" + sfx);
+    RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, x_source, x_step,
+                                             x_source_shape, x_step_shape, x_ranges,
+                                             0, 0, 0, 0, input_tensor_infos[0].qnn_data_type,
+                                             input_tensor_infos[0].quant_param, do_op_validation, false, false));
+    cell_inputs[0] = x_step;
+
+    // initial_h for this step
+    cell_inputs[13] = prev_h_name;
 
     // GRU outputs:
     // time_major=true:  Y [1, batch, hidden], Y_h [1, batch, hidden]
@@ -391,24 +403,22 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                       std::vector<std::string>(param_names), do_op_validation),
                   "Failed to create GRU node.");
 
-    // Derive next step's initial_h from Y (out[0]) - Y_h (out[1]) is unreliable on QNN CPU.
-    // Need [1, batch, hidden] for initial_h.
-    std::string y_as_h = utils::UniqueNameGenerator().New(node_unit, "_Y_as_h" + sfx);
+    // Derive next step's initial_h.
+    // QNN CPU's Y_h (out[1]) is unreliable, so on CPU we derive h from Y (out[0]) via Transpose.
+    // On HTP (time_major=true), Y_h (out[1]) is already [1, batch, hidden] and can be used directly.
     if (time_major) {
-      // Y is already [1, batch, hidden] - just use a no-op Reshape
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_name, y_as_h,
-                                                       y_shape, {1, batch_size, hidden_size},
-                                                       output_tensor_infos[0].qnn_data_type,
-                                                       output_tensor_infos[0].quant_param, do_op_validation, false, false));
+      // HTP: use Y_h directly as next step's initial_h
+      prev_h_name = yh_name;
     } else {
-      // Y is [batch, 1, hidden] - Transpose to [1, batch, hidden]
+      // CPU: Y is [batch, 1, hidden] - Transpose to [1, batch, hidden]
+      std::string y_as_h = utils::UniqueNameGenerator().New(node_unit, "_Y_as_h" + sfx);
       RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
           node_unit.Index(), y_name, y_as_h,
           y_shape, {1, 0, 2}, {1, batch_size, hidden_size},
           output_tensor_infos[0].qnn_data_type, output_tensor_infos[0].quant_param,
           do_op_validation, false, false));
+      prev_h_name = y_as_h;
     }
-    prev_h_name = y_as_h;
 
     // Reshape Y -> [batch, hidden] for packing across time steps.
     std::string y_2d = utils::UniqueNameGenerator().New(node_unit, "_Y2d" + sfx);
@@ -432,30 +442,39 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                   "Failed to create Y Pack node.");
   }
 
-  // Final Y_h: last step's Y is already [1, batch, hidden] - use prev_h_name directly.
-  // Give it a stable name via a no-op Reshape so it can be referenced as Y_h.
-  const std::string y_h_final = utils::UniqueNameGenerator().New(node_unit, "_Yh_final_" + direction);
-  RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_name, y_h_final,
-                                                   {1, batch_size, hidden_size}, {1, batch_size, hidden_size},
-                                                   output_tensor_infos[1].qnn_data_type,
-                                                   output_tensor_infos[1].quant_param, do_op_validation, false, false));
-
   // Map to ONNX output shapes:
-  //   Y:   [seq, batch, hidden] -> ONNX [seq, 1, batch, hidden]  (Reshape)
-  //   Y_h: [1, batch, hidden]   -> ONNX [1, batch, hidden]       (no-op Reshape)
-  std::vector<std::vector<uint32_t>> onnx_shapes = {{seq_length, 1, batch_size, hidden_size}, {1, batch_size, hidden_size}};
-  const std::string* srcs[2] = {&y_all, &y_h_final};
-  std::vector<std::vector<uint32_t>> src_shapes = {{seq_length, batch_size, hidden_size}, {1, batch_size, hidden_size}};
+  //   Y:   [seq, batch, hidden] -> ONNX [seq, 1, batch, hidden]  (Reshape to insert num_directions dim)
+  //   Y_h: [1, batch, hidden]   -> ONNX [1, batch, hidden]       (already correct shape, use prev_h_name)
   for (size_t i = 0; i < 2; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
-      const std::string out_name = is_bidirection
-                                       ? utils::UniqueNameGenerator().New(*srcs[i], "_unsqueeze_" + direction)
-                                       : onnx_outputs[i].name;
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(*srcs[i], out_name, src_shapes[i], onnx_shapes[i],
-                                                       output_tensor_infos[i].qnn_data_type,
-                                                       output_tensor_infos[i].quant_param, do_op_validation, false,
-                                                       qnn_model_wrapper.IsGraphOutput(out_name)));
-      uni_gru_output_names.emplace_back(out_name);
+      if (i == 0) {
+        // Y: Reshape [seq, batch, hidden] -> [seq, 1, batch, hidden]
+        const std::string out_name = is_bidirection
+                                         ? utils::UniqueNameGenerator().New(y_all, "_unsqueeze_" + direction)
+                                         : onnx_outputs[i].name;
+        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_all, out_name,
+                                                         {seq_length, batch_size, hidden_size},
+                                                         {seq_length, 1, batch_size, hidden_size},
+                                                         output_tensor_infos[0].qnn_data_type,
+                                                         output_tensor_infos[0].quant_param, do_op_validation, false,
+                                                         qnn_model_wrapper.IsGraphOutput(out_name)));
+        uni_gru_output_names.emplace_back(out_name);
+      } else {
+        // Y_h: prev_h_name is already [1, batch, hidden] from the last step.
+        if (!is_bidirection) {
+          // Unidirectional: surface under the ONNX output name via Reshape (registers as APP_READ).
+          RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_name, onnx_outputs[i].name,
+                                                           {1, batch_size, hidden_size},
+                                                           {1, batch_size, hidden_size},
+                                                           output_tensor_infos[1].qnn_data_type,
+                                                           output_tensor_infos[1].quant_param, do_op_validation, false,
+                                                           qnn_model_wrapper.IsGraphOutput(onnx_outputs[i].name)));
+          uni_gru_output_names.emplace_back(onnx_outputs[i].name);
+        } else {
+          // Bidirectional: pass directly to Concat.
+          uni_gru_output_names.emplace_back(prev_h_name);
+        }
+      }
     } else {
       uni_gru_output_names.emplace_back("");
     }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -227,7 +227,8 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   const std::string null_tensor_name = utils::UniqueNameGenerator().New(node_unit, "_null_tensor_" + direction);
   QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_UNDEFINED,
                                        QnnQuantParamsWrapper(), std::vector<uint32_t>{0});
-  qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper)),
+                "Failed to add null tensor for GRU.");
 
   // Base GRU input template (weights, biases) - shared across all unrolled cells
   std::vector<std::string> qnn_gru_input_names(14, null_tensor_name);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -189,9 +189,10 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   }
 
   OrtNodeAttrHelper node_helper(node_unit);
-  const uint32_t hidden_size = node_helper.Get("hidden_size", 0);
-  const int32_t hidden_size_sign = SafeInt<int32_t>(hidden_size);
-  RETURN_IF_NOT(hidden_size > 0, "hidden size is not set for GRU");
+  const int64_t hidden_size_i64 = node_helper.Get("hidden_size", static_cast<int64_t>(0));
+  RETURN_IF_NOT(hidden_size_i64 > 0, "hidden_size is not set for GRU");
+  const uint32_t hidden_size = SafeInt<uint32_t>(hidden_size_i64);
+  const int32_t hidden_size_sign = SafeInt<int32_t>(hidden_size_i64);
   const int64_t linear_before_reset = node_helper.Get("linear_before_reset", static_cast<int64_t>(0));
   const int64_t layout = node_helper.Get("layout", static_cast<int64_t>(0));
 
@@ -220,9 +221,11 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), time_major,
                                      QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));
 
-  // Null tensor for optional inputs
-  const std::string null_tensor_name = "null_tensor";
-  QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_FLOAT_32,
+  // Null tensor for optional inputs — use a node-scoped unique name to avoid colliding with
+  // other ops' null tensors (e.g. LSTM uses the same pattern), and match LSTM's dtype of
+  // QNN_DATATYPE_UNDEFINED so the two null tensors are interchangeable if they ever share a graph.
+  const std::string null_tensor_name = utils::UniqueNameGenerator().New(node_unit, "_null_tensor_" + direction);
+  QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_UNDEFINED,
                                        QnnQuantParamsWrapper(), std::vector<uint32_t>{0});
   qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -318,8 +318,10 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                          static_cast<uint32_t>(linear_before_reset),
                                          QNN_OP_GRU_PARAM_LINEAR_BEFORE_RESET, param_names));
 
-  // time_major: set to true since current builder only supports time major GRU (layout=0)
-  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), true,
+  // time_major: set to false to work around a QNN CPU backend bug where batch elements get
+  // incorrect (duplicated) values when time_major=true. We transpose the input from
+  // [seq, batch, input] to [batch, seq, input] before the GRU and transpose the output back.
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
                                      QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));
 
   // Common null tensor for optional inputs
@@ -329,7 +331,23 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
 
   std::vector<std::string> qnn_gru_input_names(14, null_tensor_name);
-  qnn_gru_input_names[0] = input_names[0];
+
+  // Transpose X from time-major [seq, batch, input] to batch-first [batch, seq, input]
+  // to match time_major=false.
+  const std::string x_transposed_name = utils::UniqueNameGenerator().New(input_names[0], "_transposed_" + direction);
+  RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
+      node_unit.Index(),
+      input_names[0],
+      x_transposed_name,
+      input_tensor_infos[0].shape,                              // [seq, batch, input]
+      {1, 0, 2},                                                // perm: swap seq and batch
+      {batch_size, seq_length, input_size},                     // [batch, seq, input]
+      input_tensor_infos[0].qnn_data_type,
+      input_tensor_infos[0].quant_param,
+      do_op_validation,
+      /*is_for_input=*/false,
+      /*is_for_output=*/false));
+  qnn_gru_input_names[0] = x_transposed_name;
 
   // input W: ONNX in[1] [num_directions, 3*hidden_size, input_size], gate order: z, r, h
   {
@@ -545,11 +563,11 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   // }
 
   // outputs
-  // QNN out[0]: Y [seq_length, batch_size, hidden_size]
+  // QNN out[0]: Y [batch_size, seq_length, hidden_size] (time_major=false)
   // QNN out[1]: Y_h [1, batch_size, hidden_size] - QNN CPU may not give the correct final hidden
   //              state in out[1], so we derive Y_h from the appropriate time step of out[0] instead.
   std::vector<std::vector<uint32_t>> qnn_gru_output_shapes = {
-      {seq_length, batch_size, hidden_size},
+      {batch_size, seq_length, hidden_size},
       {1, batch_size, hidden_size}};
 
   std::vector<std::string> qnn_gru_output_names = {
@@ -571,16 +589,37 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                                 std::vector<std::string>(param_names), do_op_validation),
                 "QNN EP: Failed to create Qnn GRU node.");
 
-  // Map QNN outputs to ONNX outputs with appropriate reshapes/slices.
+  // Map QNN outputs to ONNX outputs with appropriate transposes/reshapes/slices.
   //
-  // QNN out[0]: Y [seq_length, batch_size, hidden_size]
+  // QNN out[0] (time_major=false): Y [batch_size, seq_length, hidden_size]
+  //   -> Transpose to [seq_length, batch_size, hidden_size] (time-major format)
   //   -> ONNX out[0]: Y [seq_length, 1, batch_size, hidden_size] (add num_directions dim via Reshape)
   //
   // QNN out[1] is unreliable on some backends (may return first-step state instead of final state).
-  // Instead, derive Y_h by slicing the correct time step from out[0]:
+  // Instead, derive Y_h by slicing the correct time step from the transposed Y:
   //   - forward:  Y[seq_length-1, :, :] = final hidden state
   //   - reverse:  Y[0, :, :] = final hidden state (last processed in reverse order)
   // Then reshape [batch_size, hidden_size] -> [1, batch_size, hidden_size] for ONNX Y_h.
+
+  // Transpose QNN Y from [batch, seq, hidden] to [seq, batch, hidden]
+  const std::string y_transposed_name = utils::UniqueNameGenerator().New(
+      qnn_gru_output_names[0], "_transposed_" + direction);
+  RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
+      node_unit.Index(),
+      qnn_gru_output_names[0],
+      y_transposed_name,
+      qnn_gru_output_shapes[0],                                // [batch, seq, hidden]
+      {1, 0, 2},                                                // perm: swap batch and seq
+      {seq_length, batch_size, hidden_size},                    // [seq, batch, hidden]
+      output_tensor_infos[0].qnn_data_type,
+      output_tensor_infos[0].quant_param,
+      do_op_validation,
+      /*is_for_input=*/false,
+      /*is_for_output=*/false));
+
+  // Transposed Y shape in time-major format
+  const std::vector<uint32_t> y_time_major_shape = {seq_length, batch_size, hidden_size};
+
   std::vector<std::vector<uint32_t>> onnx_gru_output_shapes = {
       {seq_length, 1, batch_size, hidden_size},
       {1, batch_size, hidden_size}};
@@ -595,9 +634,9 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
 
       if (i == 0) {
         // Y: Reshape [seq, batch, hidden] -> [seq, 1, batch, hidden]
-        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/qnn_gru_output_names[0],
+        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/y_transposed_name,
                                                          /*output_name=*/reshape_output_name,
-                                                         /*input_shape=*/qnn_gru_output_shapes[0],
+                                                         /*input_shape=*/y_time_major_shape,
                                                          /*output_shape=*/onnx_gru_output_shapes[0],
                                                          /*tensor_data_type=*/output_tensor_infos[0].qnn_data_type,
                                                          /*quantize_param=*/output_tensor_infos[0].quant_param,
@@ -605,7 +644,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                                          /*is_for_input=*/false,
                                                          /*is_for_output=*/qnn_model_wrapper.IsGraphOutput(reshape_output_name)));
       } else {
-        // Y_h: slice the final hidden state from Y (out[0]) and reshape to [1, batch, hidden].
+        // Y_h: slice the final hidden state from the transposed Y and reshape to [1, batch, hidden].
         // For forward direction: take Y[seq_length-1, :, :] (last time step).
         // For reverse direction: take Y[0, :, :] (first index = last processed in reverse).
         const int32_t y_h_t = (direction == "forward") ? SafeInt<int32_t>(seq_length) - 1 : 0;
@@ -617,9 +656,9 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
         std::vector<uint32_t> y_h_slice_shape = {batch_size, hidden_size};
         RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                                  /*node_unit=*/node_unit,
-                                                 /*input_name=*/qnn_gru_output_names[0],
+                                                 /*input_name=*/y_transposed_name,
                                                  /*output_name=*/y_h_slice_name,
-                                                 /*input_shape=*/qnn_gru_output_shapes[0],
+                                                 /*input_shape=*/y_time_major_shape,
                                                  /*output_shape=*/y_h_slice_shape,
                                                  /*ranges=*/y_h_ranges,
                                                  /*begin_mask=*/0b000U,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -15,70 +15,6 @@ class GRUOpBuilder : public BaseOpBuilder {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GRUOpBuilder);
 
  protected:
-  /*
-  ONNX GRU inputs:
-  in[0]: X [seq_length, batch_size, input_size]
-  in[1]: W [num_directions, 3*hidden_size, input_size], gate order: z (update), r (reset), h (new)
-  in[2]: R [num_directions, 3*hidden_size, hidden_size], gate order: z (update), r (reset), h (new)
-
-  ONNX GRU optional inputs:
-  in[3]: B [num_directions, 6*hidden_size], order: [Wb[zrh], Rb[zrh]]
-  in[4]: sequence_lens  ---> not supported
-  in[5]: initial_h [num_directions, batch_size, hidden_size]
-
-  ONNX GRU Parameters:
-  - activations      ---> not supported by QNN
-  - activation_alpha ---> not supported by QNN
-  - activation_beta  ---> not supported by QNN
-  - clip             ---> not supported by QNN
-  - direction
-  - hidden_size
-  - linear_before_reset
-  - layout: The shape format of inputs X, initial_h and outputs Y, Y_h.
-            If 0, the following shapes are expected:
-                X.shape = [seq_length, batch_size, input_size],
-                Y.shape = [seq_length, num_directions, batch_size, hidden_size],
-                initial_h.shape = Y_h.shape = [num_directions, batch_size, hidden_size].
-            If 1, the following shapes are expected:
-                X.shape = [batch_size, seq_length, input_size],
-                Y.shape = [batch_size, seq_length, num_directions, hidden_size],
-                initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].
-
-  ONNX GRU optional outputs:
-  out[0]: Y [seq_length, num_directions, batch_size, hidden_size]
-  out[1]: Y_h [num_directions, batch_size, hidden_size]
-
-  QNN GRU inputs:
-  in[0]: x_t: 3D of shape [seq_length, batch_size, input_size] if time_major
-                           [batch_size, seq_length, input_size] else
-  in[1]: W_xz: input-to-update weights [hidden_size, input_size]   = ONNX in[1][direction, 0*hidden_size:1*hidden_size, :]
-  in[2]: W_xr: input-to-reset weights [hidden_size, input_size]    = ONNX in[1][direction, 1*hidden_size:2*hidden_size, :]
-  in[3]: W_xn: input-to-new weights [hidden_size, input_size]      = ONNX in[1][direction, 2*hidden_size:3*hidden_size, :]
-  in[4]: W_hz: recurrent-to-update weights [hidden_size, hidden_size] = ONNX in[2][direction, 0*hidden_size:1*hidden_size, :]
-  in[5]: W_hr: recurrent-to-reset weights [hidden_size, hidden_size]  = ONNX in[2][direction, 1*hidden_size:2*hidden_size, :]
-  in[6]: W_hn: recurrent-to-new weights [hidden_size, hidden_size]    = ONNX in[2][direction, 2*hidden_size:3*hidden_size, :]
-
-  # optional inputs
-  in[7]:  b_xz: input-to-update gate bias [hidden_size]     = ONNX in[3][direction, 0*hidden_size:1*hidden_size]
-  in[8]:  b_xr: input-to-reset gate bias [hidden_size]      = ONNX in[3][direction, 1*hidden_size:2*hidden_size]
-  in[9]:  b_xn: input-to-new gate bias [hidden_size]        = ONNX in[3][direction, 2*hidden_size:3*hidden_size]
-  in[10]: b_hz: recurrent-to-update gate bias [hidden_size] = ONNX in[3][direction, 3*hidden_size:4*hidden_size]
-  in[11]: b_hr: recurrent-to-reset gate bias [hidden_size]  = ONNX in[3][direction, 4*hidden_size:5*hidden_size]
-  in[12]: b_hn: recurrent-to-new gate bias [hidden_size]    = ONNX in[3][direction, 5*hidden_size:6*hidden_size]
-  in[13]: initial_h [1, batch_size, hidden_size]             = ONNX in[5][direction:direction+1, :, :] as [1, batch_size, hidden_size]
-  in[14]: reset ---> not used
-
-  QNN GRU Parameters:
-  - direction
-  - linear_before_reset
-  - time_major
-
-  QNN GRU outputs:
-  out[0]: Y 3D of shape [seq_length, batch_size, hidden_size] if time_major
-                        [batch_size, seq_length, hidden_size] else
-  out[1]: Y_h [1, batch_size, hidden_size]
-  */
-
   Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                             const OrtNodeUnit& node_unit,
                             const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
@@ -141,34 +77,22 @@ Ort::Status GRUOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wr
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(output_name)) {
     return Ort::Status();
   }
-  // add strided_slice or reshape
-  // this is not general condition, only limited to caller in this builder
   size_t minSize = std::min(input_shape.size(), output_shape.size());
-  if (input_shape[0] == 1 && std::equal(output_shape.rbegin(), output_shape.rbegin() + minSize, input_shape.rbegin())) {
-    // add Reshape
-    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(input_name,
-                                                     output_name,
-                                                     input_shape,
-                                                     output_shape,
-                                                     tensor_data_type,
-                                                     quantize_param.Copy(),
-                                                     quantize_param.Copy(),
-                                                     do_op_validation,
-                                                     is_for_input,
-                                                     is_for_output));
+  uint32_t in_elems = 1, out_elems = 1;
+  for (auto s : input_shape) in_elems *= s;
+  for (auto s : output_shape) out_elems *= s;
+  if (in_elems == out_elems && input_shape[0] == 1 &&
+      std::equal(output_shape.rbegin(), output_shape.rbegin() + minSize, input_shape.rbegin())) {
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(input_name, output_name, input_shape, output_shape,
+                                                     tensor_data_type, quantize_param.Copy(), quantize_param.Copy(),
+                                                     do_op_validation, is_for_input, is_for_output));
   } else {
-    // add StridedSlice
-    // inputs
     QnnTensorWrapper input_tensorwrapper(input_name, is_for_input ? QNN_TENSOR_TYPE_APP_WRITE : QNN_TENSOR_TYPE_NATIVE,
-                                         tensor_data_type, quantize_param.Copy(),
-                                         std::vector<uint32_t>(input_shape));
+                                         tensor_data_type, quantize_param.Copy(), std::vector<uint32_t>(input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)),
                   "Failed to add input tensor for inserted StridedSlice or Reshape.");
 
-    // params
     const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_STRIDED_SLICE);
-
-    // ranges
     std::vector<uint32_t> ranges_data;
     for (size_t i = 0; i < ranges.size(); i++) {
       for (size_t j = 0; j < 3; j++) {
@@ -177,41 +101,26 @@ Ort::Status GRUOpBuilder::AddStridedSliceOrReshape(QnnModelWrapper& qnn_model_wr
     }
     QnnParamWrapper ranges_param_wrapper(node_unit.Index(), node_name, QNN_OP_STRIDED_SLICE_PARAM_RANGES,
                                          {static_cast<uint32_t>(ranges.size()), 3}, std::move(ranges_data), true);
-    std::vector<std::string> param_names = {
-        ranges_param_wrapper.GetParamTensorName(),
-    };
+    std::vector<std::string> param_names = {ranges_param_wrapper.GetParamTensorName()};
     qnn_model_wrapper.AddParamWrapper(std::move(ranges_param_wrapper));
 
-    // begin_mask
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, begin_mask,
                                            QNN_OP_STRIDED_SLICE_PARAM_BEGIN_MASK, param_names));
-
-    // end_mask
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, end_mask,
                                            QNN_OP_STRIDED_SLICE_PARAM_END_MASK, param_names));
-
-    // shrink_axes
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, shrink_axes,
                                            QNN_OP_STRIDED_SLICE_PARAM_SHRINK_AXES, param_names));
-
-    // new_axes_mask
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, new_axes_mask,
                                            QNN_OP_STRIDED_SLICE_PARAM_NEW_AXES_MASK, param_names));
 
-    // outputs
-    QnnTensorWrapper output_tensorwrapper(output_name,
-                                          is_for_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
-                                          tensor_data_type,
-                                          quantize_param.Copy(),
-                                          std::vector<uint32_t>(output_shape));
+    QnnTensorWrapper output_tensorwrapper(output_name, is_for_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
+                                          tensor_data_type, quantize_param.Copy(), std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
                   "Failed to add output tensor for inserted StridedSlice.");
-    // addNode
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE, {input_name},
-                                                  {output_name}, std::move(param_names), do_op_validation),
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE,
+                                                  {input_name}, {output_name}, std::move(param_names), do_op_validation),
                   "Failed to create manually inserted Qnn StridedSlice node.");
   }
-
   return Ort::Status();
 }
 
@@ -222,28 +131,23 @@ Ort::Status GRUOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   if (node_unit.Inputs().size() > 4 && node_unit.Inputs()[4].Exists()) {
     TensorInfo tensor_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[4], tensor_info));
-
     RETURN_IF_NOT(tensor_info.is_initializer, "QNN EP: dynamic sequence_length is not supported.");
-
     std::vector<uint8_t> sequence_lens_bytes;
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(tensor_info.initializer_tensor, sequence_lens_bytes));
     const size_t num_elems = sequence_lens_bytes.size() / sizeof(int32_t);
     gsl::span<const int32_t> sequence_lens{reinterpret_cast<const int32_t*>(sequence_lens_bytes.data()), num_elems};
-    RETURN_IF(std::any_of(sequence_lens.begin(),
-                          sequence_lens.end(),
+    RETURN_IF(std::any_of(sequence_lens.begin(), sequence_lens.end(),
                           [sequence_lens](int i) { return i != sequence_lens[0]; }),
               "QNN EP: Only support GRU with same sequence length.");
   }
 
   OrtNodeAttrHelper node_helper(node_unit);
   const float clip = node_helper.Get("clip", (float)0.0);
-  RETURN_IF(clip != 0,
-            "QNN EP doesn't support non-default clip for GRU.");
+  RETURN_IF(clip != 0, "QNN EP doesn't support non-default clip for GRU.");
   const std::vector<std::string> activations = node_helper.Get("activations", std::vector<std::string>{});
   RETURN_IF((activations.size() >= 2 && (activations[0] != "sigmoid" || activations[1] != "tanh")) ||
                 (activations.size() == 4 && (activations[2] != "sigmoid" || activations[3] != "tanh")),
             "QNN EP doesn't support non-default activations for GRU.");
-  // TODO: Add support for layout==1
   const int64_t layout = node_helper.Get("layout", static_cast<int64_t>(0));
   RETURN_IF_NOT(layout == 0,
                 ("QNN EP: Unsupport layout mode" + std::to_string(layout) + " for " + node_unit.Name()).c_str());
@@ -267,6 +171,9 @@ Ort::Status GRUOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
+// Manually unrolls the GRU across time steps and batch elements.
+// Each QNN GRU node processes a single (time_step, batch_element) with batch_size=1, seq_length=1.
+// This works around QNN CPU/HTP backend bugs where batch_size > 1 produces incorrect results.
 Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
                                              const OrtNodeUnit& node_unit,
                                              const std::string& direction,
@@ -284,7 +191,6 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(onnx_inputs[i], input_tensor_infos[i]));
     }
   }
-  // QNN GRU has 2 mandatory outputs
   std::vector<TensorInfo> output_tensor_infos(2);
   for (size_t i = 0; i < 2; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
@@ -305,383 +211,240 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   const uint32_t seq_length = input_tensor_infos[0].shape[0];
   const int32_t direction_idx = input_tensor_infos[1].shape[0] < 2 || direction == "forward" ? 0 : 1;
 
-  // params
+  // GRU parameters - shared by all unrolled cells
   std::vector<std::string> param_names;
-
-  // direction
+  // Always use forward direction for individual cells; time step ordering handled by unrolling loop
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_" + direction,
-                                         direction == "forward" ? QNN_OP_GRU_DIRECTION_FORWARD : QNN_OP_GRU_DIRECTION_REVERSE,
-                                         QNN_OP_GRU_PARAM_DIRECTION, param_names));
-
-  // linear_before_reset
+                                         QNN_OP_GRU_DIRECTION_FORWARD, QNN_OP_GRU_PARAM_DIRECTION, param_names));
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(linear_before_reset),
                                          QNN_OP_GRU_PARAM_LINEAR_BEFORE_RESET, param_names));
-
-  // time_major: set to false to work around a QNN CPU backend bug where batch elements get
-  // incorrect (duplicated) values when time_major=true. We transpose the input from
-  // [seq, batch, input] to [batch, seq, input] before the GRU and transpose the output back.
   RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
                                      QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));
 
-  // Common null tensor for optional inputs
+  // Null tensor for optional inputs
   const std::string null_tensor_name = "null_tensor";
   QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_FLOAT_32,
                                        QnnQuantParamsWrapper(), std::vector<uint32_t>{0});
   qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
 
+  // Base GRU input template (weights, biases) - shared across all unrolled cells
   std::vector<std::string> qnn_gru_input_names(14, null_tensor_name);
 
-  // Transpose X from time-major [seq, batch, input] to batch-first [batch, seq, input]
-  // to match time_major=false.
-  const std::string x_transposed_name = utils::UniqueNameGenerator().New(input_names[0], "_transposed_" + direction);
-  RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
-      node_unit.Index(),
-      input_names[0],
-      x_transposed_name,
-      input_tensor_infos[0].shape,                              // [seq, batch, input]
-      {1, 0, 2},                                                // perm: swap seq and batch
-      {batch_size, seq_length, input_size},                     // [batch, seq, input]
-      input_tensor_infos[0].qnn_data_type,
-      input_tensor_infos[0].quant_param,
-      do_op_validation,
-      /*is_for_input=*/false,
-      /*is_for_output=*/false));
-  qnn_gru_input_names[0] = x_transposed_name;
-
-  // input W: ONNX in[1] [num_directions, 3*hidden_size, input_size], gate order: z, r, h
+  // Slice W, R, B weights (same as before - shared across all cells)
+  // W: ONNX in[1] [num_directions, 3*hidden_size, input_size]
   {
-    // QNN in[1] (W_xz) = ONNX in[1][direction, 0*hidden_size:1*hidden_size, :]
-    // QNN in[2] (W_xr) = ONNX in[1][direction, 1*hidden_size:2*hidden_size, :]
-    // QNN in[3] (W_xn) = ONNX in[1][direction, 2*hidden_size:3*hidden_size, :]
-    uint32_t begin_mask = 0b000U;
-    uint32_t end_mask = 0b000U;
-    uint32_t shrink_axes = 0b001U;
-    uint32_t new_axes_mask = 0b000U;
-    std::vector<uint32_t> qnn_input_indices = {1, 2, 3};
+    std::vector<uint32_t> qnn_idx = {1, 2, 3};
     std::vector<int32_t> begins = {0, 1, 2};
-    std::vector<std::string> qnn_gru_weight_name = {
+    std::vector<std::string> names = {
         utils::UniqueNameGenerator().New(input_names[1], "_input_to_update_gate_weight_" + direction),
         utils::UniqueNameGenerator().New(input_names[1], "_input_to_reset_gate_weight_" + direction),
-        utils::UniqueNameGenerator().New(input_names[1], "_input_to_new_gate_weight_" + direction),
-    };
+        utils::UniqueNameGenerator().New(input_names[1], "_input_to_new_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
-      std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
-                                                  {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
-                                                  {0, SafeInt<int32_t>(input_size), 1}};
-      std::vector<uint32_t> output_shape = {hidden_size, input_size};
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
-                                               /*node_unit=*/node_unit,
-                                               /*input_name=*/input_names[1],
-                                               /*output_name=*/qnn_gru_weight_name[i],
-                                               /*input_shape=*/input_tensor_infos[1].shape,
-                                               /*output_shape=*/output_shape,
-                                               /*ranges=*/ranges,
-                                               /*begin_mask=*/begin_mask,
-                                               /*end_mask=*/end_mask,
-                                               /*shrink_axes=*/shrink_axes,
-                                               /*new_axes_mask=*/new_axes_mask,
-                                               /*tensor_data_type=*/input_tensor_infos[1].qnn_data_type,
-                                               /*QnnQuantParamsWrapper=*/input_tensor_infos[1].quant_param,
-                                               /*do_op_validation=*/do_op_validation,
-                                               /*is_for_input=*/false,
-                                               /*is_for_output=*/false));
-      qnn_gru_input_names[qnn_input_indices[i]] = qnn_gru_weight_name[i];
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[1], names[i],
+                                               input_tensor_infos[1].shape, {hidden_size, input_size},
+                                               {{direction_idx, direction_idx + 1, 1},
+                                                {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
+                                                {0, SafeInt<int32_t>(input_size), 1}},
+                                               0, 0, 0b001U, 0, input_tensor_infos[1].qnn_data_type,
+                                               input_tensor_infos[1].quant_param, do_op_validation, false, false));
+      qnn_gru_input_names[qnn_idx[i]] = names[i];
     }
   }
-
-  // input R: ONNX in[2] [num_directions, 3*hidden_size, hidden_size], gate order: z, r, h
+  // R: ONNX in[2] [num_directions, 3*hidden_size, hidden_size]
   {
-    // QNN in[4] (W_hz) = ONNX in[2][direction, 0*hidden_size:1*hidden_size, :]
-    // QNN in[5] (W_hr) = ONNX in[2][direction, 1*hidden_size:2*hidden_size, :]
-    // QNN in[6] (W_hn) = ONNX in[2][direction, 2*hidden_size:3*hidden_size, :]
-    uint32_t begin_mask = 0b000U;
-    uint32_t end_mask = 0b000U;
-    uint32_t shrink_axes = 0b001U;
-    uint32_t new_axes_mask = 0b000U;
-    std::vector<uint32_t> qnn_input_indices = {4, 5, 6};
+    std::vector<uint32_t> qnn_idx = {4, 5, 6};
     std::vector<int32_t> begins = {0, 1, 2};
-    std::vector<std::string> qnn_gru_weight_name = {
+    std::vector<std::string> names = {
         utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_update_gate_weight_" + direction),
         utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_reset_gate_weight_" + direction),
-        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_new_gate_weight_" + direction),
-    };
+        utils::UniqueNameGenerator().New(input_names[2], "_recurrent_to_new_gate_weight_" + direction)};
     for (size_t i = 0; i < 3; i++) {
-      std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
-                                                  {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
-                                                  {0, hidden_size_sign, 1}};
-      std::vector<uint32_t> output_shape = {hidden_size, hidden_size};
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
-                                               /*node_unit=*/node_unit,
-                                               /*input_name=*/input_names[2],
-                                               /*output_name=*/qnn_gru_weight_name[i],
-                                               /*input_shape=*/input_tensor_infos[2].shape,
-                                               /*output_shape=*/output_shape,
-                                               /*ranges=*/ranges,
-                                               /*begin_mask=*/begin_mask,
-                                               /*end_mask=*/end_mask,
-                                               /*shrink_axes=*/shrink_axes,
-                                               /*new_axes_mask=*/new_axes_mask,
-                                               /*tensor_data_type=*/input_tensor_infos[2].qnn_data_type,
-                                               /*QnnQuantParamsWrapper=*/input_tensor_infos[2].quant_param,
-                                               /*do_op_validation=*/do_op_validation,
-                                               /*is_for_input=*/false,
-                                               /*is_for_output=*/false));
-      qnn_gru_input_names[qnn_input_indices[i]] = qnn_gru_weight_name[i];
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[2], names[i],
+                                               input_tensor_infos[2].shape, {hidden_size, hidden_size},
+                                               {{direction_idx, direction_idx + 1, 1},
+                                                {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1},
+                                                {0, hidden_size_sign, 1}},
+                                               0, 0, 0b001U, 0, input_tensor_infos[2].qnn_data_type,
+                                               input_tensor_infos[2].quant_param, do_op_validation, false, false));
+      qnn_gru_input_names[qnn_idx[i]] = names[i];
     }
   }
-
-  // input B: ONNX in[3] [num_directions, 6*hidden_size], order: [Wb[zrh], Rb[zrh]]
+  // B: ONNX in[3] [num_directions, 6*hidden_size]
   {
-    // QNN in[7]  (b_xz) = ONNX in[3][direction, 0*hidden_size:1*hidden_size]
-    // QNN in[8]  (b_xr) = ONNX in[3][direction, 1*hidden_size:2*hidden_size]
-    // QNN in[9]  (b_xn) = ONNX in[3][direction, 2*hidden_size:3*hidden_size]
-    // QNN in[10] (b_hz) = ONNX in[3][direction, 3*hidden_size:4*hidden_size]
-    // QNN in[11] (b_hr) = ONNX in[3][direction, 4*hidden_size:5*hidden_size]
-    // QNN in[12] (b_hn) = ONNX in[3][direction, 5*hidden_size:6*hidden_size]
-    uint32_t begin_mask = 0b00U;
-    uint32_t end_mask = 0b00U;
-    uint32_t shrink_axes = 0b01U;
-    uint32_t new_axes_mask = 0b00U;
-    std::vector<uint32_t> output_shape = {hidden_size};
-    std::vector<uint32_t> qnn_input_indices = {7, 8, 9, 10, 11, 12};
+    std::vector<uint32_t> qnn_idx = {7, 8, 9, 10, 11, 12};
     if (onnx_inputs.size() > 3 && onnx_inputs[3].Exists()) {
       std::vector<int32_t> begins = {0, 1, 2, 3, 4, 5};
-      std::vector<std::string> qnn_gru_bias_name = {
+      std::vector<std::string> names = {
           utils::UniqueNameGenerator().New(input_names[3], "_input_to_update_gate_bias_" + direction),
           utils::UniqueNameGenerator().New(input_names[3], "_input_to_reset_gate_bias_" + direction),
           utils::UniqueNameGenerator().New(input_names[3], "_input_to_new_gate_bias_" + direction),
           utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_update_gate_bias_" + direction),
           utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_reset_gate_bias_" + direction),
-          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_new_gate_bias_" + direction),
-      };
+          utils::UniqueNameGenerator().New(input_names[3], "_recurrent_to_new_gate_bias_" + direction)};
       for (size_t i = 0; i < 6; i++) {
-        std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
-                                                    {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}};
-        RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
-                                                 /*node_unit=*/node_unit,
-                                                 /*input_name=*/input_names[3],
-                                                 /*output_name=*/qnn_gru_bias_name[i],
-                                                 /*input_shape=*/input_tensor_infos[3].shape,
-                                                 /*output_shape=*/output_shape,
-                                                 /*ranges=*/ranges,
-                                                 /*begin_mask=*/begin_mask,
-                                                 /*end_mask=*/end_mask,
-                                                 /*shrink_axes=*/shrink_axes,
-                                                 /*new_axes_mask=*/new_axes_mask,
-                                                 /*tensor_data_type=*/input_tensor_infos[3].qnn_data_type,
-                                                 /*QnnQuantParamsWrapper=*/input_tensor_infos[3].quant_param,
-                                                 /*do_op_validation=*/do_op_validation,
-                                                 /*is_for_input=*/false,
-                                                 /*is_for_output=*/false));
-        qnn_gru_input_names[qnn_input_indices[i]] = qnn_gru_bias_name[i];
+        RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[3], names[i],
+                                                 input_tensor_infos[3].shape, {hidden_size},
+                                                 {{direction_idx, direction_idx + 1, 1},
+                                                  {begins[i] * hidden_size_sign, (begins[i] + 1) * hidden_size_sign, 1}},
+                                                 0, 0, 0b01U, 0, input_tensor_infos[3].qnn_data_type,
+                                                 input_tensor_infos[3].quant_param, do_op_validation, false, false));
+        qnn_gru_input_names[qnn_idx[i]] = names[i];
       }
     } else {
-      // prepare zero bias
       std::string zero_bias_name = utils::UniqueNameGenerator().New(node_unit, "_zero_bias");
-      QnnTensorWrapper zero_bias_tensor_wrapper(zero_bias_name,
-                                                QNN_TENSOR_TYPE_STATIC,
-                                                input_tensor_infos[0].qnn_data_type,
-                                                QnnQuantParamsWrapper(),
-                                                std::vector<uint32_t>(output_shape),
-                                                std::vector<uint8_t>(
-                                                    utils::GetElementSizeByType(input_tensor_infos[0].qnn_data_type) * hidden_size,
-                                                    0));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zero_bias_tensor_wrapper)),
-                    "Failed to add additional zero bias for QNN GRU node.");
-      for (size_t i = 0; i < 6; i++) {
-        qnn_gru_input_names[qnn_input_indices[i]] = zero_bias_name;
-      }
+      QnnTensorWrapper zero_tw(zero_bias_name, QNN_TENSOR_TYPE_STATIC, input_tensor_infos[0].qnn_data_type,
+                               QnnQuantParamsWrapper(), std::vector<uint32_t>{hidden_size},
+                               std::vector<uint8_t>(utils::GetElementSizeByType(input_tensor_infos[0].qnn_data_type) * hidden_size, 0));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zero_tw)), "Failed to add zero bias.");
+      for (size_t i = 0; i < 6; i++) qnn_gru_input_names[qnn_idx[i]] = zero_bias_name;
     }
   }
-
-  // input initial_h: ONNX in[5] [num_directions, batch_size, hidden_size]
+  // initial_h: ONNX in[5] [num_directions, batch_size, hidden_size] -> [1, batch_size, hidden_size]
+  std::string initial_h_name;
   {
-    // QNN in[13] = ONNX in[5][direction_idx:direction_idx+1, :, :] as [1, batch_size, hidden_size]
-    // shrink_axes must be 0 so the direction dim is kept as 1 (not squeezed), matching QNN in[13]'s
-    // expected shape [1, batch_size, hidden_size]. For unidirectional (num_directions=1), the
-    // Reshape path is taken instead since input already has shape [1, batch, hidden].
-    uint32_t begin_mask = 0b000U;
-    uint32_t end_mask = 0b000U;
-    uint32_t shrink_axes = 0b000U;
-    uint32_t new_axes_mask = 0b000U;
-    std::vector<std::vector<int32_t>> ranges = {{direction_idx, direction_idx + 1, 1},
-                                                {0, SafeInt<int32_t>(batch_size), 1},
-                                                {0, hidden_size_sign, 1}};
-    std::vector<uint32_t> output_shape = {1, batch_size, hidden_size};
+    std::vector<uint32_t> h_shape = {1, batch_size, hidden_size};
     if (onnx_inputs.size() > 5 && onnx_inputs[5].Exists()) {
-      const std::string qnn_gru_initial_h_name = utils::UniqueNameGenerator().New(input_names[5], direction);
-      RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
-                                               /*node_unit=*/node_unit,
-                                               /*input_name=*/input_names[5],
-                                               /*output_name=*/qnn_gru_initial_h_name,
-                                               /*input_shape=*/input_tensor_infos[5].shape,
-                                               /*output_shape=*/output_shape,
-                                               /*ranges=*/ranges,
-                                               /*begin_mask=*/begin_mask,
-                                               /*end_mask=*/end_mask,
-                                               /*shrink_axes=*/shrink_axes,
-                                               /*new_axes_mask=*/new_axes_mask,
-                                               /*tensor_data_type=*/input_tensor_infos[5].qnn_data_type,
-                                               /*QnnQuantParamsWrapper=*/input_tensor_infos[5].quant_param,
-                                               /*do_op_validation=*/do_op_validation,
-                                               /*is_for_input=*/false,
-                                               /*is_for_output=*/false));
-      qnn_gru_input_names[13] = qnn_gru_initial_h_name;
+      initial_h_name = utils::UniqueNameGenerator().New(input_names[5], direction);
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[5], initial_h_name,
+                                               input_tensor_infos[5].shape, h_shape,
+                                               {{direction_idx, direction_idx + 1, 1},
+                                                {0, SafeInt<int32_t>(batch_size), 1}, {0, hidden_size_sign, 1}},
+                                               0, 0, 0, 0, input_tensor_infos[5].qnn_data_type,
+                                               input_tensor_infos[5].quant_param, do_op_validation, false, false));
     } else {
-      // prepare zero initial_h
-      const std::string& node_name = node_unit.Name();
-      std::string zero_initial_h_name = utils::UniqueNameGenerator().New(node_name, "_GRU_initial_h");
-      QnnTensorWrapper zero_initial_h_wrapper(zero_initial_h_name,
-                                              QNN_TENSOR_TYPE_STATIC,
-                                              input_tensor_infos[0].qnn_data_type,
-                                              QnnQuantParamsWrapper(),
-                                              std::vector<uint32_t>(output_shape),
-                                              std::vector<uint8_t>(
-                                                  utils::GetElementSizeByType(input_tensor_infos[0].qnn_data_type) * batch_size * hidden_size,
-                                                  0));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zero_initial_h_wrapper)),
-                    "Failed to add initial hidden state for QNN GRU node.");
-      qnn_gru_input_names[13] = zero_initial_h_name;
+      initial_h_name = utils::UniqueNameGenerator().New(node_unit.Name(), "_GRU_initial_h");
+      QnnTensorWrapper zero_h(initial_h_name, QNN_TENSOR_TYPE_STATIC, input_tensor_infos[0].qnn_data_type,
+                              QnnQuantParamsWrapper(), std::vector<uint32_t>(h_shape),
+                              std::vector<uint8_t>(utils::GetElementSizeByType(input_tensor_infos[0].qnn_data_type) * batch_size * hidden_size, 0));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zero_h)), "Failed to add initial hidden state.");
     }
   }
 
-  // {
-  //   // QNN in[14]
-  //   // prepare reset
-  //   const std::string& node_name = node_unit.Name();
-  //   std::string reset_name = utils::UniqueNameGenerator().New(node_name, "_GRU_reset");
-  //   QnnTensorWrapper reset_wrapper(reset_name,
-  //                                  QNN_TENSOR_TYPE_STATIC,
-  //                                  QNN_DATATYPE_BOOL_8,
-  //                                  QnnQuantParamsWrapper(),
-  //                                  std::vector<uint32_t>({}),
-  //                                  std::vector<uint8_t>({1}));
-  //   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reset_wrapper)),
-  //                 "Failed to add reset for QNN GRU node.");
-  //   qnn_gru_input_names[13] = reset_name;
-  // }
-
-  // outputs
-  // QNN out[0]: Y [batch_size, seq_length, hidden_size] (time_major=false)
-  // QNN out[1]: Y_h [1, batch_size, hidden_size] - QNN CPU may not give the correct final hidden
-  //              state in out[1], so we derive Y_h from the appropriate time step of out[0] instead.
-  std::vector<std::vector<uint32_t>> qnn_gru_output_shapes = {
-      {batch_size, seq_length, hidden_size},
-      {1, batch_size, hidden_size}};
-
-  std::vector<std::string> qnn_gru_output_names = {
-      utils::UniqueNameGenerator().New(node_unit, "_QNN_GRU_output_all_hidden_state_" + direction),
-      utils::UniqueNameGenerator().New(node_unit, "_QNN_GRU_output_last_hidden_state_" + direction)};
-
-  for (size_t j = 0; j < qnn_gru_output_names.size(); j++) {
-    QnnTensorWrapper output_tensorwrapper(qnn_gru_output_names[j],
-                                          QNN_TENSOR_TYPE_NATIVE,
-                                          output_tensor_infos[j].qnn_data_type,
-                                          output_tensor_infos[j].quant_param.Copy(),
-                                          std::vector<uint32_t>(qnn_gru_output_shapes[j]));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
-                  ("QNN EP: Failed to add " + std::to_string(j) + "th output tensor for QNN GRU.").c_str());
+  // Split initial_h [1, batch, hidden] -> per-batch [hidden_size] tensors
+  std::vector<std::string> prev_h_names(batch_size);
+  for (uint32_t b = 0; b < batch_size; b++) {
+    prev_h_names[b] = utils::UniqueNameGenerator().New(node_unit, "_h_init_b" + std::to_string(b) + "_" + direction);
+    RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, initial_h_name, prev_h_names[b],
+                                             {1, batch_size, hidden_size}, {hidden_size},
+                                             {{0, 1, 1}, {SafeInt<int32_t>(b), SafeInt<int32_t>(b + 1), 1}, {0, hidden_size_sign, 1}},
+                                             0, 0, 0b011U, 0, input_tensor_infos[0].qnn_data_type,
+                                             output_tensor_infos[1].quant_param, do_op_validation, false, false));
   }
-  const std::string gru_node_name = utils::UniqueNameGenerator().New(node_unit, "_" + direction);
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(gru_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_GRU,
-                                                std::move(qnn_gru_input_names), std::vector<std::string>(qnn_gru_output_names),
-                                                std::vector<std::string>(param_names), do_op_validation),
-                "QNN EP: Failed to create Qnn GRU node.");
 
-  // Map QNN outputs to ONNX outputs with appropriate transposes/reshapes/slices.
-  //
-  // QNN out[0] (time_major=false): Y [batch_size, seq_length, hidden_size]
-  //   -> Transpose to [seq_length, batch_size, hidden_size] (time-major format)
-  //   -> ONNX out[0]: Y [seq_length, 1, batch_size, hidden_size] (add num_directions dim via Reshape)
-  //
-  // QNN out[1] is unreliable on some backends (may return first-step state instead of final state).
-  // Instead, derive Y_h by slicing the correct time step from the transposed Y:
-  //   - forward:  Y[seq_length-1, :, :] = final hidden state
-  //   - reverse:  Y[0, :, :] = final hidden state (last processed in reverse order)
-  // Then reshape [batch_size, hidden_size] -> [1, batch_size, hidden_size] for ONNX Y_h.
+  // Unroll across time steps and batch elements
+  std::vector<std::string> qnn_all_hidden_state_names(seq_length);
 
-  // Transpose QNN Y from [batch, seq, hidden] to [seq, batch, hidden]
-  const std::string y_transposed_name = utils::UniqueNameGenerator().New(
-      qnn_gru_output_names[0], "_transposed_" + direction);
-  RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(
-      node_unit.Index(),
-      qnn_gru_output_names[0],
-      y_transposed_name,
-      qnn_gru_output_shapes[0],                                // [batch, seq, hidden]
-      {1, 0, 2},                                                // perm: swap batch and seq
-      {seq_length, batch_size, hidden_size},                    // [seq, batch, hidden]
-      output_tensor_infos[0].qnn_data_type,
-      output_tensor_infos[0].quant_param,
-      do_op_validation,
-      /*is_for_input=*/false,
-      /*is_for_output=*/false));
+  for (uint32_t step = 0; step < seq_length; step++) {
+    uint32_t t = direction == "forward" ? step : seq_length - step - 1;
+    std::vector<std::string> per_batch_h(batch_size);
 
-  // Transposed Y shape in time-major format
-  const std::vector<uint32_t> y_time_major_shape = {seq_length, batch_size, hidden_size};
+    for (uint32_t b = 0; b < batch_size; b++) {
+      std::vector<std::string> cell_inputs = qnn_gru_input_names;
+      const std::string sfx = "_t" + std::to_string(t) + "_b" + std::to_string(b) + "_" + direction;
 
-  std::vector<std::vector<uint32_t>> onnx_gru_output_shapes = {
-      {seq_length, 1, batch_size, hidden_size},
-      {1, batch_size, hidden_size}};
+      // Slice X[t, b, :] -> [input_size], reshape to [1, 1, input_size]
+      std::string x_flat = utils::UniqueNameGenerator().New(input_names[0], "_xf" + sfx);
+      RETURN_IF_ERROR(AddStridedSliceOrReshape(qnn_model_wrapper, node_unit, input_names[0], x_flat,
+                                               input_tensor_infos[0].shape, {input_size},
+                                               {{SafeInt<int32_t>(t), SafeInt<int32_t>(t + 1), 1},
+                                                {SafeInt<int32_t>(b), SafeInt<int32_t>(b + 1), 1},
+                                                {0, SafeInt<int32_t>(input_size), 1}},
+                                               0, 0, 0b011U, 0, input_tensor_infos[0].qnn_data_type,
+                                               input_tensor_infos[0].quant_param, do_op_validation, false, false));
+      std::string x_3d = utils::UniqueNameGenerator().New(input_names[0], "_x3d" + sfx);
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(x_flat, x_3d, {input_size}, {1, 1, input_size},
+                                                       input_tensor_infos[0].qnn_data_type,
+                                                       input_tensor_infos[0].quant_param, do_op_validation, false, false));
+      cell_inputs[0] = x_3d;
 
+      // Reshape prev_h [hidden_size] -> [1, 1, hidden_size] for initial_h
+      std::string h_3d = utils::UniqueNameGenerator().New(node_unit, "_h3d" + sfx);
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(prev_h_names[b], h_3d, {hidden_size}, {1, 1, hidden_size},
+                                                       input_tensor_infos[0].qnn_data_type,
+                                                       output_tensor_infos[1].quant_param, do_op_validation, false, false));
+      cell_inputs[13] = h_3d;
+
+      // GRU outputs: Y [1, 1, hidden], Y_h [1, 1, hidden]
+      std::string y_name = utils::UniqueNameGenerator().New(node_unit, "_Y" + sfx);
+      std::string yh_name = utils::UniqueNameGenerator().New(node_unit, "_Yh" + sfx);
+      for (const auto& [name, idx] : std::vector<std::pair<std::string, size_t>>{{y_name, 0}, {yh_name, 1}}) {
+        QnnTensorWrapper tw(name, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[idx].qnn_data_type,
+                            output_tensor_infos[idx].quant_param.Copy(), std::vector<uint32_t>{1, 1, hidden_size});
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add GRU output tensor.");
+      }
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(node_unit, "_cell" + sfx),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_GRU,
+                        std::move(cell_inputs), {y_name, yh_name},
+                        std::vector<std::string>(param_names), do_op_validation),
+                    "Failed to create GRU node.");
+
+      // Reshape Y [1, 1, hidden] -> [hidden_size]
+      std::string h_flat = utils::UniqueNameGenerator().New(node_unit, "_hf" + sfx);
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(y_name, h_flat, {1, 1, hidden_size}, {hidden_size},
+                                                       output_tensor_infos[0].qnn_data_type,
+                                                       output_tensor_infos[0].quant_param, do_op_validation, false, false));
+      per_batch_h[b] = h_flat;
+      prev_h_names[b] = h_flat;
+    }
+
+    // Pack per-batch [hidden] -> [batch, hidden]
+    std::string packed = utils::UniqueNameGenerator().New(node_unit, "_pk_t" + std::to_string(t) + "_" + direction);
+    {
+      std::vector<std::string> pp;
+      RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), packed, 0, QNN_OP_PACK_PARAM_AXIS, pp));
+      QnnTensorWrapper tw(packed, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
+                          output_tensor_infos[0].quant_param.Copy(), {batch_size, hidden_size});
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Pack output.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(packed, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
+                                                    std::move(per_batch_h), {packed}, std::move(pp), do_op_validation),
+                    "Failed to create Pack node.");
+    }
+    qnn_all_hidden_state_names[t] = packed;
+  }
+
+  // Pack time steps [batch, hidden] * seq -> [seq, batch, hidden]
+  const std::string y_all = utils::UniqueNameGenerator().New(node_unit, "_Y_all_" + direction);
+  {
+    std::vector<std::string> pp;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), y_all, 0, QNN_OP_PACK_PARAM_AXIS, pp));
+    QnnTensorWrapper tw(y_all, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[0].qnn_data_type,
+                        output_tensor_infos[0].quant_param.Copy(), {seq_length, batch_size, hidden_size});
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Y Pack output.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(y_all, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
+                                                  std::move(qnn_all_hidden_state_names), {y_all}, std::move(pp), do_op_validation),
+                  "Failed to create Y Pack node.");
+  }
+
+  // Pack final hidden states [hidden] * batch -> [batch, hidden]
+  const std::string y_h_packed = utils::UniqueNameGenerator().New(node_unit, "_Yh_pk_" + direction);
+  {
+    std::vector<std::string> pp;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), y_h_packed, 0, QNN_OP_PACK_PARAM_AXIS, pp));
+    QnnTensorWrapper tw(y_h_packed, QNN_TENSOR_TYPE_NATIVE, output_tensor_infos[1].qnn_data_type,
+                        output_tensor_infos[1].quant_param.Copy(), {batch_size, hidden_size});
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Y_h Pack output.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(y_h_packed, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
+                                                  std::vector<std::string>(prev_h_names), {y_h_packed}, std::move(pp), do_op_validation),
+                  "Failed to create Y_h Pack node.");
+  }
+
+  // Map to ONNX output shapes
+  std::vector<std::vector<uint32_t>> onnx_shapes = {{seq_length, 1, batch_size, hidden_size}, {1, batch_size, hidden_size}};
   for (size_t i = 0; i < 2; i++) {
     if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
-      // For bidirectional: use a unique intermediate name that will be consumed by a Concat op.
-      // For unidirectional: use the ONNX output name directly.
-      const std::string reshape_output_name = is_bidirection
-                                                  ? utils::UniqueNameGenerator().New(qnn_gru_output_names[i], "_unsqueeze_" + direction)
-                                                  : onnx_outputs[i].name;
-
-      if (i == 0) {
-        // Y: Reshape [seq, batch, hidden] -> [seq, 1, batch, hidden]
-        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/y_transposed_name,
-                                                         /*output_name=*/reshape_output_name,
-                                                         /*input_shape=*/y_time_major_shape,
-                                                         /*output_shape=*/onnx_gru_output_shapes[0],
-                                                         /*tensor_data_type=*/output_tensor_infos[0].qnn_data_type,
-                                                         /*quantize_param=*/output_tensor_infos[0].quant_param,
-                                                         /*do_op_validation=*/do_op_validation,
-                                                         /*is_for_input=*/false,
-                                                         /*is_for_output=*/qnn_model_wrapper.IsGraphOutput(reshape_output_name)));
-      } else {
-        // Y_h: slice the final hidden state from the transposed Y and reshape to [1, batch, hidden].
-        // For forward direction: take Y[seq_length-1, :, :] (last time step).
-        // For reverse direction: take Y[0, :, :] (first index = last processed in reverse).
-        const int32_t y_h_t = (direction == "forward") ? SafeInt<int32_t>(seq_length) - 1 : 0;
-        const std::string y_h_slice_name = utils::UniqueNameGenerator().New(
-            qnn_gru_output_names[0], "_y_h_slice_" + direction);
-        std::vector<std::vector<int32_t>> y_h_ranges = {{y_h_t, y_h_t + 1, 1},
-                                                         {0, SafeInt<int32_t>(batch_size), 1},
-                                                         {0, hidden_size_sign, 1}};
-        std::vector<uint32_t> y_h_slice_shape = {batch_size, hidden_size};
-        RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
-                                                 /*node_unit=*/node_unit,
-                                                 /*input_name=*/y_transposed_name,
-                                                 /*output_name=*/y_h_slice_name,
-                                                 /*input_shape=*/y_time_major_shape,
-                                                 /*output_shape=*/y_h_slice_shape,
-                                                 /*ranges=*/y_h_ranges,
-                                                 /*begin_mask=*/0b000U,
-                                                 /*end_mask=*/0b000U,
-                                                 /*shrink_axes=*/0b001U,
-                                                 /*new_axes_mask=*/0b000U,
-                                                 /*tensor_data_type=*/output_tensor_infos[1].qnn_data_type,
-                                                 /*QnnQuantParamsWrapper=*/output_tensor_infos[1].quant_param,
-                                                 /*do_op_validation=*/do_op_validation,
-                                                 /*is_for_input=*/false,
-                                                 /*is_for_output=*/false));
-        // Reshape [batch, hidden] -> [1, batch, hidden] for ONNX Y_h format.
-        RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/y_h_slice_name,
-                                                         /*output_name=*/reshape_output_name,
-                                                         /*input_shape=*/y_h_slice_shape,
-                                                         /*output_shape=*/onnx_gru_output_shapes[1],
-                                                         /*tensor_data_type=*/output_tensor_infos[1].qnn_data_type,
-                                                         /*quantize_param=*/output_tensor_infos[1].quant_param,
-                                                         /*do_op_validation=*/do_op_validation,
-                                                         /*is_for_input=*/false,
-                                                         /*is_for_output=*/qnn_model_wrapper.IsGraphOutput(reshape_output_name)));
-      }
-      uni_gru_output_names.emplace_back(reshape_output_name);
+      const std::string out_name = is_bidirection
+                                       ? utils::UniqueNameGenerator().New(y_all, "_unsqueeze_" + direction)
+                                       : onnx_outputs[i].name;
+      const std::string& src = (i == 0) ? y_all : y_h_packed;
+      const std::vector<uint32_t> src_shape = (i == 0) ? std::vector<uint32_t>{seq_length, batch_size, hidden_size}
+                                                       : std::vector<uint32_t>{batch_size, hidden_size};
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(src, out_name, src_shape, onnx_shapes[i],
+                                                       output_tensor_infos[i].qnn_data_type,
+                                                       output_tensor_infos[i].quant_param, do_op_validation, false,
+                                                       qnn_model_wrapper.IsGraphOutput(out_name)));
+      uni_gru_output_names.emplace_back(out_name);
     } else {
       uni_gru_output_names.emplace_back("");
     }
@@ -695,54 +458,36 @@ Ort::Status GRUOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                                                       const Ort::Logger& logger,
                                                       bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
-
   OrtNodeAttrHelper node_helper(node_unit);
   std::string direction = node_helper.Get("direction", "forward");
   RETURN_IF_NOT(inputs.size() >= 3 && inputs.size() <= 6, "GRU should receive inputs ranging from 3 to 6!");
 
   if (direction == "bidirectional") {
-    std::vector<std::string> uni_gru_output_names_forward, uni_gru_output_names_reverse;
-    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, "forward", input_names, logger, do_op_validation, true,
-                                       uni_gru_output_names_forward));
-    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, "reverse", input_names, logger, do_op_validation, true,
-                                       uni_gru_output_names_reverse));
-
-    // Concat forward and reverse output along the num_directions axis
+    std::vector<std::string> fwd_out, rev_out;
+    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, "forward", input_names, logger, do_op_validation, true, fwd_out));
+    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, "reverse", input_names, logger, do_op_validation, true, rev_out));
     for (size_t i = 0; i < 2; i++) {
       TensorInfo output_info = {};
       if (node_unit.Outputs().size() > i && node_unit.Outputs()[i].Exists()) {
         RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[i], output_info));
-        std::string onnx_output_name = node_unit.Outputs()[i].name;
-
-        // param
-        std::vector<std::string> concat_param_names;
-        RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), onnx_output_name,
+        std::string name = node_unit.Outputs()[i].name;
+        std::vector<std::string> cp;
+        RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), name,
                                                static_cast<uint32_t>(output_info.shape.size() - 3),
-                                               QNN_OP_CONCAT_PARAM_AXIS, concat_param_names));
-
-        // create tensor and add op
-        Qnn_TensorType_t output_tensor_type = qnn_model_wrapper.IsGraphOutput(onnx_output_name) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-        QnnTensorWrapper concat_output_tensorwrapper(onnx_output_name,
-                                                     output_tensor_type,
-                                                     output_info.qnn_data_type,
-                                                     output_info.quant_param.Copy(),
-                                                     std::vector<uint32_t>(output_info.shape));
-        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(concat_output_tensorwrapper)),
-                      "QNN EP: Failed to add output tensor for QNN Concat.");
+                                               QNN_OP_CONCAT_PARAM_AXIS, cp));
+        Qnn_TensorType_t tt = qnn_model_wrapper.IsGraphOutput(name) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+        QnnTensorWrapper tw(name, tt, output_info.qnn_data_type, output_info.quant_param.Copy(),
+                            std::vector<uint32_t>(output_info.shape));
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tw)), "Failed to add Concat output.");
         RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_CONCAT),
-                                                      QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                      QNN_OP_CONCAT,
-                                                      {uni_gru_output_names_forward[i], uni_gru_output_names_reverse[i]},
-                                                      {onnx_output_name},
-                                                      std::move(concat_param_names), do_op_validation),
-                      "QNN EP: Failed to create Qnn Concat node.");
+                                                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CONCAT,
+                                                      {fwd_out[i], rev_out[i]}, {name}, std::move(cp), do_op_validation),
+                      "Failed to create Concat node.");
       }
     }
   } else {
-    // not used, just a placeholder
-    std::vector<std::string> uni_gru_output_names;
-    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, direction, input_names, logger, do_op_validation, false,
-                                       uni_gru_output_names));
+    std::vector<std::string> uni_out;
+    RETURN_IF_ERROR(AddUnidirectionGRU(qnn_model_wrapper, node_unit, direction, input_names, logger, do_op_validation, false, uni_out));
   }
   return Ort::Status();
 }

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #if !defined(ORT_MINIMAL_BUILD)
 

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -461,7 +461,7 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_all_initializer) {
                                0,                                                                                     // layout
                                ExpectedEPNodeAssignment::All,
                                0,
-                               QDQTolerance(0.008f));
+                               QDQTolerance(0.004f));
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
@@ -512,7 +512,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_forward) {
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.03f);
+                      0.04f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
@@ -536,7 +536,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.27f);
+                      0.006f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional) {
@@ -560,7 +560,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional) {
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.25f);
+                      0.02f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_B) {
@@ -583,7 +583,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_B) {
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.07f);
+                      0.03f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_H) {
@@ -606,7 +606,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_H) {
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.035f);
+                      0.04f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_all_initializer) {
@@ -630,7 +630,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_all_initializer) {
                       0,                                                                                     // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.14f);
+                      0.02f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -1,0 +1,662 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <unordered_map>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+#include "test/unittest_util/tester_types.h"
+
+#include "core/graph/onnx_protobuf.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+/*
+  ONNX GRU inputs:
+  in[0]: X [seq_length, batch_size, input_size]
+  in[1]: W [num_directions, 3*hidden_size, input_size]
+  in[2]: R [num_directions, 3*hidden_size, hidden_size]
+
+  ONNX GRU optional inputs:
+  in[3]: B [num_directions, 6*hidden_size]
+  in[4]: sequence_lens [batch_size]  (not used)
+  in[5]: initial_h [num_directions, batch_size, hidden_size]
+
+  ONNX GRU Parameters:
+  - direction
+  - hidden_size
+  - linear_before_reset: When computing the output of the hidden gate, apply the
+                         linear transformation before multiplying by the output of
+                         the reset gate. Default: 0.
+  - layout: The shape format of inputs X, initial_h and outputs Y, Y_h.
+            If 0, the following shapes are expected:
+                X.shape = [seq_length, batch_size, input_size],
+                Y.shape = [seq_length, num_directions, batch_size, hidden_size],
+                initial_h.shape = Y_h.shape = [num_directions, batch_size, hidden_size].
+            If 1, the following shapes are expected:
+                X.shape = [batch_size, seq_length, input_size],
+                Y.shape = [batch_size, seq_length, num_directions, hidden_size],
+                initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].
+
+  ONNX GRU optional outputs:
+  out[0]: Y [seq_length, num_directions, batch_size, hidden_size]
+  out[1]: Y_h [num_directions, batch_size, hidden_size]
+*/
+
+template <typename InputType>
+void _BuildGRUTestCase(ModelTestBuilder& builder,
+                       const TestInputDef<float>& X_def,
+                       const TestInputDef<float>& W_def,
+                       const TestInputDef<float>& R_def,
+                       const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                       const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                       const bool has_Y,
+                       const bool has_Y_h,
+                       const std::string direction,
+                       const int64_t hidden_size,
+                       const int64_t layout,
+                       const int64_t linear_before_reset,
+                       const std::vector<QuantParams<InputType>>& output_qparams) {
+  static constexpr bool kIsFp16 = std::is_same<InputType, Ort::Float16_t>::value;
+  static constexpr bool kIsU8 = std::is_same<InputType, uint8_t>::value;
+
+  auto add_input = [&](const char* name, const TestInputDef<float>& def) -> std::string {
+    if constexpr (kIsFp16) {
+      TestInputDef<Ort::Float16_t> fp16_def = ConvertToFP16InputDef(def);
+      MakeTestInput(builder, name, fp16_def);
+      return name;
+    } else if constexpr (kIsU8) {
+      MakeTestInput(builder, name, def);
+      QuantParams<uint8_t> qparams = GetTestInputQuantParams<uint8_t>(def);
+      return AddQDQNodePair<uint8_t>(builder, std::string("qdq_") + name, name, qparams.scale, qparams.zero_point);
+    } else {
+      MakeTestInput(builder, name, def);
+      return name;
+    }
+  };
+
+  // Required inputs
+  const std::string x_name = add_input("X", X_def);
+  const std::string w_name = add_input("W", W_def);
+  const std::string r_name = add_input("R", R_def);
+
+  // Optional inputs are positional for GRU; represent missing values with empty string.
+  std::vector<std::string> input_names;
+  input_names.reserve(6);
+  input_names.push_back(x_name);
+  input_names.push_back(w_name);
+  input_names.push_back(r_name);
+
+  // B
+  if (B_def) {
+    input_names.push_back(add_input("B", B_def->get()));
+  } else {
+    input_names.push_back("");
+  }
+
+  // sequence_lens (not used)
+  input_names.push_back("");
+
+  // initial_h
+  if (H_def) {
+    input_names.push_back(add_input("initial_h", H_def->get()));
+  } else {
+    input_names.push_back("");
+  }
+
+  // Outputs
+  auto make_output = [&](const char* name) -> std::string {
+    if (name == nullptr || name[0] == '\0') return "";
+    if constexpr (kIsU8) {
+      return std::string("gru_") + name;
+    } else {
+      builder.MakeOutput(name);
+      return name;
+    }
+  };
+
+  const std::string y_out = has_Y ? make_output("Y") : std::string("");
+  const std::string y_h_out = has_Y_h ? make_output("Y_h") : std::string("");
+
+  std::vector<std::string> output_names;
+  output_names.push_back(y_out);
+  output_names.push_back(y_h_out);
+
+  // Attributes
+  std::vector<ONNX_NAMESPACE::AttributeProto> attrs;
+  attrs.push_back(builder.MakeStringAttribute("direction", direction));
+  attrs.push_back(builder.MakeScalarAttribute("hidden_size", hidden_size));
+  attrs.push_back(builder.MakeScalarAttribute("layout", layout));
+  attrs.push_back(builder.MakeScalarAttribute("linear_before_reset", linear_before_reset));
+
+  builder.AddNode("gru", "GRU", input_names, output_names, "", attrs);
+
+  ORT_UNUSED_PARAMETER(output_qparams);
+  if constexpr (kIsU8) {
+    size_t i = 0;
+    if (has_Y) {
+      AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, "qdq_Y", y_out, output_qparams[i].scale,
+                                                     output_qparams[i].zero_point);
+      ++i;
+    }
+    if (has_Y_h) {
+      AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, "qdq_Y_h", y_h_out, output_qparams[i].scale,
+                                                     output_qparams[i].zero_point);
+      ++i;
+    }
+  }
+}
+
+template <typename InputType>
+static GetTestModelFn BuildGRUTestCase(const TestInputDef<float>& X_def,
+                                       const TestInputDef<float>& W_def,
+                                       const TestInputDef<float>& R_def,
+                                       const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                       const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                       const bool has_Y,
+                                       const bool has_Y_h,
+                                       const std::string direction,
+                                       const int64_t hidden_size,
+                                       const int64_t layout,
+                                       const int64_t linear_before_reset = 0) {
+  return [X_def, W_def, R_def, B_def, H_def,
+          has_Y, has_Y_h,
+          direction, hidden_size, layout, linear_before_reset](ModelTestBuilder& builder) {
+    _BuildGRUTestCase<InputType>(builder, X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                 direction, hidden_size, layout, linear_before_reset, {});
+  };
+}
+
+template <typename InputQType>
+static GetTestQDQModelFn<InputQType> BuildQDQGRUTestCase(const TestInputDef<float>& X_def,
+                                                         const TestInputDef<float>& W_def,
+                                                         const TestInputDef<float>& R_def,
+                                                         const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                                         const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                                         const bool has_Y,
+                                                         const bool has_Y_h,
+                                                         const std::string direction,
+                                                         const int64_t hidden_size,
+                                                         const int64_t layout,
+                                                         const int64_t linear_before_reset = 0) {
+  return [X_def, W_def, R_def, B_def, H_def,
+          has_Y, has_Y_h,
+          direction, hidden_size, layout, linear_before_reset](ModelTestBuilder& builder,
+                                                               std::vector<QuantParams<InputQType>>& output_qparams) {
+    _BuildGRUTestCase<InputQType>(builder, X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                  direction, hidden_size, layout, linear_before_reset, output_qparams);
+  };
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+// Runs a GRU model on the QNN HTP backend with QDQ quantization.
+template <typename QuantType>
+static void RunHtpQDQGRUOpTest(const TestInputDef<float>& X_def,
+                                const TestInputDef<float>& W_def,
+                                const TestInputDef<float>& R_def,
+                                const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                const bool has_Y,
+                                const bool has_Y_h,
+                                const std::string direction,
+                                const int64_t hidden_size,
+                                const int64_t layout,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
+                                const int64_t linear_before_reset = 0,
+                                QDQTolerance tolerance = QDQTolerance(),
+                                int opset = 22) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildGRUTestCase<float>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                               direction, hidden_size, layout, linear_before_reset),
+                       BuildQDQGRUTestCase<QuantType>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                                      direction, hidden_size, layout, linear_before_reset),
+                       provider_options,
+                       opset,
+                       expected_ep_assignment,
+                       tolerance);
+}
+
+// Runs a GRU model on the QNN HTP backend with FP16 precision.
+static void RunHtpFp16GRUOpTest(const TestInputDef<float>& X_def,
+                                 const TestInputDef<float>& W_def,
+                                 const TestInputDef<float>& R_def,
+                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                 const bool has_Y,
+                                 const bool has_Y_h,
+                                 const std::string direction,
+                                 const int64_t hidden_size,
+                                 const int64_t layout,
+                                 ExpectedEPNodeAssignment expected_ep_assignment,
+                                 const int64_t linear_before_reset = 0,
+                                 float tolerance = 0.004f,
+                                 int opset = 22) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  TestFp16ModelAccuracy(BuildGRUTestCase<float>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                                direction, hidden_size, layout, linear_before_reset),
+                        BuildGRUTestCase<Ort::Float16_t>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                                         direction, hidden_size, layout, linear_before_reset),
+                        provider_options,
+                        opset,
+                        expected_ep_assignment,
+                        tolerance);
+}
+
+// Runs a GRU model on the QNN CPU backend with FP32.
+static void RunCpuFP32GRUOpTest(const TestInputDef<float>& X_def,
+                                 const TestInputDef<float>& W_def,
+                                 const TestInputDef<float>& R_def,
+                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                 const bool has_Y,
+                                 const bool has_Y_h,
+                                 const std::string direction,
+                                 const int64_t hidden_size,
+                                 const int64_t layout,
+                                 ExpectedEPNodeAssignment expected_ep_assignment,
+                                 const int64_t linear_before_reset = 0,
+                                 float tolerance = 0.004f,
+                                 int opset = 22) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+
+  RunQnnModelTest(BuildGRUTestCase<float>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                         direction, hidden_size, layout, linear_before_reset),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  tolerance);
+}
+
+// ============================================================
+// HTP QDQ Tests
+// ============================================================
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                               std::ref(B_def),                                                                        // B
+                               std::ref(H_def),                                                                        // initial_h
+                               true,                                                                                   // has_Y
+                               true,                                                                                   // has_Y_h
+                               direction,                                                                              // direction
+                               hidden_size,                                                                            // hidden_size
+                               0,                                                                                      // layout
+                               ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_reverse) {
+  std::string direction = "reverse";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                               std::ref(B_def),                                                                        // B
+                               std::ref(H_def),                                                                        // initial_h
+                               true,                                                                                   // has_Y
+                               true,                                                                                   // has_Y_h
+                               direction,                                                                              // direction
+                               hidden_size,                                                                            // hidden_size
+                               0,                                                                                      // layout
+                               ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                               std::ref(B_def),                                                                        // B
+                               std::ref(H_def),                                                                        // initial_h
+                               true,                                                                                   // has_Y
+                               true,                                                                                   // has_Y_h
+                               direction,                                                                              // direction
+                               hidden_size,                                                                            // hidden_size
+                               0,                                                                                      // layout
+                               ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_wo_B) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                               std::nullopt,                                                                           // B
+                               std::ref(H_def),                                                                        // initial_h
+                               true,                                                                                   // has_Y
+                               true,                                                                                   // has_Y_h
+                               direction,                                                                              // direction
+                               hidden_size,                                                                            // hidden_size
+                               0,                                                                                      // layout
+                               ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_wo_H) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                               std::ref(B_def),                                                                        // B
+                               std::nullopt,                                                                           // initial_h
+                               true,                                                                                   // has_Y
+                               true,                                                                                   // has_Y_h
+                               direction,                                                                              // direction
+                               hidden_size,                                                                            // hidden_size
+                               0,                                                                                      // layout
+                               ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_all_initializer) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, true, -0.5f, 0.5f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, true, -0.5f, 0.5f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -0.5f, 0.5f),            // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, true, -0.5f, 0.5f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, true, -0.5f, 0.5f), // R
+                               std::ref(B_def),                                                                       // B
+                               std::ref(H_def),                                                                       // initial_h
+                               true,                                                                                  // has_Y
+                               true,                                                                                  // has_Y_h
+                               direction,                                                                             // direction
+                               hidden_size,                                                                           // hidden_size
+                               0,                                                                                     // layout
+                               ExpectedEPNodeAssignment::All,
+                               0,
+                               QDQTolerance(0.008f));
+}
+
+TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                               std::ref(B_def),                                                                        // B
+                               std::ref(H_def),                                                                        // initial_h
+                               true,                                                                                   // has_Y
+                               true,                                                                                   // has_Y_h
+                               direction,                                                                              // direction
+                               hidden_size,                                                                            // hidden_size
+                               0,                                                                                      // layout
+                               ExpectedEPNodeAssignment::All,
+                               1);                                                                                     // linear_before_reset
+}
+
+// ============================================================
+// HTP FP16 Tests
+// ============================================================
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
+  std::string direction = "reverse";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.27f);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.25f);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_B) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::nullopt,                                                                           // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.07f);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_H) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::nullopt,                                                                           // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.035f);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_all_initializer) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, true, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, true, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),            // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, true, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, true, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                       // B
+                      std::ref(H_def),                                                                       // initial_h
+                      true,                                                                                  // has_Y
+                      true,                                                                                  // has_Y_h
+                      direction,                                                                             // direction
+                      hidden_size,                                                                           // hidden_size
+                      0,                                                                                     // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.14f);
+}
+
+TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All,
+                      1);                                                                                     // linear_before_reset
+}
+
+// ============================================================
+// CPU FP32 Tests
+// ============================================================
+
+TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -341,7 +341,7 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_layout1_forward) {
       std::exception);
 }
 
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Runs a GRU model on the QNN HTP backend with QDQ quantization.
 template <typename QuantType>
@@ -902,7 +902,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
                       0.03f);
 }
 
-#endif  // defined(__aarch64__) || defined(_M_ARM64)
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -314,6 +314,33 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_Y_h_only_forward) {
                       ExpectedEPNodeAssignment::All);
 }
 
+// layout=1: ORT CPU EP does not support batchwise layout, so session initialization throws.
+// Verify the expected failure so the test actively guards against silent regressions.
+TEST_F(QnnCPUBackendTests, GRU_fp32_layout1_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 6;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  // layout=1: X [batch, seq, input], initial_h [batch, num_directions, hidden]
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+  EXPECT_THROW(
+      RunCpuFP32GRUOpTest(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
+                          TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                          TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                          std::ref(B_def),                                                                         // B
+                          std::ref(H_def),                                                                         // initial_h
+                          true,                                                                                    // has_Y
+                          true,                                                                                    // has_Y_h
+                          direction,                                                                               // direction
+                          hidden_size,                                                                             // hidden_size
+                          1,                                                                                       // layout
+                          ExpectedEPNodeAssignment::None),
+      std::exception);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64)
 
 // Runs a GRU model on the QNN HTP backend with QDQ quantization.
@@ -578,6 +605,33 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_Y_h_only_bidirectional) {
                               ExpectedEPNodeAssignment::All);
 }
 
+// layout=1: ORT CPU EP does not support batchwise layout, so session initialization throws.
+// Verify the expected failure so the test actively guards against silent regressions.
+TEST_F(QnnHTPBackendTests, GRU_QDQ_layout1_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  // layout=1: X [batch, seq, input], initial_h [batch, num_directions, hidden]
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+  EXPECT_THROW(
+      RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
+                                  TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                                  TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                                  std::ref(B_def),                                                                         // B
+                                  std::ref(H_def),                                                                         // initial_h
+                                  true,                                                                                    // has_Y
+                                  true,                                                                                    // has_Y_h
+                                  direction,                                                                               // direction
+                                  hidden_size,                                                                             // hidden_size
+                                  1,                                                                                       // layout
+                                  ExpectedEPNodeAssignment::None),
+      std::exception);
+}
+
 TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
   std::string direction = "forward";
   uint32_t num_direction = 1;
@@ -795,6 +849,33 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_Y_h_only_bidirectional) {
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.02f);
+}
+
+// layout=1: ORT CPU EP does not support batchwise layout, so session initialization throws.
+// Verify the expected failure so the test actively guards against silent regressions.
+TEST_F(QnnHTPBackendTests, GRU_Fp16_layout1_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  // layout=1: X [batch, seq, input], initial_h [batch, num_directions, hidden]
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+  EXPECT_THROW(
+      RunHtpFp16GRUOpTest(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
+                          TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                          TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                          std::ref(B_def),                                                                         // B
+                          std::ref(H_def),                                                                         // initial_h
+                          true,                                                                                    // has_Y
+                          true,                                                                                    // has_Y_h
+                          direction,                                                                               // direction
+                          hidden_size,                                                                             // hidden_size
+                          1,                                                                                       // layout
+                          ExpectedEPNodeAssignment::None),
+      std::exception);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -196,24 +196,24 @@ static GetTestQDQModelFn<InputQType> BuildQDQGRUTestCase(const TestInputDef<floa
 
 // Runs a GRU model on the QNN CPU backend with FP32.
 static void RunCpuFP32GRUOpTest(const TestInputDef<float>& X_def,
-                                 const TestInputDef<float>& W_def,
-                                 const TestInputDef<float>& R_def,
-                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
-                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
-                                 const bool has_Y,
-                                 const bool has_Y_h,
-                                 const std::string direction,
-                                 const int64_t hidden_size,
-                                 const int64_t layout,
-                                 ExpectedEPNodeAssignment expected_ep_assignment,
-                                 const int64_t linear_before_reset = 0,
-                                 float tolerance = 0.004f,
-                                 int opset = 22) {
+                                const TestInputDef<float>& W_def,
+                                const TestInputDef<float>& R_def,
+                                const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                const bool has_Y,
+                                const bool has_Y_h,
+                                const std::string direction,
+                                const int64_t hidden_size,
+                                const int64_t layout,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
+                                const int64_t linear_before_reset = 0,
+                                float tolerance = 0.004f,
+                                int opset = 22) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";
 
   RunQnnModelTest(BuildGRUTestCase<float>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
-                                         direction, hidden_size, layout, linear_before_reset),
+                                          direction, hidden_size, layout, linear_before_reset),
                   provider_options,
                   opset,
                   expected_ep_assignment,
@@ -233,16 +233,16 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_forward) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All);
 }
 
@@ -255,16 +255,16 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All);
 }
 
@@ -273,19 +273,19 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
 // Runs a GRU model on the QNN HTP backend with QDQ quantization.
 template <typename QuantType>
 static void RunHtpQDQGRUOpTest(const TestInputDef<float>& X_def,
-                                const TestInputDef<float>& W_def,
-                                const TestInputDef<float>& R_def,
-                                const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
-                                const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
-                                const bool has_Y,
-                                const bool has_Y_h,
-                                const std::string direction,
-                                const int64_t hidden_size,
-                                const int64_t layout,
-                                ExpectedEPNodeAssignment expected_ep_assignment,
-                                const int64_t linear_before_reset = 0,
-                                QDQTolerance tolerance = QDQTolerance(),
-                                int opset = 22) {
+                               const TestInputDef<float>& W_def,
+                               const TestInputDef<float>& R_def,
+                               const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                               const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                               const bool has_Y,
+                               const bool has_Y_h,
+                               const std::string direction,
+                               const int64_t hidden_size,
+                               const int64_t layout,
+                               ExpectedEPNodeAssignment expected_ep_assignment,
+                               const int64_t linear_before_reset = 0,
+                               QDQTolerance tolerance = QDQTolerance(),
+                               int opset = 22) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -302,19 +302,19 @@ static void RunHtpQDQGRUOpTest(const TestInputDef<float>& X_def,
 
 // Runs a GRU model on the QNN HTP backend with FP16 precision.
 static void RunHtpFp16GRUOpTest(const TestInputDef<float>& X_def,
-                                 const TestInputDef<float>& W_def,
-                                 const TestInputDef<float>& R_def,
-                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
-                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
-                                 const bool has_Y,
-                                 const bool has_Y_h,
-                                 const std::string direction,
-                                 const int64_t hidden_size,
-                                 const int64_t layout,
-                                 ExpectedEPNodeAssignment expected_ep_assignment,
-                                 const int64_t linear_before_reset = 0,
-                                 float tolerance = 0.004f,
-                                 int opset = 22) {
+                                const TestInputDef<float>& W_def,
+                                const TestInputDef<float>& R_def,
+                                const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                const bool has_Y,
+                                const bool has_Y_h,
+                                const std::string direction,
+                                const int64_t hidden_size,
+                                const int64_t layout,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
+                                const int64_t linear_before_reset = 0,
+                                float tolerance = 0.004f,
+                                int opset = 22) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
 
@@ -341,17 +341,17 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_forward) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                               std::ref(B_def),                                                                        // B
-                               std::ref(H_def),                                                                        // initial_h
-                               true,                                                                                   // has_Y
-                               true,                                                                                   // has_Y_h
-                               direction,                                                                              // direction
-                               hidden_size,                                                                            // hidden_size
-                               0,                                                                                      // layout
-                               ExpectedEPNodeAssignment::All);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_reverse) {
@@ -363,17 +363,17 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_reverse) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                               std::ref(B_def),                                                                        // B
-                               std::ref(H_def),                                                                        // initial_h
-                               true,                                                                                   // has_Y
-                               true,                                                                                   // has_Y_h
-                               direction,                                                                              // direction
-                               hidden_size,                                                                            // hidden_size
-                               0,                                                                                      // layout
-                               ExpectedEPNodeAssignment::All);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional) {
@@ -385,17 +385,17 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                               std::ref(B_def),                                                                        // B
-                               std::ref(H_def),                                                                        // initial_h
-                               true,                                                                                   // has_Y
-                               true,                                                                                   // has_Y_h
-                               direction,                                                                              // direction
-                               hidden_size,                                                                            // hidden_size
-                               0,                                                                                      // layout
-                               ExpectedEPNodeAssignment::All);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_wo_B) {
@@ -406,17 +406,17 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_wo_B) {
   uint32_t input_size = 5;
   uint32_t seq_len = 6;
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                               std::nullopt,                                                                           // B
-                               std::ref(H_def),                                                                        // initial_h
-                               true,                                                                                   // has_Y
-                               true,                                                                                   // has_Y_h
-                               direction,                                                                              // direction
-                               hidden_size,                                                                            // hidden_size
-                               0,                                                                                      // layout
-                               ExpectedEPNodeAssignment::All);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::nullopt,                                                                            // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_wo_H) {
@@ -427,17 +427,17 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_wo_H) {
   uint32_t input_size = 5;
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                               std::ref(B_def),                                                                        // B
-                               std::nullopt,                                                                           // initial_h
-                               true,                                                                                   // has_Y
-                               true,                                                                                   // has_Y_h
-                               direction,                                                                              // direction
-                               hidden_size,                                                                            // hidden_size
-                               0,                                                                                      // layout
-                               ExpectedEPNodeAssignment::All);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::nullopt,                                                                            // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_all_initializer) {
@@ -449,19 +449,19 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_all_initializer) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, true, -0.5f, 0.5f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, true, -0.5f, 0.5f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -0.5f, 0.5f),            // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, true, -0.5f, 0.5f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, true, -0.5f, 0.5f), // R
-                               std::ref(B_def),                                                                       // B
-                               std::ref(H_def),                                                                       // initial_h
-                               true,                                                                                  // has_Y
-                               true,                                                                                  // has_Y_h
-                               direction,                                                                             // direction
-                               hidden_size,                                                                           // hidden_size
-                               0,                                                                                     // layout
-                               ExpectedEPNodeAssignment::All,
-                               0,
-                               QDQTolerance(0.004f));
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -0.5f, 0.5f),             // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, true, -0.5f, 0.5f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, true, -0.5f, 0.5f),  // R
+                              std::ref(B_def),                                                                        // B
+                              std::ref(H_def),                                                                        // initial_h
+                              true,                                                                                   // has_Y
+                              true,                                                                                   // has_Y_h
+                              direction,                                                                              // direction
+                              hidden_size,                                                                            // hidden_size
+                              0,                                                                                      // layout
+                              ExpectedEPNodeAssignment::All,
+                              0,
+                              QDQTolerance(0.004f));
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
@@ -473,18 +473,18 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                               std::ref(B_def),                                                                        // B
-                               std::ref(H_def),                                                                        // initial_h
-                               true,                                                                                   // has_Y
-                               true,                                                                                   // has_Y_h
-                               direction,                                                                              // direction
-                               hidden_size,                                                                            // hidden_size
-                               0,                                                                                      // layout
-                               ExpectedEPNodeAssignment::All,
-                               1);                                                                                     // linear_before_reset
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All,
+                              1);  // linear_before_reset
 }
 
 // ============================================================
@@ -500,16 +500,16 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_forward) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.04f);
@@ -524,16 +524,16 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.006f);
@@ -548,16 +548,16 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.02f);
@@ -571,16 +571,16 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_B) {
   uint32_t input_size = 5;
   uint32_t seq_len = 6;
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::nullopt,                                                                           // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::nullopt,                                                                            // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.03f);
@@ -594,16 +594,16 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_wo_H) {
   uint32_t input_size = 5;
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::nullopt,                                                                           // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::nullopt,                                                                            // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.04f);
@@ -618,16 +618,16 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_all_initializer) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, true, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, true, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),            // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, true, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, true, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                       // B
-                      std::ref(H_def),                                                                       // initial_h
-                      true,                                                                                  // has_Y
-                      true,                                                                                  // has_Y_h
-                      direction,                                                                             // direction
-                      hidden_size,                                                                           // hidden_size
-                      0,                                                                                     // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, true, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, true, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.02f);
@@ -642,18 +642,18 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
-                      1,                                                                                     // linear_before_reset
+                      1,  // linear_before_reset
                       0.03f);
 }
 

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -227,7 +227,7 @@ static void RunCpuFP32GRUOpTest(const TestInputDef<float>& X_def,
 TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_forward) {
   std::string direction = "forward";
   uint32_t num_direction = 1;
-  uint32_t batch_size = 1;  // QNN CPU GRU only reliably processes single-batch with initial_h
+  uint32_t batch_size = 6;
   uint32_t hidden_size = 4;
   uint32_t input_size = 5;
   uint32_t seq_len = 6;
@@ -249,7 +249,7 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_forward) {
 TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
-  uint32_t batch_size = 1;  // QNN CPU GRU only reliably processes single-batch with initial_h
+  uint32_t batch_size = 6;
   uint32_t hidden_size = 4;
   uint32_t input_size = 5;
   uint32_t seq_len = 6;

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -268,6 +268,52 @@ TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
                       ExpectedEPNodeAssignment::All);
 }
 
+// Y-only (has_Y=true, has_Y_h=false)
+TEST_F(QnnCPUBackendTests, GRU_fp32_Y_only_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 6;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      false,                                                                                   // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
+// Y_h-only (has_Y=false, has_Y_h=true)
+TEST_F(QnnCPUBackendTests, GRU_fp32_Y_h_only_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 6;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      false,                                                                                   // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64)
 
 // Runs a GRU model on the QNN HTP backend with QDQ quantization.
@@ -464,6 +510,74 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_sanity_bidirectional_all_initializer) {
                               QDQTolerance(0.004f));
 }
 
+TEST_F(QnnHTPBackendTests, GRU_QDQ_u16_sanity_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint16_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                               TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                               TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                               std::ref(B_def),                                                                         // B
+                               std::ref(H_def),                                                                         // initial_h
+                               true,                                                                                    // has_Y
+                               true,                                                                                    // has_Y_h
+                               direction,                                                                               // direction
+                               hidden_size,                                                                             // hidden_size
+                               0,                                                                                       // layout
+                               ExpectedEPNodeAssignment::All);
+}
+
+// Y-only (has_Y=true, has_Y_h=false) — exercises the bidirectional Concat path for Y
+TEST_F(QnnHTPBackendTests, GRU_QDQ_Y_only_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              false,                                                                                   // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
+}
+
+// Y_h-only (has_Y=false, has_Y_h=true) — exercises the bidirectional Concat path for Y_h
+TEST_F(QnnHTPBackendTests, GRU_QDQ_Y_h_only_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              false,                                                                                   // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              0,                                                                                       // layout
+                              ExpectedEPNodeAssignment::All);
+}
+
 TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
   std::string direction = "forward";
   uint32_t num_direction = 1;
@@ -628,6 +742,56 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional_all_initializer) {
                       direction,                                                                              // direction
                       hidden_size,                                                                            // hidden_size
                       0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.02f);
+}
+
+// Y-only (has_Y=true, has_Y_h=false) — exercises the bidirectional Concat path for Y
+TEST_F(QnnHTPBackendTests, GRU_Fp16_Y_only_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      false,                                                                                   // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.02f);
+}
+
+// Y_h-only (has_Y=false, has_Y_h=true) — exercises the bidirectional Concat path for Y_h
+TEST_F(QnnHTPBackendTests, GRU_Fp16_Y_h_only_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 3;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      false,                                                                                   // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
                       0.02f);

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -607,6 +607,7 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_Y_h_only_bidirectional) {
 
 // layout=1: ORT CPU EP does not support batchwise layout, so session initialization throws.
 // Verify the expected failure so the test actively guards against silent regressions.
+// On Linux aarch64 the test framework skips unsupported ops without throwing, so no EXPECT_THROW there.
 TEST_F(QnnHTPBackendTests, GRU_QDQ_layout1_forward) {
   std::string direction = "forward";
   uint32_t num_direction = 1;
@@ -617,6 +618,19 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_layout1_forward) {
   // layout=1: X [batch, seq, input], initial_h [batch, num_directions, hidden]
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+#if defined(__linux__) && defined(__aarch64__)
+  RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
+                              TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                              TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                              std::ref(B_def),                                                                         // B
+                              std::ref(H_def),                                                                         // initial_h
+                              true,                                                                                    // has_Y
+                              true,                                                                                    // has_Y_h
+                              direction,                                                                               // direction
+                              hidden_size,                                                                             // hidden_size
+                              1,                                                                                       // layout
+                              ExpectedEPNodeAssignment::None);
+#else
   EXPECT_THROW(
       RunHtpQDQGRUOpTest<uint8_t>(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
                                   TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
@@ -630,6 +644,7 @@ TEST_F(QnnHTPBackendTests, GRU_QDQ_layout1_forward) {
                                   1,                                                                                       // layout
                                   ExpectedEPNodeAssignment::None),
       std::exception);
+#endif
 }
 
 TEST_F(QnnHTPBackendTests, GRU_QDQ_linear_before_reset) {
@@ -692,6 +707,14 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  // Linux x86_64 accumulates larger FP16 rounding error in the reverse unroll
+  // (observed: Y max-rel ~0.14, Y_h max-rel ~0.008).
+  // TODO: Remove the platform-aware tolerance once the accuracy issue on Linux x86_64 is solved
+#if defined(__linux__) && defined(__x86_64__)
+  constexpr float kTolerance = 0.15f;
+#else
+  constexpr float kTolerance = 0.006f;
+#endif
   RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
                       TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
                       TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
@@ -704,7 +727,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
                       0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       0,
-                      0.006f);
+                      kTolerance);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_bidirectional) {
@@ -853,6 +876,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_Y_h_only_bidirectional) {
 
 // layout=1: ORT CPU EP does not support batchwise layout, so session initialization throws.
 // Verify the expected failure so the test actively guards against silent regressions.
+// On Linux aarch64 the test framework skips unsupported ops without throwing, so no EXPECT_THROW there.
 TEST_F(QnnHTPBackendTests, GRU_Fp16_layout1_forward) {
   std::string direction = "forward";
   uint32_t num_direction = 1;
@@ -863,6 +887,19 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_layout1_forward) {
   // layout=1: X [batch, seq, input], initial_h [batch, num_directions, hidden]
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+#if defined(__linux__) && defined(__aarch64__)
+  RunHtpFp16GRUOpTest(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                      std::ref(B_def),                                                                         // B
+                      std::ref(H_def),                                                                         // initial_h
+                      true,                                                                                    // has_Y
+                      true,                                                                                    // has_Y_h
+                      direction,                                                                               // direction
+                      hidden_size,                                                                             // hidden_size
+                      1,                                                                                       // layout
+                      ExpectedEPNodeAssignment::None);
+#else
   EXPECT_THROW(
       RunHtpFp16GRUOpTest(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
                           TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
@@ -876,6 +913,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_layout1_forward) {
                           1,                                                                                       // layout
                           ExpectedEPNodeAssignment::None),
       std::exception);
+#endif
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
@@ -887,6 +925,14 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
   uint32_t seq_len = 6;
   auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
   auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  // Linux x86_64 accumulates larger FP16 rounding error with linear_before_reset
+  // (observed: Y max-rel ~0.204, Y_h max-rel ~0.013).
+  // TODO: Remove the platform-aware tolerance once the accuracy issue on Linux x86_64 is solved
+#if defined(__linux__) && defined(__x86_64__)
+  constexpr float kTolerance = 0.25f;
+#else
+  constexpr float kTolerance = 0.03f;
+#endif
   RunHtpFp16GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
                       TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
                       TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
@@ -899,7 +945,7 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
                       0,                                                                                       // layout
                       ExpectedEPNodeAssignment::All,
                       1,  // linear_before_reset
-                      0.03f);
+                      kTolerance);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -510,7 +510,9 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_forward) {
                       direction,                                                                              // direction
                       hidden_size,                                                                            // hidden_size
                       0,                                                                                      // layout
-                      ExpectedEPNodeAssignment::All);
+                      ExpectedEPNodeAssignment::All,
+                      0,
+                      0.03f);
 }
 
 TEST_F(QnnHTPBackendTests, GRU_Fp16_sanity_reverse) {
@@ -651,7 +653,8 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
                       hidden_size,                                                                            // hidden_size
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
-                      1);                                                                                     // linear_before_reset
+                      1,                                                                                     // linear_before_reset
+                      0.03f);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64)

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -194,6 +194,80 @@ static GetTestQDQModelFn<InputQType> BuildQDQGRUTestCase(const TestInputDef<floa
   };
 }
 
+// Runs a GRU model on the QNN CPU backend with FP32.
+static void RunCpuFP32GRUOpTest(const TestInputDef<float>& X_def,
+                                 const TestInputDef<float>& W_def,
+                                 const TestInputDef<float>& R_def,
+                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
+                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
+                                 const bool has_Y,
+                                 const bool has_Y_h,
+                                 const std::string direction,
+                                 const int64_t hidden_size,
+                                 const int64_t layout,
+                                 ExpectedEPNodeAssignment expected_ep_assignment,
+                                 const int64_t linear_before_reset = 0,
+                                 float tolerance = 0.004f,
+                                 int opset = 22) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+
+  RunQnnModelTest(BuildGRUTestCase<float>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
+                                         direction, hidden_size, layout, linear_before_reset),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  tolerance);
+}
+
+// ============================================================
+// CPU FP32 Tests
+// ============================================================
+
+TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 1;  // QNN CPU GRU only reliably processes single-batch with initial_h
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
+  std::string direction = "bidirectional";
+  uint32_t num_direction = 2;
+  uint32_t batch_size = 1;  // QNN CPU GRU only reliably processes single-batch with initial_h
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
+  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
+                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
+                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
+                      std::ref(B_def),                                                                        // B
+                      std::ref(H_def),                                                                        // initial_h
+                      true,                                                                                   // has_Y
+                      true,                                                                                   // has_Y_h
+                      direction,                                                                              // direction
+                      hidden_size,                                                                            // hidden_size
+                      0,                                                                                      // layout
+                      ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64)
 
 // Runs a GRU model on the QNN HTP backend with QDQ quantization.
@@ -252,32 +326,6 @@ static void RunHtpFp16GRUOpTest(const TestInputDef<float>& X_def,
                         opset,
                         expected_ep_assignment,
                         tolerance);
-}
-
-// Runs a GRU model on the QNN CPU backend with FP32.
-static void RunCpuFP32GRUOpTest(const TestInputDef<float>& X_def,
-                                 const TestInputDef<float>& W_def,
-                                 const TestInputDef<float>& R_def,
-                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> B_def,
-                                 const std::optional<std::reference_wrapper<TestInputDef<float>>> H_def,
-                                 const bool has_Y,
-                                 const bool has_Y_h,
-                                 const std::string direction,
-                                 const int64_t hidden_size,
-                                 const int64_t layout,
-                                 ExpectedEPNodeAssignment expected_ep_assignment,
-                                 const int64_t linear_before_reset = 0,
-                                 float tolerance = 0.004f,
-                                 int opset = 22) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-
-  RunQnnModelTest(BuildGRUTestCase<float>(X_def, W_def, R_def, B_def, H_def, has_Y, has_Y_h,
-                                         direction, hidden_size, layout, linear_before_reset),
-                  provider_options,
-                  opset,
-                  expected_ep_assignment,
-                  tolerance);
 }
 
 // ============================================================
@@ -604,54 +652,6 @@ TEST_F(QnnHTPBackendTests, GRU_Fp16_linear_before_reset) {
                       0,                                                                                      // layout
                       ExpectedEPNodeAssignment::All,
                       1);                                                                                     // linear_before_reset
-}
-
-// ============================================================
-// CPU FP32 Tests
-// ============================================================
-
-TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_forward) {
-  std::string direction = "forward";
-  uint32_t num_direction = 1;
-  uint32_t batch_size = 3;
-  uint32_t hidden_size = 4;
-  uint32_t input_size = 5;
-  uint32_t seq_len = 6;
-  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
-  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
-                      ExpectedEPNodeAssignment::All);
-}
-
-TEST_F(QnnCPUBackendTests, GRU_fp32_sanity_bidirectional) {
-  std::string direction = "bidirectional";
-  uint32_t num_direction = 2;
-  uint32_t batch_size = 3;
-  uint32_t hidden_size = 4;
-  uint32_t input_size = 5;
-  uint32_t seq_len = 6;
-  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -1.0f, 1.0f);
-  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -1.0f, 1.0f);
-  RunCpuFP32GRUOpTest(TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),             // X
-                      TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),  // W
-                      TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f), // R
-                      std::ref(B_def),                                                                        // B
-                      std::ref(H_def),                                                                        // initial_h
-                      true,                                                                                   // has_Y
-                      true,                                                                                   // has_Y_h
-                      direction,                                                                              // direction
-                      hidden_size,                                                                            // hidden_size
-                      0,                                                                                      // layout
-                      ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
**Overview**
- This PR adds GRU support to the QNN Execution Provider, covering both QNN CPU and QNN HTP           backends

**Handle Qnn Backend Issue**
| QNN CPU | QNN HTP |
|------|----------|
| 1. Accuracy issue on `time_major=true` <br> 2. Accuracy issue on the second output `Y_H` |  Need to unroll time steps to avoid accuracy issue |

In this PR, we propose the workarounds/solutions
1. Always unroll time steps for GRU (aligned with qairt-converter)
2. If on QNN CPU
    - Use `time_major=false` with necessary Transpose
    - Use the first output `Y` to acquire `Y_H`

**Test Coverage**
- CPU FP32: forward, bidirectional
- HTP QDQ uint8: forward, reverse, bidirectional (with/without B, with/without H), all-initializer, linear_before_reset
- HTP FP16: same configurations as QDQ
- ONNX backend tests: test_gru_defaults, test_gru_seq_length, test_gru_with_initial_bias

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Prevent CPU Fallback on GRU Op and leverage QNN backend accelerators
