### PR TITLE
Fix quantized Gelu <-> Erf fusion

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -414,8 +414,13 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
   }
 
   // Build-time GELU should remain float-in/float-out so surrounding DQ/Q nodes can be lowered separately.
-  const OrtNodeUnitIODef* root_input = &div_inputs[0];
-  const OrtNodeUnitIODef* validate_root_input = root_input;
+  if (div_inputs.empty()) {
+    return nullptr;
+  }
+
+  // Copy IODef values to avoid dangling references from temporary vectors returned by Inputs()/Outputs().
+  OrtNodeUnitIODef root_input = div_inputs[0];
+  OrtNodeUnitIODef validate_root_input = root_input;
 
   const OrtNodeUnit* root_input_parent = GetParentOfInput(qnn_model_wrapper,
                                                           *div_node_unit,
@@ -423,32 +428,44 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
                                                           node_to_node_unit,
                                                           node_unit_to_qnn_node_group);
   if (root_input_parent != nullptr &&
-      root_input_parent->OpType() == DEQUANTIZE_LINEAR &&
-      !root_input_parent->Inputs().empty()) {
-    validate_root_input = &root_input_parent->Inputs()[0];
+      root_input_parent->OpType() == DEQUANTIZE_LINEAR) {
+    const auto& parent_inputs = root_input_parent->Inputs();
+    if (parent_inputs.empty()) {
+      return nullptr;
+    }
+    validate_root_input = parent_inputs[0];
   }
 
-  if (pattern_match.final_mul_node_unit == nullptr || pattern_match.final_mul_node_unit->Outputs().empty()) {
+  if (pattern_match.final_mul_node_unit == nullptr) {
     return nullptr;
   }
-  const OrtNodeUnitIODef* final_output = &pattern_match.final_mul_node_unit->Outputs()[0];
-  const OrtNodeUnitIODef* validate_final_output = final_output;
+
+  const auto& final_mul_outputs = pattern_match.final_mul_node_unit->Outputs();
+  if (final_mul_outputs.empty()) {
+    return nullptr;
+  }
+
+  OrtNodeUnitIODef final_output = final_mul_outputs[0];
+  OrtNodeUnitIODef validate_final_output = final_output;
 
   const OrtNodeUnit* final_output_child = GetOnlyChildOfOutput(qnn_model_wrapper,
                                                                *pattern_match.final_mul_node_unit,
-                                                               pattern_match.final_mul_node_unit->Outputs()[0],
+                                                               final_mul_outputs[0],
                                                                node_to_node_unit,
                                                                node_unit_to_qnn_node_group);
   if (final_output_child != nullptr &&
-      final_output_child->OpType() == QUANTIZE_LINEAR &&
-      !final_output_child->Outputs().empty()) {
-    validate_final_output = &final_output_child->Outputs()[0];
+      final_output_child->OpType() == QUANTIZE_LINEAR) {
+    const auto& child_outputs = final_output_child->Outputs();
+    if (child_outputs.empty()) {
+      return nullptr;
+    }
+    validate_final_output = child_outputs[0];
   }
 
   Ort::Status status = ValidateOnQnn(qnn_model_wrapper,
                                      pattern_match.node_units,
-                                     *validate_root_input,
-                                     *validate_final_output);
+                                     validate_root_input,
+                                     validate_final_output);
   if (!status.IsOK()) {
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_WARNING,
@@ -460,10 +477,10 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
 
   return std::make_unique<GeluFusion>(std::move(pattern_match.node_units),
                                       &erf_node_unit,
-                                      *validate_root_input,
-                                      *validate_final_output,
-                                      *root_input,
-                                      *final_output);
+                                      validate_root_input,
+                                      validate_final_output,
+                                      root_input,
+                                      final_output);
 }
 
 GeluFusion::GeluFusion(std::vector<const OrtNodeUnit*>&& node_units,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -319,13 +319,9 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     return nullptr;
   }
 
+  // Reject fusion if QDQ nodes are found inside the GELU topology to possibly avoid accuracy variation.
   if (erf_node_unit.UnitType() == OrtNodeUnit::Type::QDQGroup) {
-    ORT_CXX_LOG(logger,
-                ORT_LOGGING_LEVEL_WARNING,
-                ("[GeluFusion] QDQ nodes were found inside the GELU topology (" + erf_node_unit.Name() +
-                 "). The fused GELU may cause accuracy variation. Re-generate the quantized model without internal "
-                 "GELU QDQ if possible.")
-                    .c_str());
+    return nullptr;
   }
 
   const auto& erf_inputs = erf_node_unit.Inputs();
