### PR TITLE
[OpBuilder] Support HTP MatMulNBits.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cassert>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
@@ -10,39 +16,68 @@
 namespace onnxruntime {
 namespace qnn {
 /* Op Resolution
-    --> Incoming ONNX Node
+  --> Incoming ONNX Node
     1. MatMulNBits
-    Attributes : INT64
-      - accuracy_level  : 4
-      - bits            : 4
-      - block_size      : 32
-      - K               :
-      - N               :
-    Inputs
-      - A           :                 : (fp16/32) : [batch_size{1}, sequence_len, K]
-      - B           : Init            : (uint8)   : [N, K/block_size, (block_size * bits) / 8]
-      - scales      : Init            : (fp32)    : [N * K / block_size]
-      - zero_points : (optional)Init  : (uint8)   : [N * K / (block_size * 2)]
-      - bias        : (optional)Init  : [fp16/32] : [N]
-    Outputs
-      -  Y          :                 : (fp16/32) : [batch_size{1}, sequence_len, N]
-  <-- Outgoing QNN Node
-  1. FullyConnected
-  Attributes
-    -
-  Inputs
-    - Input           : (fp16/32)         : [batch_size{1}, sequence_len, K]
-    - Weight          : Static : (qint4)  : [N, K]
-      - Scales        : fp32              : [(N * K) / block_size{32}]
-      - Offsets       : int32_t           : [(N * K) / block_size{32}]
-    - Bias            : Static :(fp16/32) : [1, N]
-  Outputs
-    - Output          : (fp16/32)         : [batch_size{1} * sequence_len, N]
-  2. Reshape
-  Inputs
-    - Input           : (fp16/32)         : [batch_size{1} * sequence_len, N]
-  Outputs
-    - Output          : (fp16/32)         : [batch_size{1}, sequence_len, N]
+      Attributes : INT64
+        - bits            : 2(HTP), 4(GPU/HTP), 8(HTP)
+        - block_size      : 32(GPU), 16x(HTP if bits=2), 8x(HTP if bits=4), 4x(HTP if bits=8)
+        - K               :
+        - N               :
+      Inputs
+        - A           :                 : fp16/fp32 : [batch_size, sequence_len, K]
+        - B           : Init            : uint8     : [N, K / block_size, (block_size * bits) / 8]
+        - scales      : Init            : fp16/fp32 : [N, K / block_size]
+        - zero_points : (optional)Init  : uint8     : [N, (K / block_size) * bits / 8]
+      Outputs
+        -  Y          :                 : fp16/fp32 : [batch_size, sequence_len, N]
+  <-- Outgoing QNN Node (GPU)
+    1. FullyConnected
+      Attributes
+        -
+      Inputs
+        - Input           :        : fp16/fp32            : [batch_size, sequence_len, K]
+        - Weight          : Static : qint4(BlockEncoding) : [N, K]
+          - Scales        :        : fp32                 : [N * (K / block_size)]
+          - Offsets       :        : int32_t              : [N * (K / block_size)]
+      Outputs
+        - Output          :        : fp16/fp32            : [batch_size * sequence_len, N]
+    2. Reshape
+      Inputs
+        - Input           :        : fp16/fp32            : [batch_size * sequence_len, N]
+      Outputs
+        - Output          :        : fp16/fp32            : [batch_size, sequence_len, N]
+  <-- Outgoing QNN Node (HTP)
+    1. Reshape
+      Inputs
+        - Input           :        : fp16/fp32                    : [batch_size, sequence_len, K]
+      Outputs
+        - Output          :        : fp16/fp32                    : [batch_size, 1, sequence_len, K]
+    2. Cast (workaround for fp32)
+      Inputs
+        - Input           :        : fp32                         : [batch_size, 1, sequence_len, K]
+      Outputs
+        - Output          :        : fp16                         : [batch_size, 1, sequence_len, K]
+    3. Conv2d
+      Attributes : UINT32
+        - stride     : [1, 1]
+        - pad_amount : [[0, 0], [0, 0]]
+      Inputs
+        - Input           :        : fp16                         : [batch_size, 1, sequence_len, K]
+        - Weight          : Static : qint8(BwFloatBlockEncoding)  : [1, 1, K, N]
+          - Scales        :        : fp32                         : [N * (K / block_size)]
+          - Offsets       :        : fp32                         : [N * (K / block_size)]
+      Outputs
+        - Output          :        : fp16                         : [batch_size, 1, sequence_len, N]
+    4. Cast (workaround for fp32)
+      Inputs
+        - Input           :        : fp16                         : [batch_size, 1, sequence_len, N]
+      Outputs
+        - Output          :        : fp32                         : [batch_size, 1, sequence_len, N]
+    5. Reshape
+      Inputs
+        - Input           :        : fp16/fp32                    : [batch_size, 1, sequence_len, N]
+      Outputs
+        - Output          :        : fp16/fp32                    : [batch_size, sequence_len, N]
 */
 
 class MatMulNBitsOpBuilder : public BaseOpBuilder {
@@ -66,127 +101,167 @@ class MatMulNBitsOpBuilder : public BaseOpBuilder {
                                           std::vector<std::string>&& input_names,
                                           const Ort::Logger& logger,
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
-
- private:
-  void DQQToSignedFixedPoint4(std::vector<uint8_t>& quant_data, int64_t num_blocks, int64_t block_size) const;
 };
 
-void MatMulNBitsOpBuilder::DQQToSignedFixedPoint4(std::vector<uint8_t>& quant_data,
-                                                  int64_t num_blocks,
-                                                  int64_t block_size) const {
-  for (int64_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
-    uint32_t zero_point = 8;
-    for (int64_t val_idx = 0; val_idx < (block_size / 2); ++val_idx) {
-      SafeInt<int64_t> safe_index = block_idx;
-      safe_index *= (block_size / 2);
-      safe_index += val_idx;
+namespace {
+constexpr int64_t kByteBits = 8;
 
-      size_t index = gsl::narrow_cast<size_t>(safe_index);
-      uint8_t quant_value_4x2 = quant_data[index];
+// GPU-related constraints.
+const std::unordered_set<int64_t> kGpuSupportedBits{4};
+const std::unordered_set<int64_t> kGpuSupportedBlockSize{32};
 
-      int8_t quant_upper_value =
-          gsl::narrow_cast<int8_t>(((quant_value_4x2 >> 4) & 0xF) - zero_point);
-      int8_t quant_lower_value =
-          gsl::narrow_cast<int8_t>(((quant_value_4x2 >> 0) & 0xF) - zero_point);
+// HTP-related constraints.
+// HTP expects block size to be multiple of a value according to bits.
+const std::unordered_map<int64_t, int64_t> kHtpSupportedBitsAndBlockSizeMultipliers{{2, 16}, {4, 8}, {8, 4}};
 
-      quant_data[index] = ((quant_upper_value & 0xF) << 4) | (quant_lower_value & 0xF);
+template <typename T>
+void UnpackDataToDatatype(const std::vector<uint8_t>& packed_data,
+                          const int64_t bits,
+                          const int64_t num_elements_per_uint8,
+                          std::vector<T>& unpacked_data) {
+  unpacked_data.clear();
+  unpacked_data.reserve(packed_data.size() * num_elements_per_uint8);
+
+  const uint8_t mask = static_cast<uint8_t>((1u << bits) - 1);
+
+  for (const uint8_t& value : packed_data) {
+    for (int64_t idx = 0; idx < num_elements_per_uint8; ++idx) {
+      int64_t shift = bits * idx;
+      uint8_t masked_val = (value >> shift) & mask;
+      unpacked_data.push_back(static_cast<T>(masked_val));
     }
   }
 }
+}  // namespace
 
 Ort::Status MatMulNBitsOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                                 const OrtNodeUnit& node_unit,
                                                 const Ort::Logger& logger) const {
   bool is_gpu_backend = IsGpuBackend(qnn_model_wrapper.GetQnnBackendType());
-  RETURN_IF_NOT(is_gpu_backend, "MatMulNBits Op Supported Only for Qnn Gpu Backend");
-
-  Qnn_DataType_t input_datatype = QNN_DATATYPE_FLOAT_32;
-  Qnn_DataType_t datatype = QNN_DATATYPE_FLOAT_32;
-
-  OrtNodeAttrHelper node_helper(node_unit);
+  bool is_htp_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
+  RETURN_IF_NOT(is_gpu_backend || is_htp_backend, "MatMulNBits is supported only for QNN GPU/HTP backend.");
 
   // Extract Parameters
-  const int64_t bits = node_helper.Get("bits", static_cast<int64_t>(4));
-  const int64_t block_size = node_helper.Get("block_size", static_cast<int64_t>(32));
+  OrtNodeAttrHelper node_helper(node_unit);
+  const int64_t K = node_helper.Get("K", static_cast<int64_t>(0));
+  const int64_t N = node_helper.Get("N", static_cast<int64_t>(0));
+  const int64_t bits = node_helper.Get("bits", static_cast<int64_t>(0));
+  const int64_t block_size = node_helper.Get("block_size", static_cast<int64_t>(0));
 
-  const int64_t K = node_helper.Get("K", static_cast<int64_t>(1));
-  const int64_t N = node_helper.Get("N", static_cast<int64_t>(1));
+  if (is_gpu_backend) {
+    RETURN_IF(kGpuSupportedBits.find(bits) == kGpuSupportedBits.end(),
+              ("QNN GPU does not support MatMulNBits with bits=" + std::to_string(bits)).c_str());
+    RETURN_IF(kGpuSupportedBlockSize.find(block_size) == kGpuSupportedBlockSize.end(),
+              ("QNN GPU does not support MatMulNBits with block_size=" + std::to_string(block_size)).c_str());
+  } else {
+    auto it = kHtpSupportedBitsAndBlockSizeMultipliers.find(bits);
+    RETURN_IF(it == kHtpSupportedBitsAndBlockSizeMultipliers.end(),
+              ("QNN HTP does not support MatMulNBits with bits=" + std::to_string(bits)).c_str());
+    RETURN_IF(block_size % it->second != 0,
+              ("QNN HTP does not support MatMulNBits with block_size=" + std::to_string(block_size)).c_str());
+  }
+  RETURN_IF_NOT((K % block_size) == 0, "K must be divisible by block_size.");
 
-  RETURN_IF_NOT(bits == 4, "Invalid bits. Qnn Gpu Only Supports MatMulNBits with bits == 4");
-  RETURN_IF_NOT(block_size == 32, "Invalid block_size. Qnn Gpu Only Supports MatMulNBits with block_size == 32");
-  RETURN_IF_NOT((K % block_size) == 0, "K must be divisible by block_size");
-  RETURN_IF_NOT(((N * K) % (2 * block_size)) == 0,
-                "Invalid configuration. N * K must be divisible by 2 * block_size");
+  const int64_t total_blocks = (N * K) / block_size;
+  RETURN_IF_NOT(total_blocks > 0, "(N * K) / block_size must be > 0");
 
-  const int64_t num_blocks = (N * K) / block_size;
-  RETURN_IF_NOT(num_blocks > 0, "Invalid configuration. (N * K) / block_size must be > 0");
+  const int64_t num_elements_per_uint8 = kByteBits / bits;
+  const int64_t num_zp_per_uint8 = K / block_size < num_elements_per_uint8 ? K / block_size : num_elements_per_uint8;
 
   const auto& inputs = node_unit.Inputs();
-  // 1. input : Datatype should be float16 or float32
-  // Float16 Dlc serialization failing, Skipping float16 support for this op builder
-  // TODO :: Add Float16 Support
+  // 1. A: Input datatype should be float16 or float32.
   {
     const OrtNodeUnitIODef& input_tensor = inputs[0];
     TensorInfo input_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_tensor, input_info));
+
+    Qnn_DataType_t input_datatype;
     RETURN_IF_ERROR(utils::GetQnnDataType(input_tensor.quant_param.has_value(),
                                           input_tensor.type,
                                           input_datatype));
-    RETURN_IF(input_datatype != QNN_DATATYPE_FLOAT_32, "Unsupported Input datatype");
+
+    RETURN_IF(input_datatype != QNN_DATATYPE_FLOAT_32 && input_datatype != QNN_DATATYPE_FLOAT_16,
+              "Unsupported input A datatype, expecting float32 or float16.");
+
+    // Restrict to 3D input for HTP backend due to later inserted Reshape.
+    RETURN_IF(is_htp_backend && input_info.shape.size() != 3,
+              "Unsupported input A rank, expecting 3D for HTP backend.");
   }
 
-  // 2. weight : weight supported with packed int4 into int8.
+  // 2. B: Weight is supported in packed uint8 format.
   {
-    const OrtNodeUnitIODef& input_tensor = inputs[1];
-    TensorInfo input_info{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_tensor, input_info));
-
-    const std::vector<uint32_t> input_shape = input_info.shape;
-    SafeInt<int64_t> safe_total_elements = std::accumulate(input_shape.begin(),
-                                                           input_shape.end(),
+    const OrtNodeUnitIODef& weight_tensor = inputs[1];
+    TensorInfo weight_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(weight_tensor, weight_info));
+    SafeInt<int64_t> safe_total_elements = std::accumulate(weight_info.shape.begin(),
+                                                           weight_info.shape.end(),
                                                            SafeInt<int64_t>{1},
                                                            std::multiplies<>());
     const int64_t total_elements = static_cast<int64_t>(safe_total_elements);
-    RETURN_IF_NOT(((total_elements * 2) == (N * K)),
-                  "Invalid B dimensions. Qnn Gpu Only Supports MatMulNBits with bits == 4 in packed format");
+    RETURN_IF_NOT((total_elements * num_elements_per_uint8) == (N * K),
+                  ("Unexpected input B size, expecting " + std::to_string(N * K / num_elements_per_uint8)).c_str());
   }
 
-  // 3. scales : scales only float32 datatype
+  // 3. scales: Scales should be float32 datatype and have N*K/block_size elements.
   {
-    const OrtNodeUnitIODef& input_tensor = inputs[2];
-    TensorInfo input_info{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_tensor, input_info));
-    RETURN_IF_ERROR(utils::GetQnnDataType(input_tensor.quant_param.has_value(),
-                                          input_tensor.type,
-                                          input_datatype));
-    RETURN_IF(input_datatype != QNN_DATATYPE_FLOAT_32, "Unsupported Input datatype");
+    const OrtNodeUnitIODef& scales_tensor = inputs[2];
+    Qnn_DataType_t scales_datatype;
+    RETURN_IF_ERROR(utils::GetQnnDataType(scales_tensor.quant_param.has_value(),
+                                          scales_tensor.type,
+                                          scales_datatype));
+    RETURN_IF(scales_datatype != QNN_DATATYPE_FLOAT_32 && scales_datatype != QNN_DATATYPE_FLOAT_16,
+              "Unsupported input scales datatype, expecting float32 or float16.");
+
+    TensorInfo scales_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(scales_tensor, scales_info));
+    SafeInt<int64_t> safe_total_elements = std::accumulate(scales_info.shape.begin(),
+                                                           scales_info.shape.end(),
+                                                           SafeInt<int64_t>{1},
+                                                           std::multiplies<>());
+    const int64_t total_elements = static_cast<int64_t>(safe_total_elements);
+    RETURN_IF_NOT(total_elements == total_blocks,
+                  ("Unexpected input scales size, expecting " + std::to_string(total_blocks)).c_str());
   }
 
-  // 4. If input 3 exists, it has to be zero point.
+  // 4. zero_points: (optional) Zero points should be uint8 datatype and have N*K/block_size/(8/bits).
   if (inputs.size() > 3 && inputs[3].Exists()) {
-    const OrtNodeUnitIODef& input_tensor = inputs[3];
-    TensorInfo input_info{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_tensor, input_info));
-    RETURN_IF_ERROR(utils::GetQnnDataType(input_tensor.quant_param.has_value(),
-                                          input_tensor.type,
-                                          datatype));
-    RETURN_IF((datatype != QNN_DATATYPE_UINT_8), "Invalid zero point datatype.");
+    const OrtNodeUnitIODef& zp_tensor = inputs[3];
+    Qnn_DataType_t zp_datatype;
+    RETURN_IF_ERROR(utils::GetQnnDataType(zp_tensor.quant_param.has_value(),
+                                          zp_tensor.type,
+                                          zp_datatype));
+    RETURN_IF((zp_datatype != QNN_DATATYPE_UINT_8), "Unsupported input zero_points datatype, expecting uint8.");
 
-    std::vector<uint8_t> per_block_uint8_offset;
-    const auto& zero_points_tensor_name = input_tensor.name;
-    const OrtValueInfo* zero_points_tensor_proto = qnn_model_wrapper.GetConstantTensor(zero_points_tensor_name);
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(zero_points_tensor_proto, per_block_uint8_offset));
+    TensorInfo zp_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(zp_tensor, zp_info));
+    SafeInt<int64_t> safe_total_elements = std::accumulate(zp_info.shape.begin(),
+                                                           zp_info.shape.end(),
+                                                           SafeInt<int64_t>{1},
+                                                           std::multiplies<>());
+    const int64_t total_elements = static_cast<int64_t>(safe_total_elements);
+    RETURN_IF_NOT((total_elements * num_zp_per_uint8) == total_blocks,
+                  ("Unexpected input zero_points size, expecting " +
+                   std::to_string(total_blocks / num_zp_per_uint8))
+                      .c_str());
 
