### PR TITLE
Fixes issue ScatterND fallback to CPU due to negative concrete indices

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -101,7 +101,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateSimpleOpBuilder("Relu", *this);
   CreateSimpleOpBuilder("Round", *this);
   CreateSimpleOpBuilder("ScatterElements", *this);
-  CreateSimpleOpBuilder("ScatterND", *this);
+  CreateScatterNDOpBuilder("ScatterND", *this);
   CreateSimpleOpBuilder("Sigmoid", *this);
   CreateSimpleOpBuilder("Sign", *this);
   CreateSimpleOpBuilder("Sin", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -96,6 +96,7 @@ void CreateResizeOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateRMSNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateRoiAlignOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateRotaryEmbeddingOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateScatterNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSimpleOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSliceOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSoftmaxOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
@@ -1,0 +1,186 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gsl/gsl>
+
+#include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace utils {
+
+template <typename SrcType>
+bool NormalizeIndicesBytes(const std::vector<uint8_t>& onnx_bytes,
+                           const std::function<int64_t(size_t)>& axis_dim_for_element,
+                           std::vector<uint8_t>& qnn_bytes,
+                           bool& has_negative_indices) {
+  if (onnx_bytes.size() % sizeof(SrcType) != 0) {
+    return false;
+  }
+
+  const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
+  gsl::span<const SrcType> onnx_indices{reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
+
+  qnn_bytes.resize(num_elems * sizeof(int32_t));
+  gsl::span<int32_t> qnn_indices{reinterpret_cast<int32_t*>(qnn_bytes.data()), num_elems};
+
+  for (size_t i = 0; i < num_elems; i++) {
+    const int64_t axis_dim = axis_dim_for_element(i);
+    // int64 arithmetic prevents wraparound when int32 idx + axis_dim >= 2^31.
+    int64_t idx = static_cast<int64_t>(onnx_indices[i]);
+
+    if (idx < 0) {
+      has_negative_indices = true;
+      idx += axis_dim;
+    }
+
+    if (idx < 0 || idx >= axis_dim ||
+        idx > static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
+      return false;
+    }
+
+    qnn_indices[i] = static_cast<int32_t>(idx);
+  }
+
+  return true;
+}
+
+template bool NormalizeIndicesBytes<int32_t>(
+    const std::vector<uint8_t>&, const std::function<int64_t(size_t)>&,
+    std::vector<uint8_t>&, bool&);
+template bool NormalizeIndicesBytes<int64_t>(
+    const std::vector<uint8_t>&, const std::function<int64_t(size_t)>&,
+    std::vector<uint8_t>&, bool&);
+
+namespace {
+
+// Registers the indices tensor and, for dynamic int64 inputs, inserts a
+// runtime Cast(INT_32).
+Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
+                                       TensorInfo indices_info,
+                                       const std::string& indices_tensor_name,
+                                       std::vector<uint8_t>&& qnn_indices_bytes,
+                                       const Ort::Logger& logger,
+                                       std::vector<std::string>& input_names,
+                                       bool do_op_validation) {
+  std::vector<uint32_t> cast_output_shape(indices_info.shape);
+
+  if (!qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name)) {
+    const Qnn_TensorType_t tensor_type = indices_info.is_initializer
+                                             ? QNN_TENSOR_TYPE_STATIC
+                                             : qnn_model_wrapper.GetTensorType(indices_tensor_name);
+    QnnTensorWrapper input_tensorwrapper(indices_tensor_name,
+                                         tensor_type,
+                                         indices_info.qnn_data_type, QnnQuantParamsWrapper(),
+                                         std::move(indices_info.shape),
+                                         std::move(qnn_indices_bytes));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)),
+                  "Failed to add tensor.");
+  } else {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("Tensor already added, skip it: " + indices_tensor_name).c_str());
+  }
+
+  auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name);
+  std::string indices_casted_name = indices_tensor_name;
+  if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
+    // Initializers are converted to INT_32 before registration, so INT_64 here
+    // implies a dynamic input.
+    RETURN_IF_NOT(!indices_info.is_initializer,
+                  "Internal error: static indices tensor registered with INT_64 dtype.");
+    indices_casted_name += "_int32";
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(
+        UniqueNameGenerator().New(indices_tensor_name, QNN_OP_CAST),
+        indices_tensor_name,
+        indices_casted_name,
+        QNN_TENSOR_TYPE_NATIVE,
+        QNN_DATATYPE_INT_32,
+        QnnQuantParamsWrapper(),
+        std::move(cast_output_shape),
+        do_op_validation));
+  }
+  input_names.push_back(indices_casted_name);
+  return Ort::Status();
+}
+
+}  // namespace
+
+Ort::Status NormalizeIndicesForScatterND(QnnModelWrapper& qnn_model_wrapper,
+                                         const OrtNodeUnitIODef& indices_input,
+                                         const std::vector<uint32_t>& data_shape,
+                                         const Ort::Logger& logger,
+                                         std::vector<std::string>& input_names,
+                                         bool do_op_validation) {
+  std::string indices_tensor_name = indices_input.name;
+
+  TensorInfo indices_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
+
+  RETURN_IF_NOT(!indices_info.shape.empty(),
+                "ScatterND-style indices tensor must have rank >= 1.");
+  const uint32_t k = indices_info.shape.back();
+  RETURN_IF_NOT(k > 0 && static_cast<size_t>(k) <= data_shape.size(),
+                "ScatterND-style indices last-dim must be in (0, rank(data)].");
+
+  std::vector<uint8_t> qnn_indices_bytes;
+  bool has_negative_indices = false;
+  bool rewrote_bytes = false;
+
+  const auto axis_dim_for_element = [k, &data_shape](size_t element_index) -> int64_t {
+    const size_t col = element_index % static_cast<size_t>(k);
+    return static_cast<int64_t>(data_shape[col]);
+  };
+
+  if (indices_info.is_initializer) {
+    std::vector<uint8_t> onnx_indices_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor,
+                                                            onnx_indices_bytes));
+
+    if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
+      RETURN_IF_NOT((NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
+                                                    qnn_indices_bytes, has_negative_indices)),
+                    "QNN does not support negative or out-of-range index values for ScatterND-style ops");
+      indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
+      rewrote_bytes = true;
+    } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
+      RETURN_IF_NOT((NormalizeIndicesBytes<int32_t>(onnx_indices_bytes, axis_dim_for_element,
+                                                    qnn_indices_bytes, has_negative_indices)),
+                    "QNN does not support negative or out-of-range index values for ScatterND-style ops");
+      rewrote_bytes = has_negative_indices;
+      if (!rewrote_bytes) {
+        qnn_indices_bytes = std::move(onnx_indices_bytes);
+      }
+    } else {
+      qnn_indices_bytes = std::move(onnx_indices_bytes);
+    }
+  }
+
+  // When we rewrite the bytes, rename so a sibling op consuming the same ONNX
+  // initializer under a different axis bound cannot alias our copy.
+  if (indices_info.is_initializer && rewrote_bytes) {
+    indices_tensor_name = UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
+    RETURN_IF(qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name),
+              ("Rewritten ScatterND indices name collided with existing tensor: " +
+               indices_tensor_name)
+                  .c_str());
+  }
+
+  return AddNormalizedIndicesTensor(qnn_model_wrapper, std::move(indices_info), indices_tensor_name,
+                                    std::move(qnn_indices_bytes), logger, input_names, do_op_validation);
+}
+
+}  // namespace utils
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
@@ -24,12 +24,7 @@ namespace utils {
 template <typename SrcType>
 bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
-                           std::vector<uint8_t>& qnn_bytes,
-                           bool& has_negative_indices) {
-  if (onnx_bytes.size() % sizeof(SrcType) != 0) {
-    return false;
-  }
-
+                           std::vector<uint8_t>& qnn_bytes) {
   const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
   const auto onnx_indices = gsl::span<const SrcType>{
       reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
@@ -42,29 +37,24 @@ bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
     const int64_t axis_dim = axis_dim_for_element(i);
     // int64 prevents wraparound on int32 idx + axis_dim >= 2^31.
     int64_t idx = static_cast<int64_t>(onnx_indices[i]);
-
     if (idx < 0) {
-      has_negative_indices = true;
       idx += axis_dim;
     }
-
+    // ORT core validates shapes/dtypes; value-range is the actual safeguard
+    // because ONNX allows out-of-range ints to ship in user models.
     if (idx < 0 || idx >= axis_dim ||
         idx > static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
       return false;
     }
-
     qnn_indices[i] = static_cast<int32_t>(idx);
   }
 
   return true;
 }
 
