### PR TITLE
Add gcov-based code coverage support (Linux x86_64)

### DIFF
--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -14,10 +14,15 @@ on:
         description: "Python version for the build (3.10, 3.11, 3.12, 3.13)"
         default: "3.10"
         type: string
+  # TEMP: remove before merge — workflow_dispatch cannot be triggered on a non-default branch via UI/API,
+  # so this push trigger is added temporarily to validate CI runner behavior before merging.
+  push:
+    branches:
+      - dev/yuhuchua/enable-coverage-tool
 
 jobs:
   coverage-linux-x86_64:
-    name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}"
+    name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn || '3.10' }}"
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     steps:
       - uses: actions/checkout@v6
@@ -27,13 +32,13 @@ jobs:
       - name: Run Coverage (Linux x86_64, always Debug)
         run: |
           python3 qcom/build_and_test.py \
-            --target-py-version ${{ inputs.target_py_vsn }} \
+            --target-py-version ${{ inputs.target_py_vsn || '3.10' }} \
             coverage_linux_x86_64
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}-${{ github.sha }}"
+          name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn || '3.10' }}-${{ github.sha }}"
           retention-days: 7
           path: build/linux-x86_64/Debug/coverage/

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -9,15 +9,15 @@ permissions:
 
 on:
   workflow_dispatch:
-    inputs:
-      target_py_vsn:
-        description: "Python version for the build (3.10, 3.11, 3.12, 3.13)"
-        default: "3.10"
-        type: string
+  # TEMP: remove before merge — workflow_dispatch cannot be triggered on a non-default branch via UI/API,
+  # so this push trigger is added temporarily to validate CI runner behavior before merging.
+  push:
+    branches:
+      - dev/yuhuchua/enable-coverage-tool
 
 jobs:
   coverage-linux-x86_64:
-    name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}"
+    name: "coverage-linux-x86_64"
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     steps:
       - uses: actions/checkout@v6
@@ -26,14 +26,16 @@ jobs:
 
       - name: Run Coverage (Linux x86_64, always Debug)
         run: |
+          # Python version does not affect C++ code coverage results.
+          # 3.10 matches DEFAULT_PYTHON_LINUX in qcom/ep_build/util.py.
           python3 qcom/build_and_test.py \
-            --target-py-version ${{ inputs.target_py_vsn }} \
+            --target-py-version 3.10 \
             coverage_linux_x86_64
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}-${{ github.sha }}"
+          name: "coverage-linux-x86_64-${{ github.sha }}"
           retention-days: 7
           path: build/linux-x86_64/Debug/coverage/

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -9,11 +9,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  # TEMP: remove before merge — workflow_dispatch cannot be triggered on a non-default branch via UI/API,
-  # so this push trigger is added temporarily to validate CI runner behavior before merging.
-  push:
-    branches:
-      - dev/yuhuchua/enable-coverage-tool
 
 jobs:
   coverage-linux-x86_64:

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -1,0 +1,39 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+name: Qualcomm Internal Coverage
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_py_vsn:
+        description: "Python version for the build (3.10, 3.11, 3.12, 3.13)"
+        default: "3.10"
+        type: string
+
+jobs:
+  coverage-linux-x86_64:
+    name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}"
+    runs-on: ["self-hosted", "X64", "Linux", "Build"]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Run Coverage (Linux x86_64, always Debug)
+        run: |
+          python3 qcom/build_and_test.py \
+            --target-py-version ${{ inputs.target_py_vsn }} \
+            coverage_linux_x86_64
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}-${{ github.sha }}"
+          retention-days: 7
+          path: build/linux-x86_64/Debug/coverage/

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -14,15 +14,10 @@ on:
         description: "Python version for the build (3.10, 3.11, 3.12, 3.13)"
         default: "3.10"
         type: string
-  # TEMP: remove before merge — workflow_dispatch cannot be triggered on a non-default branch via UI/API,
-  # so this push trigger is added temporarily to validate CI runner behavior before merging.
-  push:
-    branches:
-      - dev/yuhuchua/enable-coverage-tool
 
 jobs:
   coverage-linux-x86_64:
-    name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn || '3.10' }}"
+    name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}"
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     steps:
       - uses: actions/checkout@v6
@@ -32,13 +27,13 @@ jobs:
       - name: Run Coverage (Linux x86_64, always Debug)
         run: |
           python3 qcom/build_and_test.py \
-            --target-py-version ${{ inputs.target_py_vsn || '3.10' }} \
+            --target-py-version ${{ inputs.target_py_vsn }} \
             coverage_linux_x86_64
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn || '3.10' }}-${{ github.sha }}"
+          name: "coverage-linux-x86_64-py${{ inputs.target_py_vsn }}-${{ github.sha }}"
           retention-days: 7
           path: build/linux-x86_64/Debug/coverage/

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Run Coverage (Linux x86_64, always Debug)
+      - name: Run Coverage (Linux x86_64, always RelWithDebInfo)
         run: |
           # Python version does not affect C++ code coverage results.
           # 3.10 matches DEFAULT_PYTHON_LINUX in qcom/ep_build/util.py.
