### PR TITLE
Fix typo in docker qairt_sdk variable

### DIFF
--- a/qcom/ep_build/tasks/docker.py
+++ b/qcom/ep_build/tasks/docker.py
@@ -116,7 +116,7 @@ class DockerBuildAndTestTask(DockerRunTask):
 
         if qairt_sdk_root is not None:
             volumes_with_caches[qairt_sdk_root] = Path("/ort_caches/qairt")
-            cmd.append("--qairt-sdk-root=/ort_caches/qairt")
+            cmd.append("--qairt-sdk=/ort_caches/qairt")
 
         if ccache_root is not None:
             volumes_with_caches[ccache_root] = Path("/ort_caches/ccache")


### PR DESCRIPTION
### Description
Argument for build_and_test.py is actually --qairt-sdk and not --qairt-sdk-root as was previously being used



### Motivation and Context
Resolves an issue where specifying QAIRT_SDK_ROOT and then attempting to build linux in docker container caused an issue