-    RETURN_IF_NOT((per_block_uint8_offset.size() * 2) == (num_blocks * sizeof(uint8_t)),
-                  "Only packed uint4 into uint8 offset supported by op builder");
-    const uint8_t expected_offset_value = 0b10001000;
-    for (size_t i = 0; i < per_block_uint8_offset.size(); i++) {
-      RETURN_IF_NOT(per_block_uint8_offset[i] == expected_offset_value, "Unsupported zero point value");
+    // QNN GPU expects symmetric quantization.
+    if (is_gpu_backend) {
+      std::vector<uint8_t> per_block_uint8_offset;
+      const OrtValueInfo* zero_points_tensor_proto = qnn_model_wrapper.GetConstantTensor(zp_tensor.name);
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(zero_points_tensor_proto, per_block_uint8_offset));
+
+      // Since zero_points are stored as uint4 and packed to uint8, the value is expected to be 2^(bits-1)
+      // (i.e., 0b1000) and packed to 0b10001000.
+      const uint8_t expected_offset_value = 0b10001000;
+      for (size_t i = 0; i < per_block_uint8_offset.size(); i++) {
+        RETURN_IF_NOT(per_block_uint8_offset[i] == expected_offset_value,
+                      "Unsupported input zero_points value, expecting 0b1000 for bits=4.");
+      }
     }
   }
 
   RETURN_IF((inputs.size() > 4 && inputs[4].Exists()) || (inputs.size() > 5 && inputs[5].Exists()),
-            "Unsupported inputs g_idx or bias");
+            "Unsupported inputs g_idx or bias.");
 
   // Validate Process
   std::vector<std::string> input_names;