@@ -33,4 +33,4 @@ jobs:
         with:
           name: "coverage-linux-x86_64-${{ github.sha }}"
           retention-days: 7
-          path: build/linux-x86_64/Debug/coverage/
+          path: build/linux-x86_64/RelWithDebInfo/coverage/

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -77,6 +77,10 @@ option(onnxruntime_CROSS_COMPILING "Cross compiling onnx runtime" OFF)
 option(onnxruntime_GCOV_COVERAGE "Compile with options necessary to run code coverage" OFF)
 option(onnxruntime_DONT_VECTORIZE "Do not vectorize operations in Eigen" OFF)
 
+# Coverage builds are only supported on Linux with GCC.
+# Pass -DENABLE_COVERAGE=ON to cmake to enable (e.g. via build.sh --enable-coverage).
+option(ENABLE_COVERAGE "Enable GCC code coverage instrumentation (Linux only)" OFF)
+
 option(onnxruntime_USE_FULL_PROTOBUF "Link to libprotobuf instead of libprotobuf-lite when this option is ON" OFF)
 option(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS "Dump debug information about node inputs and outputs when executing the model." OFF)
 cmake_dependent_option(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS_ENABLE_DUMP_TO_SQLDB "Build dump debug information about node inputs and outputs with support for sql database." OFF "onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS" OFF)

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -221,6 +221,8 @@ if(ENABLE_COVERAGE)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(onnxruntime_providers_qnn PRIVATE
             --coverage
+            # -g and -O0 are explicit so that debug info and no optimization are
+            # always present regardless of the CMake build type.
             -g
             -O0
             -fprofile-abs-path

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -71,8 +71,13 @@
 
   # Set linker flags for function(s) exported by EP DLL
   if(UNIX)
+    if("$ENV{ENABLE_COVERAGE}" MATCHES "1|ON|YES|TRUE")
+      set(qnn_version_script "${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script_coverage.lds")
+    else()
+      set(qnn_version_script "${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script.lds")
+    endif()
     target_link_options(onnxruntime_providers_qnn PRIVATE
-                        "LINKER:--version-script=${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script.lds"
+                        "LINKER:--version-script=${qnn_version_script}"
                         "LINKER:--gc-sections"
                         "LINKER:-rpath=\$ORIGIN"
     )
@@ -212,3 +217,16 @@
           LIBRARY   DESTINATION ${CMAKE_INSTALL_LIBDIR}
           RUNTIME   DESTINATION ${CMAKE_INSTALL_BINDIR}
           FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Code Coverage Configuration
+if("$ENV{ENABLE_COVERAGE}" MATCHES "1|ON|YES|TRUE")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(onnxruntime_providers_qnn PRIVATE
+            --coverage
+            -g
+            -O0
+            -fprofile-abs-path
+        )
+        target_link_options(onnxruntime_providers_qnn PRIVATE --coverage)
+    endif()
+endif()

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -218,7 +218,7 @@
           FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Code Coverage Configuration
-# Currently only supported on Linux x86_64 with GCC.
+# Currently only supported on Linux with GCC.
 # Future: extend to Android (aarch64 cross-compile) — requires ADB-based test execution,
 # pulling .gcda files from device, and lcov path substitution for cross-compiled sources.
 if(ENABLE_COVERAGE)

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -3,6 +3,10 @@
 
   add_compile_definitions(USE_QNN=1)
 
+  # Coverage builds are only supported on Linux with GCC.
+  # Pass -DENABLE_COVERAGE=ON to cmake to enable (e.g. via build.sh --enable-coverage).
+  option(ENABLE_COVERAGE "Enable GCC code coverage instrumentation (Linux only)" OFF)
+
   file(GLOB_RECURSE
        onnxruntime_providers_qnn_ep_srcs CONFIGURE_DEPENDS
        "${ONNXRUNTIME_ROOT}/core/providers/qnn/*.h"
@@ -71,13 +75,8 @@
 
   # Set linker flags for function(s) exported by EP DLL
   if(UNIX)
-    if("$ENV{ENABLE_COVERAGE}" MATCHES "1|ON|YES|TRUE")
-      set(qnn_version_script "${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script_coverage.lds")
-    else()
-      set(qnn_version_script "${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script.lds")
-    endif()
     target_link_options(onnxruntime_providers_qnn PRIVATE
-                        "LINKER:--version-script=${qnn_version_script}"
+                        "LINKER:--version-script=${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script.lds"
                         "LINKER:--gc-sections"
                         "LINKER:-rpath=\$ORIGIN"
     )
@@ -219,8 +218,11 @@
           FRAMEWORK DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Code Coverage Configuration
-if("$ENV{ENABLE_COVERAGE}" MATCHES "1|ON|YES|TRUE")
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+# Currently only supported on Linux x86_64 with GCC.
+# Future: extend to Android (aarch64 cross-compile) — requires ADB-based test execution,
+# pulling .gcda files from device, and lcov path substitution for cross-compiled sources.
+if(ENABLE_COVERAGE)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(onnxruntime_providers_qnn PRIVATE
             --coverage
             -g

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -3,10 +3,6 @@
 
   add_compile_definitions(USE_QNN=1)
 
-  # Coverage builds are only supported on Linux with GCC.
-  # Pass -DENABLE_COVERAGE=ON to cmake to enable (e.g. via build.sh --enable-coverage).
-  option(ENABLE_COVERAGE "Enable GCC code coverage instrumentation (Linux only)" OFF)
-
   file(GLOB_RECURSE
        onnxruntime_providers_qnn_ep_srcs CONFIGURE_DEPENDS
        "${ONNXRUNTIME_ROOT}/core/providers/qnn/*.h"

--- a/onnxruntime/core/providers/qnn/version_script_coverage.lds
+++ b/onnxruntime/core/providers/qnn/version_script_coverage.lds
@@ -1,7 +1,0 @@
-VERS_1.0 {
-  # Export all symbols so that unit tests can call EP-internal functions directly.
-  # This file is only used for coverage builds (ENABLE_COVERAGE=1).
-  # Do NOT use in production builds.
-  global:
-    *;
-};

--- a/onnxruntime/core/providers/qnn/version_script_coverage.lds
+++ b/onnxruntime/core/providers/qnn/version_script_coverage.lds
@@ -1,0 +1,7 @@
+VERS_1.0 {
+  # Export all symbols so that unit tests can call EP-internal functions directly.
+  # This file is only used for coverage builds (ENABLE_COVERAGE=1).
+  # Do NOT use in production builds.
+  global:
+    *;
+};

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -25,7 +25,6 @@ from ep_build.plan import (
     task,
 )
 from ep_build.task import (
-    BashScriptsWithVenvTask,
     CompositeTask,
     ConvertArchiveTask,
     ExtractArchiveTask,
@@ -37,6 +36,7 @@ from ep_build.tasks.build import (
     BuildEpDockerTask,
     BuildEpLinuxTask,
     BuildEpWindowsTask,
+    GenerateCoverageTask,
     QdcTestsTask,
 )
 from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, DockerBuildTask
@@ -548,15 +548,10 @@ class TaskLibrary:
                             "build",
                             extra_args=["--enable-coverage"],
                         ),
-                        BashScriptsWithVenvTask(
+                        GenerateCoverageTask(
                             "Generating HTML coverage report",
                             self.__venv_path,
-                            [
-                                [
-                                    str(REPO_ROOT / "qcom" / "scripts" / "linux" / "generate_coverage.sh"),
-                                    f"--build-dir={build_dir}",
-                                ]
-                            ],
+                            build_dir,
                         ),
                     ],
                 )

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -25,6 +25,7 @@ from ep_build.plan import (
     task,
 )
 from ep_build.task import (
+    BashScriptsWithVenvTask,
     CompositeTask,
     ConvertArchiveTask,
     ExtractArchiveTask,
@@ -522,6 +523,42 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                )
+            )
+
+    if is_host_linux() and is_host_x86_64():
+
+        @public_task("Build with code coverage and generate HTML report (Linux x86_64, always Debug)")
+        @depends(["create_venv"])
+        def coverage_linux_x86_64(self, plan: Plan) -> str:
+            build_dir = REPO_ROOT / "build" / "linux-x86_64"
+            return plan.add_step(
+                CompositeTask(
+                    "Coverage build, test, and report",
+                    [
+                        BuildEpLinuxTask(
+                            "Building ONNX Runtime for Linux (Debug + coverage)",
+                            self.__venv_path,
+                            "linux",
+                            "x86_64",
+                            "Debug",
+                            self.__target_py_version,
+                            self.__ort_prebuilt_root,
+                            self.__qairt_sdk_root,
+                            "build",
+                            extra_args=["--enable-coverage"],
+                        ),
+                        BashScriptsWithVenvTask(
+                            "Generating HTML coverage report",
+                            self.__venv_path,
+                            [
+                                [
+                                    str(REPO_ROOT / "qcom" / "scripts" / "linux" / "generate_coverage.sh"),
+                                    f"--build-dir={build_dir}",
+                                ]
+                            ],
+                        ),
+                    ],
                 )
             )
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -528,7 +528,7 @@ class TaskLibrary:
 
     if is_host_linux() and is_host_x86_64():
 
-        @public_task("Build with code coverage and generate HTML report (Linux x86_64, always Debug)")
+        @public_task("Build with code coverage and generate HTML report (Linux x86_64, RelWithDebInfo)")
         @depends(["create_venv"])
         def coverage_linux_x86_64(self, plan: Plan) -> str:
             build_dir = REPO_ROOT / "build" / "linux-x86_64"
@@ -537,11 +537,11 @@ class TaskLibrary:
                     "Coverage build, test, and report",
                     [
                         BuildEpLinuxTask(
-                            "Building ONNX Runtime for Linux (Debug + coverage)",
+                            "Building ONNX Runtime for Linux (RelWithDebInfo + coverage)",
                             self.__venv_path,
                             "linux",
                             "x86_64",
-                            "Debug",
+                            "RelWithDebInfo",
                             self.__target_py_version,
                             self.__ort_prebuilt_root,
                             self.__qairt_sdk_root,

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -155,6 +155,22 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
         super().__init__(group_name, [cmd], env=ort_build_env_vars())
 
 
+class GenerateCoverageTask(BashScriptsWithVenvTask):
+    """Run generate_coverage.sh to collect gcov data and produce an HTML coverage report."""
+
+    def __init__(
+        self,
+        group_name: str | None,
+        venv: Path | None,
+        build_dir: Path,
+    ) -> None:
+        cmd = [
+            str(REPO_ROOT / "qcom" / "scripts" / "linux" / "generate_coverage.sh"),
+            f"--build-dir={build_dir}",
+        ]
+        super().__init__(group_name, venv, [cmd])
+
+
 class AdbTestsTask(RunInTempDirectoryTask):
     def __init__(
         self,

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -156,17 +156,24 @@ class BuildEpWindowsTask(RunPowershellScriptsTask):
 
 
 class GenerateCoverageTask(BashScriptsWithVenvTask):
-    """Run generate_coverage.sh to collect gcov data and produce an HTML coverage report."""
+    """Run generate_coverage.sh to collect gcov data and produce an HTML coverage report.
+
+    Uses BashScriptsWithVenvTask (rather than BashScriptsTask) intentionally:
+    Phase 2 will invoke Python tools (e.g. lcov_cobertura, diff-cover) that require
+    the venv to be active.
+    """
 
     def __init__(
         self,
         group_name: str | None,
         venv: Path | None,
         build_dir: Path,
+        config: str = "RelWithDebInfo",
     ) -> None:
         cmd = [
             str(REPO_ROOT / "qcom" / "scripts" / "linux" / "generate_coverage.sh"),
             f"--build-dir={build_dir}",
+            f"--config={config}",
         ]
         super().__init__(group_name, venv, [cmd])
 

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -67,6 +67,12 @@ cmake_windows_x86_64:
   sha256: cf35a516c4f5f4646b301e51c8e24b168cc012c3b1453b8f675303b54eb0ef45
   content_root: cmake-{version}-windows-x86_64
   bindir: bin
+lcov_linux_x86_64:
+  version: 1.16
+  url: https://github.com/linux-test-project/lcov/releases/download/v{version}/lcov-{version}.tar.gz
+  sha256: 987031ad5528c8a746d4b52b380bc1bffe412de1f2b9c2ba5224995668e3240b
+  content_root: lcov-{version}
+  bindir: bin
 linux_oe_gcc112_toolchain:
   # This package comes from AI Hub, which in turn copies it from the QAIRT build.
   version: 20250402d

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -305,7 +305,7 @@ else
     fi
 
     if [ -n "${enable_coverage}" ]; then
-      export ENABLE_COVERAGE=1
+      common_args+=(--cmake_extra_defines "ENABLE_COVERAGE:BOOL=ON")
     fi
 
     "${python_for_build}" ${REPO_ROOT}/tools/ci_build/build.py \

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -39,6 +39,7 @@ use_cache=1
 warnings_as_errors=1
 build_java=
 build_archive=
+enable_coverage=
 for i in "$@"; do
   case $i in
     --build-archive)
@@ -63,6 +64,10 @@ for i in "$@"; do
       ;;
     --build-java)
       build_java=1
+      shift
+      ;;
+    --enable-coverage)
+      enable_coverage=1
       shift
       ;;
     --ort-home=*)
@@ -297,6 +302,10 @@ else
     fi
     if [[ "${ORT_NIGHTLY_BUILD:-}" == "1" ]]; then
       package_args+=(--wheel_name_suffix "qcom-internal")
+    fi
+
+    if [ -n "${enable_coverage}" ]; then
+      export ENABLE_COVERAGE=1
     fi
 
     "${python_for_build}" ${REPO_ROOT}/tools/ci_build/build.py \

--- a/qcom/scripts/linux/generate_coverage.sh
+++ b/qcom/scripts/linux/generate_coverage.sh
@@ -5,7 +5,7 @@
 # Generate ONNX Runtime QNN EP code coverage report.
 #
 # Prerequisites:
-#   - A Debug build compiled with coverage instrumentation (ENABLE_COVERAGE=1).
+#   - A build compiled with coverage instrumentation (--enable-coverage flag in build.sh).
 #     Use: python qcom/build_and_test.py coverage_linux_x86_64
 #   - lcov 1.x (auto-installed via packages.yml)
 #   - genhtml (bundled with lcov)
@@ -14,6 +14,7 @@
 # Usage:
 #   bash generate_coverage.sh \
 #       --build-dir=/path/to/build/linux-x86_64 \
+#       [--config=Debug|RelWithDebInfo|Release] \
 #       [--output-dir=/path/to/report] \
 #       [--test-filter="*Qnn*"]
 
@@ -28,6 +29,7 @@ set_strict_mode
 # Parse arguments
 # ---------------------------------------------------------------------------
 build_dir=""
+config="RelWithDebInfo"
 output_dir=""
 test_filter="*Qnn*"
 
@@ -35,6 +37,9 @@ for arg in "$@"; do
     case "${arg}" in
         --build-dir=*)
             build_dir="${arg#--build-dir=}"
