### PR TITLE
[QNN-EP] Handle broadcast for 5D Matmul with 4d input_0.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -174,6 +174,44 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
   RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_info_0, org_input_0_name, input_names,
                                 logger, do_op_validation));
 
+  // If input_0's rank is less than input_1's rank (e.g., input_0 is 2D but input_1 is 5D),
+  // Insert a Reshape node that prepends leading 1s to input_0 to match input_1's rank.
+  const size_t rank_0 = input_info_0.shape.size() < 2 ? 2 : input_info_0.shape.size();  // After ProcessInput0, 1D becomes 2D
+  const size_t rank_1 = input_info_1.shape.size() < 2 ? 2 : input_info_1.shape.size();
+  if (rank_0 < rank_1) {
+    // The input tensor is already in the map from ProcessInput0(); capture its name before popping.
+    const std::string current_input_0_name = input_names.back();
+    const std::string broadcast_input_0_name =
+        utils::UniqueNameGenerator().New(org_input_0_name, "_reshape_broadcast");
+
+    // Determine the actual current shape of input_0 after ProcessInput0 (1D -> 2D, otherwise unchanged).
+    std::vector<uint32_t> current_shape_0 =
+        (input_info_0.shape.size() == 1) ? std::vector<uint32_t>{1, input_info_0.shape[0]} : input_info_0.shape;
+
+    // Prepend (rank_1 - rank_0) ones to match input_1's rank.
+    std::vector<uint32_t> broadcast_shape_0(rank_1 - rank_0, 1);
+    broadcast_shape_0.insert(broadcast_shape_0.end(), current_shape_0.begin(), current_shape_0.end());
+
+    QnnQuantParamsWrapper broadcast_quant_param_0 = input_info_0.quant_param.Copy();
+    RETURN_IF_ERROR(
+        broadcast_quant_param_0.HandleUnsqueeze<uint32_t>(current_shape_0, broadcast_shape_0));
+
+    // Only add the Reshape output tensor — the input is already registered in the tensor map.
+    QnnTensorWrapper broadcast_output_tensor(broadcast_input_0_name, QNN_TENSOR_TYPE_NATIVE,
+                                             input_info_0.qnn_data_type, broadcast_quant_param_0.Copy(),
+                                             std::vector<uint32_t>(broadcast_shape_0));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(broadcast_output_tensor)),
+                  "QNN EP: Failed to add broadcast-reshape output tensor for MatMul input_0.");
+
+    input_names.pop_back();
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      broadcast_input_0_name,
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
+                      {current_input_0_name}, {broadcast_input_0_name}, {}, do_op_validation),
+                  "QNN EP: Failed to create broadcast-reshape node for MatMul input_0.");
+    input_names.push_back(broadcast_input_0_name);
+  }
+
   // Process input 1.
   const std::string& org_input_1_name = inputs[1].name;
   std::string input_1_name = org_input_1_name;
@@ -393,7 +431,14 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
       CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1, use_fully_connected));
   bool reshape_input_0 = input_info_0.shape.size() == 1;
   bool reshape_input_1 = input_info_1.shape.size() == 1;
-  bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2);
+  // When input_0 is rank-broadcast-reshaped to match input_1's higher rank (e.g., 2D -> 5D),
+  // the QNN MatMul output already has the correct shape matching output_info.shape, so no
+  // output reshape is needed for this case.
+  const bool broadcast_input_0_rank =
+      !use_fully_connected && !reshape_input_0 &&
+      (input_info_0.shape.size() < input_info_1.shape.size());
+  bool reshape_output = !broadcast_input_0_rank &&
+                        (reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2));
 
   // For QNN MatMul: set the input transpose parameters to their default values of 0. These parameters should be
   // optional, but older versions of QNN SDK failed validation if not explicitly provided.

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -294,6 +294,32 @@ TEST_F(QnnHTPBackendTests, MatMulOp) {
   // RunMatMulOpTest({3, 3, 3}, {3, 2}, true, false, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
 }
 
+// input_0: [2, 64], input_1: [1, 192, 33, 64, 1] -> input_0 reshaped to [1, 1, 1, 64, 64]
+TEST_F(QnnHTPBackendTests, MatMulOp_2DInput0_5DInput1_ReshapeBroadcast) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  const std::vector<int64_t> shape_0 = {64, 64};
+  const std::vector<int64_t> shape_1 = {1, 192, 33, 64, 1};
+
+  TestInputDef<float> input0_def(
+      shape_0, false,
+      GetFloatDataInRange(-0.1f, 0.1f,
+                          static_cast<size_t>(std::accumulate(shape_0.begin(), shape_0.end(),
+                                                              static_cast<int64_t>(1),
+                                                              std::multiplies<int64_t>()))));
+  TestInputDef<float> input1_def(
+      shape_1, false,
+      GetFloatDataInRange(-0.1f, 0.1f,
+                          static_cast<size_t>(std::accumulate(shape_1.begin(), shape_1.end(),
+                                                              static_cast<int64_t>(1),
+                                                              std::multiplies<int64_t>()))));
+
+  RunQnnModelTest(BuildMatMulOpTestCase(input0_def, input1_def),
+                  provider_options, 18, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
 // Broken on v79 and v81 devices with several results outside of acceptable tolerance.
 // Example:
 // Inaccuracy detected for output 'output_0', element 0


### PR DESCRIPTION
### Description
2D input_0 to 5D Matmul is broadcasted by QNN_EP to 4D input_0.
To make shapes of same dimension, we need to add a reshape before input_0.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