@@ -201,39 +276,79 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
                                                 const Ort::Logger& logger,
                                                 std::vector<std::string>& input_names,
                                                 bool do_op_validation) const {
-  if (do_op_validation) {
-    bool is_gpu_backend = IsGpuBackend(qnn_model_wrapper.GetQnnBackendType());
-    RETURN_IF_NOT(is_gpu_backend, "MatMulNBits Op Supported Only for Qnn Gpu Backend");
-  }
-  OrtNodeAttrHelper node_helper(node_unit);
+  bool is_htp_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
 
   // Extract Parameters
-  const int64_t block_size = node_helper.Get("block_size", static_cast<int64_t>(32));
-  const int64_t K = node_helper.Get("K", static_cast<int64_t>(1));
-  const int64_t N = node_helper.Get("N", static_cast<int64_t>(1));
+  OrtNodeAttrHelper node_helper(node_unit);
+  const int64_t K = node_helper.Get("K", static_cast<int64_t>(0));
+  const int64_t N = node_helper.Get("N", static_cast<int64_t>(0));
+  const int64_t bits = node_helper.Get("bits", static_cast<int64_t>(0));
+  const int64_t block_size = node_helper.Get("block_size", static_cast<int64_t>(0));
+
+  // Should already be guaranteed in IsOpSupported.
+  assert(K > 0 && N > 0 && bits > 0 && block_size > 0);
+
+  const int64_t num_elements_per_uint8 = kByteBits / bits;
+  const int64_t num_zp_per_uint8 = K / block_size < num_elements_per_uint8 ? K / block_size : num_elements_per_uint8;
 
   // Prepare essential parameters
-  const int64_t num_blocks = (N * K) / block_size;
+  const int64_t total_blocks = (N * K) / block_size;
   const auto& inputs = node_unit.Inputs();
 
-  // 1. Add Input
+  // 1. Add input A.
   {
-    const OrtNodeUnitIODef& input_tensor = inputs[0];
-    const std::string& input_tensor_name = input_tensor.name;
-    if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_tensor_name)) {
-      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + input_tensor_name).c_str());
-    } else {
-      TensorInfo input_info{};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_tensor, input_info));
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
 
-      QnnTensorWrapper input_tensor_wrapper;
-      RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(input_info, input_tensor_name, input_tensor_wrapper));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor_wrapper)), "Failed to add tensor.");
+    if (is_htp_backend) {
+      // Add pre-Reshape to unsqueeze shape to 4D for HTP backend.
+      TensorInfo input_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
+
+      // Input A having 3D shape is guaranteed in IsOpSupported.
+      assert(input_info.shape.size() == 3);
+      std::vector<uint32_t> reshape_output_shape = {input_info.shape[0], 1, input_info.shape[1], input_info.shape[2]};
+
+      const std::string reshape_output_name = utils::UniqueNameGenerator().New(input_names[0], "_reshape_4d");
+      QnnTensorWrapper reshape_output_tensor_wrapper(reshape_output_name,
+                                                     QNN_TENSOR_TYPE_NATIVE,
+                                                     input_info.qnn_data_type,
+                                                     input_info.quant_param.Copy(),
+                                                     std::vector<uint32_t>(reshape_output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_output_tensor_wrapper)),
+                    "Failed to add pre-Reshape output tensor.");
+
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_reshape_4d"),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                    QNN_OP_RESHAPE,
+                                                    {input_names[0]},
+                                                    {reshape_output_name},
+                                                    {},
+                                                    do_op_validation),
+                    "Failed to add pre-Reshape node.");
+
+      // Reroute to pre-Reshape output.
+      input_names[0] = reshape_output_name;
+
+      if (input_info.qnn_data_type == QNN_DATATYPE_FLOAT_32) {
+        // Workaround: Add pre-Cast to cast float32 to float16 to pass HTP validation.
+        // TODO: Remove the additional Cast once HTP supports float32.
+        const std::string cast_output_name = utils::UniqueNameGenerator().New(input_names[0], "_cast_fp16");
+        RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(node_unit, "_cast_fp16"),
+                                                      reshape_output_name,
+                                                      cast_output_name,
+                                                      QNN_TENSOR_TYPE_NATIVE,
+                                                      QNN_DATATYPE_FLOAT_16,
+                                                      input_info.quant_param.Copy(),
+                                                      std::vector<uint32_t>(reshape_output_shape),
+                                                      do_op_validation));
+
+        // Reroute to pre-Cast output.
+        input_names[0] = cast_output_name;
+      }
     }
-    input_names.push_back(input_tensor_name);
   }
 
-  // 2. Add Weights and add its Quantization Data
+  // 2. Add input B and corresponding quantization parameters.
   {
     const auto& weight_tensor = inputs[1];
     const auto& scales_tensor = inputs[2];
@@ -242,44 +357,114 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
     if (qnn_model_wrapper.IsQnnTensorWrapperExist(weight_tensor_name)) {
       ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + weight_tensor_name).c_str());
     } else {
-      const std::vector<uint32_t> block_sizes = {1, gsl::narrow_cast<uint32_t>(block_size)};
-
-      // 2.1 Quantization Weight Data
+      // 2.1 Block-quantized data.
       std::vector<uint8_t> quant_data;
       Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
       const OrtValueInfo* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(weight_tensor_proto, quant_data, false));
 
-      // 2.2 Quantization Scales
+      // 2.2 Block-quantized scales.
       std::vector<uint8_t> per_block_uint8_scale;
       const OrtValueInfo* scale_tensor_proto = qnn_model_wrapper.GetConstantTensor(scales_tensor.name);
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_tensor_proto, per_block_uint8_scale));
-      RETURN_IF_NOT(per_block_uint8_scale.size() == (num_blocks * sizeof(float)),
-                    "Scale Initializer Invalid Size");
-      float* per_block_float_scale_ptr = reinterpret_cast<float*>(per_block_uint8_scale.data());
-      const std::vector<float> per_block_float_scale(per_block_float_scale_ptr,
-                                                     per_block_float_scale_ptr + num_blocks);
 
-      // 2.3 Quantization Offsets : QNN Support only symmetric quantization with default value of 0
-      std::vector<int32_t> per_block_int32_offset(num_blocks, 0);
+      const size_t elem_byte_size = utils::GetElementSizeByType(scales_tensor.type);
+      RETURN_IF_NOT(per_block_uint8_scale.size() == (total_blocks * elem_byte_size), "Unexpected scales data size.");
 
-      // 2.4 Transform quantized weights to signed fixed point 4.
-      DQQToSignedFixedPoint4(quant_data, num_blocks, block_size);
+      std::vector<float> per_block_float_scale;
+      if (scales_tensor.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        float* per_block_float_scale_ptr = reinterpret_cast<float*>(per_block_uint8_scale.data());
+        per_block_float_scale = std::vector<float>(per_block_float_scale_ptr, per_block_float_scale_ptr + total_blocks);
+      } else {
+        Ort::Float16_t* per_block_fp16_scale_ptr = reinterpret_cast<Ort::Float16_t*>(per_block_uint8_scale.data());
+        per_block_float_scale.reserve(total_blocks);
+        for (int64_t idx = 0; idx < total_blocks; ++idx) {
+          per_block_float_scale.emplace_back(static_cast<float>(per_block_fp16_scale_ptr[idx]));
+        }
+      }
 
-      // 2.5 Create Quantization Parameter and create Weight Tensor
-      QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper(per_block_float_scale,
-                                                                   per_block_int32_offset,
-                                                                   block_sizes,
-                                                                   QNN_DATATYPE_SFIXED_POINT_4);
+      if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+        // 2.3 Block-quantized offsets
+        // QNN GPU only supports symmetric quantization. Since block-quantized data is transformed to signed fixed
+        // point 4 below, the value should be 0.
+        std::vector<int32_t> per_block_int32_offset(total_blocks, 0);
 
