### PR TITLE
fix: propagate QNN tensor ID when override name already registered

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -100,6 +100,8 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
       // two APP_READ tensors with the same external name (which reduces the composed
       // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
       if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Outputs()[0].name)) {
+        // The tensor name override is used to align the output name of DLC produced by IRBackend
+        // with the output name of original onnx graph for better consistency.
         qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
                                                 /*external=*/node_unit.Outputs()[0].name);
       }
@@ -117,10 +119,12 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
         qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
       // Only register the override for the first Q node that consumes this graph input.
       // If another Q node already maps to the same external name, skip registration so
-      // that the second output becomes a separate APP_WRITE tensor instead of creating
+      // that the second input becomes a separate APP_WRITE tensor instead of creating
       // two APP_WRITE tensors with the same external name (which reduces the composed
       // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
       if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Inputs()[0].name)) {
+        // The tensor name override is used to align the input name of DLC produced by IRBackend
+        // with the input name of original onnx graph for better consistency.
         qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
                                                 /*external=*/node_unit.Inputs()[0].name);
       }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -94,8 +94,15 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name)) {
-      qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
-                                              /*external=*/node_unit.Outputs()[0].name);
+      // Only register the override for the first DQ node that consumes this graph output.
+      // If another DQ node already maps to the same external name, skip registration so
+      // that the second output becomes a separate APP_READ tensor instead of creating
+      // two APP_READ tensors with the same external name (which reduces the composed
+      // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
+      if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Outputs()[0].name)) {
+        qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
+                                                /*external=*/node_unit.Outputs()[0].name);
+      }
       return MAKE_EP_FAIL("QNN EP is configured to not take DQ nodes that generate a graph output.");
     }
   }
@@ -108,8 +115,15 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
-      qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
-                                              /*external=*/node_unit.Inputs()[0].name);
+      // Only register the override for the first Q node that consumes this graph input.
+      // If another Q node already maps to the same external name, skip registration so
+      // that the second output becomes a separate APP_WRITE tensor instead of creating
+      // two APP_WRITE tensors with the same external name (which reduces the composed
+      // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
+      if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Inputs()[0].name)) {
+        qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
+                                                /*external=*/node_unit.Inputs()[0].name);
+      }
       return MAKE_EP_FAIL("QNN EP is configured to not take Q nodes that consume a graph input.");
     }
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.cc
@@ -250,6 +250,23 @@ uint32_t GetQnnTensorID(const Qnn_Tensor_t& qnn_tensor) {
                     ORT_EP_FAIL);
 }
 