-template bool NormalizeIndicesBytes<int32_t>(
-    gsl::span<const uint8_t>, const std::function<int64_t(size_t)>&,
-    std::vector<uint8_t>&, bool&);
 template bool NormalizeIndicesBytes<int64_t>(
     gsl::span<const uint8_t>, const std::function<int64_t(size_t)>&,
-    std::vector<uint8_t>&, bool&);
+    std::vector<uint8_t>&);
 
 namespace {
 
@@ -98,10 +88,9 @@ Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
 
   auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name);
   std::string indices_casted_name = indices_tensor_name;
+  // Initializers are rewritten to INT_32 before this point, so INT_64 here
+  // implies a dynamic input that needs a runtime Cast.
   if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
-    // Initializers are INT_32 by this point, so INT_64 means dynamic input.
-    RETURN_IF_NOT(!indices_info.is_initializer,
-                  "Internal error: static indices tensor registered with INT_64 dtype.");
     indices_casted_name += "_int32";
     RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(
         UniqueNameGenerator().New(indices_tensor_name, QNN_OP_CAST),
@@ -130,53 +119,29 @@ Ort::Status NormalizeIndicesForScatterND(QnnModelWrapper& qnn_model_wrapper,
   TensorInfo indices_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
 
-  RETURN_IF_NOT(!indices_info.shape.empty(),
-                "ScatterND-style indices tensor must have rank >= 1.");
-  const uint32_t k = indices_info.shape.back();
-  RETURN_IF_NOT(k > 0 && static_cast<size_t>(k) <= data_shape.size(),
-                "ScatterND-style indices last-dim must be in (0, rank(data)].");
+  // ORT core validates ONNX schema (rank>=1, last-dim <= rank(data), int64 dtype).
+  const uint32_t index_tuple_size = indices_info.shape.back();
 
-  std::vector<uint8_t> qnn_indices_bytes;
-  bool has_negative_indices = false;
-  bool rewrote_bytes = false;
-
-  const auto axis_dim_for_element = [k, &data_shape](size_t element_index) -> int64_t {
-    const size_t col = element_index % static_cast<size_t>(k);
+  const auto axis_dim_for_element = [index_tuple_size, &data_shape](size_t element_index) -> int64_t {
+    const size_t col = element_index % static_cast<size_t>(index_tuple_size);
     return static_cast<int64_t>(data_shape[col]);
   };
+
+  std::vector<uint8_t> qnn_indices_bytes;
 
   if (indices_info.is_initializer) {
     std::vector<uint8_t> onnx_indices_bytes;
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor,
                                                             onnx_indices_bytes));
 
-    if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
-      RETURN_IF_NOT((NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
-                                                    qnn_indices_bytes, has_negative_indices)),
-                    kOutOfRangeMsg);
-      indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
-      rewrote_bytes = true;
-    } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
-      RETURN_IF_NOT((NormalizeIndicesBytes<int32_t>(onnx_indices_bytes, axis_dim_for_element,
-                                                    qnn_indices_bytes, has_negative_indices)),
-                    kOutOfRangeMsg);
-      rewrote_bytes = has_negative_indices;
-      if (!rewrote_bytes) {
-        qnn_indices_bytes = std::move(onnx_indices_bytes);
-      }
-    } else {
-      qnn_indices_bytes = std::move(onnx_indices_bytes);
-    }
-  }
+    RETURN_IF_NOT(NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
+                                                 qnn_indices_bytes),
+                  kOutOfRangeMsg);
+    indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
 