-      std::vector<uint32_t> weight_shape = {static_cast<uint32_t>(N), static_cast<uint32_t>(K)};
-      QnnTensorWrapper weight_tensor_wrapper(weight_tensor_name,
-                                             weight_tensor_type,
-                                             QNN_DATATYPE_SFIXED_POINT_4,
-                                             std::move(quantize_param),
-                                             std::move(weight_shape),
-                                             std::move(quant_data));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)), "Failed to add tensor.");
+        // 2.4 Transform block-quantized data to signed fixed point 4.
+        RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(quant_data, bits));
+
+        // 2.5 Create QNN wrappers.
+        const std::vector<uint32_t> block_sizes = {1, gsl::narrow_cast<uint32_t>(block_size)};
+        QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper(per_block_float_scale,
+                                                                     per_block_int32_offset,
+                                                                     block_sizes,
+                                                                     QNN_DATATYPE_SFIXED_POINT_4);
+
+        std::vector<uint32_t> weight_shape = {gsl::narrow_cast<uint32_t>(N), gsl::narrow_cast<uint32_t>(K)};
+        QnnTensorWrapper weight_tensor_wrapper(weight_tensor_name,
+                                               weight_tensor_type,
+                                               QNN_DATATYPE_SFIXED_POINT_4,
+                                               std::move(quantize_param),
+                                               std::move(weight_shape),
+                                               std::move(quant_data));
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)),
+                      "Failed to add weight tensor.");
+      } else {
+        // 2.3 Block-quantized offsets
+        std::vector<float> per_block_float_zp;
+        if (inputs.size() > 3 && inputs[3].Exists()) {
+          // Unpack block-quantized offsets to float each.
+          std::vector<uint8_t> per_block_uint8_zp;
+          const OrtValueInfo* zp_tensor_proto = qnn_model_wrapper.GetConstantTensor(inputs[3].name);
+          RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(zp_tensor_proto, per_block_uint8_zp));
+          UnpackDataToDatatype<float>(per_block_uint8_zp, bits, num_zp_per_uint8, per_block_float_zp);
+
+          // Shift offsets for transformation from unsigned to signed fixed point and negate the values to align with
+          // QNN definition for offsets.
+          const float offset_shift = static_cast<float>(1 << (bits - 1));
+          for (size_t idx = 0; idx < per_block_float_zp.size(); ++idx) {
+            per_block_float_zp[idx] = -(per_block_float_zp[idx] - offset_shift);
+          }
+        } else {
+          // Default to 0.
+          per_block_float_zp.assign(total_blocks, 0);
+        }
+
+        // 2.4 Block-quantized data.
+        // Transform data from unsigned to signed fixed point.
+        RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(quant_data, bits));
+        // Unpack block-quantized data to uint8_t each.
+        std::vector<uint8_t> unpacked_quant_data;
+        UnpackDataToDatatype<uint8_t>(quant_data, bits, num_elements_per_uint8, unpacked_quant_data);
+
+        // Transpose block-quantized data to [K, N] which equals to [1, 1, K, N].
+        std::vector<uint8_t> transposed_unpacked_quant_data;
+        RETURN_IF_ERROR(utils::TwoDimensionTranspose<uint8_t>(
+            unpacked_quant_data,
+            {gsl::narrow_cast<uint32_t>(N), gsl::narrow_cast<uint32_t>(K)},
+            transposed_unpacked_quant_data,
+            logger,
+            do_op_validation));
+
+        // 2.5 Create QNN wrappers.
+        // Note that unlike weights requiring transpose, scales/offsets are expected in original ONNX shape.
+        const std::vector<uint32_t> block_sizes = {1, 1, gsl::narrow_cast<uint32_t>(block_size), 1};
+        QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper(per_block_float_scale,
+                                                                     per_block_float_zp,
+                                                                     gsl::narrow_cast<uint32_t>(bits),
+                                                                     block_sizes);
+
+        // Shape is for Conv2d, expecting in HWIO.
+        std::vector<uint32_t> weight_shape = {1, 1, gsl::narrow_cast<uint32_t>(K), gsl::narrow_cast<uint32_t>(N)};
+        QnnTensorWrapper weight_tensor_wrapper(weight_tensor_name,
+                                               weight_tensor_type,
+                                               // HTP will derive the actual data type from quant param.
+                                               QNN_DATATYPE_SFIXED_POINT_8,
+                                               std::move(quantize_param),
+                                               std::move(weight_shape),
+                                               std::move(transposed_unpacked_quant_data));
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)),
+                      "Failed to add weight tensor.");
+      }
     }
     input_names.push_back(weight_tensor_name);
   }
@@ -292,66 +477,145 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                               std::vector<std::string>&& input_names,
                                                               const Ort::Logger& logger,
                                                               bool do_op_validation) const {
-  if (do_op_validation) {
-    bool is_gpu_backend = IsGpuBackend(qnn_model_wrapper.GetQnnBackendType());
-    RETURN_IF_NOT(is_gpu_backend, "MatMulNBits Op Supported Only for Qnn Gpu Backend");
-  }
-
-  OrtNodeAttrHelper node_helper(node_unit);
   // Extract Parameters
-  const int64_t N = node_helper.Get("N", static_cast<int64_t>(1));
+  OrtNodeAttrHelper node_helper(node_unit);
+  const int64_t N = node_helper.Get("N", static_cast<int64_t>(0));
 
-  // 1. Add Output for Reshape
   const OrtNodeUnitIODef& output_tensor = node_unit.Outputs()[0];
-  const std::string& output_tensor_name = output_tensor.name;
-  if (qnn_model_wrapper.IsQnnTensorWrapperExist(output_tensor_name)) {
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + output_tensor_name).c_str());
-  } else {
-    QnnTensorWrapper output_tensor_wrapper;
-    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(output_tensor, output_tensor_wrapper));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)), "Failed to add output");
-  }
-
-  // 2. Add Output for Pre Reshape(FullyConnected)
-  const std::string pre_reshape_name = utils::UniqueNameGenerator().New(output_tensor_name, "_pre_reshape");
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output_tensor, output_info));
-  std::vector<uint32_t> pre_reshape_shape(2);
-  pre_reshape_shape[0] = static_cast<uint32_t>(std::accumulate(output_info.shape.begin(),
-                                                               output_info.shape.end(),
-                                                               SafeInt<uint32_t>{1},
-                                                               std::multiplies<>()) /
-                                               N);
-  pre_reshape_shape[1] = gsl::narrow_cast<uint32_t>(N);
-  QnnTensorWrapper output_tensor_wrapper(pre_reshape_name,
-                                         QNN_TENSOR_TYPE_NATIVE,
-                                         output_info.qnn_data_type,
-                                         output_info.quant_param.Copy(),
-                                         std::vector<uint32_t>(pre_reshape_shape));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)), "Failed to add tensor.");
 
-  // 3. Add FullyConnected Op
-  const std::string fully_connected_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_FULLY_CONNECTED);
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(fully_connected_node_name,
-                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                QNN_OP_FULLY_CONNECTED,
-                                                std::move(input_names),
-                                                {pre_reshape_name},
-                                                {},
-                                                do_op_validation),
-                "Failed to add fused Matmul node.");
+  if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    // 1. Add Output for Reshape
+    const std::string& output_tensor_name = output_tensor.name;
+    if (qnn_model_wrapper.IsQnnTensorWrapperExist(output_tensor_name)) {
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + output_tensor_name).c_str());
+    } else {
+      QnnTensorWrapper output_tensor_wrapper;
+      RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(output_tensor, output_tensor_wrapper));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)),
+                    "Failed to add post-Reshape output tensor");
+    }
 
-  // 4. Add Reshape Op
-  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_tensor_name);
-  RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(pre_reshape_name,
-                                                   output_tensor_name,
-                                                   pre_reshape_shape,
-                                                   output_info.shape,
+    // 2. Add Output for Pre Reshape(FullyConnected)
+    const std::string pre_reshape_name = utils::UniqueNameGenerator().New(output_tensor_name, "_pre_reshape");
+    std::vector<uint32_t> pre_reshape_shape(2);
+    pre_reshape_shape[0] = gsl::narrow_cast<uint32_t>(std::accumulate(output_info.shape.begin(),
+                                                                      output_info.shape.end(),
+                                                                      SafeInt<uint32_t>{1},
+                                                                      std::multiplies<>()) /
+                                                      N);
+    pre_reshape_shape[1] = gsl::narrow_cast<uint32_t>(N);
+    QnnTensorWrapper output_tensor_wrapper(pre_reshape_name,
+                                           QNN_TENSOR_TYPE_NATIVE,
+                                           output_info.qnn_data_type,
+                                           output_info.quant_param.Copy(),
+                                           std::vector<uint32_t>(pre_reshape_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)),
+                  "Failed to add FC output tensor.");
+
+    // 3. Add FullyConnected Op
+    const std::string fully_connected_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_FULLY_CONNECTED);
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(fully_connected_node_name,
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_FULLY_CONNECTED,
+                                                  std::move(input_names),
+                                                  {pre_reshape_name},
+                                                  {},
+                                                  do_op_validation),
+                  "Failed to add FC node.");
+
+    // 4. Add Reshape Op
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_tensor_name);
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(pre_reshape_name,
+                                                     output_tensor_name,
+                                                     pre_reshape_shape,
+                                                     output_info.shape,
+                                                     output_info.qnn_data_type,
+                                                     output_info.quant_param,
+                                                     do_op_validation,
+                                                     false,
+                                                     is_graph_output));
+  } else {
+    // 1. Add MatMul as Conv2d with default stride/pad amount.
+    std::vector<std::string> param_tensor_names;
+
+    std::vector<uint32_t> stride = {1, 1};
+    QnnParamWrapper stride_param_wrapper(node_unit.Index(),
+                                         node_unit.Name(),
+                                         QNN_OP_CONV_2D_PARAM_STRIDE,
+                                         {2},
+                                         std::move(stride));
+    param_tensor_names.push_back(stride_param_wrapper.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(stride_param_wrapper));
+
+    std::vector<uint32_t> pad_amount = {0, 0, 0, 0};
+    QnnParamWrapper pad_amount_param_wrapper(node_unit.Index(),
+                                             node_unit.Name(),
+                                             QNN_OP_CONV_2D_PARAM_PAD_AMOUNT,
+                                             {2, 2},
+                                             std::move(pad_amount));
+    param_tensor_names.push_back(pad_amount_param_wrapper.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_param_wrapper));
+
+    // Input originally having 3D shape is guaranteed in IsOpSupported.
+    assert(output_info.shape.size() == 3);
+    std::vector<uint32_t> conv2d_output_shape = {output_info.shape[0], 1, output_info.shape[1], output_info.shape[2]};
+
+    const std::string conv2d_output_name = utils::UniqueNameGenerator().New(output_tensor.name, "_conv2d");
+    QnnTensorWrapper conv2d_output_tensor_wrapper(conv2d_output_name,
+                                                  QNN_TENSOR_TYPE_NATIVE,
+                                                  QNN_DATATYPE_FLOAT_16,  // HTP Conv2d BQ kernel only supports FP16.
+                                                  output_info.quant_param.Copy(),
+                                                  std::vector<uint32_t>(conv2d_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(conv2d_output_tensor_wrapper)),
+                  "Failed to add Conv2d output tensor.");
+
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_CONV_2D,
+                                                  std::move(input_names),
+                                                  {conv2d_output_name},
+                                                  std::move(param_tensor_names),
+                                                  do_op_validation),
+                  "Failed to add Conv2d node.");
+
+    std::string reshape_input_name = conv2d_output_name;
+    if (output_info.qnn_data_type == QNN_DATATYPE_FLOAT_32) {
+      // 2. Workaround: Add post-Cast to cast float16 back to float32 to pass HTP validation.
+      // TODO: Remove the additional Cast once HTP supports float32.
+      const std::string cast_output_name = utils::UniqueNameGenerator().New(output_tensor.name, "_cast_fp32");
+      RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(node_unit, "_cast_fp32"),
+                                                    conv2d_output_name,
+                                                    cast_output_name,
+                                                    QNN_TENSOR_TYPE_NATIVE,
+                                                    QNN_DATATYPE_FLOAT_32,
+                                                    output_info.quant_param.Copy(),
+                                                    std::vector<uint32_t>(conv2d_output_shape),
+                                                    do_op_validation));
+
+      reshape_input_name = cast_output_name;
+    }
+
+    // 3. Add post-Reshape to squeeze shape back.
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_tensor.name);
+    QnnTensorWrapper reshape_output_tensor_wrapper(output_tensor.name,
+                                                   is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
                                                    output_info.qnn_data_type,
-                                                   output_info.quant_param,
-                                                   do_op_validation,
-                                                   false,
-                                                   is_graph_output));
+                                                   output_info.quant_param.Copy(),
+                                                   std::vector<uint32_t>(output_info.shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_output_tensor_wrapper)),
+                  "Failed to add post-Reshape output tensor.");
+
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_reshape_3d"),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_RESHAPE,
+                                                  {reshape_input_name},
+                                                  {output_tensor.name},
+                                                  {},
+                                                  do_op_validation),
+                  "Failed to add post-Reshape node.");
+  }
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -197,6 +197,36 @@ QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> scales,
   }
 }
 
