### PR TITLE
fix device compatibility arguments

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2434,7 +2434,7 @@ OrtStatus* QnnEp::GetHardwareDeviceIncompatibilityDetails(const OrtHardwareDevic
                                                           OrtDeviceEpIncompatibilityDetails* details) noexcept {
   // This function is always called by temporary QnnEp, so no need to check if backend is already setup.
   std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>> dummy_map;
-  Ort::Status status = qnn_backend_manager_->SetupBackend(true, true, false, false, false, nullptr, dummy_map);
+  Ort::Status status = qnn_backend_manager_->SetupBackend(false, false, false, false, false, nullptr, dummy_map);
 
   if (!status.IsOK()) {
     const std::string error_message = status.GetErrorMessage();


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Fix the device compatibility arguments

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The argument of `load_from_cached_context` and `need_load_system_lib` should be `false` for device compatibility.
- It is set to `true` in https://github.com/onnxruntime/onnxruntime-qnn/pull/117/changes#diff-ee58cc5d11eb6509cb8fc2f796a8fa847761fdd3d9fe15b2364a8594475f659aR2146