-  // Rename so a sibling op reusing the same ONNX initializer under a different
-  // axis bound cannot alias our rewritten copy.
-  if (indices_info.is_initializer && rewrote_bytes) {
+    // Rename so a sibling op reusing the same ONNX initializer under a different
+    // axis bound cannot alias our rewritten copy.
     indices_tensor_name = UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
-    RETURN_IF(qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name),
-              ("Rewritten ScatterND indices name collided with existing tensor: " +
-               indices_tensor_name)
-                  .c_str());
   }
 
   return AddNormalizedIndicesTensor(qnn_model_wrapper, std::move(indices_info), indices_tensor_name,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
@@ -40,7 +40,7 @@ bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
 
   for (size_t i = 0; i < num_elems; ++i) {
     const int64_t axis_dim = axis_dim_for_element(i);
-    // int64 arithmetic prevents wraparound when int32 idx + axis_dim >= 2^31.
+    // int64 prevents wraparound on int32 idx + axis_dim >= 2^31.
     int64_t idx = static_cast<int64_t>(onnx_indices[i]);
 
     if (idx < 0) {
@@ -71,8 +71,6 @@ namespace {
 constexpr const char* kOutOfRangeMsg =
     "QNN does not support negative or out-of-range index values for ScatterND-style ops";
 
-// Registers the indices tensor and, for dynamic int64 inputs, inserts a
-// runtime Cast(INT_32).
 Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
                                        TensorInfo indices_info,
                                        const std::string& indices_tensor_name,
@@ -101,8 +99,7 @@ Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
   auto& input_tensorwrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_tensor_name);
   std::string indices_casted_name = indices_tensor_name;
   if (input_tensorwrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
-    // Initializers are converted to INT_32 before registration, so INT_64 here
-    // implies a dynamic input.
+    // Initializers are INT_32 by this point, so INT_64 means dynamic input.
     RETURN_IF_NOT(!indices_info.is_initializer,
                   "Internal error: static indices tensor registered with INT_64 dtype.");
     indices_casted_name += "_int32";
@@ -172,8 +169,8 @@ Ort::Status NormalizeIndicesForScatterND(QnnModelWrapper& qnn_model_wrapper,
     }
   }
 
-  // When we rewrite the bytes, rename so a sibling op consuming the same ONNX
-  // initializer under a different axis bound cannot alias our copy.
+  // Rename so a sibling op reusing the same ONNX initializer under a different
+  // axis bound cannot alias our rewritten copy.
   if (indices_info.is_initializer && rewrote_bytes) {
     indices_tensor_name = UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
     RETURN_IF(qnn_model_wrapper.IsQnnTensorWrapperExist(indices_tensor_name),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
@@ -22,7 +22,7 @@ namespace qnn {
 namespace utils {
 
 template <typename SrcType>
-bool NormalizeIndicesBytes(const std::vector<uint8_t>& onnx_bytes,
+bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
                            std::vector<uint8_t>& qnn_bytes,
                            bool& has_negative_indices) {
@@ -31,12 +31,14 @@ bool NormalizeIndicesBytes(const std::vector<uint8_t>& onnx_bytes,
   }
 
   const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
-  gsl::span<const SrcType> onnx_indices{reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
+  const auto onnx_indices = gsl::span<const SrcType>{
+      reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
 
   qnn_bytes.resize(num_elems * sizeof(int32_t));
-  gsl::span<int32_t> qnn_indices{reinterpret_cast<int32_t*>(qnn_bytes.data()), num_elems};
+  const auto qnn_indices = gsl::span<int32_t>{
+      reinterpret_cast<int32_t*>(qnn_bytes.data()), num_elems};
 
-  for (size_t i = 0; i < num_elems; i++) {
+  for (size_t i = 0; i < num_elems; ++i) {
     const int64_t axis_dim = axis_dim_for_element(i);
     // int64 arithmetic prevents wraparound when int32 idx + axis_dim >= 2^31.
     int64_t idx = static_cast<int64_t>(onnx_indices[i]);
@@ -58,13 +60,16 @@ bool NormalizeIndicesBytes(const std::vector<uint8_t>& onnx_bytes,
 }
 
 template bool NormalizeIndicesBytes<int32_t>(
-    const std::vector<uint8_t>&, const std::function<int64_t(size_t)>&,
+    gsl::span<const uint8_t>, const std::function<int64_t(size_t)>&,
     std::vector<uint8_t>&, bool&);
 template bool NormalizeIndicesBytes<int64_t>(
-    const std::vector<uint8_t>&, const std::function<int64_t(size_t)>&,
+    gsl::span<const uint8_t>, const std::function<int64_t(size_t)>&,
     std::vector<uint8_t>&, bool&);
 
 namespace {
+
+constexpr const char* kOutOfRangeMsg =
+    "QNN does not support negative or out-of-range index values for ScatterND-style ops";
 
 // Registers the indices tensor and, for dynamic int64 inputs, inserts a
 // runtime Cast(INT_32).
@@ -151,13 +156,13 @@ Ort::Status NormalizeIndicesForScatterND(QnnModelWrapper& qnn_model_wrapper,
     if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
       RETURN_IF_NOT((NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
                                                     qnn_indices_bytes, has_negative_indices)),
-                    "QNN does not support negative or out-of-range index values for ScatterND-style ops");
+                    kOutOfRangeMsg);
       indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
       rewrote_bytes = true;
     } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
       RETURN_IF_NOT((NormalizeIndicesBytes<int32_t>(onnx_indices_bytes, axis_dim_for_element,
                                                     qnn_indices_bytes, has_negative_indices)),
-                    "QNN does not support negative or out-of-range index values for ScatterND-style ops");
+                    kOutOfRangeMsg);
       rewrote_bytes = has_negative_indices;
       if (!rewrote_bytes) {
         qnn_indices_bytes = std::move(onnx_indices_bytes);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
@@ -1,0 +1,47 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// Adapts ONNX Gather/Scatter indices to QNN's accepted form. ONNX allows
+// negative (count-from-end) INT_64 indices; QNN rejects both -- a single
+// negative static index otherwise silently drops the node to CPU.
+// Dynamic int64 indices get a runtime Cast(INT_32), but negative values at
+// runtime pass through uncorrected.
+namespace utils {
+
+// Rewrites raw index bytes as INT_32 so every value lands in [0, axis_dim).
+// Returns false if any index is out of range, or if `onnx_bytes.size()` is not
+// a multiple of `sizeof(SrcType)`. `axis_dim_for_element(i)` supplies the open
+// upper bound for element i so callers can encode per-op layout.
+template <typename SrcType>
+bool NormalizeIndicesBytes(const std::vector<uint8_t>& onnx_bytes,
+                           const std::function<int64_t(size_t)>& axis_dim_for_element,
+                           std::vector<uint8_t>& qnn_bytes,
+                           bool& has_negative_indices);
+
+// ScatterND-style: indices' last dim `k` is tuple depth; column c bounds
+// against `data_shape[c]`.
+Ort::Status NormalizeIndicesForScatterND(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnitIODef& indices_input,
+    const std::vector<uint32_t>& data_shape,
+    const Ort::Logger& logger,
+    std::vector<std::string>& input_names,
+    bool do_op_validation);
+
+}  // namespace utils
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
@@ -1,11 +1,10 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MIT
 
-// Adapts ONNX Gather/Scatter indices to QNN's accepted form. ONNX allows
-// negative (count-from-end) INT_64 indices; QNN rejects both -- a single
-// negative static index otherwise silently drops the node to CPU.
-// Dynamic int64 indices get a runtime Cast(INT_32), but negative values at
-// runtime pass through uncorrected.
+// ONNX Gather/Scatter allow negative and INT_64 indices; QNN rejects both.
+// A single negative static index otherwise silently drops the node to CPU.
+// Dynamic INT_64 indices get a runtime Cast; negative runtime values are
+// NOT corrected.
 
 #pragma once
 
@@ -25,19 +24,16 @@ class QnnModelWrapper;
 
 namespace utils {
 
-// Rewrites raw index bytes as INT_32 so every value lands in [0, axis_dim).
-// Returns false if any index is out of range, or if `onnx_bytes.size()` is not
-// a multiple of `sizeof(SrcType)`. `axis_dim_for_element(i)` supplies the open
-// upper bound for element i so callers can encode per-op layout. `qnn_bytes`
-// is resized to hold the rewritten INT_32 output.
+// Returns false on out-of-range index or non-aligned `onnx_bytes` size.
+// `axis_dim_for_element(i)` is the per-element open upper bound -- lets
+// callers encode op-specific layout (e.g. ScatterND's per-column bound).
 template <typename SrcType>
 bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
                            std::vector<uint8_t>& qnn_bytes,
                            bool& has_negative_indices);
 
-// ScatterND-style: indices' last dim `k` is tuple depth; column c bounds
-// against `data_shape[c]`.
+// ScatterND: indices' last dim is tuple depth; column c bounds `data_shape[c]`.
 Ort::Status NormalizeIndicesForScatterND(
     QnnModelWrapper& qnn_model_wrapper,
     const OrtNodeUnitIODef& indices_input,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
@@ -1,12 +1,20 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MIT
 
+// Adapts ONNX Gather/Scatter indices to QNN's accepted form. ONNX allows
+// negative (count-from-end) INT_64 indices; QNN rejects both -- a single
+// negative static index otherwise silently drops the node to CPU.
+// Dynamic int64 indices get a runtime Cast(INT_32), but negative values at
+// runtime pass through uncorrected.
+
 #pragma once
 
 #include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
+
+#include <gsl/gsl>
 
 #include "core/providers/qnn/ort_api.h"
 
@@ -15,19 +23,15 @@ namespace qnn {
 
 class QnnModelWrapper;
 
-// Adapts ONNX Gather/Scatter indices to QNN's accepted form. ONNX allows
-// negative (count-from-end) INT_64 indices; QNN rejects both -- a single
-// negative static index otherwise silently drops the node to CPU.
-// Dynamic int64 indices get a runtime Cast(INT_32), but negative values at
-// runtime pass through uncorrected.
 namespace utils {
 
 // Rewrites raw index bytes as INT_32 so every value lands in [0, axis_dim).
 // Returns false if any index is out of range, or if `onnx_bytes.size()` is not
 // a multiple of `sizeof(SrcType)`. `axis_dim_for_element(i)` supplies the open
-// upper bound for element i so callers can encode per-op layout.
+// upper bound for element i so callers can encode per-op layout. `qnn_bytes`
+// is resized to hold the rewritten INT_32 output.
 template <typename SrcType>
-bool NormalizeIndicesBytes(const std::vector<uint8_t>& onnx_bytes,
+bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
                            std::vector<uint8_t>& qnn_bytes,
                            bool& has_negative_indices);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
@@ -24,14 +24,13 @@ class QnnModelWrapper;
 
 namespace utils {
 
-// Returns false on out-of-range index or non-aligned `onnx_bytes` size.
-// `axis_dim_for_element(i)` is the per-element open upper bound -- lets
-// callers encode op-specific layout (e.g. ScatterND's per-column bound).
+// Returns false on out-of-range index. `axis_dim_for_element(i)` is the
+// per-element open upper bound -- lets callers encode op-specific layout
+// (e.g. ScatterND's per-column bound).
 template <typename SrcType>
 bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
-                           std::vector<uint8_t>& qnn_bytes,
-                           bool& has_negative_indices);
+                           std::vector<uint8_t>& qnn_bytes);
 
 // ScatterND: indices' last dim is tuple depth; column c bounds `data_shape[c]`.
 Ort::Status NormalizeIndicesForScatterND(

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
@@ -49,8 +49,7 @@ Ort::Status ScatterNDOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper
 
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
 
-  // QNN ScatterND rejects negative and int64 indices; rewrite static indices so
-  // the node stays on QNN instead of silently falling back to CPU.
+  // QNN rejects negative/INT_64 indices; rewrite statics to keep the node on QNN.
   TensorInfo data_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], data_info));
   RETURN_IF_ERROR(utils::NormalizeIndicesForScatterND(

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
@@ -1,0 +1,112 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+constexpr std::array<std::string_view, 3> kSupportedReductions = {"none", "add", "mul"};
+}  // namespace
+
+class ScatterNDOpBuilder : public BaseOpBuilder {
+ public:
+  ScatterNDOpBuilder() : BaseOpBuilder("ScatterNDOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ScatterNDOpBuilder);
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status ScatterNDOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                              const OrtNodeUnit& node_unit,
+                                              const Ort::Logger& logger,
+                                              std::vector<std::string>& input_names,
+                                              bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  RETURN_IF(inputs.size() != 3, "QNN EP: ScatterND operator must have three inputs.");
+
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+
+  // QNN ScatterND rejects negative and int64 indices; rewrite static indices so
+  // the node stays on QNN instead of silently falling back to CPU.
+  TensorInfo data_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], data_info));
+  RETURN_IF_ERROR(utils::NormalizeIndicesForScatterND(
+      qnn_model_wrapper, inputs[1], data_info.shape,
+      logger, input_names, do_op_validation));
+
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));
+  return Ort::Status();
+}
+
+Ort::Status ScatterNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                            const OrtNodeUnit& node_unit,
+                                                            std::vector<std::string>&& input_names,
+                                                            const Ort::Logger& logger,
+                                                            bool do_op_validation) const {
+  if (input_names.empty()) {
+    return Ort::Status();
+  }
+
+  if (do_op_validation) {
+    // TODO: Remove once QNN CPU supports ScatterND.
+    RETURN_IF(qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::CPU,
+              "QNN EP does not support ScatterND op on CPU backend. Falling back to ORT CPU.");
+  }
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  const std::string reduction = node_helper.Get("reduction", "none");
+  RETURN_IF_NOT(utils::ArrayHasString(kSupportedReductions, reduction),
+                ("ScatterND does not support reduction " + reduction).c_str());
+
+  Qnn_Scalar_t reduction_scalar = QNN_SCALAR_INIT;
+  reduction_scalar.dataType = QNN_DATATYPE_UINT_32;
+  if (reduction == "none") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_NONE;
+  } else if (reduction == "add") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_ADD;
+  } else if (reduction == "mul") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_MUL;
+  } else {
+    return MAKE_EP_FAIL(("Unexpected ScatterND reduction: " + reduction).c_str());
+  }
+
+  QnnParamWrapper reduction_param(node_unit.Index(), node_unit.Name(),
+                                  QNN_OP_SCATTER_ND_PARAM_REDUCTION, reduction_scalar);
+  std::vector<std::string> param_tensor_names = {reduction_param.GetParamTensorName()};
+  qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
+
+  return ProcessOutputs(qnn_model_wrapper, node_unit,
+                        std::move(input_names),
+                        std::move(param_tensor_names),
+                        logger, do_op_validation, GetQnnOpType(node_unit.OpType()));
+}
+
+void CreateScatterNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<ScatterNDOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
@@ -16,6 +17,11 @@ class SimpleOpBuilder : public BaseOpBuilder {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(SimpleOpBuilder);
 
  protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
   Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                           const OrtNodeUnit& node_unit,
                                           std::vector<std::string>&& input_names,
@@ -57,8 +63,9 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
                   ("GridSample does not support padding_mode " + padding_mode).c_str());
   }
 
-  // To DO: Remove once QNN CPU supports ScatterND
   const auto qnn_backend_type = qnn_model_wrapper.GetQnnBackendType();
+
+  // TODO: Remove once QNN CPU supports ScatterND.
   if (op_type == "ScatterND") {
     RETURN_IF(qnn_backend_type == QnnBackendType::CPU,
               "QNN EP does not support ScatterND op on CPU backend. Falling back to ORT CPU.");
@@ -358,6 +365,36 @@ Ort::Status ProcessReductionAttribute(QnnModelWrapper& qnn_model_wrapper,
   qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
 
   return Ort::Status();
+}
+
+Ort::Status SimpleOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                           const OrtNodeUnit& node_unit,
+                                           const Ort::Logger& logger,
+                                           std::vector<std::string>& input_names,
+                                           bool do_op_validation) const {
+  // Prefer a dedicated op builder (see gathernd_op_builder.cc) over extending
+  // this dispatch if another op needs ProcessInputs intervention.
+  const std::string& op_type = node_unit.OpType();
+
+  // QNN's ScatterND rejects negative and int64 indices; rewrite static indices
+  // so the node stays on QNN instead of silently falling back to CPU.
+  if (op_type == "ScatterND") {
+    const auto& inputs = node_unit.Inputs();
+    RETURN_IF(inputs.size() != 3, "QNN EP: ScatterND operator must have three inputs.");
+
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+
+    TensorInfo data_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], data_info));
+    RETURN_IF_ERROR(utils::NormalizeIndicesForScatterND(
+        qnn_model_wrapper, inputs[1], data_info.shape,
+        logger, input_names, do_op_validation));
+
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));
+    return Ort::Status();
+  }
+
+  return BaseOpBuilder::ProcessInputs(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
 }
 
 Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -3,7 +3,6 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