+void SetQnnTensorID(Qnn_Tensor_t& qnn_tensor, uint32_t id) {
+  if (QNN_TENSOR_VERSION_1 == qnn_tensor.version) {
+    qnn_tensor.v1.id = id;
+    return;
+  }
+
+#ifdef QNN_TENSOR_V2_INIT
+  if (QNN_TENSOR_VERSION_2 == qnn_tensor.version) {
+    qnn_tensor.v2.id = id;
+    return;
+  }
+#endif  // QNN_TENSOR_V2_INIT
+
+  ORT_CXX_API_THROW("QNN tensor version not supported, QNN tensor version: " + std::to_string(qnn_tensor.version),
+                    ORT_EP_FAIL);
+}
+
 Qnn_TensorType_t GetQnnTensorType(const Qnn_Tensor_t& qnn_tensor) {
   if (QNN_TENSOR_VERSION_1 == qnn_tensor.version) {
     return qnn_tensor.v1.type;
@@ -455,10 +472,14 @@ bool CreateTensorInQnnGraph(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                             const std::string& node_name,
                             const std::string& tensor_name,
                             Qnn_Tensor_t& qnn_tensor,
-                            std::unordered_map<std::string, bool>& tensors_created_table,
+                            std::unordered_map<std::string, uint32_t>& tensors_created_table,
                             std::string& error_msg) {
-  if (tensors_created_table.find(tensor_name) != tensors_created_table.end()) {
-    error_msg = "Tensor created already: " + tensor_name;
+  auto existing = tensors_created_table.find(tensor_name);
+  if (existing != tensors_created_table.end()) {
+    // Multiple internal tensors may share the same override name (e.g., when a graph input
+    // is consumed by multiple QDQ pairs and offload_graph_io_quantization=1). Copy the
+    // previously assigned QNN tensor ID so subsequent references use the correct tensor.
+    SetQnnTensorID(qnn_tensor, existing->second);
     return true;
   }
 
@@ -505,14 +526,14 @@ bool CreateTensorInQnnGraph(const QNN_INTERFACE_VER_TYPE& qnn_interface,
     return false;
   }
 
-  tensors_created_table.emplace(tensor_name, true);
+  tensors_created_table.emplace(tensor_name, GetQnnTensorID(qnn_tensor));
   return true;
 }
 
 bool QnnParamWrapper::CreateQnnGraphParam(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                                           const Qnn_GraphHandle_t& graph,
                                           const std::string& node_name,
-                                          std::unordered_map<std::string, bool>& tensors_created_table,
+                                          std::unordered_map<std::string, uint32_t>& tensors_created_table,
                                           std::string& error_msg) {
   std::stringstream ss;
   switch (qnn_param_.paramType) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -178,10 +178,11 @@ bool CreateTensorInQnnGraph(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                             const std::string& node_name,
                             const std::string& tensor_name,
                             Qnn_Tensor_t& qnn_tensor,
-                            std::unordered_map<std::string, bool>& tensors_created_table,
+                            std::unordered_map<std::string, uint32_t>& tensors_created_table,
                             std::string& error_msg);
 
 uint32_t GetQnnTensorID(const Qnn_Tensor_t& qnn_tensor);
+void SetQnnTensorID(Qnn_Tensor_t& qnn_tensor, uint32_t id);
 Qnn_TensorType_t GetQnnTensorType(const Qnn_Tensor_t& qnn_tensor);
 const char* GetQnnTensorName(const Qnn_Tensor_t& qnn_tensor);
 Qnn_TensorDataFormat_t GetQnnTensorDataFormat(const Qnn_Tensor_t& qnn_tensor);
@@ -355,7 +356,7 @@ class QnnTensorWrapper {
   bool CreateQnnGraphTensor(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                             const Qnn_GraphHandle_t& graph,
                             const std::string& node_name,
-                            std::unordered_map<std::string, bool>& tensors_created_table,
+                            std::unordered_map<std::string, uint32_t>& tensors_created_table,
                             std::string& error_msg) {
     return CreateTensorInQnnGraph(qnn_interface, graph, node_name, GetResolvedTensorName(),
                                   qnn_tensor_, tensors_created_table, error_msg);
@@ -475,7 +476,7 @@ class QnnParamWrapper {
   bool CreateQnnGraphParam(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                            const Qnn_GraphHandle_t& graph,
                            const std::string& node_name,
-                           std::unordered_map<std::string, bool>& tensors_created_table,
+                           std::unordered_map<std::string, uint32_t>& tensors_created_table,
                            std::string& error_msg);
 
  private:

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -183,7 +183,7 @@ bool QnnModelWrapper::CreateQnnInputOutputTensors(const std::string& qnn_node_na
         it->second.SetResolvedTensorName(*name);
       }
       std::string error_string;
-      auto rt = it->second.CreateQnnGraphTensor(qnn_interface_, graph_, qnn_node_name, tensor_created_map_, error_string);
+      auto rt = it->second.CreateQnnGraphTensor(qnn_interface_, graph_, qnn_node_name, qnn_tensor_id_map_, error_string);
       if (!rt) {
         ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, error_string.c_str());
         return false;
@@ -210,7 +210,7 @@ bool QnnModelWrapper::CreateQnnParamTensors(const std::string& qnn_node_name,
     ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, ("Add parameter tensor: " + it->second.GetName()).c_str());
     if (!do_op_validation) {
       std::string error_string;
-      auto rt = it->second.CreateQnnGraphParam(qnn_interface_, graph_, qnn_node_name, tensor_created_map_, error_string);
+      auto rt = it->second.CreateQnnGraphParam(qnn_interface_, graph_, qnn_node_name, qnn_tensor_id_map_, error_string);
       if (!rt) {
         ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, error_string.c_str());
         return false;
@@ -595,7 +595,7 @@ bool QnnModelWrapper::RegisterGraphInputOutputInOrder() {
       if (it->second.GetTensorType() != expected_type) {
         continue;
       }
-      if (tensor_created_map_.count(name)) {
+      if (qnn_tensor_id_map_.count(name)) {
         continue;
       }
 
@@ -606,7 +606,7 @@ bool QnnModelWrapper::RegisterGraphInputOutputInOrder() {
       }
 
       std::string error;
-      if (!it->second.CreateQnnGraphTensor(qnn_interface_, graph_, io_type, tensor_created_map_, error)) {
+      if (!it->second.CreateQnnGraphTensor(qnn_interface_, graph_, io_type, qnn_tensor_id_map_, error)) {
         ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR,
                     (std::string("Failed to pre-register ") + io_type + ": " + name + ". " + error).c_str());
         return false;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -397,6 +397,18 @@ class QnnModelWrapper {
   // Maps internal QNN tensor name to original ONNX name. Used by offload_graph_io_quantization.
   void SetTensorNameOverride(const std::string& internal, const std::string& original) const;
 
+  // Returns true if 'external' is already the target of any tensor name override.
+  // Used to prevent two Q-node outputs from mapping to the same external graph-input name,
+  // which would cause RegisterGraphInputOutputInOrder to create only one APP_WRITE tensor
+  // while graph_inputs_ still tracks two entries, leaving a null slot in qnn_tensor_infos.
+  bool IsExternalOverrideTarget(const std::string& external) const {
+    if (tensor_name_overrides_ == nullptr) return false;
+    for (const auto& [internal, ext] : *tensor_name_overrides_) {
+      if (ext == external) return true;
+    }
+    return false;
+  }
+
  private:
   bool CreateQnnInputOutputTensors(const std::string& qnn_node_name,
                                    const std::vector<std::string>& names,
@@ -409,14 +421,6 @@ class QnnModelWrapper {
                              const std::vector<std::string>& param_tensor_names,
                              std::vector<Qnn_Param_t>& qnn_params,
                              bool do_op_validation = false);
-
-  bool IsQnnTensorCreated(const std::string& tensor_name) {
-    auto pos = tensor_created_map_.find(tensor_name);
-    if (pos == tensor_created_map_.end()) {
-      return false;
-    }
-    return pos->second;
-  }
 
   void GetGraphInputOutputTensorWrapper(const std::vector<std::string>& names,
                                         std::vector<QnnTensorWrapper>& wrappers_list);
@@ -475,7 +479,7 @@ class QnnModelWrapper {
   std::vector<QnnOpProperty> qnn_op_property_list_;
   // <tensor_name, qnn_tensor_id> -- stores the QNN-assigned ID once the tensor is created
   // it includes normal qnn_tensors and qnn_tensors inside param_tensors
-  std::unordered_map<std::string, uint32_t> tensor_created_map_;
+  std::unordered_map<std::string, uint32_t> qnn_tensor_id_map_;
   const GraphInputOutputInfo& graph_inputs_;
   const GraphInputOutputInfo& graph_outputs_;
   QnnBackendType qnn_backend_type_ = QnnBackendType::CPU;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -473,9 +473,9 @@ class QnnModelWrapper {
   // All QnnParamWrapper for the graph
   std::unordered_map<std::string, QnnParamWrapper> model_params_map_;
   std::vector<QnnOpProperty> qnn_op_property_list_;
-  // <tensor_name, qnn_tensor_created> -- true means qnn tensor created in qnn graph
-  // it includs normal qnn_tensors and qnn_tensors inside param_tensors
-  std::unordered_map<std::string, bool> tensor_created_map_;
+  // <tensor_name, qnn_tensor_id> -- stores the QNN-assigned ID once the tensor is created
+  // it includes normal qnn_tensors and qnn_tensors inside param_tensors
+  std::unordered_map<std::string, uint32_t> tensor_created_map_;
   const GraphInputOutputInfo& graph_inputs_;
   const GraphInputOutputInfo& graph_outputs_;
   QnnBackendType qnn_backend_type_ = QnnBackendType::CPU;

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -2276,6 +2276,60 @@ TEST_F(QnnCPUBackendTests, PartitionAddedInputRegisteredAsGraphInputOffloadGraph
   }
 }
 
+// Returns a model where a single graph input fans out to two separate Q->DQ chains,
+// both feeding into an Add node. This triggers the duplicate-name scenario in
+// RegisterGraphInputOutputInOrder when offload_graph_io_quantization=1.
+static GetTestModelFn BuildGraphInputFanoutQDQModel() {
+  return [](ModelTestBuilder& builder) {
+    builder.graph_->set_name("graph_input_fanout_qdq_graph");
+
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({1, 3}, false, {1.0f, 2.0f, 3.0f}));
+    builder.MakeInitializer<float>("scale", {}, {1.0f / 255.0f});
+    builder.MakeInitializer<uint8_t>("zero_point", {}, {0});
+
+    // Two Q->DQ pairs on the same graph input. With offload_graph_io_quantization=1,
+    // both Q nodes stay on CPU and both DQ outputs are registered as QNN graph inputs
+    // with the override name "input" — triggering the duplicate-name id-assignment bug.
+    builder.AddNode("q_a", "QuantizeLinear", {"input", "scale", "zero_point"}, {"q_a_out"}, kOnnxDomain);
+    builder.AddNode("dq_a", "DequantizeLinear", {"q_a_out", "scale", "zero_point"}, {"dq_a_out"}, kOnnxDomain);
+
+    builder.AddNode("q_b", "QuantizeLinear", {"input", "scale", "zero_point"}, {"q_b_out"}, kOnnxDomain);
+    builder.AddNode("dq_b", "DequantizeLinear", {"q_b_out", "scale", "zero_point"}, {"dq_b_out"}, kOnnxDomain);
+
+    builder.AddNode("add", "Add", {"dq_a_out", "dq_b_out"}, {"add_out"}, kOnnxDomain);
+    builder.MakeOutput("add_out");
+  };
+}
+
+// Regression test for AISW-174227: a graph input that fans out to multiple QDQ pairs
+// with offload_graph_io_quantization=1 must not fail graph composition. Previously,
+// the second DQ tensor received QNN tensor id=0 (never set) because CreateTensorInQnnGraph
+// returned early when it found the override name already in tensors_created_table.
+TEST_F(QnnCPUBackendTests, OffloadGraphIoQuantizationMultipleQDQPairsOnGraphInput) {
+  std::unique_ptr<ModelAndBuilder> model;
+  CreateModelInMemory(model, BuildGraphInputFanoutQDQModel(), "graph_input_fanout_qdq", 18);
+
+  Ort::SessionOptions so;
+  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+
+  onnxruntime::ProviderOptions options;
+#if defined(_WIN32)
+  options["backend_path"] = "QnnCpu.dll";
+#else
+  options["backend_path"] = "libQnnCpu.so";
+#endif
+  options["offload_graph_io_quantization"] = "1";
+
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+  options["num_graph_prepare_threads"] = "1";
+#endif
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+
+  ASSERT_NO_THROW(Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
+}
+
 // Returns a function that builds a model with 3 Relu ops to test I/O ordering.
 static GetTestModelFn BuildMultiReluModelForIOOrderTest() {
   return [](ModelTestBuilder& builder) {

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -2297,7 +2297,12 @@ static GetTestModelFn BuildGraphInputFanoutQDQModel() {
     builder.AddNode("dq_b", "DequantizeLinear", {"q_b_out", "scale", "zero_point"}, {"dq_b_out"}, kOnnxDomain);
 
     builder.AddNode("add", "Add", {"dq_a_out", "dq_b_out"}, {"add_out"}, kOnnxDomain);
-    builder.MakeOutput("add_out");
+
+    // Q->DQ pair on the graph output. With offload_graph_io_quantization=1,
+    // this DQ node stays on CPU and add_out is registered as a QNN graph output.
+    builder.AddNode("q_out", "QuantizeLinear", {"add_out", "scale", "zero_point"}, {"q_out_out"}, kOnnxDomain);
+    builder.AddNode("dq_out", "DequantizeLinear", {"q_out_out", "scale", "zero_point"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
   };
 }
 
@@ -2340,7 +2345,7 @@ TEST_F(QnnCPUBackendTests, OffloadGraphIoQuantizationMultipleQDQPairsOnGraphInpu
       memory_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size()));
 
   const char* input_name = "input";
-  const char* output_name = "add_out";
+  const char* output_name = "output";
   std::vector<Ort::Value> ort_outputs = session.Run(
       Ort::RunOptions{nullptr}, &input_name, ort_inputs.data(), 1, &output_name, 1);
 

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -2283,7 +2283,7 @@ static GetTestModelFn BuildGraphInputFanoutQDQModel() {
   return [](ModelTestBuilder& builder) {
     builder.graph_->set_name("graph_input_fanout_qdq_graph");
 
-    MakeTestInput<float>(builder, "input", TestInputDef<float>({1, 3}, false, {1.0f, 2.0f, 3.0f}));
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({1, 3}, false, {0.1f, 0.2f, 0.3f}));
     builder.MakeInitializer<float>("scale", {}, {1.0f / 255.0f});
     builder.MakeInitializer<uint8_t>("zero_point", {}, {0});
 
@@ -2301,16 +2301,18 @@ static GetTestModelFn BuildGraphInputFanoutQDQModel() {
   };
 }
 
-// Regression test for AISW-174227: a graph input that fans out to multiple QDQ pairs
-// with offload_graph_io_quantization=1 must not fail graph composition. Previously,
-// the second DQ tensor received QNN tensor id=0 (never set) because CreateTensorInQnnGraph
-// returned early when it found the override name already in tensors_created_table.
+// Tests that a graph input fanning out to multiple QDQ pairs with offload_graph_io_quantization=1
+// composes without error. Two bugs were fixed:
+//   1. CreateTensorInQnnGraph returned early on a duplicate override name, leaving the second
+//      DQ tensor with QNN tensor id=0 (never set).
+//   2. GetGraphInputOutputTensorWrapper must deduplicate wrappers sharing the same override name
+//      to avoid passing more inputs to graphExecute than the QNN graph has APP_WRITE tensors.
 TEST_F(QnnCPUBackendTests, OffloadGraphIoQuantizationMultipleQDQPairsOnGraphInput) {
   std::unique_ptr<ModelAndBuilder> model;
   CreateModelInMemory(model, BuildGraphInputFanoutQDQModel(), "graph_input_fanout_qdq", 18);
 
   Ort::SessionOptions so;
-  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+  so.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
 
   onnxruntime::ProviderOptions options;
 #if defined(_WIN32)
@@ -2327,7 +2329,26 @@ TEST_F(QnnCPUBackendTests, OffloadGraphIoQuantizationMultipleQDQPairsOnGraphInpu
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
 
-  ASSERT_NO_THROW(Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
+  Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+
+  // Run inference: verify output ≈ 2 * input (two identical DQ branches added together).
+  std::vector<float> input_data = {0.1f, 0.2f, 0.3f};
+  std::array<int64_t, 2> input_shape = {1, 3};
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::vector<Ort::Value> ort_inputs;
+  ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
+      memory_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size()));
+
+  const char* input_name = "input";
+  const char* output_name = "add_out";
+  std::vector<Ort::Value> ort_outputs = session.Run(
+      Ort::RunOptions{nullptr}, &input_name, ort_inputs.data(), 1, &output_name, 1);
+
+  ASSERT_EQ(ort_outputs.size(), 1u);
+  const float* output_data = ort_outputs[0].GetTensorData<float>();
+  EXPECT_NEAR(output_data[0], 2.0f * input_data[0], 0.02f);
+  EXPECT_NEAR(output_data[1], 2.0f * input_data[1], 0.02f);
+  EXPECT_NEAR(output_data[2], 2.0f * input_data[2], 0.02f);
 }
 
 // Returns a function that builds a model with 3 Relu ops to test I/O ordering.


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Change `tensors_created_table` from `unordered_map<string, bool>` to `unordered_map<string, uint32_t>` to store the QNN-assigned tensor ID on first creation. When a duplicate name is found, copy the stored ID to the current tensor via a new `SetQnnTensorID` helper, mirroring the existing `GetQnnTensorID` pattern.
- Add regression test `OffloadGraphIoQuantizationMultipleQDQPairsOnGraphInput` that reproduces the fan-out scenario using the CPU backend.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- When `offload_graph_io_quantization=1` and a graph input is consumed by multiple QDQ pairs, all those pairs share the same override name (e.g. "h0"). `RegisterGraphInputOutputInOrder` calls `CreateTensorInQnnGraph` for each, but the second call finds the name already in `tensors_created_table` and returns early without setting `qnn_tensor.id`, leaving it as 0. Later graph composition fails with `"Failed to compose Qnn graph"`.