+            ;;
+        --config=*)
+            config="${arg#--config=}"
             ;;
         --output-dir=*)
             output_dir="${arg#--output-dir=}"
@@ -44,11 +49,12 @@ for arg in "$@"; do
             ;;
         -h|--help)
             cat <<EOF
-Usage: $(basename "${BASH_SOURCE[0]}") --build-dir=<path> [--output-dir=<path>] [--test-filter=<str>]
+Usage: $(basename "${BASH_SOURCE[0]}") --build-dir=<path> [--config=<cfg>] [--output-dir=<path>] [--test-filter=<str>]
 
-  --build-dir=<path>    Required. Build root containing a Debug/ subdirectory (e.g. build/linux-x86_64).
-  --output-dir=<path>   Optional. Output directory for HTML report. Default: <build-dir>/Debug/coverage
-  --test-filter=<str>   Optional. GTest filter string.            Default: *Qnn*
+  --build-dir=<path>    Required. Build root (e.g. build/linux-x86_64).
+  --config=<cfg>        Optional. Build configuration subdirectory.  Default: RelWithDebInfo
+  --output-dir=<path>   Optional. Output directory for HTML report.  Default: <build-dir>/<config>/coverage
+  --test-filter=<str>   Optional. GTest filter string.               Default: *Qnn*
 EOF
             exit 0
             ;;