-#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
@@ -17,11 +16,6 @@ class SimpleOpBuilder : public BaseOpBuilder {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(SimpleOpBuilder);
 
  protected:
-  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
-                            const OrtNodeUnit& node_unit,
-                            const Ort::Logger& logger,
-                            std::vector<std::string>& input_names,
-                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
   Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                           const OrtNodeUnit& node_unit,
                                           std::vector<std::string>&& input_names,
@@ -46,7 +40,6 @@ class SimpleOpBuilder : public BaseOpBuilder {
 
   static constexpr std::array<std::string_view, 3> gridsample_supported_modes = {"bilinear", "nearest", "linear"};
   static constexpr std::array<std::string_view, 3> gridsample_supported_padding_modes = {"zeros", "border", "reflection"};
-  static constexpr std::array<std::string_view, 3> scatternd_supported_reduction = {"none", "add", "mul"};
   static constexpr std::array<std::string_view, 4> scatterelements_supported_reduction = {"none", "add", "mul", "max"};
 };
 
@@ -64,12 +57,6 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
   }
 
   const auto qnn_backend_type = qnn_model_wrapper.GetQnnBackendType();
-
-  // TODO: Remove once QNN CPU supports ScatterND.
-  if (op_type == "ScatterND") {
-    RETURN_IF(qnn_backend_type == QnnBackendType::CPU,
-              "QNN EP does not support ScatterND op on CPU backend. Falling back to ORT CPU.");
-  }
 
   // TODO: Remove once QNN HTP PRelu bug is fixed
   if (op_type == "PRelu") {
@@ -144,14 +131,6 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
     RETURN_IF(input_info.shape.size() > 4,
               "QNN EP does not support Softplus with input rank > 4.");
-  }
-
-  // QNN ScatterND doesn't support MAX, MIN reduction
-  if (op_type == "ScatterND") {
-    OrtNodeAttrHelper node_helper(node_unit);
-    std::string reduction = node_helper.Get("reduction", "none");
-    RETURN_IF_NOT(utils::ArrayHasString(scatternd_supported_reduction, reduction),
-                  ("ScatterND does not support reduction " + reduction).c_str());
   }
 
   // QNN ScatterElements doesn't support MIN reduction
