### PR TITLE
Re-enable static-library build mode and add QnnModelWrapper unit tests

### DIFF
--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -48,7 +48,7 @@ else()
     message(STATUS "  Python Executable: ${Python3_EXECUTABLE}")
     message(STATUS "  CMake Generator: ${CMAKE_GENERATOR}")
 
-    if (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
+    if(onnxruntime_BUILD_QNN_EP_STATIC_LIB OR ${CMAKE_SYSTEM_NAME} STREQUAL "Android")
         set(QNN_LIBRARY_KIND static_lib)
     else()
         set(QNN_LIBRARY_KIND shared_lib)

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -38,12 +38,20 @@
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_qnn_ep_srcs})
 
   set(onnxruntime_providers_qnn_all_srcs ${onnxruntime_providers_qnn_ep_srcs})
-  if(WIN32)
+  if(WIN32 AND NOT onnxruntime_BUILD_QNN_EP_STATIC_LIB)
     # Sets the DLL version info on Windows: https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
     list(APPEND onnxruntime_providers_qnn_all_srcs "${ONNXRUNTIME_ROOT}/core/providers/qnn/onnxruntime_providers_qnn.rc")
   endif()
 
-  onnxruntime_add_shared_library_module(onnxruntime_providers_qnn ${onnxruntime_providers_qnn_all_srcs})
+  if(onnxruntime_BUILD_QNN_EP_STATIC_LIB)
+    onnxruntime_add_static_library(onnxruntime_providers_qnn ${onnxruntime_providers_qnn_all_srcs})
+    # Expose BUILD_QNN_EP_STATIC_LIB to all consumers (e.g. the test binary) so
+    # that code guarded by #if BUILD_QNN_EP_STATIC_LIB uses the same type
+    # definitions as the library itself, avoiding ODR violations.
+    target_compile_definitions(onnxruntime_providers_qnn PUBLIC BUILD_QNN_EP_STATIC_LIB=1)
+  else()
+    onnxruntime_add_shared_library_module(onnxruntime_providers_qnn ${onnxruntime_providers_qnn_all_srcs})
+  endif()
   onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json)
 
   target_link_libraries(onnxruntime_providers_qnn PRIVATE ${ABSEIL_LIBS})
@@ -57,8 +65,8 @@
                                                                   ${onnxruntime_QNN_HOME}/include/QNN
                                                                   ${onnxruntime_QNN_HOME}/include)
 
-  # Set preprocessor definitions used in onnxruntime_providers_qnn.rc
-  if(WIN32)
+  # Set preprocessor definitions used in onnxruntime_providers_qnn.rc (DLL-only)
+  if(WIN32 AND NOT onnxruntime_BUILD_QNN_EP_STATIC_LIB)
     if(NOT QNN_SDK_VERSION)
       set(QNN_DLL_FILE_DESCRIPTION "ONNX Runtime QNN Provider")
     else()