@@ -65,16 +71,20 @@ if [ -z "${build_dir}" ]; then
     die "--build-dir is required. Run with --help for usage."
 fi
 
-if [ ! -d "${build_dir}/Debug" ]; then
-    die "Debug build directory not found: ${build_dir}/Debug"
+# Resolve to absolute path so that cd inside subshells does not break relative paths.
+build_dir="$(realpath "${build_dir}")"
+
+if [ ! -d "${build_dir}/${config}" ]; then
+    die "Build directory not found: ${build_dir}/${config}"
 fi
 
 if [ -z "${output_dir}" ]; then
-    output_dir="${build_dir}/Debug/coverage"
+    output_dir="${build_dir}/${config}/coverage"
 fi
 
 log_info "=== QNN EP Coverage Report Generator ==="
 log_info "build_dir   : ${build_dir}"
+log_info "config      : ${config}"
 log_info "output_dir  : ${output_dir}"
 log_info "test_filter : ${test_filter}"
 
@@ -95,7 +105,7 @@ lcov_bindir="$(get_lcov_bindir)"
 export PATH="${lcov_bindir}:${PATH}"
 
 if ! command -v lcov &>/dev/null; then
-    die "lcov not found after package install. Check packages.yml entry for lcov_linux_$(uname -m)."
+    die "lcov not found after package install. Check packages.yml entry for lcov_$(get_host_platform)."
 fi
 if ! command -v genhtml &>/dev/null; then
     die "genhtml not found. It should be bundled with lcov in ${lcov_bindir}."