@@ -315,31 +294,6 @@ Ort::Status ProcessGridSampleAttributes(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// Process Reduction attribute of ScatterND op
-Ort::Status ProcessScatterNDReductionAttribute(QnnModelWrapper& qnn_model_wrapper,
-                                               const OrtNodeUnit& node_unit,
-                                               std::vector<std::string>& param_tensor_names) {
-  OrtNodeAttrHelper node_helper(node_unit);
-  std::string reduction = node_helper.Get("reduction", "none");
-  Qnn_Scalar_t reduction_qnn_scalar = QNN_SCALAR_INIT;
-  reduction_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-  if ("none" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_NONE;
-  } else if ("add" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_ADD;
-  } else if ("mul" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_MUL;
-  } else {
-    return MAKE_EP_FAIL("ScatterND support only reduction:{none, add, mul}.");
-  }
-  QnnParamWrapper reduction_param(node_unit.Index(), node_unit.Name(), QNN_OP_SCATTER_ND_PARAM_REDUCTION,
-                                  reduction_qnn_scalar);
-  param_tensor_names.push_back(reduction_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
-
-  return Ort::Status();
-}
-
 // Process Reduction attribute of ScatterElements op
 Ort::Status ProcessReductionAttribute(QnnModelWrapper& qnn_model_wrapper,
                                       const OrtNodeUnit& node_unit,
@@ -365,36 +319,6 @@ Ort::Status ProcessReductionAttribute(QnnModelWrapper& qnn_model_wrapper,
   qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
 
   return Ort::Status();
-}
-
-Ort::Status SimpleOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
-                                           const OrtNodeUnit& node_unit,
-                                           const Ort::Logger& logger,
-                                           std::vector<std::string>& input_names,
-                                           bool do_op_validation) const {
-  // Prefer a dedicated op builder (see gathernd_op_builder.cc) over extending
-  // this dispatch if another op needs ProcessInputs intervention.
-  const std::string& op_type = node_unit.OpType();
-
-  // QNN's ScatterND rejects negative and int64 indices; rewrite static indices
-  // so the node stays on QNN instead of silently falling back to CPU.
-  if (op_type == "ScatterND") {
-    const auto& inputs = node_unit.Inputs();
-    RETURN_IF(inputs.size() != 3, "QNN EP: ScatterND operator must have three inputs.");
-
-    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
-
-    TensorInfo data_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], data_info));
-    RETURN_IF_ERROR(utils::NormalizeIndicesForScatterND(
-        qnn_model_wrapper, inputs[1], data_info.shape,
-        logger, input_names, do_op_validation));
-
-    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));
-    return Ort::Status();
-  }
-
-  return BaseOpBuilder::ProcessInputs(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
 }
 
 Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
