### PR TITLE
[OpBuilder] Fix MatMul uint16 handling.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -212,27 +212,25 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
   }
   input_names.emplace_back(input_1_name);
 
-  // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to quantized uint8
-  // OR converts from asymmetric quantized uint16 to symmetric quantized uint16)
-  // to avoid a QNN validation failure.
+  // Inserts a QNN Convert op before uint16 input[1] to avoid QNN HTP validation failure.
   //
-  // QNN graph WITHOUT workaround (fails validation):
+  // QNN graph that fails validation:
   //     input_0_uint16 ---> MatMul ---> output_uint16
   //                         ^
   //                         |
   //     input_1_uint16 -----+
   //
-  // For Dynamic weights, QNN graph WITH workaround (passes validation):
-  //     input_0_uint16 ----------------------> MatMul ---> output_uint16
-  //                                            ^
-  //                                            |
-  //     input_1_uint16 --> Convert(to uint8) --+
+  // For dynamic weights, QNN graph that passes validation:
+  //     input_0_uint16 ---------------------------> MatMul ---> output_uint16
+  //                                                   ^
+  //                                                   |
+  //     input_1_uint16_asym --> Convert(uint16_sym) --+
   //
-  // For Static weights, QNN graph WITH workaround (passes validation):
-  //     input_0_uint16 ------------------------------> MatMul ---> output_uint16
-  //                                                      ^
-  //                                                      |
-  //     input_1_uint16 --> Convert(to symmetric int16) --+
+  // For static weights, QNN graph that passes validation:
+  //     input_0_uint16 ---------------------> MatMul ---> output_uint16
+  //                                             ^
+  //                                             |
+  //     input_1_uint16 --> Convert(int16_sym) --+
   if (!input_info_0.is_initializer &&
       input_info_0.qnn_data_type == input_info_1.qnn_data_type &&
       input_info_0.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) {
@@ -248,16 +246,22 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
       input_1_shape = {input_info_1.shape[0], 1};
     }
     if (!input_info_1.is_initializer) {
-      RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
-                                             convert_input_name,
-                                             convert_output_name,
-                                             input_info_1.qnn_data_type,
-                                             QNN_DATATYPE_UFIXED_POINT_8,
-                                             quant_param.scaleOffsetEncoding.offset,
-                                             quant_param.scaleOffsetEncoding.scale,
-                                             input_1_shape,
-                                             false,  // asymmetric
-                                             do_op_validation));
+      // Only insert Convert for asymmetric quantization (i.e., offset != 2^(16-1)).
+      if (quant_param.scaleOffsetEncoding.offset != 32768) {
+        RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
+                                               convert_input_name,
+                                               convert_output_name,
+                                               input_info_1.qnn_data_type,
+                                               QNN_DATATYPE_UFIXED_POINT_16,
+                                               quant_param.scaleOffsetEncoding.offset,
+                                               quant_param.scaleOffsetEncoding.scale,
+                                               input_1_shape,
+                                               true,  // symmetric
+                                               do_op_validation));
+        input_names.push_back(convert_output_name);
+      } else {
+        input_names.push_back(convert_input_name);
+      }
     } else {
       RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
                                              convert_input_name,
@@ -269,8 +273,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
                                              input_1_shape,
                                              true,  // symmetric
                                              do_op_validation));
+      input_names.push_back(convert_output_name);
     }
-    input_names.push_back(convert_output_name);
   }
   return Ort::Status();
 }

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -337,13 +337,17 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ) {
 }
 
 // Tests MatMul with two uint16 (quantized) inputs that are both dynamic.
-// This exercises a workaround in QNN EP that inserts a QNN Convert op before input[1] (converts from uint16 to uint8).
-// This workaround prevents a validation error for this specific MatMul configuration.
+// This exercises a logic in QNN EP that inserts a QNN Convert op before input[1] to convert asymmetric uint16 into
+// symmetric one.
 // Got specific shapes and input ranges (quant params) from customer model.
 TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_dynamic_inputs) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
+#ifdef __linux__
+  // W16A16 requires minimum HTP arch v73.
+  provider_options["htp_arch"] = "73";
+#endif
 
   // Test with rank 4 inputs
   {
@@ -388,7 +392,6 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_dynamic_inputs) {
   }
 }
 
-#ifndef __linux__
 // Tests MatMul with two uint16 (quantized) inputs with weight as static.
 // This exercises a workaround in QNN EP that inserts a QNN Convert op before input[1] (converts from uint16 to sint16).
 // This workaround prevents a validation error for this specific MatMul configuration.
@@ -397,6 +400,10 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_static_weight) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
+#ifdef __linux__
+  // W16A16 requires minimum HTP arch v73.
+  provider_options["htp_arch"] = "73";
+#endif
 
   // Test with rank 4 inputs
   {
@@ -440,7 +447,6 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_static_weight) {
         provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
   }
 }
-#endif
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
MatMul builder inserted a Convert at dynamic input 1 to convert uint16 to asymmetric uint8 in order to pass HTP validation. However, HTP now supports symmetric uint16 for MatMul input 1 and such Convert is no longer required, which in fact may cause accuracy issue. Revise the Convert insertion logic to only insert one to convert asymmetric uint16 to symmetric uint16.
TODO: There is similar logic for static input 1 where a Convert is inserted to convert uint16 into symmetric int16. Since not sure the original motivation, leave modification for such case like dynamic input 1 as future work if encoutering real cases.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
MEP PSD8 model suffers accuracy issue due to MatMul opbuilder converting dynamic input 1 from uint16 to uint8.