@@ -117,18 +127,23 @@ log_info "Found ${gcno_count} .gcno file(s)."
 # ---------------------------------------------------------------------------
 log_info "--- Clearing stale coverage counters ---"
 lcov --zerocounters --directory "${build_dir}" 2>&1 || true
-rm -f "${build_dir}/Debug/coverage_lcov.info" \
-      "${build_dir}/Debug/coverage_lcov_filtered.info"
+rm -f "${build_dir}/${config}/coverage_lcov.info" \
+      "${build_dir}/${config}/coverage_lcov_filtered.info"
 
 # ---------------------------------------------------------------------------
 # Run tests to generate .gcda runtime data
 # ---------------------------------------------------------------------------
 log_info "--- Running tests (filter: ${test_filter}) ---"
+test_exit=0
 (
-    cd "${build_dir}/Debug"
-    export LD_LIBRARY_PATH="${build_dir}/Debug${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    cd "${build_dir}/${config}"
+    export LD_LIBRARY_PATH="${build_dir}/${config}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     ./onnxruntime_provider_test --gtest_filter="${test_filter}"
-)
+) || test_exit=$?
+
+if [ "${test_exit}" -ne 0 ]; then
+    log_warn "Tests exited with ${test_exit}; continuing to collect coverage from .gcda written so far."
+fi
 
 gcda_count=$(find "${build_dir}" -name '*.gcda' | wc -l)
 if [ "${gcda_count}" -eq 0 ]; then