@@ -525,11 +449,6 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   if (op_type == "GridSample") {
     RETURN_IF_ERROR(ProcessGridSampleAttributes(qnn_model_wrapper, node_unit, param_tensor_names));
-  }
-
-  if (op_type == "ScatterND") {
-    // Process reduction attribute
-    RETURN_IF_ERROR(ProcessScatterNDReductionAttribute(qnn_model_wrapper, node_unit, param_tensor_names));
   }
 
   if (op_type == "ScatterElements") {

--- a/onnxruntime/test/providers/qnn/scatternd_test.cc
+++ b/onnxruntime/test/providers/qnn/scatternd_test.cc
@@ -30,8 +30,7 @@ ProviderOptions MakeHtpProviderOptions() {
 
 }  // namespace
 
-// Regression: -1 in int64 static indices. Trailing Cast makes scatter_out
-// internal to exercise the non-graph-output path.
+// Trailing Cast keeps scatter_out non-graph-output.
 TEST_F(QnnHTPBackendTests, ScatterNDInternalOutputNegativeIndex) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 50;
@@ -58,8 +57,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDInternalOutputNegativeIndex) {
                   ExpectedEPNodeAssignment::All);
 }
 
-// Different tuple columns bound against different data dims, exercising the
-// column-indexed axis_dim lookup.
+// Exercises the column-indexed axis_dim lookup.
 TEST_F(QnnHTPBackendTests, ScatterNDMultipleNegativeIndicesAcrossColumns) {
   constexpr int64_t kDim0 = 4;
   constexpr int64_t kDim1 = 6;
@@ -89,8 +87,6 @@ TEST_F(QnnHTPBackendTests, ScatterNDMultipleNegativeIndicesAcrossColumns) {
                   ExpectedEPNodeAssignment::All);
 }
 
-// reduction=add combined with negative indices exercises both attribute
-// processing and the indices rewrite path together.
 TEST_F(QnnHTPBackendTests, ScatterNDReductionAddWithNegativeIndices) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 8;
@@ -118,8 +114,8 @@ TEST_F(QnnHTPBackendTests, ScatterNDReductionAddWithNegativeIndices) {
                   ExpectedEPNodeAssignment::All);
 }
 
-// Regression for an AI Hub compile job: ScatterND(-1) embedded between
-// producer/consumer ops must compile all the way through QNN finalization.
+// Regression for an AI Hub compile job: ScatterND(-1) between producer/consumer
+// ops must compile all the way through QNN finalization.
 TEST_F(QnnHTPBackendTests, ScatterNDEndToEndNegativeIndexInGraph) {
   constexpr int64_t kRows = 2;
   constexpr int64_t kCols = 64;
@@ -155,8 +151,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDEndToEndNegativeIndexInGraph) {
                   ExpectedEPNodeAssignment::All);
 }
 
-// Shared indices initializer across two ScatterND nodes: names must not
-// collide and both nodes must land on QNN.
+// Verifies the rename avoids collisions when a shared initializer is rewritten.
 TEST_F(QnnHTPBackendTests, ScatterNDSharedNegativeIndicesInitializer) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 16;

--- a/onnxruntime/test/providers/qnn/scatternd_test.cc
+++ b/onnxruntime/test/providers/qnn/scatternd_test.cc
@@ -35,7 +35,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDInternalOutputNegativeIndex) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 50;
 