@@ -69,18 +77,20 @@
     target_compile_definitions(onnxruntime_providers_qnn PRIVATE FILE_NAME=\"onnxruntime_providers_qnn.dll\")
   endif()
 
-  # Set linker flags for function(s) exported by EP DLL
-  if(UNIX)
-    target_link_options(onnxruntime_providers_qnn PRIVATE
-                        "LINKER:--version-script=${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script.lds"
-                        "LINKER:--gc-sections"
-                        "LINKER:-rpath=\$ORIGIN"
-    )
-  elseif(WIN32)
-    set_property(TARGET onnxruntime_providers_qnn APPEND_STRING PROPERTY LINK_FLAGS
-                  "-DEF:${ONNXRUNTIME_ROOT}/core/providers/qnn/symbols.def")
-  else()
-    message(FATAL_ERROR "onnxruntime_providers_qnn unknown platform, need to specify shared library exports for it")
+  # Set linker flags for function(s) exported by EP DLL (not applicable for static lib)
+  if(NOT onnxruntime_BUILD_QNN_EP_STATIC_LIB)
+    if(UNIX)
+      target_link_options(onnxruntime_providers_qnn PRIVATE
+                          "LINKER:--version-script=${ONNXRUNTIME_ROOT}/core/providers/qnn/version_script.lds"
+                          "LINKER:--gc-sections"
+                          "LINKER:-rpath=\$ORIGIN"
+      )
+    elseif(WIN32)
+      set_property(TARGET onnxruntime_providers_qnn APPEND_STRING PROPERTY LINK_FLAGS
+                    "-DEF:${ONNXRUNTIME_ROOT}/core/providers/qnn/symbols.def")
+    else()
+      message(FATAL_ERROR "onnxruntime_providers_qnn unknown platform, need to specify shared library exports for it")
+    endif()
   endif()
 
   # Set compile options

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -203,6 +203,10 @@ if(onnxruntime_USE_QNN AND NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_RED
   list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_qnn)
   if(NOT onnxruntime_BUILD_QNN_EP_STATIC_LIB)
     list(APPEND onnxruntime_test_providers_dependencies onnxruntime_providers_shared)
+  else()
+    # In static-lib mode the QNN EP object code must be linked into the test binary
+    # (in shared-lib mode it is loaded at runtime, so it is only a build dependency).
+    list(APPEND onnxruntime_test_providers_libs onnxruntime_providers_qnn)
   endif()
 endif()
 
@@ -328,6 +332,12 @@ block()
 
   # For onnxruntime_cxx_api.h
   target_include_directories(onnxruntime_provider_test PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session)
+
+  # Propagate BUILD_QNN_EP_STATIC_LIB so that tests guarded by
+  # #if BUILD_QNN_EP_STATIC_LIB (e.g. qnn_model_wrapper_test.cc) are compiled in.
+  if(onnxruntime_BUILD_QNN_EP_STATIC_LIB)
+    target_compile_definitions(onnxruntime_provider_test PRIVATE BUILD_QNN_EP_STATIC_LIB=1)
+  endif()
 
   add_custom_command(
     TARGET onnxruntime_provider_test POST_BUILD

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -15,9 +15,42 @@
 // that allows QNN EP to built either as a static library or a dynamic shared library.
 // The preprocessor macro `BUILD_QNN_EP_STATIC_LIB` is defined and set to 1 if QNN EP
 // is built as a static library.
+
+#if BUILD_QNN_EP_STATIC_LIB
+// ORT internal headers required by static-lib code paths (e.g. qnn_telemetry.cc).
+// Mirrors the include set in ORT core's ort_api.h for the BUILD_QNN_EP_STATIC_LIB=1 case.
+#ifdef _WIN32
+#include <Windows.h>
+#include <winmeta.h>
+#include "core/platform/tracing.h"
+#include "core/platform/windows/logging/etw_sink.h"
+#include "core/platform/windows/telemetry.h"
+// logging.h (and its transitive dependency on date/date.h) is only needed on Windows
+// for logging::EtwRegistrationManager::SupportsETW() in qnn_telemetry.cc.
+// It must not be included on Android/Linux where date/date.h is unavailable in
+// the cross-compilation environment used with --use_qnn static_lib.
+#include "core/common/logging/logging.h"
+#endif
+#include "core/platform/env.h"
+#include "core/common/common.h"
+// Provides kOnnxDomain, kMSDomain, kMSInternalNHWCDomain etc. used throughout QNN EP source files.
+#include "core/graph/constants.h"
+// Provides ReinterpretAsSpan used throughout QNN EP source files.
+#include "core/common/span_utils.h"
+#endif  // BUILD_QNN_EP_STATIC_LIB
+
 // Includes when building QNN EP as a shared library
 // #include "core/providers/shared_library/provider_api.h"
+#if !BUILD_QNN_EP_STATIC_LIB
+// In shared-lib/plugin mode the ORT C++ API must be manually initialized after
+// the plugin is loaded into the host process; ORT_API_MANUAL_INIT suppresses
+// the automatic global initializer so we can call Ort::InitApi() ourselves.
+// In static-lib mode we are directly linked into the host binary which owns
+// OrtGetApiBase(), so the normal auto-initialization must be used — defining
+// ORT_API_MANUAL_INIT here would produce an LNK2038 mismatch against the rest
+// of the test binary (all compiled without this macro).
 #define ORT_API_MANUAL_INIT
+#endif  // !BUILD_QNN_EP_STATIC_LIB
 #include "core/session/onnxruntime_cxx_api.h"
 
 #include "core/session/onnxruntime_c_api.h"
@@ -29,6 +62,12 @@
 #include "core/session/onnxruntime_run_options_config_keys.h"
 
 namespace onnxruntime {
+
+#if BUILD_QNN_EP_STATIC_LIB
+// Mirrors ORT core's ort_api.h: provides access to the default ORT Env (and its telemetry
+// provider) without going through the public C API.
+inline const Env& GetDefaultEnv() { return Env::Default(); }
+#endif
 
 #define MAKE_FAIL(msg) Ort::Status(msg, ORT_FAIL)
 #define MAKE_EP_FAIL(msg) Ort::Status(msg, ORT_EP_FAIL)
@@ -130,6 +169,10 @@ namespace onnxruntime {
 #endif
 
 // QNN-EP COPY START
+// These symbols are copied from ORT core headers for use in shared-lib builds where
+// ORT core headers are not directly available. In static-lib builds they come from the
+// real ORT core headers (span_utils.h, constants.h) that are already on the include path.
+#if !BUILD_QNN_EP_STATIC_LIB
 // Below are GSL utilities copied from core/common/span_utils.h directly.
 template <class U, class T>
 [[nodiscard]] inline gsl::span<U> ReinterpretAsSpan(gsl::span<T> src) {
@@ -143,6 +186,7 @@ template <class U, class T>
 inline constexpr const char* kOnnxDomain = "";
 inline constexpr const char* kMSDomain = "com.microsoft";
 inline constexpr const char* kMSInternalNHWCDomain = "com.ms.internal.nhwc";
+#endif  // !BUILD_QNN_EP_STATIC_LIB
 // QNN-EP COPY END
 
 class OrtLoggingManager {

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -386,8 +386,11 @@ OrtStatus* CreateEpFactories(const char* registration_name,
     return nullptr;  // Cannot create status without ORT API
   }
 
-  // Manual init for the C++ API
+  // Manual init for the C++ API (only needed in shared-lib/plugin mode; in static-lib
+  // mode the host binary owns OrtGetApiBase() and the auto-initializer handles this).
+#if !BUILD_QNN_EP_STATIC_LIB
   Ort::InitApi(ort_api);
+#endif  // !BUILD_QNN_EP_STATIC_LIB
 
   if (max_factories < 1) {
     return ort_api->CreateStatus(ORT_INVALID_ARGUMENT,

--- a/onnxruntime/core/providers/qnn/qnn_telemetry.cc
+++ b/onnxruntime/core/providers/qnn/qnn_telemetry.cc
@@ -106,9 +106,9 @@ QnnTelemetry& QnnTelemetry::Instance() {
 
 bool QnnTelemetry::SupportsETW() {
 #if BUILD_QNN_EP_STATIC_LIB
-  const Env& env = GetDefaultEnv();
-  auto& provider = env.GetTelemetryProvider();
-  return provider.SupportsETW();
+  // Telemetry base class doesn't expose SupportsETW(); delegate to EtwRegistrationManager
+  // which is the correct static-lib API for this check.
+  return logging::EtwRegistrationManager::SupportsETW();
 #else
   // Check for Windows 10 SDK or later (same logic as etw_sink.h)
   // VER_PRODUCTBUILD > 9600 means Windows 10 SDK or later

--- a/onnxruntime/core/providers/qnn/qnn_telemetry.h
+++ b/onnxruntime/core/providers/qnn/qnn_telemetry.h
@@ -7,6 +7,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#include <evntprov.h>  // For PEVENT_FILTER_DESCRIPTOR, used by EtwInternalCallback in both static and shared lib builds
 
 #if !BUILD_QNN_EP_STATIC_LIB
 #include <TraceLoggingProvider.h>

--- a/onnxruntime/test/providers/qnn/qnn_model_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_model_wrapper_test.cc
@@ -3,17 +3,19 @@
 
 #include "gtest/gtest.h"
 
-// These tests require direct access to both real ORT internals (Model, Graph, GraphViewer)
-// and QNN EP builder internals (QnnModelWrapper, QnnTensorWrapper). This is only possible
-// when QNN EP is built as a static library, because the shared library build redefines
-// ORT types as opaque wrappers in provider_api.h / provider_wrappedtypes.h.
+// These tests require direct access to both QNN EP builder internals
+// (QnnModelWrapper, QnnTensorWrapper) and the OrtGraph abstract interface.
+// This is only possible when QNN EP is built as a static library, because the
+// shared library build redefines ORT types as opaque wrappers in
+// provider_api.h / provider_wrappedtypes.h.
 #if !defined(ORT_MINIMAL_BUILD) && BUILD_QNN_EP_STATIC_LIB
 
-#include "core/graph/model.h"
+#include <cassert>
+#include <cstring>
+
+#include "core/graph/ep_api_types.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_def.h"
-#include "test/util/include/default_providers.h"
-#include "test/util/include/test_environment.h"
 
 using namespace onnxruntime;
 using namespace onnxruntime::qnn;
@@ -23,32 +25,124 @@ namespace test {
 
 namespace {
 
+// Minimal stub implementation of OrtGraph's pure virtual interface.
+// AddTensorWrapper never calls any OrtGraph methods — it only consults
+// graph_inputs_ / graph_outputs_ inside QnnModelWrapper — so all virtual
+// methods can return trivial/empty values.
+// Using OrtGraph directly (not EpGraph) avoids depending on GraphViewer,
+// Graph, Model, or EpGraph::Create, all of which are ORT internals not
+// exported from onnxruntime.dll.
+struct FakeOrtGraph : public OrtGraph {
+  FakeOrtGraph() : OrtGraph(OrtGraphIrApi::kEpApi) {}
+
+  const std::string& GetName() const override {
+    static const std::string kName = "FakeGraph";
+    return kName;
+  }
+  std::unique_ptr<onnxruntime::ModelMetadata> GetModelMetadata() const override { return nullptr; }
+  const ORTCHAR_T* GetModelPath() const override { return nullptr; }
+  int64_t GetOnnxIRVersion() const override { return 0; }
+  onnxruntime::Status GetNumOperatorSets(size_t& n) const override {
+    n = 0;
+    return {};
+  }
+  onnxruntime::Status GetOperatorSets(gsl::span<const char*>, gsl::span<int64_t>) const override { return {}; }
+  size_t GetNumInputs() const override { return 0; }
+  onnxruntime::Status GetInputs(gsl::span<const OrtValueInfo*>) const override { return {}; }
+  size_t GetNumOutputs() const override { return 0; }
+  onnxruntime::Status GetOutputs(gsl::span<const OrtValueInfo*>) const override { return {}; }
+  size_t GetNumInitializers() const override { return 0; }
+  onnxruntime::Status GetInitializers(gsl::span<const OrtValueInfo*>) const override { return {}; }
+  size_t GetNumNodes() const override { return 0; }
+  onnxruntime::Status GetNodes(gsl::span<const OrtNode*>) const override { return {}; }
+  onnxruntime::Status GetParentNode(const OrtNode*& node) const override {
+    node = nullptr;
+    return {};
+  }
+};
+
+// Synthesize an Ort::Logger with ORT_LOGGING_LEVEL_FATAL without instantiating
+// logging::LoggingManager (whose constructor and destructor are ORT internals not
+// exported from onnxruntime.dll and therefore unavailable in this test binary).
+//
+// Ort::Logger is trivially copyable and its header documents it as "the size of
+// two pointers". Its private layout is:
+//   [const OrtLogger* logger_,  OrtLoggingLevel cached_severity_level_]
+// cached_severity_level_ sits immediately after logger_ (no padding: a pointer
+// is followed by a 32-bit int, which requires no gap on any ABI used here).
+//
+// With cached_severity_level_ = ORT_LOGGING_LEVEL_FATAL all ORT_CXX_LOG severity
+// guards evaluate to false, so the null logger_ pointer is never forwarded to
+// OrtApi::Logger_LogMessage.
+static Ort::Logger MakeFatalOrtLogger() {
+  static_assert(sizeof(Ort::Logger) == 2 * sizeof(void*),
+                "Ort::Logger size mismatch — update layout assumptions in MakeFatalOrtLogger");
+  static_assert(std::is_trivially_copyable<Ort::Logger>::value,
+                "Ort::Logger must be trivially copyable for memcpy to be valid");
+  // NOTE: The static_asserts above guard against SIZE changes but cannot detect field
+  // REORDERING (private members are inaccessible to offsetof). If a new field is inserted
+  // before cached_severity_level_, the struct size may remain unchanged (due to padding)
+  // while the offset sizeof(void*) would now point at the wrong field.
+  //
+  // The assert below is a runtime canary: GetLoggingSeverityLevel() reads
+  // cached_severity_level_ directly. If the memcpy landed at the wrong offset, the method
+  // will not return FATAL and the assert fires immediately in debug builds.
+  Ort::Logger logger;
+  const OrtLoggingLevel fatal = ORT_LOGGING_LEVEL_FATAL;
+  std::memcpy(reinterpret_cast<char*>(&logger) + sizeof(void*), &fatal, sizeof(OrtLoggingLevel));
+  assert(logger.GetLoggingSeverityLevel() == ORT_LOGGING_LEVEL_FATAL &&
+         "MakeFatalOrtLogger: offset sizeof(void*) for cached_severity_level_ is wrong — "
+         "Ort::Logger layout has changed, update the memcpy offset");
+  return logger;
+}
+
 // Helper to create a minimal QnnModelWrapper for unit testing.
 // AddTensorWrapper does not invoke any QNN SDK functions, so we can use
 // null handles and a zeroed-out interface struct.
+// OrtEpApi and OrtModelEditorApi are zero-initialized members: AddTensorWrapper
+// never calls through api_ptrs_, so null function pointers are safe here.
 struct QnnModelWrapperTestContext {
-  std::unique_ptr<onnxruntime::Model> model;
-  std::unique_ptr<GraphViewer> graph_viewer;
+  // FakeOrtGraph: stub for the OrtGraph& required by QnnModelWrapper's constructor.
+  // Stored as a member so the const-ref in QnnModelWrapper stays valid.
+  FakeOrtGraph fake_graph;
   QNN_INTERFACE_VER_TYPE qnn_interface;
   Qnn_BackendHandle_t backend_handle;
+  // Ort::Logger with FATAL severity — all ORT_CXX_LOG guards fail, so the null
+  // internal OrtLogger* is never used. This member must outlive any QnnModelWrapper
+  // created by CreateWrapper().
+  Ort::Logger ort_logger;
   std::unordered_map<std::string, size_t> input_index_map;
   std::unordered_map<std::string, size_t> output_index_map;
+  // Stored as members so QnnModelWrapper's const-refs remain valid for its lifetime.
+  GraphInputOutputInfo graph_inputs_info;
+  GraphInputOutputInfo graph_outputs_info;
+  // Zero-initialized API tables stored as members (not static locals) to make
+  // per-instance ownership explicit and avoid the singleton appearance.
+  OrtEpApi zero_ep_api{};
+  OrtModelEditorApi zero_model_editor_api{};
 
-  QnnModelWrapperTestContext() : qnn_interface(QNN_INTERFACE_VER_TYPE_INIT),
-                                 backend_handle(nullptr) {
-    model = std::make_unique<onnxruntime::Model>("test", false, DefaultLoggingManager().DefaultLogger());
-    Graph& graph = model->MainGraph();
-    graph_viewer = std::make_unique<GraphViewer>(graph);
-  }
+  QnnModelWrapperTestContext()
+      : qnn_interface(QNN_INTERFACE_VER_TYPE_INIT),
+        backend_handle(nullptr),
+        ort_logger(MakeFatalOrtLogger()) {}
 
   std::unique_ptr<QnnModelWrapper> CreateWrapper(const ModelSettings& settings) {
+    // Sync index maps into GraphInputOutputInfo. QnnModelWrapper stores const-refs
+    // to graph_inputs_info / graph_outputs_info, which are members of this struct
+    // and outlive any wrapper created here.
+    graph_inputs_info.indices = input_index_map;
+    graph_outputs_info.indices = output_index_map;
+
+    const ApiPtrs api_ptrs{Ort::GetApi(), zero_ep_api, zero_model_editor_api};
+
     return std::make_unique<QnnModelWrapper>(
-        *graph_viewer,
-        DefaultLoggingManager().DefaultLogger(),
+        fake_graph,
+        api_ptrs,
+        ort_logger,
         qnn_interface,
         backend_handle,
-        input_index_map,
-        output_index_map,
+        graph_inputs_info,
+        graph_outputs_info,
         QnnBackendType::HTP,
         settings);
   }
@@ -132,6 +226,26 @@ TEST(QnnModelWrapperTest, AddTensorWrapper_SharedMemoryEnabled_IntermediateTenso
   EXPECT_EQ(GetQnnTensorMemType(stored.GetQnnTensor()), QNN_TENSORMEMTYPE_RAW);
 }
 
+// Verifies that mem-type is determined by index-map membership, not tensor type.
+// An APP_WRITE tensor that is absent from input_index_map must retain RAW even
+// when htp_shared_memory is enabled.
+TEST(QnnModelWrapperTest, AddTensorWrapper_SharedMemoryEnabled_AppWriteNotInInputMap_MemTypeIsRaw) {
+  QnnModelWrapperTestContext ctx;
+  // "unregistered" is intentionally absent from input_index_map and output_index_map.
+
+  ModelSettings settings{};
+  settings.htp_shared_memory = true;
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  QnnTensorWrapper tensor("unregistered", QNN_TENSOR_TYPE_APP_WRITE, QNN_DATATYPE_FLOAT_32,
+                          QnnQuantParamsWrapper(), std::vector<uint32_t>{1, 256});
+
+  ASSERT_TRUE(wrapper->AddTensorWrapper(std::move(tensor)));
+
+  const auto& stored = wrapper->GetQnnTensorWrapper("unregistered");
+  EXPECT_EQ(GetQnnTensorMemType(stored.GetQnnTensor()), QNN_TENSORMEMTYPE_RAW);
+}
+
 // Verifies that when htp_shared_memory is disabled, a graph output tensor
 // retains QNN_TENSORMEMTYPE_RAW.
 TEST(QnnModelWrapperTest, AddTensorWrapper_SharedMemoryDisabled_GraphOutput_MemTypeIsRaw) {
@@ -212,6 +326,8 @@ TEST(QnnModelWrapperTest, AddTensorWrapper_EmptyName_ReturnsFalse) {
                           QnnQuantParamsWrapper(), std::vector<uint32_t>{1, 256});
 
   EXPECT_FALSE(wrapper->AddTensorWrapper(std::move(tensor)));
+  // Verify the tensor was not written into the internal map.
+  EXPECT_FALSE(wrapper->IsQnnTensorWrapperExist(""));
 }
 
 }  // namespace test


### PR DESCRIPTION
  ## Summary

  - Re-enables the `onnxruntime_BUILD_QNN_EP_STATIC_LIB` CMake option. In static-lib mode the QNN EP is compiled directly into the host binary rather than loaded as a plugin DLL/SO.
  - Fixes build breakages in static-lib mode across `ort_api.h`, `qnn_provider_factory.cc`, and `qnn_telemetry`.
  - Adds 9 unit tests for `QnnModelWrapper::AddTensorWrapper()` that exercise the `htp_shared_memory` mem-type logic, enabled only under `BUILD_QNN_EP_STATIC_LIB`.

  ## Motivation

Static-lib mode is required to write unit tests that access QNN EP builder internals (`QnnModelWrapper`, `QnnTensorWrapper`) directly. In shared-lib/plugin mode, ORT redefines EP-facing types as opaque wrappers (`provider_wrappedtypes.h`), making internal headers inaccessible from test code.

  ## Changes

  ### CMake (`cmake/`)

  | File | Change |
  |------|--------|
  | `onnxruntime_providers_qnn.cmake` | Build static or shared target based on `onnxruntime_BUILD_QNN_EP_STATIC_LIB`;
  guard DLL `.rc` and linker-export flags behind `!static` |
  | `onnxruntime_unittests.cmake` | Link static EP into test binary (not just a build dep); propagate
  `BUILD_QNN_EP_STATIC_LIB` define to test target |
  | `onnxruntime_prebuilt.cmake` | Select `static_lib` QNN SDK flavour when building static EP |

  ### `ort_api.h`

  - Wraps `#define ORT_API_MANUAL_INIT` behind `#if !BUILD_QNN_EP_STATIC_LIB`. In static-lib mode the host binary owns `OrtGetApiBase()` and handles auto-initialization; defining `ORT_API_MANUAL_INIT` would cause an LNK2038 ODR mismatch.
  - Adds ORT core includes (`logging.h`, `env.h`, telemetry headers, etc.) for the static-lib path, where ORT internals are on the include path.
  - Guards the "QNN-EP COPY" section (`ReinterpretAsSpan`, domain constants) behind `#if !BUILD_QNN_EP_STATIC_LIB` to avoid redefinition against the real ORT core headers.
  - Adds `GetDefaultEnv()` helper for static-lib telemetry path.

  ### `qnn_provider_factory.cc`

  - Guards `Ort::InitApi(ort_api)` behind `#if !BUILD_QNN_EP_STATIC_LIB`. In static-lib mode the C++ API is already initialized by the host.

  ### `qnn_telemetry.h` / `qnn_telemetry.cc`

  - Adds `<evntprov.h>` (needed for `PEVENT_FILTER_DESCRIPTOR` in `EtwInternalCallback`) to both build modes.
  - Fixes `SupportsETW()` in static-lib path: delegates to `logging::EtwRegistrationManager::SupportsETW()` (the telemetry
    base class does not expose this method directly).

  ### `qnn_model_wrapper_test.cc`

  New test file, active only under  `#if !defined(ORT_MINIMAL_BUILD) && BUILD_QNN_EP_STATIC_LIB`.

  **Test infrastructure design decisions:**

  - `FakeOrtGraph` — minimal `OrtGraph` stub. `AddTensorWrapper` never calls any `OrtGraph` virtual method; it only reads the
    `graph_inputs_info`/`graph_outputs_info` stored inside the wrapper. Using `OrtGraph` directly avoids depending on `GraphViewer`, `Graph`, or `EpGraph::Create`, which are ORT internals not exported from `onnxruntime.dll`.

  - `MakeFatalOrtLogger()` — synthesizes an `Ort::Logger` with `ORT_LOGGING_LEVEL_FATAL` via `memcpy`, avoiding `LoggingManager` whose constructor/destructor are not exported from `onnxruntime.dll`.
    Two `static_assert`s guard the size/trivial-copyable assumptions; a runtime `assert` on `GetLoggingSeverityLevel()` catches field reordering that the size check cannot detect.

  - `OrtEpApi` / `OrtModelEditorApi` — zero-initialized context members (not `static` locals). `AddTensorWrapper` never calls through `api_ptrs_`, so null function pointers are safe.

  **Test cases (9 total):**

  | Test | Condition | Expected mem type |
  |------|-----------|-------------------|
  | `SharedMemoryDisabled_GraphInput_MemTypeIsRaw` | input, disabled | RAW |
  | `SharedMemoryEnabled_GraphInput_MemTypeIsMemHandle` | input, enabled | MEMHANDLE |
  | `SharedMemoryEnabled_GraphOutput_MemTypeIsMemHandle` | output, enabled | MEMHANDLE |
  | `SharedMemoryEnabled_IntermediateTensor_MemTypeIsRaw` | `NATIVE`, not in maps, enabled | RAW |
  | `SharedMemoryEnabled_AppWriteNotInInputMap_MemTypeIsRaw` | `APP_WRITE`, not in input map, enabled | RAW (membership,
   not type, drives behavior) |
  | `SharedMemoryDisabled_GraphOutput_MemTypeIsRaw` | output, disabled | RAW |
  | `SharedMemoryEnabled_BothInputAndOutput_MemTypeIsMemHandle` | both I/O, enabled | both MEMHANDLE |
  | `DuplicateTensor_ReturnsTrueWithoutOverwrite` | same name added twice | returns `true`; original dtype preserved |
  | `EmptyName_ReturnsFalse` | empty name | returns `false`; map not modified |

  ## Test plan

  ```bash
  # Build and run in static-lib mode (Windows x86)
  python qcom/build_and_test.py build_ort_windows_x86_static
  ./build_x86_static/RelWithDebInfo/onnxruntime_provider_test \
      --gtest_filter="QnnModelWrapperTest.*"
  ```