@@ -142,7 +157,7 @@ fi
 # ---------------------------------------------------------------------------
 log_info "--- Collecting coverage data ---"
 (
-    cd "${build_dir}/Debug"
+    cd "${build_dir}/${config}"
     lcov --capture \
          --directory "${build_dir}" \
          --output-file coverage_lcov.info \
@@ -154,7 +169,7 @@ log_info "--- Collecting coverage data ---"
 # ---------------------------------------------------------------------------
 log_info "--- Filtering coverage data ---"
 (
-    cd "${build_dir}/Debug"
+    cd "${build_dir}/${config}"
     # Step 1: extract only QNN EP production sources
     lcov --extract coverage_lcov.info \
          "*/onnxruntime/core/providers/qnn/*" \
@@ -176,7 +191,7 @@ log_info "--- Filtering coverage data ---"
 # ---------------------------------------------------------------------------
 log_info "--- Generating HTML report ---"
 mkdir -p "${output_dir}"
-genhtml "${build_dir}/Debug/coverage_lcov_filtered.info" \
+genhtml "${build_dir}/${config}/coverage_lcov_filtered.info" \
         --output-directory "${output_dir}" \
         --branch-coverage \
         --rc lcov_branch_coverage=1
@@ -184,8 +199,8 @@ genhtml "${build_dir}/Debug/coverage_lcov_filtered.info" \
 # ---------------------------------------------------------------------------
 # Copy .info files to output_dir
 # ---------------------------------------------------------------------------
-cp "${build_dir}/Debug/coverage_lcov.info"          "${output_dir}/coverage_lcov.info"
-cp "${build_dir}/Debug/coverage_lcov_filtered.info" "${output_dir}/coverage_lcov_filtered.info"
+cp "${build_dir}/${config}/coverage_lcov.info"          "${output_dir}/coverage_lcov.info"
+cp "${build_dir}/${config}/coverage_lcov_filtered.info" "${output_dir}/coverage_lcov_filtered.info"
 
 log_info "=== Coverage report complete ==="
 log_info "HTML report  : ${output_dir}/index.html"

--- a/qcom/scripts/linux/generate_coverage.sh
+++ b/qcom/scripts/linux/generate_coverage.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Generate ONNX Runtime QNN EP code coverage report.
+#
+# Prerequisites:
+#   - A Debug build compiled with coverage instrumentation (ENABLE_COVERAGE=1).
+#     Use: python qcom/build_and_test.py coverage_linux_x86_64
+#   - lcov 2.x (auto-installed via packages.yml)
+#   - genhtml (bundled with lcov)
+#   - Perl (must be present on the host; raise an error if missing)
+#
+# Usage:
+#   bash generate_coverage.sh \
+#       --build-dir=/path/to/build/linux-x86_64 \
+#       [--output-dir=/path/to/report] \
+#       [--test-filter="*Qnn*"]
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source "${REPO_ROOT}/qcom/scripts/linux/common.sh"
+source "${REPO_ROOT}/qcom/scripts/linux/tools.sh"
+
+set_strict_mode
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+build_dir=""
+output_dir=""
+test_filter="*Qnn*"
+
+for arg in "$@"; do
+    case "${arg}" in
+        --build-dir=*)
+            build_dir="${arg#--build-dir=}"
+            ;;
+        --output-dir=*)
+            output_dir="${arg#--output-dir=}"
+            ;;
+        --test-filter=*)
+            test_filter="${arg#--test-filter=}"
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") --build-dir=<path> [--output-dir=<path>] [--test-filter=<str>]
+
+  --build-dir=<path>    Required. Build root containing a Debug/ subdirectory (e.g. build/linux-x86_64).
+  --output-dir=<path>   Optional. Output directory for HTML report. Default: <build-dir>/Debug/coverage
+  --test-filter=<str>   Optional. GTest filter string.            Default: *Qnn*
+EOF
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: ${arg}"
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate arguments
+# ---------------------------------------------------------------------------
+if [ -z "${build_dir}" ]; then
+    die "--build-dir is required. Run with --help for usage."
+fi
+
+if [ ! -d "${build_dir}/Debug" ]; then
+    die "Debug build directory not found: ${build_dir}/Debug"
+fi
+
+if [ -z "${output_dir}" ]; then
+    output_dir="${build_dir}/Debug/coverage"
+fi
+
+log_info "=== QNN EP Coverage Report Generator ==="
+log_info "build_dir   : ${build_dir}"
+log_info "output_dir  : ${output_dir}"
+log_info "test_filter : ${test_filter}"
+
+# ---------------------------------------------------------------------------
+# Locate Perl (required by lcov)
+# ---------------------------------------------------------------------------
+log_info "--- Checking Perl ---"
+if ! command -v perl &>/dev/null; then
+    die "Perl not found in PATH. lcov requires Perl. Please install perl (e.g. apt install perl)."
+fi
+log_info "Using Perl: $(command -v perl)  ($(perl --version 2>&1 | head -1 || true))"
+
+# ---------------------------------------------------------------------------
+# Locate lcov / genhtml (auto-installed via packages.yml)
+# ---------------------------------------------------------------------------
+log_info "--- Locating lcov ---"
+lcov_bindir="$(get_lcov_bindir)"
+export PATH="${lcov_bindir}:${PATH}"
+
+if ! command -v lcov &>/dev/null; then
+    die "lcov not found after package install. Check packages.yml entry for lcov_linux_$(uname -m)."
+fi
+if ! command -v genhtml &>/dev/null; then
+    die "genhtml not found. It should be bundled with lcov in ${lcov_bindir}."
+fi
+
+lcov_version=$(lcov --version 2>&1 | head -1 || true)
+log_info "Using lcov   : $(command -v lcov)  (${lcov_version})"
+log_info "Using genhtml: $(command -v genhtml)"
+
+# Verify .gcno files exist (compile-time notes from gcov instrumentation)
+gcno_count=$(find "${build_dir}" -name '*.gcno' | wc -l)
+if [ "${gcno_count}" -eq 0 ]; then
+    die "No .gcno files found under ${build_dir}. Was the build compiled with --enable-coverage?"
+fi
+log_info "Found ${gcno_count} .gcno file(s)."
+
+# ---------------------------------------------------------------------------
+# Clear stale counters
+# ---------------------------------------------------------------------------
+log_info "--- Clearing stale coverage counters ---"
+lcov --zerocounters --directory "${build_dir}" 2>&1 || true
+rm -f "${build_dir}/Debug/coverage_lcov.info" \
+      "${build_dir}/Debug/coverage_lcov_filtered.info"
+
+# ---------------------------------------------------------------------------
+# Run tests to generate .gcda runtime data
+# ---------------------------------------------------------------------------
+log_info "--- Running tests (filter: ${test_filter}) ---"
+(
+    cd "${build_dir}/Debug"
+    export LD_LIBRARY_PATH="${build_dir}/Debug${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    ./onnxruntime_provider_test --gtest_filter="${test_filter}"
+)
+
+gcda_count=$(find "${build_dir}" -name '*.gcda' | wc -l)
+if [ "${gcda_count}" -eq 0 ]; then
+    log_warn "No .gcda files found — coverage data may be sparse."
+else
+    log_info "Found ${gcda_count} .gcda file(s)."
+fi
+
+# ---------------------------------------------------------------------------
+# Collect coverage data
+# ---------------------------------------------------------------------------
+log_info "--- Collecting coverage data ---"
+(
+    cd "${build_dir}/Debug"
+    lcov --capture \
+         --directory "${build_dir}" \
+         --output-file coverage_lcov.info \
+         --rc lcov_branch_coverage=1
+)
+
+# ---------------------------------------------------------------------------
+# Filter: allowlist QNN EP sources only; strip third-party, test, and deps
+# ---------------------------------------------------------------------------
+log_info "--- Filtering coverage data ---"
+(
+    cd "${build_dir}/Debug"
+    # Step 1: extract only QNN EP production sources
+    lcov --extract coverage_lcov.info \
+         "*/onnxruntime/core/providers/qnn/*" \
+         --output-file coverage_lcov_filtered.info \
+         --rc lcov_branch_coverage=1
+
+    # Step 2: remove anything that slipped through (tests, deps, system headers)
+    lcov --remove coverage_lcov_filtered.info \
+         '/usr/*' \
+         '*/googletest/*' \
+         '*/test/*' \
+         '*/_deps/*' \
+         --output-file coverage_lcov_filtered.info \
+         --rc lcov_branch_coverage=1
+)
+
+# ---------------------------------------------------------------------------
+# Generate HTML report
+# ---------------------------------------------------------------------------
+log_info "--- Generating HTML report ---"
+mkdir -p "${output_dir}"
+genhtml "${build_dir}/Debug/coverage_lcov_filtered.info" \
+        --output-directory "${output_dir}" \
+        --branch-coverage \
+        --rc lcov_branch_coverage=1
+
+# ---------------------------------------------------------------------------
+# Copy .info files to output_dir
+# ---------------------------------------------------------------------------
+cp "${build_dir}/Debug/coverage_lcov.info"          "${output_dir}/coverage_lcov.info"
+cp "${build_dir}/Debug/coverage_lcov_filtered.info" "${output_dir}/coverage_lcov_filtered.info"
+
+log_info "=== Coverage report complete ==="
+log_info "HTML report  : ${output_dir}/index.html"
+log_info "lcov raw     : ${output_dir}/coverage_lcov.info"
+log_info "lcov filtered: ${output_dir}/coverage_lcov_filtered.info"