@@ -469,8 +465,8 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
   if (!status.IsOK()) {
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_WARNING,
-                ("[GeluFusion] ValidateOnQnn failed for Erf='" + erf_node_unit.Name() +
-                 "': " + std::string(status.GetErrorMessage()))
+                ("[GeluFusion] ValidateOnQnn failed for GELU pattern (target Erf='" + erf_node_unit.Name() +
+                 "'): " + std::string(status.GetErrorMessage()))
                     .c_str());
     return nullptr;
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -36,6 +36,44 @@ static Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
 
 namespace {
 
+// Quantized GELU subgraphs can route the same logical root tensor through generated
+// duplicated-value names such as `.../duplicated` or `.../duplicated_token_*`.
+std::string_view CanonicalizeRootTensorName(std::string_view tensor_name) {
+  constexpr std::string_view kDuplicatedSuffix = "/duplicated";
+  constexpr std::string_view kGeneratedTokenSuffix = "_token_";
+
+  // 1. Fast path: most tensor names are not duplicated aliases.
+  const size_t duplicated_pos = tensor_name.rfind(kDuplicatedSuffix);
+  if (duplicated_pos == std::string_view::npos) {
+    return tensor_name;
+  }
+
+  // 2. Inspect the suffix after `/duplicated`.
+  const size_t suffix_pos = duplicated_pos + kDuplicatedSuffix.size();
+  const std::string_view trailing_suffix = tensor_name.substr(suffix_pos);
+
+  // 3. Keep the name unchanged unless the remainder is empty or a generated token,
+  // so we do not collapse unrelated user-defined names that merely contain the same text.
+  const bool has_generated_token_suffix =
+      trailing_suffix.size() >= kGeneratedTokenSuffix.size() &&
+      trailing_suffix.substr(0, kGeneratedTokenSuffix.size()) == kGeneratedTokenSuffix;
+  if (!trailing_suffix.empty() && !has_generated_token_suffix) {
+    return tensor_name;
+  }
+
+  // 4. Strip the duplicated suffix so equivalent roots compare equal.
+  return tensor_name.substr(0, duplicated_pos);
+}
+
+std::string_view GetNodeUnitTypeString(const OrtNodeUnit& node_unit) {
+  return node_unit.UnitType() == OrtNodeUnit::Type::QDQGroup ? "QDQGroup" : "SingleNode";
+}
+
+std::string GetNodeUnitDescription(const OrtNodeUnit& node_unit) {
+  return "'" + node_unit.Name() + "' (op='" + node_unit.OpType() + "', unit_type='" +
+         std::string(GetNodeUnitTypeString(node_unit)) + "')";
+}
+
 struct GeluPatternMatchResult {
   std::vector<const OrtNodeUnit*> node_units;
   const OrtNodeUnit* final_mul_node_unit = nullptr;  // traces location of MUL with skip connection with root.
@@ -45,30 +83,41 @@ struct GeluPatternMatchContext {
   QnnModelWrapper& qnn_model_wrapper;
   const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit;
   const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group;
-  const std::string& root_input_name;
+  const Ort::Logger& logger;
+  std::string_view root_input_name;
 };
 
-/* Checks if the given NodeUnit has an input tensor with the specified name. */
-bool HasInputWithName(const OrtNodeUnit& node_unit, std::string_view input_name) {
+bool HasInputWithEquivalentName(const OrtNodeUnit& node_unit, std::string_view input_name) {
+  const std::string_view canonical_input_name = CanonicalizeRootTensorName(input_name);
   const auto& inputs = node_unit.Inputs();
-  return std::any_of(inputs.begin(), inputs.end(), [&input_name](const OrtNodeUnitIODef& input) {
-    return input.name == input_name;
+
+  return std::any_of(inputs.begin(), inputs.end(), [&canonical_input_name](const OrtNodeUnitIODef& input) {
+    return CanonicalizeRootTensorName(input.name) == canonical_input_name;
   });
 }
 
-const OrtNodeUnit* GetProducerForInput(const OrtNodeUnit& consumer_node_unit,
-                                       size_t input_index,
-                                       const GeluPatternMatchContext& ctx) {
-  const auto& inputs = consumer_node_unit.Inputs();
-  if (input_index >= inputs.size()) {
-    return nullptr;
+bool IsStandaloneQdqNodeUnit(const OrtNodeUnit* node_unit) {
+  return node_unit != nullptr &&
+         node_unit->UnitType() == OrtNodeUnit::Type::SingleNode &&
+         (node_unit->OpType() == QUANTIZE_LINEAR || node_unit->OpType() == DEQUANTIZE_LINEAR);
+}
+
+bool WarnAndFailOnStandaloneQdq(const OrtNodeUnit* node_unit,
+                                const OrtNodeUnit& /*erf_node_unit*/,
+                                const Ort::Logger& logger,
+                                std::string_view /*traversal_name*/) {
+  if (!IsStandaloneQdqNodeUnit(node_unit)) {
+    return false;
   }
 
-  return GetParentOfInput(ctx.qnn_model_wrapper,
-                          consumer_node_unit,
-                          inputs[input_index],
-                          ctx.node_to_node_unit,
-                          ctx.node_unit_to_qnn_node_group);
+  ORT_CXX_LOG(logger,
+              ORT_LOGGING_LEVEL_WARNING,
+              ("[GeluFusion] Mixed GELU topology detected. Culprit node unit " +
+               GetNodeUnitDescription(*node_unit) +
+               ". GELU fusion expects pattern nodes to be all SingeNodeUnits or QDQGroups"
+               ", not partially grouped patterns with SingleNodeUnits.")
+                  .c_str());
+  return true;
 }
 
 bool TryMatchErfAddPattern1(
@@ -82,25 +131,28 @@ bool TryMatchErfAddPattern1(
   //               +-------Mul(0.5)---------------------+
   //               |                                    |
   //               |                                    v
-  //            [root] --> Div -----> Erf  --> Add --> Mul ==>
-  //                      (B=1.4142...)        (1)
+  //            [root] --> Div/Mul --> Erf  --> Add --> Mul ==>
+  //                    (sqrt(2) or 1/sqrt(2))  (1)
   //
   // At this stage: "mul_after_add_node_unit" is the final Mul after Add.
-  // We now verify its non-Add input comes from Mul(root, const=0.5).
+  // We now verify its non-Add input comes from Mul(root, Mul const=0.5).
   const auto& mul_inputs = mul_after_add_node_unit->Inputs();
-  if (mul_inputs.size() < 2) {
-    return false;
-  }
 
   for (size_t i = 0; i < mul_inputs.size(); ++i) {
-    const OrtNodeUnit* producer = GetProducerForInput(*mul_after_add_node_unit,
-                                                      i,
-                                                      ctx);
+    const OrtNodeUnit* producer = GetParentOfInput(ctx.qnn_model_wrapper,
+                                                   *mul_after_add_node_unit,
+                                                   mul_inputs[i],
+                                                   ctx.node_to_node_unit,
+                                                   ctx.node_unit_to_qnn_node_group);
+    if (WarnAndFailOnStandaloneQdq(producer, erf_node_unit, ctx.logger, "GetParentOfInput")) {
+      return false;
+    }
+
     if (producer == nullptr || producer->OpType() != "Mul") {
       continue;
     }
 
-    if (!HasInputWithName(*producer, ctx.root_input_name)) {
+    if (!HasInputWithEquivalentName(*producer, ctx.root_input_name)) {
       continue;
     }
 
@@ -123,21 +175,30 @@ bool TryMatchErfAddPattern2(
   //               +------------------------------------+
   //               |                                    |
   //               |                                    v
-  //            [root] --> Div -----> Erf  --> Add --> Mul --> Mul ==>
-  //                      (B=1.4142...)        (1)            (0.5)
+  //            [root] --> Div/Mul --> Erf  --> Add --> Mul --> Mul ==>
+  //                    (sqrt(2) or 1/sqrt(2))  (1)            (0.5)
   //
   // At this stage: "mul_after_add_node_unit" is the first Mul after Add, and it must
   // already consume root. Then its child Mul is the final output node.
-  if (!HasInputWithName(*mul_after_add_node_unit, ctx.root_input_name)) {
+  if (!HasInputWithEquivalentName(*mul_after_add_node_unit, ctx.root_input_name)) {
     return false;
   }
 
-  const OrtNodeUnit* final_mul_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
-                                                                    *mul_after_add_node_unit,
-                                                                    "Mul",
-                                                                    ctx.node_to_node_unit,
-                                                                    ctx.node_unit_to_qnn_node_group);
-  if (final_mul_node_unit == nullptr) {
+  const auto& mul_outputs = mul_after_add_node_unit->Outputs();
+  if (mul_outputs.empty()) {
+    return false;
+  }
+
+  const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                                *mul_after_add_node_unit,
+                                                                mul_outputs[0],
+                                                                ctx.node_to_node_unit,
+                                                                ctx.node_unit_to_qnn_node_group);
+  if (WarnAndFailOnStandaloneQdq(final_mul_node_unit, erf_node_unit, ctx.logger, "GetOnlyChildOfOutput")) {
+    return false;
+  }
+
+  if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
     return false;
   }
 
@@ -155,47 +216,68 @@ bool TryMatchErfMulPattern(
   //               +-------------------------------------------+
   //               |                                           |
   //               |                                           v
-  //            [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
-  //                      (B=1.4142...)      (0.5)   (0.5)
-  // At this stage, identify the first Mul after Erf, followed by Add and final Mul taking root as input.
-
-  // Erf should have a Mul child
-  const OrtNodeUnit* mul_after_erf_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
-                                                                        erf_node_unit,
-                                                                        "Mul",
-                                                                        ctx.node_to_node_unit,
-                                                                        ctx.node_unit_to_qnn_node_group);
-  if (mul_after_erf_node_unit == nullptr) {
+  //            [root] --> Div/Mul --> Erf --> Mul --> Add --> Mul ==>
+  //                  (sqrt(2) or 1/sqrt(2))  (0.5)   (0.5)
+  // In this pattern, the Mul right after Erf must not consume root and have a Add and Mul seq after it.
+  const auto& erf_outputs = erf_node_unit.Outputs();
+  if (erf_outputs.empty()) {
     return false;
   }
 
-  // This Mul should NOT consume root (it multiplies by constant 0.5)
-  if (HasInputWithName(*mul_after_erf_node_unit, ctx.root_input_name)) {
-    return false;
-  }
-
-  // Mul must have an Add child
-  const OrtNodeUnit* add_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
-                                                              *mul_after_erf_node_unit,
-                                                              "Add",
-                                                              ctx.node_to_node_unit,
-                                                              ctx.node_unit_to_qnn_node_group);
-  if (add_node_unit == nullptr) {
-    return false;
-  }
-
-  // Add must have a Mul child (final node)
-  const OrtNodeUnit* final_mul_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
-                                                                    *add_node_unit,
-                                                                    "Mul",
+  const OrtNodeUnit* mul_after_erf_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                                    erf_node_unit,
+                                                                    erf_outputs[0],
                                                                     ctx.node_to_node_unit,
                                                                     ctx.node_unit_to_qnn_node_group);
-  if (final_mul_node_unit == nullptr) {
+  if (WarnAndFailOnStandaloneQdq(mul_after_erf_node_unit, erf_node_unit, ctx.logger, "GetOnlyChildOfOutput")) {
     return false;
   }
 
-  // Final Mul must consume root (skip connection)
-  if (!HasInputWithName(*final_mul_node_unit, ctx.root_input_name)) {
+  if (mul_after_erf_node_unit == nullptr || mul_after_erf_node_unit->OpType() != "Mul") {
+    return false;
+  }
+
+  if (HasInputWithEquivalentName(*mul_after_erf_node_unit, ctx.root_input_name)) {
+    return false;
+  }
+
+  const auto& mul_outputs = mul_after_erf_node_unit->Outputs();
+  if (mul_outputs.empty()) {
+    return false;
+  }
+
+  const OrtNodeUnit* add_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                          *mul_after_erf_node_unit,
+                                                          mul_outputs[0],
+                                                          ctx.node_to_node_unit,
+                                                          ctx.node_unit_to_qnn_node_group);
+  if (WarnAndFailOnStandaloneQdq(add_node_unit, erf_node_unit, ctx.logger, "GetOnlyChildOfOutput")) {
+    return false;
+  }
+
+  if (add_node_unit == nullptr || add_node_unit->OpType() != "Add") {
+    return false;
+  }
+
+  const auto& add_outputs = add_node_unit->Outputs();
+  if (add_outputs.empty()) {
+    return false;
+  }
+
+  const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
+                                                                *add_node_unit,
+                                                                add_outputs[0],
+                                                                ctx.node_to_node_unit,
+                                                                ctx.node_unit_to_qnn_node_group);
+  if (WarnAndFailOnStandaloneQdq(final_mul_node_unit, erf_node_unit, ctx.logger, "GetOnlyChildOfOutput")) {
+    return false;
+  }
+
+  if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
+    return false;
+  }
+
+  if (!HasInputWithEquivalentName(*final_mul_node_unit, ctx.root_input_name)) {
     return false;
   }
 
@@ -232,105 +314,180 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
-  ORT_UNUSED_PARAMETER(logger);
   // Looking for an Erf node (can be SingleNode or QDQGroup).
   if (erf_node_unit.OpType() != "Erf") {
     return nullptr;
   }
 
-  // Erf must have a Div or Mul parent on its input (optimizers may replace Div with Mul)
+  if (erf_node_unit.UnitType() == OrtNodeUnit::Type::QDQGroup) {
+    ORT_CXX_LOG(logger,
+                ORT_LOGGING_LEVEL_WARNING,
+                ("[GeluFusion] QDQ nodes were found inside the GELU topology (" + erf_node_unit.Name() +
+                 "). The fused GELU may cause accuracy variation. Re-generate the quantized model without internal "
+                 "GELU QDQ if possible.")
+                    .c_str());
+  }
+
   const auto& erf_inputs = erf_node_unit.Inputs();
   if (erf_inputs.empty()) {
     return nullptr;
   }
 
-  const OrtNodeUnit* div_node_unit = GetParentOfInput(qnn_model_wrapper, erf_node_unit, erf_inputs[0],
-                                                      node_to_node_unit, node_unit_to_qnn_node_group);
-  if (div_node_unit == nullptr || (div_node_unit->OpType() != "Div" && div_node_unit->OpType() != "Mul")) {
-    return nullptr;
-  }
-  const auto& div_inputs = div_node_unit->Inputs();
-  if (div_inputs.size() < 2) {
+  const OrtNodeUnit* div_node_unit = GetParentOfInput(qnn_model_wrapper,
+                                                      erf_node_unit,
+                                                      erf_inputs[0],
+                                                      node_to_node_unit,
+                                                      node_unit_to_qnn_node_group);
+  if (WarnAndFailOnStandaloneQdq(div_node_unit, erf_node_unit, logger, "GetParentOfInput")) {
     return nullptr;
   }
 
-  // Determine which GELU pattern variant by checking Erf's child node type
-  const std::string& root_input_name = div_inputs[0].name;
+  // optimizer may replace Div with Mul.
+  if (div_node_unit == nullptr || (div_node_unit->OpType() != "Div" && div_node_unit->OpType() != "Mul")) {
+    return nullptr;
+  }
+
+  const auto& div_inputs = div_node_unit->Inputs();
+
   const GeluPatternMatchContext match_ctx{qnn_model_wrapper,
                                           node_to_node_unit,
                                           node_unit_to_qnn_node_group,
-                                          root_input_name};
+                                          logger,
+                                          div_inputs[0].name};
 
   GeluPatternMatchResult pattern_match;
   bool is_match = false;
 
-  // Try ErfMul Pattern first (Erf -> Mul -> Add -> Mul)
-  const OrtNodeUnit* erf_child_mul = GetChildNodeUnitAllowQdq(qnn_model_wrapper, erf_node_unit, "Mul",
-                                                              node_to_node_unit, node_unit_to_qnn_node_group);
-  if (erf_child_mul != nullptr) {
-    // ErfMul Pattern3: Erf -> Mul -> Add -> Mul
-    // Structure: x * (Erf(x / sqrt2) * 0.5 + 0.5)
+  const auto& erf_outputs = erf_node_unit.Outputs();
+  if (erf_outputs.empty()) {
+    return nullptr;
+  }
+
+  const OrtNodeUnit* erf_child_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper,
+                                                                erf_node_unit,
+                                                                erf_outputs[0],
+                                                                node_to_node_unit,
+                                                                node_unit_to_qnn_node_group);
+  if (WarnAndFailOnStandaloneQdq(erf_child_node_unit, erf_node_unit, logger, "GetOnlyChildOfOutput")) {
+    return nullptr;
+  }
+
+  if (erf_child_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  if (erf_child_node_unit->OpType() == "Mul") {
     is_match = TryMatchErfMulPattern(div_node_unit,
                                      erf_node_unit,
                                      match_ctx,
                                      pattern_match);
-  }
-
-  // Try ErfAdd patterns if ErfMul didn't match (Erf -> Add -> Mul [-> Mul])
-  if (!is_match) {
-    const OrtNodeUnit* erf_child_add = GetChildNodeUnitAllowQdq(qnn_model_wrapper, erf_node_unit, "Add",
-                                                                node_to_node_unit, node_unit_to_qnn_node_group);
-    if (erf_child_add != nullptr) {
-      // ErfAdd Patterns 1 or 2: Erf -> Add -> Mul [-> Mul]
-      // Structure: x * 0.5 * (Erf(x / sqrt2) + 1) [with variations in Mul ordering]
-      const OrtNodeUnit* mul_node_unit = GetChildNodeUnitAllowQdq(qnn_model_wrapper, *erf_child_add, "Mul",
-                                                                  node_to_node_unit, node_unit_to_qnn_node_group);
-      if (mul_node_unit != nullptr) {
-        is_match = TryMatchErfAddPatterns(div_node_unit,
-                                          erf_node_unit,
-                                          erf_child_add,
-                                          mul_node_unit,
-                                          match_ctx,
-                                          pattern_match);
-      }
+  } else if (erf_child_node_unit->OpType() == "Add") {
+    const OrtNodeUnit* add_node_unit = erf_child_node_unit;
+    const auto& add_outputs = add_node_unit->Outputs();
+    if (add_outputs.empty()) {
+      return nullptr;
     }
+
+    const OrtNodeUnit* mul_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper,
+                                                            *add_node_unit,
+                                                            add_outputs[0],
+                                                            node_to_node_unit,
+                                                            node_unit_to_qnn_node_group);
+    if (WarnAndFailOnStandaloneQdq(mul_node_unit, erf_node_unit, logger, "GetOnlyChildOfOutput")) {
+      return nullptr;
+    }
+
+    if (mul_node_unit == nullptr || mul_node_unit->OpType() != "Mul") {
+      return nullptr;
+    }
+
+    is_match = TryMatchErfAddPatterns(div_node_unit,
+                                      erf_node_unit,
+                                      add_node_unit,
+                                      mul_node_unit,
+                                      match_ctx,
+                                      pattern_match);
   }
 
   if (!is_match) {
     return nullptr;
   }
 
-  // Validate on QNN
-  const OrtNodeUnitIODef& root_input = div_inputs[0];
+  // Build-time GELU should remain float-in/float-out so surrounding DQ/Q nodes can be lowered separately.
+  const OrtNodeUnitIODef* root_input = &div_inputs[0];
+  const OrtNodeUnitIODef* validate_root_input = root_input;
+
+  const OrtNodeUnit* root_input_parent = GetParentOfInput(qnn_model_wrapper,
+                                                          *div_node_unit,
+                                                          div_inputs[0],
+                                                          node_to_node_unit,
+                                                          node_unit_to_qnn_node_group);
+  if (root_input_parent != nullptr &&
+      root_input_parent->OpType() == DEQUANTIZE_LINEAR &&
+      !root_input_parent->Inputs().empty()) {
+    validate_root_input = &root_input_parent->Inputs()[0];
+  }
+
   if (pattern_match.final_mul_node_unit == nullptr || pattern_match.final_mul_node_unit->Outputs().empty()) {
     return nullptr;
   }
-  const OrtNodeUnitIODef& final_output = pattern_match.final_mul_node_unit->Outputs()[0];
+  const OrtNodeUnitIODef* final_output = &pattern_match.final_mul_node_unit->Outputs()[0];
+  const OrtNodeUnitIODef* validate_final_output = final_output;
 
-  Ort::Status status = ValidateOnQnn(qnn_model_wrapper, pattern_match.node_units, root_input, final_output);
+  const OrtNodeUnit* final_output_child = GetOnlyChildOfOutput(qnn_model_wrapper,
+                                                               *pattern_match.final_mul_node_unit,
+                                                               pattern_match.final_mul_node_unit->Outputs()[0],
+                                                               node_to_node_unit,
+                                                               node_unit_to_qnn_node_group);
+  if (final_output_child != nullptr &&
+      final_output_child->OpType() == QUANTIZE_LINEAR &&
+      !final_output_child->Outputs().empty()) {
+    validate_final_output = &final_output_child->Outputs()[0];
+  }
+
+  Ort::Status status = ValidateOnQnn(qnn_model_wrapper,
+                                     pattern_match.node_units,
+                                     *validate_root_input,
+                                     *validate_final_output);
   if (!status.IsOK()) {
+    ORT_CXX_LOG(logger,
+                ORT_LOGGING_LEVEL_WARNING,
+                ("[GeluFusion] ValidateOnQnn failed for Erf='" + erf_node_unit.Name() +
+                 "': " + std::string(status.GetErrorMessage()))
+                    .c_str());
     return nullptr;
   }
 
-  return std::make_unique<GeluFusion>(std::move(pattern_match.node_units), &erf_node_unit);
+  return std::make_unique<GeluFusion>(std::move(pattern_match.node_units),
+                                      &erf_node_unit,
+                                      *validate_root_input,
+                                      *validate_final_output,
+                                      *root_input,
+                                      *final_output);
 }
 
-GeluFusion::GeluFusion(std::vector<const OrtNodeUnit*>&& node_units, const OrtNodeUnit* target_node_unit)
-    : node_units_(std::move(node_units)), target_node_unit_(target_node_unit) {
+GeluFusion::GeluFusion(std::vector<const OrtNodeUnit*>&& node_units,
+                       const OrtNodeUnit* target_node_unit,
+                       OrtNodeUnitIODef validate_root_input,
+                       OrtNodeUnitIODef validate_final_output,
+                       OrtNodeUnitIODef root_input,
+                       OrtNodeUnitIODef final_output)
+    : node_units_(std::move(node_units)),
+      target_node_unit_(target_node_unit),
+      validate_root_input_(std::move(validate_root_input)),
+      validate_final_output_(std::move(validate_final_output)),
+      root_input_(std::move(root_input)),
+      final_output_(std::move(final_output)) {
 }
 
 Ort::Status GeluFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  const OrtNodeUnitIODef& root_input = node_units_[0]->Inputs()[0];
-  const OrtNodeUnitIODef& final_output = node_units_.back()->Outputs()[0];
-  return ValidateOnQnn(qmw, node_units_, root_input, final_output);
+  return ValidateOnQnn(qmw, node_units_, validate_root_input_, validate_final_output_);
 }
 
 Ort::Status GeluFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  const OrtNodeUnitIODef& root_input = node_units_[0]->Inputs()[0];
-  const OrtNodeUnitIODef& final_output = node_units_.back()->Outputs()[0];
-  return CreateOnQnn(qmw, node_units_, root_input, final_output);
+  return CreateOnQnn(qmw, node_units_, root_input_, final_output_);
 }
 
 gsl::span<const OrtNodeUnit* const> GeluFusion::GetNodeUnits() const {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -87,6 +87,10 @@ struct GeluPatternMatchContext {
   std::string_view root_input_name;
 };
 
+// Checks if a NodeUnit consumes the GELU pattern's root tensor (or an equivalent duplicate).
+// When ORT creates QDQGroups with shared parent DQ nodes, it duplicates the tensor name with
+// suffixes like "/duplicated" or "/duplicated_token_*" to maintain unique tensor-to-QDQ mappings.
+// This canonicalizes both the input_name and the NodeUnit's inputs before comparing.
 bool HasInputWithEquivalentName(const OrtNodeUnit& node_unit, std::string_view input_name) {
   const std::string_view canonical_input_name = CanonicalizeRootTensorName(input_name);
   const auto& inputs = node_unit.Inputs();
@@ -481,26 +485,26 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
 
 GeluFusion::GeluFusion(std::vector<const OrtNodeUnit*>&& node_units,
                        const OrtNodeUnit* target_node_unit,
-                       OrtNodeUnitIODef validate_root_input,
-                       OrtNodeUnitIODef validate_final_output,
-                       OrtNodeUnitIODef root_input,
-                       OrtNodeUnitIODef final_output)
+                       OrtNodeUnitIODef validation_root_input,
+                       OrtNodeUnitIODef validation_final_output,
+                       OrtNodeUnitIODef gelu_root_input,
+                       OrtNodeUnitIODef gelu_final_output)
     : node_units_(std::move(node_units)),
       target_node_unit_(target_node_unit),
-      validate_root_input_(std::move(validate_root_input)),
-      validate_final_output_(std::move(validate_final_output)),
-      root_input_(std::move(root_input)),
-      final_output_(std::move(final_output)) {
+      validation_root_input_(std::move(validation_root_input)),
+      validation_final_output_(std::move(validation_final_output)),
+      gelu_root_input_(std::move(gelu_root_input)),
+      gelu_final_output_(std::move(gelu_final_output)) {
 }
 
 Ort::Status GeluFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  return ValidateOnQnn(qmw, node_units_, validate_root_input_, validate_final_output_);
+  return ValidateOnQnn(qmw, node_units_, validation_root_input_, validation_final_output_);
 }
 
 Ort::Status GeluFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  return CreateOnQnn(qmw, node_units_, root_input_, final_output_);
+  return CreateOnQnn(qmw, node_units_, gelu_root_input_, gelu_final_output_);
 }
 
 gsl::span<const OrtNodeUnit* const> GeluFusion::GetNodeUnits() const {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -114,7 +114,7 @@ bool WarnAndFailOnStandaloneQdq(const OrtNodeUnit* node_unit,
               ORT_LOGGING_LEVEL_WARNING,
               ("[GeluFusion] Mixed GELU topology detected. Culprit node unit " +
                GetNodeUnitDescription(*node_unit) +
-               ". GELU fusion expects pattern nodes to be all SingeNodeUnits or QDQGroups"
+               ". GELU fusion expects pattern nodes to be all SingleNodeUnits or QDQGroups"
                ", not partially grouped patterns with SingleNodeUnits.")
                   .c_str());
   return true;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -157,6 +157,8 @@ bool TryMatchErfMulPattern(
   //               |                                           v
   //            [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
   //                      (B=1.4142...)      (0.5)   (0.5)
+  // At this stage, identify the first Mul after Erf, followed by Add and final Mul taking root as input.
+
   // Erf should have a Mul child
   const OrtNodeUnit* mul_after_erf_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
                                                                         erf_node_unit,
@@ -236,7 +238,7 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     return nullptr;
   }
 
-  // Erf must have a Div parent on its input
+  // Erf must have a Div or Mul parent on its input (optimizers may replace Div with Mul)
   const auto& erf_inputs = erf_node_unit.Inputs();
   if (erf_inputs.empty()) {
     return nullptr;
@@ -244,7 +246,7 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
 
   const OrtNodeUnit* div_node_unit = GetParentOfInput(qnn_model_wrapper, erf_node_unit, erf_inputs[0],
                                                       node_to_node_unit, node_unit_to_qnn_node_group);
-  if (div_node_unit == nullptr || div_node_unit->OpType() != "Div") {
+  if (div_node_unit == nullptr || (div_node_unit->OpType() != "Div" && div_node_unit->OpType() != "Mul")) {
     return nullptr;
   }
   const auto& div_inputs = div_node_unit->Inputs();
@@ -281,18 +283,15 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
     if (erf_child_add != nullptr) {
       // ErfAdd Patterns 1 or 2: Erf -> Add -> Mul [-> Mul]
       // Structure: x * 0.5 * (Erf(x / sqrt2) + 1) [with variations in Mul ordering]
-      const auto& add_inputs = erf_child_add->Inputs();
-      if (add_inputs.size() >= 2) {
-        const OrtNodeUnit* mul_node_unit = GetChildNodeUnitAllowQdq(qnn_model_wrapper, *erf_child_add, "Mul",
-                                                                    node_to_node_unit, node_unit_to_qnn_node_group);
-        if (mul_node_unit != nullptr) {
-          is_match = TryMatchErfAddPatterns(div_node_unit,
-                                            erf_node_unit,
-                                            erf_child_add,
-                                            mul_node_unit,
-                                            match_ctx,
-                                            pattern_match);
-        }
+      const OrtNodeUnit* mul_node_unit = GetChildNodeUnitAllowQdq(qnn_model_wrapper, *erf_child_add, "Mul",
+                                                                  node_to_node_unit, node_unit_to_qnn_node_group);
+      if (mul_node_unit != nullptr) {
+        is_match = TryMatchErfAddPatterns(div_node_unit,
+                                          erf_node_unit,
+                                          erf_child_add,
+                                          mul_node_unit,
+                                          match_ctx,
+                                          pattern_match);
       }
     }
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.cc
@@ -132,17 +132,12 @@ bool TryMatchErfAddPattern2(
     return false;
   }
 
-  const auto& mul_outputs = mul_after_add_node_unit->Outputs();
-  if (mul_outputs.empty()) {
-    return false;
-  }
-
-  const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
-                                                                *mul_after_add_node_unit,
-                                                                mul_outputs[0],
-                                                                ctx.node_to_node_unit,
-                                                                ctx.node_unit_to_qnn_node_group);
-  if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
+  const OrtNodeUnit* final_mul_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
+                                                                    *mul_after_add_node_unit,
+                                                                    "Mul",
+                                                                    ctx.node_to_node_unit,
+                                                                    ctx.node_unit_to_qnn_node_group);
+  if (final_mul_node_unit == nullptr) {
     return false;
   }
 
@@ -162,18 +157,13 @@ bool TryMatchErfMulPattern(
   //               |                                           v
   //            [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
   //                      (B=1.4142...)      (0.5)   (0.5)
-  const auto& erf_outputs = erf_node_unit.Outputs();
-  if (erf_outputs.empty()) {
-    return false;
-  }
-
   // Erf should have a Mul child
-  const OrtNodeUnit* mul_after_erf_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
-                                                                    erf_node_unit,
-                                                                    erf_outputs[0],
-                                                                    ctx.node_to_node_unit,
-                                                                    ctx.node_unit_to_qnn_node_group);
-  if (mul_after_erf_node_unit == nullptr || mul_after_erf_node_unit->OpType() != "Mul") {
+  const OrtNodeUnit* mul_after_erf_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
+                                                                        erf_node_unit,
+                                                                        "Mul",
+                                                                        ctx.node_to_node_unit,
+                                                                        ctx.node_unit_to_qnn_node_group);
+  if (mul_after_erf_node_unit == nullptr) {
     return false;
   }
 
@@ -183,32 +173,22 @@ bool TryMatchErfMulPattern(
   }
 
   // Mul must have an Add child
-  const auto& mul_outputs = mul_after_erf_node_unit->Outputs();
-  if (mul_outputs.empty()) {
-    return false;
-  }
-
-  const OrtNodeUnit* add_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
-                                                          *mul_after_erf_node_unit,
-                                                          mul_outputs[0],
-                                                          ctx.node_to_node_unit,
-                                                          ctx.node_unit_to_qnn_node_group);
-  if (add_node_unit == nullptr || add_node_unit->OpType() != "Add") {
+  const OrtNodeUnit* add_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
+                                                              *mul_after_erf_node_unit,
+                                                              "Add",
+                                                              ctx.node_to_node_unit,
+                                                              ctx.node_unit_to_qnn_node_group);
+  if (add_node_unit == nullptr) {
     return false;
   }
 
   // Add must have a Mul child (final node)
-  const auto& add_outputs = add_node_unit->Outputs();
-  if (add_outputs.empty()) {
-    return false;
-  }
-
-  const OrtNodeUnit* final_mul_node_unit = GetOnlyChildOfOutput(ctx.qnn_model_wrapper,
-                                                                *add_node_unit,
-                                                                add_outputs[0],
-                                                                ctx.node_to_node_unit,
-                                                                ctx.node_unit_to_qnn_node_group);
-  if (final_mul_node_unit == nullptr || final_mul_node_unit->OpType() != "Mul") {
+  const OrtNodeUnit* final_mul_node_unit = GetChildNodeUnitAllowQdq(ctx.qnn_model_wrapper,
+                                                                    *add_node_unit,
+                                                                    "Mul",
+                                                                    ctx.node_to_node_unit,
+                                                                    ctx.node_unit_to_qnn_node_group);
+  if (final_mul_node_unit == nullptr) {
     return false;
   }
 
@@ -273,17 +253,6 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
   }
 
   // Determine which GELU pattern variant by checking Erf's child node type
-  const auto& erf_outputs = erf_node_unit.Outputs();
-  if (erf_outputs.empty()) {
-    return nullptr;
-  }
-
-  const OrtNodeUnit* erf_child_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper, erf_node_unit, erf_outputs[0],
-                                                                node_to_node_unit, node_unit_to_qnn_node_group);
-  if (erf_child_node_unit == nullptr) {
-    return nullptr;
-  }
-
   const std::string& root_input_name = div_inputs[0].name;
   const GeluPatternMatchContext match_ctx{qnn_model_wrapper,
                                           node_to_node_unit,
@@ -293,40 +262,39 @@ std::unique_ptr<IQnnNodeGroup> GeluFusion::TryFusion(
   GeluPatternMatchResult pattern_match;
   bool is_match = false;
 
-  if (erf_child_node_unit->OpType() == "Mul") {
+  // Try ErfMul Pattern first (Erf -> Mul -> Add -> Mul)
+  const OrtNodeUnit* erf_child_mul = GetChildNodeUnitAllowQdq(qnn_model_wrapper, erf_node_unit, "Mul",
+                                                              node_to_node_unit, node_unit_to_qnn_node_group);
+  if (erf_child_mul != nullptr) {
     // ErfMul Pattern3: Erf -> Mul -> Add -> Mul
     // Structure: x * (Erf(x / sqrt2) * 0.5 + 0.5)
     is_match = TryMatchErfMulPattern(div_node_unit,
                                      erf_node_unit,
                                      match_ctx,
                                      pattern_match);
-  } else if (erf_child_node_unit->OpType() == "Add") {
-    // ErfAdd Patterns 1 or 2: Erf -> Add -> Mul [-> Mul]
-    // Structure: x * 0.5 * (Erf(x / sqrt2) + 1) [with variations in Mul ordering]
-    const OrtNodeUnit* add_node_unit = erf_child_node_unit;
+  }
 
-    const auto& add_inputs = add_node_unit->Inputs();
-    if (add_inputs.size() < 2) {
-      return nullptr;
+  // Try ErfAdd patterns if ErfMul didn't match (Erf -> Add -> Mul [-> Mul])
+  if (!is_match) {
+    const OrtNodeUnit* erf_child_add = GetChildNodeUnitAllowQdq(qnn_model_wrapper, erf_node_unit, "Add",
+                                                                node_to_node_unit, node_unit_to_qnn_node_group);
+    if (erf_child_add != nullptr) {
+      // ErfAdd Patterns 1 or 2: Erf -> Add -> Mul [-> Mul]
+      // Structure: x * 0.5 * (Erf(x / sqrt2) + 1) [with variations in Mul ordering]
+      const auto& add_inputs = erf_child_add->Inputs();
+      if (add_inputs.size() >= 2) {
+        const OrtNodeUnit* mul_node_unit = GetChildNodeUnitAllowQdq(qnn_model_wrapper, *erf_child_add, "Mul",
+                                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+        if (mul_node_unit != nullptr) {
+          is_match = TryMatchErfAddPatterns(div_node_unit,
+                                            erf_node_unit,
+                                            erf_child_add,
+                                            mul_node_unit,
+                                            match_ctx,
+                                            pattern_match);
+        }
+      }
     }
-
-    const auto& add_outputs = add_node_unit->Outputs();
-    if (add_outputs.empty()) {
-      return nullptr;
-    }
-
-    const OrtNodeUnit* mul_node_unit = GetOnlyChildOfOutput(qnn_model_wrapper, *add_node_unit, add_outputs[0],
-                                                            node_to_node_unit, node_unit_to_qnn_node_group);
-    if (mul_node_unit == nullptr || mul_node_unit->OpType() != "Mul") {
-      return nullptr;
-    }
-
-    is_match = TryMatchErfAddPatterns(div_node_unit,
-                                      erf_node_unit,
-                                      add_node_unit,
-                                      mul_node_unit,
-                                      match_ctx,
-                                      pattern_match);
   }
 
   if (!is_match) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
@@ -49,7 +49,12 @@ class QnnModelWrapper;
 /// </summary>
 class GeluFusion : public IQnnNodeGroup {
  public:
-  GeluFusion(std::vector<const OrtNodeUnit*>&& node_units, const OrtNodeUnit* target_node_unit);
+  GeluFusion(std::vector<const OrtNodeUnit*>&& node_units,
+             const OrtNodeUnit* target_node_unit,
+             OrtNodeUnitIODef validate_root_input,
+             OrtNodeUnitIODef validate_final_output,
+             OrtNodeUnitIODef root_input,
+             OrtNodeUnitIODef final_output);
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(GeluFusion);
 
   Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
@@ -78,6 +83,10 @@ class GeluFusion : public IQnnNodeGroup {
  private:
   std::vector<const OrtNodeUnit*> node_units_;
   const OrtNodeUnit* target_node_unit_;
+  OrtNodeUnitIODef validate_root_input_;
+  OrtNodeUnitIODef validate_final_output_;
+  OrtNodeUnitIODef root_input_;
+  OrtNodeUnitIODef final_output_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/gelu_fusion.h
@@ -49,12 +49,18 @@ class QnnModelWrapper;
 /// </summary>
 class GeluFusion : public IQnnNodeGroup {
  public:
+  /// <param name="node_units">All NodeUnits in the GELU pattern (Div/Mul, Erf, Add, Mul, etc.)</param>
+  /// <param name="target_node_unit">The Erf NodeUnit (used as the primary node for this fusion)</param>
+  /// <param name="validation_root_input">GELU pattern root input for QNN validation (quantized if outer DQ exists, else float)</param>
+  /// <param name="validation_final_output">GELU pattern final output for QNN validation (quantized if outer Q exists, else float)</param>
+  /// <param name="gelu_root_input">Root input to fused Gelu operator (float, from DQ output or pattern root)</param>
+  /// <param name="gelu_final_output">Final output from fused Gelu operator (float, before Q input or pattern end)</param>
   GeluFusion(std::vector<const OrtNodeUnit*>&& node_units,
              const OrtNodeUnit* target_node_unit,
-             OrtNodeUnitIODef validate_root_input,
-             OrtNodeUnitIODef validate_final_output,
-             OrtNodeUnitIODef root_input,
-             OrtNodeUnitIODef final_output);
+             OrtNodeUnitIODef validation_root_input,
+             OrtNodeUnitIODef validation_final_output,
+             OrtNodeUnitIODef gelu_root_input,
+             OrtNodeUnitIODef gelu_final_output);
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(GeluFusion);
 
   Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
@@ -83,10 +89,10 @@ class GeluFusion : public IQnnNodeGroup {
  private:
   std::vector<const OrtNodeUnit*> node_units_;
   const OrtNodeUnit* target_node_unit_;
-  OrtNodeUnitIODef validate_root_input_;
-  OrtNodeUnitIODef validate_final_output_;
-  OrtNodeUnitIODef root_input_;
-  OrtNodeUnitIODef final_output_;
+  OrtNodeUnitIODef validation_root_input_;
+  OrtNodeUnitIODef validation_final_output_;
+  OrtNodeUnitIODef gelu_root_input_;
+  OrtNodeUnitIODef gelu_final_output_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.cc
@@ -242,8 +242,7 @@ std::optional<SpaceToDepthPattern> MatchPattern(
     const QnnModelWrapper& qnn_model_wrapper,
     const OrtNodeUnit& reshape1,
     const MapNodeToNodeUnit& node_to_node_unit,
-    const MapNodeUnitToGroup& node_unit_to_qnn_node_group,
-    const Ort::Logger& logger) {
+    const MapNodeUnitToGroup& node_unit_to_qnn_node_group) {
   // 1. Validate the starting node op type.
   if (reshape1.OpType() != kOpReshape) {
     return std::nullopt;
@@ -260,14 +259,11 @@ std::optional<SpaceToDepthPattern> MatchPattern(
   const OrtNodeUnit* reshape2 = GetChildNodeUnitAllowQdq(qnn_model_wrapper, *transpose, kOpReshape,
                                                          node_to_node_unit, node_unit_to_qnn_node_group);
   if (reshape2 == nullptr) {
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                "SpaceToDepthFusion: no trailing Reshape2 child found after Transpose.");
     return std::nullopt;
   }
 
   // 3.1 Fast signature check for SpaceToDepth core RTR decomposition.
   if (!HasSpaceToDepthCoreSignature(qnn_model_wrapper, reshape1, *transpose, *reshape2)) {
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, "SpaceToDepthFusion: not a S2D RTR pattern.");
     return std::nullopt;
   }
 
@@ -344,7 +340,6 @@ std::optional<SpaceToDepthPattern> MatchPattern(
   // b) T(NHWC->NCHW) + RTR
   // c) RTR + T(NCHW->NHWC)
   if (core.node_count == 3) {
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, "SpaceToDepthFusion: skip RTR-only pattern.");
     return std::nullopt;
   }
 
@@ -750,7 +745,7 @@ std::unique_ptr<IQnnNodeGroup> SpaceToDepthFusion::TryFusion(
 
   // 2. Match Pattern
   auto pattern = MatchPattern(qnn_model_wrapper, reshape_node_unit,
-                              node_to_node_unit, node_unit_to_qnn_node_group, logger);
+                              node_to_node_unit, node_unit_to_qnn_node_group);
   if (!pattern.has_value()) {
     return nullptr;
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -160,20 +160,25 @@ const OrtNodeUnit* GetChildNodeUnitAllowQdq(
 
     const OrtNode* potential_child = consumers[0].node;
 
-    // 4. If the child is a DequantizeLinear, skip it and look at its child.
-    // DQ -> op -> Q -> (DQ) -> ...
-    if (Ort::ConstNode(potential_child).GetOperatorType() == DEQUANTIZE_LINEAR) {
-      const std::vector<Ort::ConstValueInfo> dq_outputs = Ort::ConstNode(potential_child).GetOutputs();
-      if (dq_outputs.size() != 1) {
+    // 4. If the child is Q/DQ wrapper(s), skip through them and look at the next math child.
+    // Example: DQ -> op -> Q -> DQ -> ...
+    while (potential_child != nullptr) {
+      const std::string child_op = Ort::ConstNode(potential_child).GetOperatorType();
+      if (child_op != QUANTIZE_LINEAR && child_op != DEQUANTIZE_LINEAR) {
+        break;
+      }
+
+      const std::vector<Ort::ConstValueInfo> qdq_outputs = Ort::ConstNode(potential_child).GetOutputs();
+      if (qdq_outputs.size() != 1) {
         return nullptr;
       }
 
-      const std::vector<Ort::ValueInfoConsumerProducerInfo> dq_consumers = dq_outputs[0].GetConsumers();
-      if (dq_consumers.size() != 1 || dq_consumers[0].node == nullptr) {
+      const std::vector<Ort::ValueInfoConsumerProducerInfo> qdq_consumers = qdq_outputs[0].GetConsumers();
+      if (qdq_consumers.size() != 1 || qdq_consumers[0].node == nullptr) {
         return nullptr;
       }
 
-      potential_child = dq_consumers[0].node;
+      potential_child = qdq_consumers[0].node;
     }
 
     // 5. Check if the child node is of the expected type.

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -659,7 +659,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
 
   TestQDQModelAccuracy(BuildGeluPattern1TestCase(input_def),
                        BuildQDQGeluPattern1TestCase<uint8_t>(input_def),
@@ -681,7 +681,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
 
   TestQDQModelAccuracy(BuildGeluPattern2TestCase(input_def),
                        BuildQDQGeluPattern2TestCase<uint8_t>(input_def),
@@ -703,7 +703,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
 
   TestQDQModelAccuracy(BuildGeluPattern3TestCase(input_def),
                        BuildQDQGeluPattern3TestCase<uint8_t>(input_def),

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -234,6 +234,7 @@ GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def, b
 }
 
 // Helper function to build QDQ GELU Pattern 1
+// QDQ is only at pattern boundaries (input and output), not around internal operators
 template <typename QuantType>
 GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<float>& input_def,
                                                           bool use_mul = false) {
@@ -252,75 +253,51 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<flo
     const std::string input_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
-    // Constants: add explicit QDQ after each initializer (to match expected QDQ patterns).
+    // Constants: float initializers (no QDQ to keep pattern operators as SingleNode)
     builder.MakeScalarInitializer<float>("one", one);
     builder.MakeScalarInitializer<float>("half", half);
-    const std::string one_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
-    const std::string half_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
 
     // GELU Pattern 1:
     // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Add(one) -> Mul(with (input * half))
     std::string norm_out = "div_out";
     if (use_mul) {
       builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
-      const std::string inv_sqrt2_qdq =
-          AddQDQNodePair<QuantType>(builder, "qdq_inv_sqrt2", "inv_sqrt2", input_qparams.scale, input_qparams.zero_point);
       builder.AddNode("Mul_inv_sqrt2",
                       "Mul",
-                      {input_qdq, inv_sqrt2_qdq},
+                      {input_qdq, "inv_sqrt2"},
                       {norm_out},
                       kOnnxDomain);
     } else {
       builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-      const std::string sqrt2_qdq =
-          AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
       builder.AddNode("Div_sqrt2",
                       "Div",
-                      {input_qdq, sqrt2_qdq},
+                      {input_qdq, "sqrt2"},
                       {norm_out},
                       kOnnxDomain);
     }
 
-    // Add explicit QDQ around Erf to match expected QDQ patterns:
-    // norm_out -> Q -> DQ -> erf_in
-    const std::string erf_in_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", norm_out, input_qparams.scale, input_qparams.zero_point);
-
-    // erf_in -> Erf -> erf_out
+    // Erf operates on float (no QDQ around it)
     builder.AddNode("Erf",
                     "Erf",
-                    {erf_in_qdq},
+                    {norm_out},
                     {"erf_out"},
                     kOnnxDomain);
 
-    // erf_out -> Q -> DQ -> erf_out_qdq
-    const std::string erf_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_out", "erf_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Add_one",
                     "Add",
-                    {erf_out_qdq, one_qdq},
+                    {"erf_out", "one"},
                     {"add_out"},
                     kOnnxDomain);
 
-    // add_out -> Q -> DQ -> add_out_qdq
-    const std::string add_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_add_out", "add_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Mul_half",
                     "Mul",
-                    {input_qdq, half_qdq},
+                    {input_qdq, "half"},
                     {"mul_half_out"},
                     kOnnxDomain);
 
-    const std::string mul_half_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_mul_half_out", "mul_half_out",
-                                  input_qparams.scale, input_qparams.zero_point);
     builder.AddNode("Mul_out",
                     "Mul",
-                    {add_out_qdq, mul_half_out_qdq},
+                    {"add_out", "mul_half_out"},
                     {"Y"},
                     kOnnxDomain);
 
@@ -330,6 +307,7 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<flo
 }
 
 // Helper function to build QDQ GELU Pattern 2
+// QDQ is only at pattern boundaries (input and output), not around internal operators
 template <typename QuantType>
 GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<float>& input_def,
                                                           bool use_mul = false) {
@@ -348,76 +326,51 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<flo
     const std::string input_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
-    // Constants: add explicit QDQ after each initializer (to match expected QDQ patterns).
+    // Constants: float initializers (no QDQ to keep pattern operators as SingleNode)
     builder.MakeScalarInitializer<float>("one", one);
     builder.MakeScalarInitializer<float>("half", half);
-    const std::string one_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
-    const std::string half_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
 
     // GELU Pattern 2:
     // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Add(one) -> Mul(with input) -> Mul(half)
     std::string norm_out = "div_out";
     if (use_mul) {
       builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
-      const std::string inv_sqrt2_qdq =
-          AddQDQNodePair<QuantType>(builder, "qdq_inv_sqrt2", "inv_sqrt2", input_qparams.scale, input_qparams.zero_point);
       builder.AddNode("Mul_inv_sqrt2",
                       "Mul",
-                      {input_qdq, inv_sqrt2_qdq},
+                      {input_qdq, "inv_sqrt2"},
                       {norm_out},
                       kOnnxDomain);
     } else {
       builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-      const std::string sqrt2_qdq =
-          AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
       builder.AddNode("Div_sqrt2",
                       "Div",
-                      {input_qdq, sqrt2_qdq},
+                      {input_qdq, "sqrt2"},
                       {norm_out},
                       kOnnxDomain);
     }
 
-    // Add explicit QDQ around Erf to match expected QDQ patterns:
-    // norm_out -> Q -> DQ -> erf_in
-    const std::string erf_in_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", norm_out, input_qparams.scale, input_qparams.zero_point);
-
-    // erf_in -> Erf -> erf_out
+    // Erf operates on float (no QDQ around it)
     builder.AddNode("Erf",
                     "Erf",
-                    {erf_in_qdq},
+                    {norm_out},
                     {"erf_out"},
                     kOnnxDomain);
 
-    // erf_out -> Q -> DQ -> erf_out_qdq
-    const std::string erf_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_out", "erf_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Add_one",
                     "Add",
-                    {erf_out_qdq, one_qdq},
+                    {"erf_out", "one"},
                     {"add_out"},
                     kOnnxDomain);
 
-    // add_out -> Q -> DQ -> add_out_qdq
-    const std::string add_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_add_out", "add_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Mul_input",
                     "Mul",
-                    {input_qdq, add_out_qdq},
+                    {input_qdq, "add_out"},
                     {"mul_out"},
                     kOnnxDomain);
 
-    // mul_out -> Q -> DQ -> mul_out_qdq
-    const std::string mul_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_mul_out", "mul_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Mul_half",
                     "Mul",
-                    {mul_out_qdq, half_qdq},
+                    {"mul_out", "half"},
                     {"Y"},
                     kOnnxDomain);
 
@@ -427,6 +380,7 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<flo
 }
 
 // Helper function to build QDQ GELU Pattern 3 (ErfMul Pattern)
+// QDQ is only at pattern boundaries (input and output), not around internal operators
 template <typename QuantType>
 GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<float>& input_def,
                                                           bool use_mul = false) {
@@ -444,69 +398,51 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<flo
     const std::string input_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
+    // Constants: float initializers (no QDQ to keep pattern operators as SingleNode)
     builder.MakeScalarInitializer<float>("half", half);
     builder.MakeScalarInitializer<float>("half2", half);
-    const std::string half_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
-    const std::string half2_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_half2", "half2", input_qparams.scale, input_qparams.zero_point);
 
-    // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Mul(0.5) -> Add(0.5)
+    // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Mul(0.5) -> Add(0.5) -> Mul(input)
     std::string norm_out = "div_out";
     if (use_mul) {
-      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
-      const std::string inv_sqrt2_qdq =
-          AddQDQNodePair<QuantType>(builder, "qdq_inv_sqrt2", "inv_sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.MakeScalarInitializer<float>("inv_sqrt_2", inv_sqrt_2);
       builder.AddNode("Mul_inv_sqrt2",
                       "Mul",
-                      {input_qdq, inv_sqrt2_qdq},
+                      {input_qdq, "inv_sqrt_2"},
                       {norm_out},
                       kOnnxDomain);
     } else {
       builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-      const std::string sqrt2_qdq =
-          AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
       builder.AddNode("Div_sqrt2",
                       "Div",
-                      {input_qdq, sqrt2_qdq},
+                      {input_qdq, "sqrt2"},
                       {norm_out},
                       kOnnxDomain);
     }
 
-    const std::string erf_in_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", norm_out, input_qparams.scale, input_qparams.zero_point);
-
+    // Erf operates on float (no QDQ around it)
     builder.AddNode("Erf",
                     "Erf",
-                    {erf_in_qdq},
+                    {norm_out},
                     {"erf_out"},
                     kOnnxDomain);
-
-    const std::string erf_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_out", "erf_out", input_qparams.scale, input_qparams.zero_point);
 
     // ErfMul Pattern: Mul(erf_out, 0.5) -> Add(0.5) -> Mul(input)
     builder.AddNode("Mul_half",
                     "Mul",
-                    {erf_out_qdq, half_qdq},
+                    {"erf_out", "half"},
                     {"mul_out"},
                     kOnnxDomain);
 
-    const std::string mul_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_mul_out", "mul_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Add_half",
                     "Add",
-                    {mul_out_qdq, half2_qdq},
+                    {"mul_out", "half2"},
                     {"add_out"},
                     kOnnxDomain);
 
-    const std::string add_out_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_add_out", "add_out", input_qparams.scale, input_qparams.zero_point);
-
     builder.AddNode("Mul_out",
                     "Mul",
-                    {input_qdq, add_out_qdq},
+                    {input_qdq, "add_out"},
                     {"Y"},
                     kOnnxDomain);
 
@@ -905,6 +841,193 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
                        /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+}
+
+// Negative test: GELU Pattern with internal QDQ nodes should NOT fuse
+// Helper function to build QDQ GELU Pattern with internal QDQ (around Erf)
+template <typename QuantType>
+GetTestQDQModelFn<QuantType> BuildQDQGeluPatternWithInternalQDQ(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder,
+                     std::vector<QuantParams<QuantType>>& output_qparams) -> void {
+    constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float half = 0.5f;
+    constexpr float one = 1.0f;
+
+    builder.graph_->set_name("qdq_gelu_internal_qdq_graph");
+
+    // input
+    MakeTestInput(builder, "input", input_def);
+    const QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+    const std::string input_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
+
+    // Constants with QDQ
+    builder.MakeScalarInitializer<float>("one", one);
+    builder.MakeScalarInitializer<float>("half", half);
+    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+    const std::string one_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
+    const std::string half_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
+    const std::string sqrt2_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
+
+    // Div node
+    builder.AddNode("Div_sqrt2",
+                    "Div",
+                    {input_qdq, sqrt2_qdq},
+                    {"div_out"},
+                    kOnnxDomain);
+
+    // INTERNAL QDQ around Erf (this makes Erf a QDQGroup and should prevent fusion)
+    const std::string erf_in_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", "div_out", input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Erf",
+                    "Erf",
+                    {erf_in_qdq},
+                    {"erf_out"},
+                    kOnnxDomain);
+
+    const std::string erf_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_out", "erf_out", input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Add_one",
+                    "Add",
+                    {erf_out_qdq, one_qdq},
+                    {"add_out"},
+                    kOnnxDomain);
+
+    const std::string add_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_add_out", "add_out", input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Mul_half",
+                    "Mul",
+                    {input_qdq, half_qdq},
+                    {"mul_half_out"},
+                    kOnnxDomain);
+
+    const std::string mul_half_out_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_mul_half_out", "mul_half_out",
+                                  input_qparams.scale, input_qparams.zero_point);
+
+    builder.AddNode("Mul_out",
+                    "Mul",
+                    {add_out_qdq, mul_half_out_qdq},
+                    {"Y"},
+                    kOnnxDomain);
+
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "Y",
+                                                     output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+}
+
+TEST_F(QnnHTPBackendTests, GeluFusionPattern_QDQ_InternalQDQ_ShouldNotFuse) {
+  const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern_QDQ_InternalQDQ";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
+
+  // This pattern has internal QDQ nodes around Erf, so fusion should be rejected.
+  // Expected: Individual nodes are assigned to QNN EP, but NOT fused as a GELU.
+  TestQDQModelAccuracy(BuildGeluPattern1TestCase(input_def, false),
+                       BuildQDQGeluPatternWithInternalQDQ<uint8_t>(input_def),
+                       provider_options,
+                       /*opset_version=*/13,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some);
+
+  // Verify that NO fused GELU op was created (count = 0)
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu", 0);
+}
+
+// Negative test: GELU Pattern with incorrect skip connection topology should NOT fuse
+// Helper function to build QDQ GELU Pattern with wrong skip connection
+template <typename QuantType>
+GetTestQDQModelFn<QuantType> BuildQDQGeluPatternWithWrongSkipConnection(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder,
+                     std::vector<QuantParams<QuantType>>& output_qparams) -> void {
+    constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float half = 0.5f;
+    constexpr float one = 1.0f;
+
+    builder.graph_->set_name("qdq_gelu_wrong_skip_graph");
+
+    // input
+    MakeTestInput(builder, "input", input_def);
+    const QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
+    const std::string input_qdq =
+        AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
+
+    // Constants: float initializers
+    builder.MakeScalarInitializer<float>("one", one);
+    builder.MakeScalarInitializer<float>("half", half);
+    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+
+    // GELU-like Pattern 1 BUT with wrong skip connection:
+    // Instead of using input for skip, we use a different tensor (div_out)
+    builder.AddNode("Div_sqrt2",
+                    "Div",
+                    {input_qdq, "sqrt2"},
+                    {"div_out"},
+                    kOnnxDomain);
+
+    builder.AddNode("Erf",
+                    "Erf",
+                    {"div_out"},
+                    {"erf_out"},
+                    kOnnxDomain);
+
+    builder.AddNode("Add_one",
+                    "Add",
+                    {"erf_out", "one"},
+                    {"add_out"},
+                    kOnnxDomain);
+
+    // WRONG: Using div_out instead of input for the skip connection
+    builder.AddNode("Mul_wrong_skip",
+                    "Mul",
+                    {"div_out", "half"},  // Should be input_qdq, not div_out
+                    {"mul_half_out"},
+                    kOnnxDomain);
+
+    builder.AddNode("Mul_out",
+                    "Mul",
+                    {"add_out", "mul_half_out"},
+                    {"Y"},
+                    kOnnxDomain);
+
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "Y",
+                                                     output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+}
+
+TEST_F(QnnHTPBackendTests, GeluFusionPattern_QDQ_WrongSkipConnection_ShouldNotFuse) {
+  const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern_QDQ_WrongSkip";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
+
+  // This pattern has correct QDQ placement but wrong skip connection topology.
+  // The skip connection uses div_out instead of the original input.
+  // Expected: Individual nodes are assigned to QNN EP, but NOT fused as a GELU.
+  TestQDQModelAccuracy(BuildGeluPattern1TestCase(input_def, false),
+                       BuildQDQGeluPatternWithWrongSkipConnection<uint8_t>(input_def),
+                       provider_options,
+                       /*opset_version=*/13,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some);
+
+  // Verify that NO fused GELU op was created (count = 0)
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu", 0);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -747,6 +747,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_2D) {
 
 // Test GELU Pattern 1 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -778,6 +779,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
 
 // Test GELU Pattern 2 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern2_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -809,6 +811,7 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
 
 // Test GELU Pattern 3 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -918,6 +921,7 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPatternWithInternalQDQ(const TestInputD
 }
 
 TEST_F(QnnHTPBackendTests, GeluFusionPattern_QDQ_InternalQDQ_ShouldNotFuse) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern_QDQ_InternalQDQ";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -1002,6 +1006,7 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPatternWithWrongSkipConnection(const Te
 }
 
 TEST_F(QnnHTPBackendTests, GeluFusionPattern_QDQ_WrongSkipConnection_ShouldNotFuse) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern_QDQ_WrongSkip";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -19,20 +19,21 @@ namespace test {
 
 namespace {
 
-// Helper function to build GELU Pattern 1: root -> Mul -> Div -> Erf -> Add -> Mul
+// Helper function to build GELU Pattern 1: root -> Mul -> Div/Mul -> Erf -> Add -> Mul
 // Pattern 1:
 //                   +-------Mul(0.5)---------------------+
 //                   |                                    |
 //                   |                                    v
-//                [root] --> Div -----> Erf  --> Add --> Mul ==>
-//                          (B=1.4142...)        (1)
-GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder) -> void {
+//                [root] --> Div/Mul -----> Erf  --> Add --> Mul ==>
+//                          (1.4142... or 1/1.4142...)   (1)
+GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def, bool use_mul = false) {
+  return [input_def, use_mul](ModelTestBuilder& builder) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float inv_sqrt_2 = 0.7071067690849304f;  // 1 / sqrt(2)
     constexpr float half = 0.5f;
     constexpr float one = 1.0f;
 
-    builder.graph_->set_name("gelu_pattern1_graph");
+    builder.graph_->set_name(use_mul ? "gelu_pattern1_mul_graph" : "gelu_pattern1_graph");
 
     // input
     MakeTestInput<float>(builder, "input", input_def);
@@ -45,18 +46,27 @@ GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def) {
                     {"mul_half_out"},
                     kOnnxDomain);
 
-    // input -> Div(sqrt2) -> div_out
-    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-    builder.AddNode("Div_sqrt2",
-                    "Div",
-                    {"input", "sqrt2"},
-                    {"div_out"},
-                    kOnnxDomain);
+    // input -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
+    if (use_mul) {
+      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
+      builder.AddNode("Mul_inv_sqrt2",
+                      "Mul",
+                      {"input", "inv_sqrt2"},
+                      {"norm_out"},
+                      kOnnxDomain);
+    } else {
+      builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+      builder.AddNode("Div_sqrt2",
+                      "Div",
+                      {"input", "sqrt2"},
+                      {"norm_out"},
+                      kOnnxDomain);
+    }
 
-    // div_out -> Erf -> erf_out
+    // norm_out -> Erf -> erf_out
     builder.AddNode("Erf",
                     "Erf",
-                    {"div_out"},
+                    {"norm_out"},
                     {"erf_out"},
                     kOnnxDomain);
 
@@ -84,31 +94,41 @@ GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def) {
 //                   +------------------------------------+
 //                   |                                    |
 //                   |                                    v
-//                [root] --> Div -----> Erf  --> Add --> Mul -->Mul ==>
-//                          (B=1.4142...)        (1)            (0.5)
-GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder) -> void {
+//                [root] --> Div/Mul -----> Erf  --> Add --> Mul -->Mul ==>
+//                          (1.4142... or 1/1.4142...)   (1)            (0.5)
+GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def, bool use_mul = false) {
+  return [input_def, use_mul](ModelTestBuilder& builder) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float inv_sqrt_2 = 0.7071067690849304f;  // 1 / sqrt(2)
     constexpr float half = 0.5f;
     constexpr float one = 1.0f;
 
-    builder.graph_->set_name("gelu_pattern2_graph");
+    builder.graph_->set_name(use_mul ? "gelu_pattern2_mul_graph" : "gelu_pattern2_graph");
 
     // input
     MakeTestInput<float>(builder, "input", input_def);
 
-    // input -> Div(sqrt2) -> div_out
-    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-    builder.AddNode("Div_sqrt2",
-                    "Div",
-                    {"input", "sqrt2"},
-                    {"div_out"},
-                    kOnnxDomain);
+    // input -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
+    if (use_mul) {
+      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
+      builder.AddNode("Mul_inv_sqrt2",
+                      "Mul",
+                      {"input", "inv_sqrt2"},
+                      {"norm_out"},
+                      kOnnxDomain);
+    } else {
+      builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+      builder.AddNode("Div_sqrt2",
+                      "Div",
+                      {"input", "sqrt2"},
+                      {"norm_out"},
+                      kOnnxDomain);
+    }
 
-    // div_out -> Erf -> erf_out
+    // norm_out -> Erf -> erf_out
     builder.AddNode("Erf",
                     "Erf",
-                    {"div_out"},
+                    {"norm_out"},
                     {"erf_out"},
                     kOnnxDomain);
 
@@ -144,30 +164,40 @@ GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def) {
 //                   +-------------------------------------------+
 //                   |                                           |
 //                   |                                           v
-//                [root] --> Div -----> Erf --> Mul --> Add --> Mul ==>
-//                          (B=1.4142...)      (0.5)   (0.5)
-GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder) -> void {
+//                [root] --> Div/Mul -----> Erf --> Mul --> Add --> Mul ==>
+//                          (1.4142... or 1/1.4142...)  (0.5)   (0.5)
+GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def, bool use_mul = false) {
+  return [input_def, use_mul](ModelTestBuilder& builder) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float inv_sqrt_2 = 0.7071067690849304f;  // 1 / sqrt(2)
     constexpr float half = 0.5f;
 
-    builder.graph_->set_name("gelu_pattern3_graph");
+    builder.graph_->set_name(use_mul ? "gelu_pattern3_mul_graph" : "gelu_pattern3_graph");
 
     // input
     MakeTestInput<float>(builder, "input", input_def);
 
-    // input -> Div(sqrt2) -> div_out
-    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
-    builder.AddNode("Div_sqrt2",
-                    "Div",
-                    {"input", "sqrt2"},
-                    {"div_out"},
-                    kOnnxDomain);
+    // input -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
+    if (use_mul) {
+      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
+      builder.AddNode("Mul_inv_sqrt2",
+                      "Mul",
+                      {"input", "inv_sqrt2"},
+                      {"norm_out"},
+                      kOnnxDomain);
+    } else {
+      builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+      builder.AddNode("Div_sqrt2",
+                      "Div",
+                      {"input", "sqrt2"},
+                      {"norm_out"},
+                      kOnnxDomain);
+    }
 
-    // div_out -> Erf -> erf_out
+    // norm_out -> Erf -> erf_out
     builder.AddNode("Erf",
                     "Erf",
-                    {"div_out"},
+                    {"norm_out"},
                     {"erf_out"},
                     kOnnxDomain);
 
@@ -453,6 +483,8 @@ ProviderOptions GetProviderOptions() {
 // Test GELU Pattern 1 with float32 model (for baseline comparison)
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_Float32) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_Float32";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -461,9 +493,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_Float32) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
 
-  RunQnnModelTest(BuildGeluPattern1TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern1TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern1TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -475,6 +516,8 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_Float32) {
 // Test GELU Pattern 2 with float32 model (for baseline comparison)
 TEST_F(QnnHTPBackendTests, GeluFusionPattern2_Float32) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern2_Float32";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -483,9 +526,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_Float32) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
 
-  RunQnnModelTest(BuildGeluPattern2TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern2TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern2TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -497,6 +549,8 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_Float32) {
 // Test GELU Pattern 3 (ErfMul Pattern) with float32 model
 TEST_F(QnnHTPBackendTests, GeluFusionPattern3_Float32) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_Float32";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -505,9 +559,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern3_Float32) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
 
-  RunQnnModelTest(BuildGeluPattern3TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern3TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern3TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -563,6 +626,10 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_LargeInput) {
 // Test GELU Pattern 1 with 3D input
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+// Test GELU Pattern 1 with 3D input
+TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
+  auto input_def = TestInputDef<float>({1, 16, 32}, false, -1.0f, 1.0f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_3D";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -571,9 +638,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 16, 32}, false, -1.0f, 1.0f);
 
-  RunQnnModelTest(BuildGeluPattern1TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern1TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern1TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -585,6 +661,8 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
 // Test GELU Pattern 2 with 3D input
 TEST_F(QnnHTPBackendTests, GeluFusionPattern2_3D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 16, 32}, false, -1.0f, 1.0f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern2_3D";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -593,9 +671,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_3D) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({1, 16, 32}, false, -1.0f, 1.0f);
 
-  RunQnnModelTest(BuildGeluPattern2TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern2TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern2TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -607,6 +694,8 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_3D) {
 // Test GELU Pattern 1 with 2D input (typical for linear layers)
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_2D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({32, 512}, false, -1.5f, 1.5f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_2D";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -615,9 +704,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_2D) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({32, 512}, false, -1.5f, 1.5f);
 
-  RunQnnModelTest(BuildGeluPattern1TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern1TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern1TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -629,6 +727,8 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_2D) {
 // Test GELU Pattern 2 with 2D input (typical for linear layers)
 TEST_F(QnnHTPBackendTests, GeluFusionPattern2_2D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({32, 512}, false, -1.5f, 1.5f);
+
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern2_2D";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -637,9 +737,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_2D) {
   ProviderOptions provider_options = GetProviderOptions();
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-  auto input_def = TestInputDef<float>({32, 512}, false, -1.5f, 1.5f);
 
-  RunQnnModelTest(BuildGeluPattern2TestCase(input_def),
+  // Test with Div
+  RunQnnModelTest(BuildGeluPattern2TestCase(input_def, false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  // Test with Mul (Div replaced by Mul)
+  RunQnnModelTest(BuildGeluPattern2TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -19,13 +19,18 @@ namespace test {
 
 namespace {
 
+void ResetQnnGraphDir(const std::filesystem::path& json_qnn_graph_dir) {
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+}
+
 // Helper function to build GELU Pattern 1: root -> Mul -> Div/Mul -> Erf -> Add -> Mul
 // Pattern 1:
 //                   +-------Mul(0.5)---------------------+
 //                   |                                    |
 //                   |                                    v
 //                [root] --> Div/Mul -----> Erf  --> Add --> Mul ==>
-//                          (1.4142... or 1/1.4142...)   (1)
+//                      (1.4142... or 1/1.4142...)   (1)
 GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def, bool use_mul = false) {
   return [input_def, use_mul](ModelTestBuilder& builder) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
@@ -38,7 +43,7 @@ GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def, b
     // input
     MakeTestInput<float>(builder, "input", input_def);
 
-    // input -> Mul(0.5) -> mul_half_out
+    // root -> Mul(0.5) -> mul_half_out
     builder.MakeScalarInitializer<float>("half", half);
     builder.AddNode("Mul_half",
                     "Mul",
@@ -46,7 +51,7 @@ GetTestModelFn BuildGeluPattern1TestCase(const TestInputDef<float>& input_def, b
                     {"mul_half_out"},
                     kOnnxDomain);
 
-    // input -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
+    // root -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
     if (use_mul) {
       builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
       builder.AddNode("Mul_inv_sqrt2",
@@ -108,7 +113,7 @@ GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def, b
     // input
     MakeTestInput<float>(builder, "input", input_def);
 
-    // input -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
+    // root -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
     if (use_mul) {
       builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
       builder.AddNode("Mul_inv_sqrt2",
@@ -140,7 +145,7 @@ GetTestModelFn BuildGeluPattern2TestCase(const TestInputDef<float>& input_def, b
                     {"add_out"},
                     kOnnxDomain);
 
-    // input * add_out -> mul_out
+    // root * add_out -> mul_out
     builder.AddNode("Mul_input",
                     "Mul",
                     {"input", "add_out"},
@@ -177,7 +182,7 @@ GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def, b
     // input
     MakeTestInput<float>(builder, "input", input_def);
 
-    // input -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
+    // root -> Div(sqrt2) or Mul(1/sqrt2) -> norm_out
     if (use_mul) {
       builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
       builder.AddNode("Mul_inv_sqrt2",
@@ -217,7 +222,7 @@ GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def, b
                     {"add_out"},
                     kOnnxDomain);
 
-    // input * add_out -> output
+    // root * add_out -> output
     builder.AddNode("Mul_out",
                     "Mul",
                     {"input", "add_out"},
@@ -230,13 +235,16 @@ GetTestModelFn BuildGeluPattern3TestCase(const TestInputDef<float>& input_def, b
 
 // Helper function to build QDQ GELU Pattern 1
 template <typename QuantType>
-GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) -> void {
+GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<float>& input_def,
+                                                          bool use_mul = false) {
+  return [input_def, use_mul](ModelTestBuilder& builder,
+                              std::vector<QuantParams<QuantType>>& output_qparams) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float inv_sqrt_2 = 0.7071067690849304f;
     constexpr float half = 0.5f;
     constexpr float one = 1.0f;
 
-    builder.graph_->set_name("qdq_gelu_pattern1_graph");
+    builder.graph_->set_name(use_mul ? "qdq_gelu_pattern1_mul_graph" : "qdq_gelu_pattern1_graph");
 
     // input
     MakeTestInput(builder, "input", input_def);
@@ -245,29 +253,40 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<flo
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
     // Constants: add explicit QDQ after each initializer (to match expected QDQ patterns).
-    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
     builder.MakeScalarInitializer<float>("one", one);
     builder.MakeScalarInitializer<float>("half", half);
-
-    const std::string sqrt2_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
     const std::string one_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
     const std::string half_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
 
     // GELU Pattern 1:
-    // input -> Div(sqrt2) -> Erf -> Add(one) -> Mul(with (input * half))
-    builder.AddNode("Div_sqrt2",
-                    "Div",
-                    {input_qdq, sqrt2_qdq},
-                    {"div_out"},
-                    kOnnxDomain);
+    // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Add(one) -> Mul(with (input * half))
+    std::string norm_out = "div_out";
+    if (use_mul) {
+      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
+      const std::string inv_sqrt2_qdq =
+          AddQDQNodePair<QuantType>(builder, "qdq_inv_sqrt2", "inv_sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.AddNode("Mul_inv_sqrt2",
+                      "Mul",
+                      {input_qdq, inv_sqrt2_qdq},
+                      {norm_out},
+                      kOnnxDomain);
+    } else {
+      builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+      const std::string sqrt2_qdq =
+          AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.AddNode("Div_sqrt2",
+                      "Div",
+                      {input_qdq, sqrt2_qdq},
+                      {norm_out},
+                      kOnnxDomain);
+    }
 
     // Add explicit QDQ around Erf to match expected QDQ patterns:
-    // div_out -> Q -> DQ -> erf_in
+    // norm_out -> Q -> DQ -> erf_in
     const std::string erf_in_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", "div_out", input_qparams.scale, input_qparams.zero_point);
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", norm_out, input_qparams.scale, input_qparams.zero_point);
 
     // erf_in -> Erf -> erf_out
     builder.AddNode("Erf",
@@ -312,13 +331,16 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern1TestCase(const TestInputDef<flo
 
 // Helper function to build QDQ GELU Pattern 2
 template <typename QuantType>
-GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) -> void {
+GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<float>& input_def,
+                                                          bool use_mul = false) {
+  return [input_def, use_mul](ModelTestBuilder& builder,
+                              std::vector<QuantParams<QuantType>>& output_qparams) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float inv_sqrt_2 = 0.7071067690849304f;
     constexpr float half = 0.5f;
     constexpr float one = 1.0f;
 
-    builder.graph_->set_name("qdq_gelu_pattern2_graph");
+    builder.graph_->set_name(use_mul ? "qdq_gelu_pattern2_mul_graph" : "qdq_gelu_pattern2_graph");
 
     // input
     MakeTestInput(builder, "input", input_def);
@@ -327,29 +349,40 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<flo
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
     // Constants: add explicit QDQ after each initializer (to match expected QDQ patterns).
-    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
     builder.MakeScalarInitializer<float>("one", one);
     builder.MakeScalarInitializer<float>("half", half);
-
-    const std::string sqrt2_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
     const std::string one_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_one", "one", input_qparams.scale, input_qparams.zero_point);
     const std::string half_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
 
     // GELU Pattern 2:
-    // input -> Div(sqrt2) -> Erf -> Add(one) -> Mul(with input) -> Mul(half)
-    builder.AddNode("Div_sqrt2",
-                    "Div",
-                    {input_qdq, sqrt2_qdq},
-                    {"div_out"},
-                    kOnnxDomain);
+    // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Add(one) -> Mul(with input) -> Mul(half)
+    std::string norm_out = "div_out";
+    if (use_mul) {
+      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
+      const std::string inv_sqrt2_qdq =
+          AddQDQNodePair<QuantType>(builder, "qdq_inv_sqrt2", "inv_sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.AddNode("Mul_inv_sqrt2",
+                      "Mul",
+                      {input_qdq, inv_sqrt2_qdq},
+                      {norm_out},
+                      kOnnxDomain);
+    } else {
+      builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+      const std::string sqrt2_qdq =
+          AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.AddNode("Div_sqrt2",
+                      "Div",
+                      {input_qdq, sqrt2_qdq},
+                      {norm_out},
+                      kOnnxDomain);
+    }
 
     // Add explicit QDQ around Erf to match expected QDQ patterns:
-    // div_out -> Q -> DQ -> erf_in
+    // norm_out -> Q -> DQ -> erf_in
     const std::string erf_in_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", "div_out", input_qparams.scale, input_qparams.zero_point);
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", norm_out, input_qparams.scale, input_qparams.zero_point);
 
     // erf_in -> Erf -> erf_out
     builder.AddNode("Erf",
@@ -395,12 +428,15 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern2TestCase(const TestInputDef<flo
 
 // Helper function to build QDQ GELU Pattern 3 (ErfMul Pattern)
 template <typename QuantType>
-GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<float>& input_def) {
-  return [input_def](ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) -> void {
+GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<float>& input_def,
+                                                          bool use_mul = false) {
+  return [input_def, use_mul](ModelTestBuilder& builder,
+                              std::vector<QuantParams<QuantType>>& output_qparams) -> void {
     constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float inv_sqrt_2 = 0.7071067690849304f;
     constexpr float half = 0.5f;
 
-    builder.graph_->set_name("qdq_gelu_pattern3_graph");
+    builder.graph_->set_name(use_mul ? "qdq_gelu_pattern3_mul_graph" : "qdq_gelu_pattern3_graph");
 
     // input
     MakeTestInput(builder, "input", input_def);
@@ -408,26 +444,37 @@ GetTestQDQModelFn<QuantType> BuildQDQGeluPattern3TestCase(const TestInputDef<flo
     const std::string input_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
 
-    builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
     builder.MakeScalarInitializer<float>("half", half);
     builder.MakeScalarInitializer<float>("half2", half);
-
-    const std::string sqrt2_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
     const std::string half_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_half", "half", input_qparams.scale, input_qparams.zero_point);
     const std::string half2_qdq =
         AddQDQNodePair<QuantType>(builder, "qdq_half2", "half2", input_qparams.scale, input_qparams.zero_point);
 
-    // input -> Div(sqrt2) -> Erf -> Mul(0.5) -> Add(0.5)
-    builder.AddNode("Div_sqrt2",
-                    "Div",
-                    {input_qdq, sqrt2_qdq},
-                    {"div_out"},
-                    kOnnxDomain);
+    // input -> Div/Mul(sqrt2 or 1/sqrt2) -> Erf -> Mul(0.5) -> Add(0.5)
+    std::string norm_out = "div_out";
+    if (use_mul) {
+      builder.MakeScalarInitializer<float>("inv_sqrt2", inv_sqrt_2);
+      const std::string inv_sqrt2_qdq =
+          AddQDQNodePair<QuantType>(builder, "qdq_inv_sqrt2", "inv_sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.AddNode("Mul_inv_sqrt2",
+                      "Mul",
+                      {input_qdq, inv_sqrt2_qdq},
+                      {norm_out},
+                      kOnnxDomain);
+    } else {
+      builder.MakeScalarInitializer<float>("sqrt2", sqrt_2);
+      const std::string sqrt2_qdq =
+          AddQDQNodePair<QuantType>(builder, "qdq_sqrt2", "sqrt2", input_qparams.scale, input_qparams.zero_point);
+      builder.AddNode("Div_sqrt2",
+                      "Div",
+                      {input_qdq, sqrt2_qdq},
+                      {norm_out},
+                      kOnnxDomain);
+    }
 
     const std::string erf_in_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", "div_out", input_qparams.scale, input_qparams.zero_point);
+        AddQDQNodePair<QuantType>(builder, "qdq_erf_in", norm_out, input_qparams.scale, input_qparams.zero_point);
 
     builder.AddNode("Erf",
                     "Erf",
@@ -499,16 +546,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_Float32) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern1TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -532,16 +580,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_Float32) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern2TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -565,16 +614,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern3_Float32) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern3TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -644,16 +694,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern1TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -677,16 +728,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_3D) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern2TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/1e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -710,16 +762,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_2D) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/2e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern1TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/2e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -743,16 +796,17 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_2D) {
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/2e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 
   // Test with Mul (Div replaced by Mul)
+  ResetQnnGraphDir(json_qnn_graph_dir);
   RunQnnModelTest(BuildGeluPattern2TestCase(input_def, true),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/2e-3f);
+                  /*fp32_abs_err=*/6e-3f);
 
   AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
 }
@@ -770,8 +824,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
 
-  TestQDQModelAccuracy(BuildGeluPattern1TestCase(input_def),
-                       BuildQDQGeluPattern1TestCase<uint8_t>(input_def),
+  TestQDQModelAccuracy(BuildGeluPattern1TestCase(input_def, false),
+                       BuildQDQGeluPattern1TestCase<uint8_t>(input_def, false),
+                       provider_options,
+                       /*opset_version=*/13,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  ResetQnnGraphDir(json_qnn_graph_dir);
+
+  TestQDQModelAccuracy(BuildGeluPattern1TestCase(input_def, true),
+                       BuildQDQGeluPattern1TestCase<uint8_t>(input_def, true),
                        provider_options,
                        /*opset_version=*/13,
                        /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
@@ -792,8 +856,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
 
-  TestQDQModelAccuracy(BuildGeluPattern2TestCase(input_def),
-                       BuildQDQGeluPattern2TestCase<uint8_t>(input_def),
+  TestQDQModelAccuracy(BuildGeluPattern2TestCase(input_def, false),
+                       BuildQDQGeluPattern2TestCase<uint8_t>(input_def, false),
+                       provider_options,
+                       /*opset_version=*/13,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  ResetQnnGraphDir(json_qnn_graph_dir);
+
+  TestQDQModelAccuracy(BuildGeluPattern2TestCase(input_def, true),
+                       BuildQDQGeluPattern2TestCase<uint8_t>(input_def, true),
                        provider_options,
                        /*opset_version=*/13,
                        /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
@@ -814,8 +888,18 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -10.0f, 10.0f);
 
-  TestQDQModelAccuracy(BuildGeluPattern3TestCase(input_def),
-                       BuildQDQGeluPattern3TestCase<uint8_t>(input_def),
+  TestQDQModelAccuracy(BuildGeluPattern3TestCase(input_def, false),
+                       BuildQDQGeluPattern3TestCase<uint8_t>(input_def, false),
+                       provider_options,
+                       /*opset_version=*/13,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+
+  ResetQnnGraphDir(json_qnn_graph_dir);
+
+  TestQDQModelAccuracy(BuildGeluPattern3TestCase(input_def, true),
+                       BuildQDQGeluPattern3TestCase<uint8_t>(input_def, true),
                        provider_options,
                        /*opset_version=*/13,
                        /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);

--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -612,8 +612,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_LargeInput) {
 // Test GELU Pattern 1 with 3D input
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-// Test GELU Pattern 1 with 3D input
-TEST_F(QnnHTPBackendTests, GeluFusionPattern1_3D) {
   auto input_def = TestInputDef<float>({1, 16, 32}, false, -1.0f, 1.0f);
 
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_3D";
@@ -749,7 +747,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_2D) {
 
 // Test GELU Pattern 1 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -783,7 +780,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
 TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern2_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
   auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
 
@@ -813,7 +809,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
 
 // Test GELU Pattern 3 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));


### PR DESCRIPTION
### Description
- Add `Div`/`Mul` support as parent to `Erf` as some optimizer replaces Div with Mul.
- Canonicalize duplicated intermediate root tensor names done by ORT.
- Validate against outer quantized I/O when the pattern is wrapped by DQ/Q.
**- Reject pattern matching when there is intermediate QDQGroups**
- Extend tests to cover both float and QDQ `Div`/`Mul` GELU variants.

### Context
- Quantized GELU fusion could fail when `Div(sqrt(2))` before `Erf` is optimized into `Mul(1 / sqrt(2))`.
- ORT generates duplicate tensor for shared root parent QDQ nodes
- SingleNodeUnit for intermediate GELU QDQ nodes instead of QDQGroup causing QNN 3110 errors due to:
-- Mixed Precision,
-- Mismatch scales, etc.
- Intermediate QDQGroups in GELU pattern may have accuracy variation and should not be fused.

### Out of Scope
- Mixed precision support.
- General handling of all mixed or partially grouped quantized GELU topologies.
- actual model: https://github.com/qcom-ai-hub/tetracode/issues/18976, scales are different and Mixed precision Div and Mul nodes
<img width="604" height="619" alt="image" src="https://github.com/user-attachments/assets/762c4a7c-357c-4e74-a515-3b3071699ae8" />