-  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
+  auto build_model = [=](ModelTestBuilder& builder) {
     std::vector<int32_t> data(kRows * kCols, 0);
     builder.MakeInitializer<int32_t>("data", {kRows, kCols}, data);
 
@@ -62,7 +62,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDMultipleNegativeIndicesAcrossColumns) {
   constexpr int64_t kDim0 = 4;
   constexpr int64_t kDim1 = 6;
 
-  auto build_model = [kDim0, kDim1](ModelTestBuilder& builder) {
+  auto build_model = [=](ModelTestBuilder& builder) {
     std::vector<int32_t> data(kDim0 * kDim1, 0);
     builder.MakeInitializer<int32_t>("data", {kDim0, kDim1}, data);
 
@@ -91,7 +91,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDReductionAddWithNegativeIndices) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 8;
 
-  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
+  auto build_model = [=](ModelTestBuilder& builder) {
     std::vector<int32_t> data(kRows * kCols, 0);
     builder.MakeInitializer<int32_t>("data", {kRows, kCols}, data);
 
@@ -120,7 +120,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDEndToEndNegativeIndexInGraph) {
   constexpr int64_t kRows = 2;
   constexpr int64_t kCols = 64;
 
-  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
+  auto build_model = [=](ModelTestBuilder& builder) {
     std::vector<float> data(kRows * kCols);
     for (int64_t i = 0; i < kRows * kCols; ++i) {
       data[i] = static_cast<float>(i) * 0.01f;
@@ -156,7 +156,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDSharedNegativeIndicesInitializer) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 16;
 
-  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
+  auto build_model = [=](ModelTestBuilder& builder) {
     std::vector<int32_t> data_a(kRows * kCols, 0);
     std::vector<int32_t> data_b(kRows * kCols, 0);
     builder.MakeInitializer<int32_t>("dataA", {kRows, kCols}, data_a);

--- a/onnxruntime/test/providers/qnn/scatternd_test.cc
+++ b/onnxruntime/test/providers/qnn/scatternd_test.cc
@@ -36,7 +36,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDInternalOutputNegativeIndex) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 50;
 
-  auto build_model = [](ModelTestBuilder& builder) {
+  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
     std::vector<int32_t> data(kRows * kCols, 0);
     builder.MakeInitializer<int32_t>("data", {kRows, kCols}, data);
 
@@ -64,7 +64,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDMultipleNegativeIndicesAcrossColumns) {
   constexpr int64_t kDim0 = 4;
   constexpr int64_t kDim1 = 6;
 
-  auto build_model = [](ModelTestBuilder& builder) {
+  auto build_model = [kDim0, kDim1](ModelTestBuilder& builder) {
     std::vector<int32_t> data(kDim0 * kDim1, 0);
     builder.MakeInitializer<int32_t>("data", {kDim0, kDim1}, data);
 
@@ -95,7 +95,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDReductionAddWithNegativeIndices) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 8;
 
-  auto build_model = [](ModelTestBuilder& builder) {
+  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
     std::vector<int32_t> data(kRows * kCols, 0);
     builder.MakeInitializer<int32_t>("data", {kRows, kCols}, data);
 
@@ -124,7 +124,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDEndToEndNegativeIndexInGraph) {
   constexpr int64_t kRows = 2;
   constexpr int64_t kCols = 64;
 
-  auto build_model = [](ModelTestBuilder& builder) {
+  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
     std::vector<float> data(kRows * kCols);
     for (int64_t i = 0; i < kRows * kCols; ++i) {
       data[i] = static_cast<float>(i) * 0.01f;
@@ -161,7 +161,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDSharedNegativeIndicesInitializer) {
   constexpr int64_t kRows = 1;
   constexpr int64_t kCols = 16;
 
-  auto build_model = [](ModelTestBuilder& builder) {
+  auto build_model = [kRows, kCols](ModelTestBuilder& builder) {
     std::vector<int32_t> data_a(kRows * kCols, 0);
     std::vector<int32_t> data_b(kRows * kCols, 0);
     builder.MakeInitializer<int32_t>("dataA", {kRows, kCols}, data_a);

--- a/onnxruntime/test/providers/qnn/scatternd_test.cc
+++ b/onnxruntime/test/providers/qnn/scatternd_test.cc
@@ -116,8 +116,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDReductionAddWithNegativeIndices) {
                   ExpectedEPNodeAssignment::All);
 }
 
-// Regression for an AI Hub compile job: ScatterND(-1) between producer/consumer
-// ops must compile all the way through QNN finalization.
+// ScatterND(-1) between producer/consumer ops must compile through QNN finalization.
 TEST_F(QnnHTPBackendTests, ScatterNDEndToEndNegativeIndexInGraph) {
   constexpr int64_t kRows = 2;
   constexpr int64_t kCols = 64;

--- a/onnxruntime/test/providers/qnn/scatternd_test.cc
+++ b/onnxruntime/test/providers/qnn/scatternd_test.cc
@@ -13,6 +13,8 @@
 
 #include "gtest/gtest.h"
 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
 namespace onnxruntime {
 namespace test {
 
@@ -190,5 +192,7 @@ TEST_F(QnnHTPBackendTests, ScatterNDSharedNegativeIndicesInitializer) {
 
 }  // namespace test
 }  // namespace onnxruntime
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/scatternd_test.cc
+++ b/onnxruntime/test/providers/qnn/scatternd_test.cc
@@ -1,0 +1,199 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "onnxruntime_c_api.h"
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "core/graph/node_attr_utils.h"
+
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+ProviderOptions MakeHtpProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return provider_options;
+}
+
+}  // namespace
+
+// Regression: -1 in int64 static indices. Trailing Cast makes scatter_out
+// internal to exercise the non-graph-output path.
+TEST_F(QnnHTPBackendTests, ScatterNDInternalOutputNegativeIndex) {
+  constexpr int64_t kRows = 1;
+  constexpr int64_t kCols = 50;
+
+  auto build_model = [](ModelTestBuilder& builder) {
+    std::vector<int32_t> data(kRows * kCols, 0);
+    builder.MakeInitializer<int32_t>("data", {kRows, kCols}, data);
+
+    std::vector<int64_t> indices = {0, -1};  // -> [0, kCols-1] after normalize
+    builder.MakeInitializer<int64_t>("indices", {1, 1, 2}, indices);
+
+    std::vector<int32_t> updates = {42};
+    builder.MakeInitializer<int32_t>("updates", {1, 1}, updates);
+
+    builder.AddNode("scatter", "ScatterND", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain);
+    builder.AddNode("cast", "Cast", {"scatter_out"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Different tuple columns bound against different data dims, exercising the
+// column-indexed axis_dim lookup.
+TEST_F(QnnHTPBackendTests, ScatterNDMultipleNegativeIndicesAcrossColumns) {
+  constexpr int64_t kDim0 = 4;
+  constexpr int64_t kDim1 = 6;
+
+  auto build_model = [](ModelTestBuilder& builder) {
+    std::vector<int32_t> data(kDim0 * kDim1, 0);
+    builder.MakeInitializer<int32_t>("data", {kDim0, kDim1}, data);
+
+    // Two index tuples, both containing negative values across columns.
+    // Tuple 0: (-1, -1) -> (kDim0-1, kDim1-1)
+    // Tuple 1: (-kDim0, -kDim1) -> (0, 0)
+    std::vector<int64_t> indices = {-1, -1, -kDim0, -kDim1};
+    builder.MakeInitializer<int64_t>("indices", {2, 2}, indices);
+
+    std::vector<int32_t> updates = {99, 77};
+    builder.MakeInitializer<int32_t>("updates", {2}, updates);
+
+    builder.AddNode("scatter", "ScatterND", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain);
+    builder.AddNode("cast", "Cast", {"scatter_out"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// reduction=add combined with negative indices exercises both attribute
+// processing and the indices rewrite path together.
+TEST_F(QnnHTPBackendTests, ScatterNDReductionAddWithNegativeIndices) {
+  constexpr int64_t kRows = 1;
+  constexpr int64_t kCols = 8;
+
+  auto build_model = [](ModelTestBuilder& builder) {
+    std::vector<int32_t> data(kRows * kCols, 0);
+    builder.MakeInitializer<int32_t>("data", {kRows, kCols}, data);
+
+    std::vector<int64_t> indices = {0, -2};  // -> [0, kCols-2]
+    builder.MakeInitializer<int64_t>("indices", {1, 1, 2}, indices);
+
+    std::vector<int32_t> updates = {5};
+    builder.MakeInitializer<int32_t>("updates", {1, 1}, updates);
+
+    builder.AddNode("scatter", "ScatterND", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain,
+                    {test::MakeAttribute("reduction", std::string("add"))});
+    builder.AddNode("cast", "Cast", {"scatter_out"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Regression for an AI Hub compile job: ScatterND(-1) embedded between
+// producer/consumer ops must compile all the way through QNN finalization.
+TEST_F(QnnHTPBackendTests, ScatterNDEndToEndNegativeIndexInGraph) {
+  constexpr int64_t kRows = 2;
+  constexpr int64_t kCols = 64;
+
+  auto build_model = [](ModelTestBuilder& builder) {
+    std::vector<float> data(kRows * kCols);
+    for (int64_t i = 0; i < kRows * kCols; ++i) {
+      data[i] = static_cast<float>(i) * 0.01f;
+    }
+    builder.MakeInitializer<float>("data_src", {kRows, kCols}, data);
+
+    std::vector<float> bias(kRows * kCols, 0.5f);
+    builder.MakeInitializer<float>("bias", {kRows, kCols}, bias);
+    builder.AddNode("pre_add", "Add", {"data_src", "bias"}, {"data"}, kOnnxDomain);
+
+    // Negative indices across both tuple columns.
+    std::vector<int64_t> indices = {0, -1, 1, -2, -kRows, 0};
+    builder.MakeInitializer<int64_t>("indices", {3, 2}, indices);
+
+    std::vector<float> updates = {10.0f, 20.0f, 30.0f};
+    builder.MakeInitializer<float>("updates", {3}, updates);
+
+    builder.AddNode("scatter", "ScatterND", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain);
+
+    std::vector<float> scale(kRows * kCols, 2.0f);
+    builder.MakeInitializer<float>("scale", {kRows, kCols}, scale);
+    builder.AddNode("post_mul", "Mul", {"scatter_out", "scale"}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Shared indices initializer across two ScatterND nodes: names must not
+// collide and both nodes must land on QNN.
+TEST_F(QnnHTPBackendTests, ScatterNDSharedNegativeIndicesInitializer) {
+  constexpr int64_t kRows = 1;
+  constexpr int64_t kCols = 16;
+
+  auto build_model = [](ModelTestBuilder& builder) {
+    std::vector<int32_t> data_a(kRows * kCols, 0);
+    std::vector<int32_t> data_b(kRows * kCols, 0);
+    builder.MakeInitializer<int32_t>("dataA", {kRows, kCols}, data_a);
+    builder.MakeInitializer<int32_t>("dataB", {kRows, kCols}, data_b);
+
+    std::vector<int64_t> indices = {0, -1};
+    builder.MakeInitializer<int64_t>("indices", {1, 1, 2}, indices);
+
+    std::vector<int32_t> updates_a = {11};
+    std::vector<int32_t> updates_b = {22};
+    builder.MakeInitializer<int32_t>("updatesA", {1, 1}, updates_a);
+    builder.MakeInitializer<int32_t>("updatesB", {1, 1}, updates_b);
+
+    builder.AddNode("scatterA", "ScatterND", {"dataA", "indices", "updatesA"},
+                    {"outA_i32"}, kOnnxDomain);
+    builder.AddNode("scatterB", "ScatterND", {"dataB", "indices", "updatesB"},
+                    {"outB_i32"}, kOnnxDomain);
+    builder.AddNode("castA", "Cast", {"outA_i32"}, {"YA"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.AddNode("castB", "Cast", {"outB_i32"}, {"YB"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("YA");
+    builder.MakeOutput("YB");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
- ONNX `ScatterND` allows negative and INT_64 indices; QNN rejects both, silently dropping the node to CPU and breaking whole-graph capture.
- New `normalize_indices_utils` rewrites static initializer indices to non-negative INT_32 at partition time, and inserts a runtime `Cast(INT_32)` for dynamic INT_64 inputs.