--- a/qcom/scripts/linux/generate_coverage.sh
+++ b/qcom/scripts/linux/generate_coverage.sh
@@ -7,7 +7,7 @@
 # Prerequisites:
 #   - A Debug build compiled with coverage instrumentation (ENABLE_COVERAGE=1).
 #     Use: python qcom/build_and_test.py coverage_linux_x86_64
-#   - lcov 2.x (auto-installed via packages.yml)
+#   - lcov 1.x (auto-installed via packages.yml)
 #   - genhtml (bundled with lcov)
 #   - Perl (must be present on the host; raise an error if missing)
 #

--- a/qcom/scripts/linux/tools.sh
+++ b/qcom/scripts/linux/tools.sh
@@ -88,6 +88,13 @@ function get_linux_oe_gcc112_toolchain_root() {
 }
 
 #
+# Get the directory containing lcov/genhtml, installing it if necessary.
+#
+function get_lcov_bindir() {
+    get_package_bindir lcov_$(get_host_platform)
+}
+
+#
 # Get the directory containing ninja, installing it if necessary.
 #
 function get_ninja_bindir() {


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                                                   
  ## Summary      
                                                                                                                                                                                                                                                                                                                    
  Adds opt-in gcov-based code coverage measurement for the QNN EP on Linux x86_64.                                                                                                                                                                                                                                  
  Coverage is always RelWithDebInfo, never affects Release builds, and has zero impact on the                                                                                                                                                                                                                                
  existing CI matrix.                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  **Build system:**                                                                                                                                                                                                                                                                                                 
  - `version_script_coverage.lds` — new linker script that exports all symbols
    (used only when `ENABLE_COVERAGE=1`; production `version_script.lds` unchanged)                                                                                                                                                                                                                                 
  - `cmake/onnxruntime_providers_qnn.cmake` — adds `--coverage -g -O0 -fprofile-abs-path` for GCC                                                                                                                                                                                                                                          
  - `qcom/scripts/linux/build.sh` — new `--enable-coverage` flag that sets `ENABLE_COVERAGE:BOOL=ON` when invoking `build.py`                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  **Coverage tooling:**                                                                                                                                                                                                                                                                                             
  - `qcom/packages.yml` — new `lcov_linux_x86_64` entry (v1.16; no extra Perl module dependencies unlike lcov 2.x)                                                                                                                                                                                                                                                                            
  - `qcom/scripts/linux/tools.sh` — new `get_lcov_bindir()` helper                                                                                                                                                                                                                                                  
  - `qcom/scripts/linux/generate_coverage.sh` — standalone script: clears stale counters, runs `onnxruntime_provider_test --gtest_filter="*Qnn*"`, collects and filters coverage data, generates HTML report via genhtml                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  **Task orchestrator:**                                                                                                                                                                                                                                                                                            
  - `qcom/build_and_test.py` — new `coverage_linux_x86_64` public task (Linux x86_64 only): RelWithDebInfo build with coverage flags → generate_coverage.sh                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  **CI:**                                                                                                                                                                                                                                                                                                           
  - `.github/workflows/qualcomm-internal-coverage.yml` — on-demand `workflow_dispatch` workflow; does not run on every PR push                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  ## How to trigger                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  **Locally:**                                                                                                                                                                                                                                                                                                      
```bash
  python qcom/build_and_test.py coverage_linux_x86_64                                                                                                                                                                                                                                                               
  # Report: build/linux-x86_64/RelWithDebInfo/coverage/index.html      
```                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  **Via GitHub Actions: **   
```                                                                                                                                                                                                                                                                                           
  Actions → "Qualcomm Internal Coverage" → Run workflow → select branch        
```                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                      