### PR TITLE
[QNN EP] Fix naming convention of Nightly wheels across Windows and Linux

### DIFF
--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -296,7 +296,7 @@ else
       package_args+=(--version_suffix "${ORT_VERSION_SUFFIX}")
     fi
     if [[ "${ORT_NIGHTLY_BUILD:-}" == "1" ]]; then
-      package_args+=(--wheel_name_suffix "qcom-internal")
+      package_args+=(--wheel_name_suffix "qcom_internal")
     fi
 
     "${python_for_build}" ${REPO_ROOT}/tools/ci_build/build.py \


### PR DESCRIPTION
This PR fixes `wheel_name_suffix` inconsistency between Windows and Linux

Wheel package names differ between platforms due to inconsistent suffix formatting:

- Linux: Uses `qcom-internal`
- Windows: Uses `qcom_internal`

This produces different wheel filenames on nightly builds, breaking reproducibility and causing confusion in artifact tracking.

This change ensures Linux nightly builds also use `qcom_internal` as the naming convention