+// Construct a BlockEncoding BQ quantization param.
+QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> scales,
+                                             gsl::span<const float> offsets,
+                                             const uint32_t bitwidth,
+                                             gsl::span<const uint32_t> block_sizes) {
+  assert(scales.size() > 0);
+  assert(scales.size() == offsets.size());
+  assert(bitwidth > 0);
+  assert(block_sizes.size() > 0);
+
+  params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK;
+  params_.bwFloatBlockEncoding.bitwidth = bitwidth;
+
+  block_encoding_tensor_rank_ = static_cast<uint32_t>(block_sizes.size());
+  block_encoding_axis_data_ = std::make_unique<uint32_t[]>(block_encoding_tensor_rank_);
+  std::memcpy(block_encoding_axis_data_.get(),
+              block_sizes.data(),
+              static_cast<size_t>(block_encoding_tensor_rank_) * sizeof(uint32_t));
+  params_.bwFloatBlockEncoding.blockSize = block_encoding_axis_data_.get();
+
+  num_blocks_ = static_cast<uint32_t>(scales.size());
+  bw_float_block_encoding_scale_offsets_data_ = std::make_unique<Qnn_FloatScaleOffset_t[]>(num_blocks_);
+  for (size_t idx = 0; idx < num_blocks_; ++idx) {
+    bw_float_block_encoding_scale_offsets_data_[idx].offset = offsets[idx];
+    bw_float_block_encoding_scale_offsets_data_[idx].scale = scales[idx];
+  }
+  params_.bwFloatBlockEncoding.floatScaleOffset = bw_float_block_encoding_scale_offsets_data_.get();
+}
+
 // Get a copy of scales. Works for both per-tensor and per-channel.
 Ort::Status QnnQuantParamsWrapper::GetScales(/*out*/ std::vector<float>& scales) const {
   RETURN_IF_NOT(params_.encodingDefinition == QNN_DEFINITION_DEFINED, "Unquantized qparams does not have scales");
@@ -383,6 +413,28 @@ Ort::Status QnnQuantParamsWrapper::Init(const Qnn_QuantizeParams_t& params, cons
         block_encoding_scale_offsets_data_[i].offset = params.blockEncoding.scaleOffset[i].offset;
       }
       params_.blockEncoding.scaleOffset = block_encoding_scale_offsets_data_.get();
+
+      break;
+    }
+    case QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK: {
+      assert(num_scaleoffsets && "Can't create Block encoding object with zero ScaleOffsets");
+      params_.encodingDefinition = params.encodingDefinition;
+      params_.quantizationEncoding = params.quantizationEncoding;
+      params_.bwFloatBlockEncoding.bitwidth = params.bwFloatBlockEncoding.bitwidth;
+
+      block_encoding_tensor_rank_ = static_cast<uint32_t>(tensor_rank);
+      block_encoding_axis_data_ = std::make_unique<uint32_t[]>(block_encoding_tensor_rank_);
+      std::memcpy(block_encoding_axis_data_.get(),
+                  params.bwFloatBlockEncoding.blockSize,
+                  static_cast<size_t>(block_encoding_tensor_rank_) * sizeof(uint32_t));
+      params_.bwFloatBlockEncoding.blockSize = block_encoding_axis_data_.get();
+
+      bw_float_block_encoding_scale_offsets_data_ = std::make_unique<Qnn_FloatScaleOffset_t[]>(num_scaleoffsets);
+      for (size_t i = 0; i < num_scaleoffsets; ++i) {
+        bw_float_block_encoding_scale_offsets_data_[i].scale = params.bwFloatBlockEncoding.floatScaleOffset[i].scale;
+        bw_float_block_encoding_scale_offsets_data_[i].offset = params.bwFloatBlockEncoding.floatScaleOffset[i].offset;
+      }
+      params_.bwFloatBlockEncoding.floatScaleOffset = bw_float_block_encoding_scale_offsets_data_.get();
 
       break;
     }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -40,6 +40,12 @@ class QnnQuantParamsWrapper {
   QnnQuantParamsWrapper(gsl::span<const float> scales, gsl::span<const int32_t> offsets,
                         gsl::span<const uint32_t> block_size, Qnn_DataType_t tensor_data_type);
 
+  // Construct a BQ quantization param with specified bitwidth and float offsets.
+  QnnQuantParamsWrapper(gsl::span<const float> scales,
+                        gsl::span<const float> offsets,
+                        const uint32_t bitwidth,
+                        gsl::span<const uint32_t> block_size);
+
   Qnn_QuantizeParams_t& Get() { return params_; }
   const Qnn_QuantizeParams_t& Get() const { return params_; }
 
@@ -75,7 +81,8 @@ class QnnQuantParamsWrapper {
 
   bool IsBlockQuantized() const {
     return params_.encodingDefinition == QNN_DEFINITION_DEFINED &&
-           (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCK);
+           (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCK ||
+            params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
   }
 
   // Get a copy of scales. Works for both per-tensor and per-channel.
@@ -178,6 +185,9 @@ class QnnQuantParamsWrapper {
   uint32_t num_blocks_ = 0;
   std::unique_ptr<uint32_t[]> block_encoding_axis_data_;
   std::unique_ptr<Qnn_ScaleOffset_t[]> block_encoding_scale_offsets_data_;
+
+  // Store BwFloatBlockEncoding scale offset data.
+  std::unique_ptr<Qnn_FloatScaleOffset_t[]> bw_float_block_encoding_scale_offsets_data_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -375,6 +375,30 @@ Ort::Status UnpackInt4ToInt8(size_t num_int4_elems, std::vector<uint8_t>& data_b
   return Ort::Status();
 }
 
+// This function exploits bit-manipulation trick to transform from unsigned to signed.
+// Formally, an unsigned value subtracts zero point (i.e.,  1 << (bits - 1)) to become a signed value. This subtraction
+// is essentially "flipping" the most-significant bit, which can be achieved through XOR with the zero point. While
+// taking the data being packed into consideration, simultaneously flipping all packed values can be faster than a
+// sequence of shifting, subtracting, and repacking operations for each packed value one by one.
+inline Ort::Status TransformUnsignedToSignedFixedPoint(std::vector<uint8_t>& quant_data, int64_t bits) {
+  uint8_t mask = 0;
+  if (bits == 2) {
+    mask = 0b10101010;
+  } else if (bits == 4) {
+    mask = 0b10001000;
+  } else if (bits == 8) {
+    mask = 0b10000000;
+  } else {
+    return MAKE_EP_FAIL("Unsupported bits to transform data from unsigned to signed.");
+  }
+
+  for (size_t idx = 0; idx < quant_data.size(); ++idx) {
+    quant_data[idx] ^= mask;
+  }
+
+  return Ort::Status();
+}
+
 inline std::vector<int64_t> GetInitializerShape(const OrtValueInfo* initializer, const OrtApi& ort_api) {
   const OrtTypeInfo* type_info = nullptr;
   OrtStatus* status = ort_api.GetValueInfoTypeInfo(initializer, &type_info);
@@ -500,6 +524,38 @@ Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
                                   std::vector<uint8_t>& transposed_data,
                                   const Ort::Logger& logger,
                                   bool skip_output_data_copy = false);
+
+template <typename T>
+Ort::Status TwoDimensionTranspose(const std::vector<T>& data,
+                                  const std::vector<uint32_t>& data_shape,
+                                  /* out */ std::vector<T>& transposed_data,
+                                  const Ort::Logger& logger,
+                                  bool skip_output_data_copy = false) {
+  transposed_data.resize(data.size(), 0);
+
+  if (skip_output_data_copy) {
+    ORT_CXX_LOG(logger,
+                ORT_LOGGING_LEVEL_VERBOSE,
+                "Only shape and dtype validation are required, so we can use dummy tensor to avoid heavy memcpy.");
+    return Ort::Status();
+  }
+
+  const size_t rows = data_shape[0];
+  const size_t cols = data_shape[1];
+
+  for (size_t row = 0; row < rows; row++) {
+    for (size_t col = 0; col < cols; col++) {
+      const size_t src_index = (row * cols + col);
+      const size_t dst_index = (col * rows + row);
+      assert(src_index < data.size());
+      assert(dst_index < transposed_data.size());
+
+      transposed_data[dst_index] = data[src_index];
+    }
+  }
+
+  return Ort::Status();
+}
 
 Ort::Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
                             const std::string& convert_input_name,

--- a/onnxruntime/test/providers/qnn/matmulnbits_test.cc
+++ b/onnxruntime/test/providers/qnn/matmulnbits_test.cc
@@ -11,12 +11,11 @@
 namespace onnxruntime {
 namespace test {
 
-#if defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Re-implement testcases from test/contrib_ops/matmul_4bits_test.cc.
 
-constexpr int QBits = 4;
-
+template <int bits>
 void QuantizeDequantize(std::vector<float>& raw_vals,
                         std::vector<uint8_t>& quant_vals,
                         std::vector<float>& scales,
@@ -24,50 +23,48 @@ void QuantizeDequantize(std::vector<float>& raw_vals,
                         int32_t N,
                         int32_t K,
                         int32_t block_size) {
-  QuantizeBlockwise<float, QBits>(quant_vals.data(),
-                                  scales.data(),
-                                  zp != nullptr ? zp->data() : nullptr,
-                                  raw_vals.data(),
-                                  block_size,
-                                  true,
-                                  K,
-                                  N,
-                                  N);
+  QuantizeBlockwise<float, bits>(quant_vals.data(),
+                                 scales.data(),
+                                 zp != nullptr ? zp->data() : nullptr,
+                                 raw_vals.data(),
+                                 block_size,
+                                 true,
+                                 K,
+                                 N,
+                                 N);
 
   // Note that raw_vals is NxK after dequant
-  DequantizeBlockwise<float, QBits>(raw_vals.data(),                       // dequantized output
-                                    quant_vals.data(),                     // quantized input
-                                    scales.data(),                         // quantization scales
-                                    zp != nullptr ? zp->data() : nullptr,  // quantization zero points
-                                    block_size,                            // quantization block size
-                                    true,                                  // columnwise quantization
-                                    K,                                     // number of rows
-                                    N);                                    // number of columns
+  DequantizeBlockwise<float, bits>(raw_vals.data(),                       // dequantized output
+                                   quant_vals.data(),                     // quantized input
+                                   scales.data(),                         // quantization scales
+                                   zp != nullptr ? zp->data() : nullptr,  // quantization zero points
+                                   block_size,                            // quantization block size
+                                   true,                                  // columnwise quantization
+                                   K,                                     // number of rows
+                                   N);                                    // number of columns
 }
 
-struct TestParams4Bits {
+struct TestParams {
   int64_t batch_count{1};
   int64_t M;
   int64_t N;
   int64_t K;
-  int64_t block_size{32};
+  int64_t block_size;
   int64_t accuracy_level{4};
 
   bool has_zero_point{false};
-  bool zp_is_4bit{true};
-  bool has_g_idx{false};
-  bool has_bias{false};
 };
 
-static void RunMatMul4BitsTest(const TestParams4Bits params,
-                               ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
+template <int bits>
+static void RunMatMulNBitsTest(const TestParams params,
                                const std::string& backend_name = "gpu",
+                               ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
                                float fp32_abs_err = 0.05f) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = backend_name;
   provider_options["offload_graph_io_quantization"] = "0";
 
-  auto model_builder = [&params](ModelTestBuilder& builder) {
+  auto model_builder = [&params, &backend_name](ModelTestBuilder& builder) {
     std::vector<std::string> input_names;
 
     RandomValueGenerator random{1234};
@@ -81,26 +78,30 @@ static void RunMatMul4BitsTest(const TestParams4Bits params,
     input_names.push_back("input0");
 
     int64_t k_blocks = (params.K + params.block_size - 1) / params.block_size;
-    int64_t blob_size = (params.block_size * QBits + 7) / 8;
+    int64_t blob_size = (params.block_size * bits + 7) / 8;
     size_t q_scale_size = static_cast<size_t>(params.N * k_blocks);
     size_t q_data_size_in_bytes = static_cast<size_t>(params.N * k_blocks * blob_size);  // packed as UInt4x2
-    const int64_t zero_point_blob_size = (k_blocks * QBits + 7) / 8;
+    const int64_t zero_point_blob_size = (k_blocks * bits + 7) / 8;
     size_t q_zp_size_in_bytes = static_cast<size_t>(params.N * zero_point_blob_size);  // packed as UInt4x2
 
     std::vector<uint8_t> input1_vals(q_data_size_in_bytes);
     std::vector<float> scales(q_scale_size);
-    // TODO
-    // Not sure why zp is not calculated from QuantizeDequantize. Since QNN GPU only support zp=8, hardcode it here
-    // as workaround.
-    std::vector<uint8_t> zp(q_zp_size_in_bytes, 0b10001000);
+    std::vector<uint8_t> zp(q_zp_size_in_bytes);
 
-    QuantizeDequantize(input1_f_vals,
-                       input1_vals,
-                       scales,
-                       nullptr,  // params.has_zero_point ? &zp : nullptr,
-                       static_cast<int32_t>(params.N),
-                       static_cast<int32_t>(params.K),
-                       static_cast<int32_t>(params.block_size));
+    // GPU backend only supports bits=4 with symmetric quantization. Hardcode zp instead of through calculation.
+    if constexpr (bits == 4) {
+      if (backend_name == "gpu") {
+        std::fill(zp.begin(), zp.end(), 0b10001000);
+      }
+    }
+
+    QuantizeDequantize<bits>(input1_f_vals,
+                             input1_vals,
+                             scales,
+                             params.has_zero_point && backend_name != "gpu" ? &zp : nullptr,
+                             static_cast<int32_t>(params.N),
+                             static_cast<int32_t>(params.K),
+                             static_cast<int32_t>(params.block_size));
 
     auto input1_def = TestInputDef<uint8_t>({params.N, k_blocks, blob_size}, true, input1_vals);
     MakeTestInput<uint8_t>(builder, "input1", input1_def);
@@ -123,16 +124,15 @@ static void RunMatMul4BitsTest(const TestParams4Bits params,
     attributes.push_back(builder.MakeScalarAttribute("K", static_cast<int64_t>(params.K)));
     attributes.push_back(builder.MakeScalarAttribute("N", static_cast<int64_t>(params.N)));
     attributes.push_back(builder.MakeScalarAttribute("block_size", static_cast<int64_t>(params.block_size)));
-    attributes.push_back(builder.MakeScalarAttribute("bits", static_cast<int64_t>(QBits)));
+    attributes.push_back(builder.MakeScalarAttribute("bits", static_cast<int64_t>(bits)));
     attributes.push_back(builder.MakeScalarAttribute("accuracy_level", static_cast<int64_t>(params.accuracy_level)));
 
-    builder.AddNode(
-        "matmul_nbits",
-        "MatMulNBits",
-        input_names,
-        {"Y"},
-        kMSDomain,
-        attributes);
+    builder.AddNode("matmul_nbits",
+                    "MatMulNBits",
+                    input_names,
+                    {"Y"},
+                    kMSDomain,
+                    attributes);
   };
 
   RunQnnModelTest(model_builder,
@@ -142,44 +142,231 @@ static void RunMatMul4BitsTest(const TestParams4Bits params,
                   fp32_abs_err);
 }
 
+#if defined(_M_ARM64)
 // QNN GPU only support FP16 activations and Q4_0 weights, with zero_points = 8
 // Accumulation with larger channel accumulates more error. Set higher abs_error with respect to K.
 TEST_F(QnnGPUBackendTests, MatMulNBits_Basic_M1_N128_K512_withZp) {
-  TestParams4Bits params;
+  TestParams params;
   params.M = 1;
   params.N = 128;
   params.K = 512;
+  params.block_size = 32;
   params.has_zero_point = true;
-  RunMatMul4BitsTest(params);
+  RunMatMulNBitsTest<4>(params);
 }
 
 TEST_F(QnnGPUBackendTests, MatMulNBits_Basic_M1_N128_K512) {
-  TestParams4Bits params;
+  TestParams params;
   params.M = 1;
   params.N = 128;
   params.K = 512;
+  params.block_size = 32;
   params.has_zero_point = false;
-  RunMatMul4BitsTest(params);
+  RunMatMulNBitsTest<4>(params);
 }
 
 TEST_F(QnnGPUBackendTests, MatMulNBits_Basic_M10_N128_K512_withZp) {
-  TestParams4Bits params;
+  TestParams params;
   params.M = 10;
   params.N = 128;
   params.K = 512;
+  params.block_size = 32;
   params.has_zero_point = true;
-  RunMatMul4BitsTest(params);
+  RunMatMulNBitsTest<4>(params);
 }
 
 TEST_F(QnnGPUBackendTests, MatMulNBits_Basic_M10_N128_K512) {
-  TestParams4Bits params;
+  TestParams params;
   params.M = 10;
   params.N = 128;
   params.K = 512;
+  params.block_size = 32;
   params.has_zero_point = false;
-  RunMatMul4BitsTest(params);
+  RunMatMulNBitsTest<4>(params);
 }
-#endif
+#endif  // defined(_M_ARM64)
+
+// TODO: Re-enable below testcases once QAIRT is upleveled to 2.47.
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B2_BS16) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<2>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B2_BS16_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<2>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B2_BS32) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<2>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B2_BS32_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<2>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B2_BS64) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<2>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B2_BS64_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<2>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B4_BS16) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<4>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B4_BS16_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<4>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B4_BS32) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<4>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B4_BS32_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<4>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B4_BS64) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<4>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B4_BS64_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<4>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B8_BS16) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<8>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B8_BS16_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<8>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B8_BS32) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<8>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B8_BS32_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<8>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B8_BS64) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunMatMulNBitsTest<8>(params, "htp");
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulNBits_M1_N2_K64_B8_BS64_ZP) {
+  TestParams params;
+  params.M = 1;
+  params.N = 2;
+  params.K = 64;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunMatMulNBitsTest<8>(params, "htp");
+}
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/unittest_util/qdq_test_utils.h
+++ b/onnxruntime/test/unittest_util/qdq_test_utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <vector>
 #include <string>
 #include <type_traits>
@@ -58,6 +59,73 @@ GetQDQTestCaseFn BuildQDQReshapeTestCase(const std::vector<int64_t>& input_shape
 
 std::vector<std::string> GetNodeOpTypesInTopologicalOrder(const Graph& graph, bool include_domain = false);
 
+// Below utility functions are copied from ORT Core with few simpliciations.
+// Refer to onnxruntime/core/mlas/lib/q4_dq.cpp for original implementations.
+
+template <int qbits, bool signed_quant>
+struct BitsTraits {
+  static_assert(qbits <= 8, "Only BitsTraits are for small number of bits!");
+
+  static constexpr int kBits = qbits;
+  static constexpr int kMax = signed_quant ? (1 << (qbits - 1)) - 1 : (1 << qbits) - 1;
+  static constexpr int kMid = signed_quant ? 0 : (1 << (qbits - 1));
+  static constexpr int kMin = signed_quant ? -(1 << (qbits - 1)) : 0;
+  static constexpr float kMaxFp = static_cast<float>(kMax);
+  static constexpr float kMinFp = static_cast<float>(kMin);
+  static constexpr float fullRange = kMaxFp - kMinFp;
+  static constexpr float halfRange = static_cast<float>(kMid - kMin);
+
+  // number of qbit elements to pack into whole bytes
+  static constexpr int kPackSize = (qbits == 8) ? 1 : ((qbits == 4) ? 2 : ((qbits == 2) ? 4 : 0));
+  static_assert(kPackSize != 0, "Packing to whole bytes not supported for this qbits!");
+};
+
+/**
+ * @brief Rectify min/max from a set of weights, and convert to scale and zero point
+ *        for quantization.
+ * @tparam ScaleT        type of scale, usually floating point of various bits
+ * @tparam qbits         number of int bits used for zero point value
+ * @tparam signed_quant  output quantized type is signed
+ * @param[in]   min
+ * @param[in]   max
+ * @param[out]  scale
+ * @param[out]  zp
+ */
+template <typename ScaleT, int qbits, bool signed_quant>
+void range2scalezp(float min, float max, ScaleT& scale, uint8_t& zp) {
+  min = std::min(min, 0.0f);
+  max = std::max(max, 0.0f);
+
+  float scale_f = (max - min) / BitsTraits<qbits, signed_quant>::fullRange;
+
+  float zero_point_fp = min;
+  if (scale_f != 0.0f) {
+    zero_point_fp = BitsTraits<qbits, signed_quant>::kMinFp - min / scale_f;
+  }
+
+  if (zero_point_fp < BitsTraits<qbits, signed_quant>::kMinFp) {
+    zp = static_cast<uint8_t>(BitsTraits<qbits, signed_quant>::kMin);
+  } else if (zero_point_fp > BitsTraits<qbits, signed_quant>::kMaxFp) {
+    zp = static_cast<uint8_t>(BitsTraits<qbits, signed_quant>::kMax);
+  } else {
+    zp = (uint8_t)std::roundf(zero_point_fp);
+  }
+  scale = ScaleT(scale_f);
+}
+
+/**
+ * @brief Rectify min/max from a set of symmetric weights, and convert
+ *        to scale for quantization.
+ */
+template <typename ScaleT, int qbits, bool signed_quant>
+void range2scale(float min, float max, ScaleT& scale) {
+  max = std::fabs(max) > std::fabs(min) ? max : min;
+
+  // Original implementation allows negative scale to better fit larger half FP space. However, since HTP backend does
+  // not support negative scale, simplify to common formulation.
+  scale = ScaleT(std::fabs(max) * 2 / BitsTraits<qbits, signed_quant>::fullRange);
+};
+
 /**
  * @brief Blockwise quantization for test purposes. This is a simplified version of MlasQuantizeBlockwise
  *        that doesn't require internal MLAS APIs.
@@ -75,24 +143,25 @@ std::vector<std::string> GetNodeOpTypesInTopologicalOrder(const Graph& graph, bo
  * @param leading_dimension Leading dimension of source matrix
  */
 template <typename T, int qbits>
-inline void QuantizeBlockwise(
-    uint8_t* dst,
-    T* scales,
-    uint8_t* zero_points,
-    const T* src,
-    int block_size,
-    bool columnwise,
-    int rows,
-    int columns,
-    int leading_dimension) {
-  static_assert(qbits == 4, "Only 4-bit quantization is supported");
+inline void QuantizeBlockwise(uint8_t* dst,
+                              T* scales,
+                              uint8_t* zero_points,
+                              const T* src,
+                              int block_size,
+                              bool columnwise,
+                              int rows,
+                              int columns,
+                              int leading_dimension) {
+  static_assert(qbits == 2 || qbits == 4 || qbits == 8, "Only 2-bit, 4-bit, or 8-bit quantization is supported");
   static_assert(std::is_same<T, float>::value, "Only float type is supported");
 
   if (!columnwise) {
     throw std::runtime_error("Only column-wise quantization is supported in test utilities");
   }
 
+  constexpr int kPackSize = BitsTraits<qbits, false>::kPackSize;
   const int k_blocks = (rows + block_size - 1) / block_size;
+  const int blob_size = (block_size + kPackSize - 1) / kPackSize;
   const bool symmetric = (zero_points == nullptr);
 
   // Process each column
@@ -117,27 +186,12 @@ inline void QuantizeBlockwise(
 
       // Calculate scale and zero point
       const int scale_idx = n * k_blocks + k_blk;
-      uint8_t zp = 8;  // Default zero point for symmetric
+      uint8_t zp = BitsTraits<qbits, false>::kMid;  // Default zero point for symmetric
 
       if (symmetric) {
-        // Symmetric quantization: map to [-8, 7]
-        // Negative scale follows MLAS convention: q in [-8,7] maps to [abs_max, -(7/8)*abs_max]
-        const float abs_max = std::max(std::abs(min_val), std::abs(max_val));
-        scales[scale_idx] = static_cast<T>(-abs_max / 8.0f);
+        range2scale<T, qbits, false>(min_val, max_val, scales[scale_idx]);
       } else {
-        // Asymmetric quantization: map to [0, 15]
-        min_val = std::min(min_val, 0.0f);
-        max_val = std::max(max_val, 0.0f);
-
-        const float scale = (max_val - min_val) / 15.0f;
-        scales[scale_idx] = static_cast<T>(scale);
-
-        if (scale != 0.0f) {
-          const float zp_fp = -min_val / scale;
-          zp = static_cast<uint8_t>(std::clamp(std::round(zp_fp), 0.0f, 15.0f));
-        } else {
-          zp = 0;
-        }
+        range2scalezp<T, qbits, false>(min_val, max_val, scales[scale_idx], zp);
       }
 
       // Quantize and pack the block
@@ -145,52 +199,58 @@ inline void QuantizeBlockwise(
       const float reciprocal_scale = (scale != 0.0f) ? (1.0f / scale) : 0.0f;
 
       // Calculate destination offset (column major, packed)
-      const int blob_size = (block_size + 1) / 2;  // 2 values per byte for 4-bit
       uint8_t* dst_block = dst + n * k_blocks * blob_size + k_blk * blob_size;
 
       // Quantize values in pairs and pack
-      for (int i = 0; i < block_len; i += 2) {
-        const int src_idx0 = (row_start + i) * leading_dimension;
-        const float val0 = static_cast<float>(src_col[src_idx0]);
+      for (int i = 0; i < block_len; i += kPackSize) {
+        uint8_t q_vals[kPackSize];
+        std::fill_n(q_vals, kPackSize, 0);
 
-        int8_t q0;
-        if (symmetric) {
-          const float q_fp = std::round(val0 * reciprocal_scale);
-          q0 = static_cast<int8_t>(std::clamp(q_fp, -8.0f, 7.0f));
-          q0 = q0 + 8;  // Convert to [0, 15] for packing
+        for (int pack_idx = 0; pack_idx < kPackSize && i + pack_idx < block_len; ++pack_idx) {
+          const int src_idx = (row_start + i + pack_idx) * leading_dimension;
+          const float val = static_cast<float>(src_col[src_idx]);
+          q_vals[pack_idx] = (uint8_t)std::clamp(std::roundf(val * reciprocal_scale + zp),
+                                                 0.0f,
+                                                 BitsTraits<qbits, false>::kMaxFp);
+        }
+
+        // Pack {kPackSize} {qbits}-bit values into one byte
+        if constexpr (qbits == 8) {
+          dst_block[i] = q_vals[0];
+        } else if constexpr (qbits == 4) {
+          dst_block[i / 2] = (q_vals[0] & 0xf) | (q_vals[1] << 4);
+        } else if constexpr (qbits == 2) {
+          dst_block[i / 4] = (q_vals[0] & 0x3) | (q_vals[1] << 2) | (q_vals[2] << 4) | (q_vals[3] << 6);
         } else {
-          const float q_fp = std::round(val0 * reciprocal_scale + zp);
-          q0 = static_cast<int8_t>(std::clamp(q_fp, 0.0f, 15.0f));
+          throw std::runtime_error("Unsupported qbits");
         }
-
-        int8_t q1 = symmetric ? 8 : zp;  // Default for padding
-        if (i + 1 < block_len) {
-          const int src_idx1 = (row_start + i + 1) * leading_dimension;
-          const float val1 = static_cast<float>(src_col[src_idx1]);
-
-          if (symmetric) {
-            const float q_fp = std::round(val1 * reciprocal_scale);
-            q1 = static_cast<int8_t>(std::clamp(q_fp, -8.0f, 7.0f));
-            q1 = q1 + 8;  // Convert to [0, 15] for packing
-          } else {
-            const float q_fp = std::round(val1 * reciprocal_scale + zp);
-            q1 = static_cast<int8_t>(std::clamp(q_fp, 0.0f, 15.0f));
-          }
-        }
-
-        // Pack two 4-bit values into one byte (low nibble, high nibble)
-        dst_block[i / 2] = (static_cast<uint8_t>(q0) & 0x0F) | ((static_cast<uint8_t>(q1) & 0x0F) << 4);
       }
 
       // Store zero point if asymmetric
       if (!symmetric) {
-        const int zp_blob_size = (k_blocks + 1) / 2;
+        const int zp_blob_size = (k_blocks + kPackSize - 1) / kPackSize;
         uint8_t* zp_block = zero_points + n * zp_blob_size;
 
-        if (k_blk % 2 == 0) {
-          zp_block[k_blk / 2] = (zp & 0x0F);
+        if constexpr (qbits == 8) {
+          zp_block[k_blk] = zp;
+        } else if constexpr (qbits == 4) {
+          if (k_blk % 2 == 0) {
+            zp_block[k_blk / 2] = (zp & 0xf);
+          } else {
+            zp_block[k_blk / 2] |= (zp << 4);
+          }
+        } else if constexpr (qbits == 2) {
+          if (k_blk % 4 == 0) {
+            zp_block[k_blk / 4] = (zp & 0x3);
+          } else if (k_blk % 4 == 1) {
+            zp_block[k_blk / 4] |= (zp << 2);
+          } else if (k_blk % 4 == 2) {
+            zp_block[k_blk / 4] |= (zp << 4);
+          } else {
+            zp_block[k_blk / 4] |= (zp << 6);
+          }
         } else {
-          zp_block[k_blk / 2] |= ((zp & 0x0F) << 4);
+          throw std::runtime_error("Unsupported qbits");
         }
       }
     }
@@ -213,23 +273,24 @@ inline void QuantizeBlockwise(
  * @param columns       Number of columns
  */
 template <typename T, int qbits>
-inline void DequantizeBlockwise(
-    T* dst,
-    const uint8_t* src,
-    const T* scales,
-    const uint8_t* zero_points,
-    int block_size,
-    bool columnwise,
-    int rows,
-    int columns) {
-  static_assert(qbits == 4, "Only 4-bit quantization is supported");
+inline void DequantizeBlockwise(T* dst,
+                                const uint8_t* src,
+                                const T* scales,
+                                const uint8_t* zero_points,
+                                int block_size,
+                                bool columnwise,
+                                int rows,
+                                int columns) {
+  static_assert(qbits == 2 || qbits == 4 || qbits == 8, "Only 2-bit, 4-bit, or 8-bit quantization is supported");
   static_assert(std::is_same<T, float>::value, "Only float type is supported");
 
   if (!columnwise) {
     throw std::runtime_error("Only column-wise dequantization is supported in test utilities");
   }
 
+  constexpr int kPackSize = BitsTraits<qbits, false>::kPackSize;
   const int k_blocks = (rows + block_size - 1) / block_size;
+  const int blob_size = (block_size + kPackSize - 1) / kPackSize;
   const bool symmetric = (zero_points == nullptr);
 
   // Process each column
@@ -246,42 +307,65 @@ inline void DequantizeBlockwise(
       const int scale_idx = n * k_blocks + k_blk;
       const float scale = static_cast<float>(scales[scale_idx]);
 
-      uint8_t zp = 8;  // Default zero point for symmetric
+      uint8_t zp = BitsTraits<qbits, false>::kMid;  // Default zero point for symmetric
       if (!symmetric) {
-        const int zp_blob_size = (k_blocks + 1) / 2;
+        const int zp_blob_size = (k_blocks + kPackSize - 1) / kPackSize;
         const uint8_t* zp_block = zero_points + n * zp_blob_size;
 
-        if (k_blk % 2 == 0) {
-          zp = zp_block[k_blk / 2] & 0x0F;
+        if constexpr (qbits == 8) {
+          zp = zp_block[k_blk];
+        } else if constexpr (qbits == 4) {
+          if (k_blk % 2 == 0) {
+            zp = zp_block[k_blk / 2] & 0xf;
+          } else {
+            zp = (zp_block[k_blk / 2] >> 4) & 0xf;
+          }
+        } else if constexpr (qbits == 2) {
+          if (k_blk % 4 == 0) {
+            zp = zp_block[k_blk / 4] & 0x3;
+          } else if (k_blk % 4 == 1) {
+            zp = (zp_block[k_blk / 4] >> 2) & 0x3;
+          } else if (k_blk % 4 == 2) {
+            zp = (zp_block[k_blk / 4] >> 4) & 0x3;
+          } else {
+            zp = (zp_block[k_blk / 4] >> 6) & 0x3;
+          }
         } else {
-          zp = (zp_block[k_blk / 2] >> 4) & 0x0F;
+          throw std::runtime_error("Unsupported qbits");
         }
       }
 
       // Calculate source offset (column major, packed)
-      const int blob_size = (block_size + 1) / 2;  // 2 values per byte for 4-bit
       const uint8_t* src_block = src + n * k_blocks * blob_size + k_blk * blob_size;
 
       // Dequantize values
       for (int i = 0; i < block_len; i++) {
-        const uint8_t packed = src_block[i / 2];
+        const uint8_t packed = src_block[i / kPackSize];
         uint8_t q_val;
 
-        if (i % 2 == 0) {
-          q_val = packed & 0x0F;  // Low nibble
+        if constexpr (qbits == 8) {
+          q_val = packed;
+        } else if constexpr (qbits == 4) {
+          if (i % 2 == 0) {
+            q_val = packed & 0xf;
+          } else {
+            q_val = (packed >> 4) & 0xf;
+          }
+        } else if constexpr (qbits == 2) {
+          if (i % 4 == 0) {
+            q_val = packed & 0x3;
+          } else if (i % 4 == 1) {
+            q_val = (packed >> 2) & 0x3;
+          } else if (i % 4 == 2) {
+            q_val = (packed >> 4) & 0x3;
+          } else {
+            q_val = (packed >> 6) & 0x3;
+          }
         } else {
-          q_val = (packed >> 4) & 0x0F;  // High nibble
+          throw std::runtime_error("Unsupported qbits");
         }
 
-        float dequant_val;
-        if (symmetric) {
-          // Convert from [0, 15] back to [-8, 7]
-          const int8_t signed_val = static_cast<int8_t>(q_val) - 8;
-          dequant_val = signed_val * scale;
-        } else {
-          dequant_val = (static_cast<float>(q_val) - zp) * scale;
-        }
-
+        float dequant_val = (q_val - zp) * scale;
         dst_col[row_start + i] = static_cast<T>(dequant_val);
       }
     }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Extend MatMulNBits op builder from GPU only to HTP. Restrict the support in 2bits/4bits and block size 32/64 for HTP. Unlike GPU using BlockEncoding, HTP requires using BwFloatBlockEncoding with bitwidth set and quint8 for tensor. Thus, extend QnnQuantParamsWrapper to accept setting encodings for QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK type. Per HTP request, MatMulNBits is transformed into Conv2d with necessary Reshape around due to HTP timeline not able to complete the implementation for MatMul in time.
Test: UT while extending hardcoding utility functions for 2bit support.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Enable for MSFT 2bit Phi3 model.

