### PR TITLE
Add Mixed-Precision 8->16 and 16->8 support for Gemm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gen
 *.DS_Store
 TestResults/
 .idea/
+QNNExecutionProvider_QNNExecutionProvider_*
 onnxruntime.egg-info
 nuget_root/
 .packages/

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
+
 #include <gsl/gsl>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -41,6 +43,415 @@ bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitI
   return bq::IsBQScale(scale_shape, weight_shape, block_axis);
 }
 
+// Float types QNN FullyConnected can run in (see HtpOpDefSupplement, FullyConnected datatypes).
+bool IsFloatQnnDataType(Qnn_DataType_t dt) {
+  return dt == QNN_DATATYPE_FLOAT_16 || dt == QNN_DATATYPE_FLOAT_32;
+}
+
+// Precision a QNN FullyConnected kernel runs at. Ordered so that a plain max()
+// picks the precision a Gemm must run at: higher tiers can represent everything a lower tier can
+enum class GemmPrecision {
+  kInt8,     // (U|S)FIXED_POINT_4/8 — HTP folds sub-byte weights into the 8-bit configuration
+  kInt16,    // (U|S)FIXED_POINT_16
+  kFloat16,  // FLOAT_16
+  kFloat32,  // FLOAT_32
+};
+
+// Maps a tensor's data type onto the kernel precision that can hold it. Types with no tier of their
+// own (BFLOAT_16, plain ints) are rejected: they only reach here when a Gemm mixes data types, and
+// there is no kernel that mixes them with anything else.
+Ort::Status GetGemmPrecision(Qnn_DataType_t data_type, /*out*/ GemmPrecision& precision) {
+  switch (data_type) {
+    case QNN_DATATYPE_UFIXED_POINT_4:
+    case QNN_DATATYPE_SFIXED_POINT_4:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+    case QNN_DATATYPE_SFIXED_POINT_8:
+      precision = GemmPrecision::kInt8;
+      return Ort::Status();
+    case QNN_DATATYPE_UFIXED_POINT_16:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+      precision = GemmPrecision::kInt16;
+      return Ort::Status();
+    case QNN_DATATYPE_FLOAT_16:
+      precision = GemmPrecision::kFloat16;
+      return Ort::Status();
+    case QNN_DATATYPE_FLOAT_32:
+      precision = GemmPrecision::kFloat32;
+      return Ort::Status();
+    default:
+      return MAKE_EP_FAIL("QNN EP: Gemm data type cannot mix with another QNN FullyConnected data type.");
+  }
+}
+
+// Data type an activation takes at `precision`. Quantized precisions keep `like`'s signedness so a
+// widened activation stays unsigned/signed like the one it came from.
+Qnn_DataType_t GetActivationDataType(GemmPrecision precision, Qnn_DataType_t like) {
+  const bool is_signed = like == QNN_DATATYPE_SFIXED_POINT_4 || like == QNN_DATATYPE_SFIXED_POINT_8 ||
+                         like == QNN_DATATYPE_SFIXED_POINT_16;
+  switch (precision) {
+    case GemmPrecision::kInt8:
+      return is_signed ? QNN_DATATYPE_SFIXED_POINT_8 : QNN_DATATYPE_UFIXED_POINT_8;
+    case GemmPrecision::kInt16:
+      return is_signed ? QNN_DATATYPE_SFIXED_POINT_16 : QNN_DATATYPE_UFIXED_POINT_16;
+    case GemmPrecision::kFloat16:
+      return QNN_DATATYPE_FLOAT_16;
+    case GemmPrecision::kFloat32:
+      return QNN_DATATYPE_FLOAT_32;
+  }
+  return QNN_DATATYPE_UNDEFINED;  // Unreachable; every GemmPrecision is handled above.
+}
+
+// A per-tensor quantization encoding.
+struct ScaleOffset {
+  float scale = 0.0f;
+  int32_t offset = 0;
+};
+
+// The one decision the whole Gemm translation hangs off: which precision FullyConnected runs at, and
+// therefore what has to be inserted around it. ProcessInputs and ProcessAttributesAndOutputs build
+// one side each and must agree, so both read this instead of re-deriving.
+//
+//   A -> [fix up in]? -> [FC at fc_act_data_type] -> [fix up out]? -> Y
+//
+// HTP forces FC's out[0] to carry its in[0] type, so an activation that does not already sit at
+// fc_act_data_type gets a Convert/Quantize/Dequantize on its side. Examples, weight tier in brackets:
+//
+//   u8  -> u8  [u8 ]  run int8    no fix-up
+//   u8  -> u16 [u8 ]  run int16   Convert u8->u16 in
+//   u16 -> u8  [u8 ]  run int16                                Convert u16->u8 out
+//   u8  -> u8  [s16]  run int16   Convert u8->u16 in           Convert u16->u8 out
+//   u8  -> f16 [s8 ]  run fp16    Dequantize in
+//   f16 -> u8  [s8 ]  run fp16                                 Quantize out
+struct GemmPrecisionPlan {
+  TensorInfo in_act = {};   // ONNX input activation, Gemm input[0]
+  TensorInfo weight = {};   // ONNX weight, Gemm input[1]
+  TensorInfo out_act = {};  // ONNX output activation, Gemm output[0]
+
+  // What FC's in[0] and out[0] both carry. A float FC's weight takes it too (see DequantizeWeight);
+  // a quantized FC's weight keeps its own ONNX type.
+  Qnn_DataType_t fc_act_data_type = QNN_DATATYPE_UNDEFINED;
+
+  // Encoding every tensor the FC chain produces carries (see AddFcChainLink). Empty when FC runs in
+  // float.
+  QnnQuantParamsWrapper chain_quant_param;
+
+  bool FixesUpInput() const { return in_act.qnn_data_type != fc_act_data_type; }
+  bool FixesUpOutput() const { return out_act.qnn_data_type != fc_act_data_type; }
+
+  // A float FC cannot take a quantized weight, so a quantized one needs a float copy.
+  bool DequantizesWeight() const {
+    return IsFloatQnnDataType(fc_act_data_type) && weight.quant_param.IsQuantized();
+  }
+};
+
+// Picks the FC precision (the max over the activations and the weight) and derives everything both
+// build phases need from it. All rejections live here, so both phases fail identically.
+Ort::Status MakeGemmPrecisionPlan(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
+                                  /*out*/ GemmPrecisionPlan& plan) {
+  plan = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], plan.in_act));
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], plan.weight));
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], plan.out_act));
+
+  const Qnn_DataType_t in_type = plan.in_act.qnn_data_type;
+  const Qnn_DataType_t out_type = plan.out_act.qnn_data_type;
+
+  // A Gemm whose activations and weight all share one data type is the common case: FC runs at that
+  // type and nothing is inserted. Answered up front so uniform types with no precision tier of their
+  // own (int32, int64) keep taking the plain path.
+  if (in_type == out_type && plan.weight.qnn_data_type == in_type) {
+    plan.fc_act_data_type = in_type;
+    plan.chain_quant_param = plan.out_act.quant_param.Copy();
+    return Ort::Status();
+  }
+
+  GemmPrecision in_precision = GemmPrecision::kInt8;
+  GemmPrecision out_precision = GemmPrecision::kInt8;
+  GemmPrecision weight_precision = GemmPrecision::kInt8;
+  RETURN_IF_ERROR(GetGemmPrecision(in_type, in_precision));
+  RETURN_IF_ERROR(GetGemmPrecision(out_type, out_precision));
+  RETURN_IF_ERROR(GetGemmPrecision(plan.weight.qnn_data_type, weight_precision));
+
+  // Same precision but a different type (e.g. U8 -> S8) is a pure re-signing. Running at either
+  // side's type leaves the other needing a fix-up that changes signedness without changing
+  // precision, which is not what a Convert expresses. Reject rather than emit such a graph.
+  RETURN_IF(in_precision == out_precision && in_type != out_type,
+            "QNN EP: unsupported mixed-precision Gemm - input and output activations run at the same "
+            "precision but have different data types.");
+
+  // Run at the highest precision any of the three needs. The weight counts because HTP has no kernel
+  // with an 8-bit activation and a 16-bit weight ("16bit Weight must have 16bit Activation"), so such
+  // a Gemm must run at int16 with both activations fixed up. The int32 bias is deliberately left out:
+  // it is an accumulator type, not a kernel precision.
+  const GemmPrecision fc_precision = std::max({in_precision, out_precision, weight_precision});
+
+  // Signedness follows whichever activation already sits at the FC precision. If neither does (the
+  // weight forced the precision up) both activations are at the same precision, and so at the same
+  // type per the check above, so either one answers.
+  const Qnn_DataType_t signedness_like = (out_precision == fc_precision) ? out_type : in_type;
+  plan.fc_act_data_type = GetActivationDataType(fc_precision, signedness_like);
+
+  // A float chain carries no encoding, so chain_quant_param stays empty and there is nothing more to
+  // derive; DequantizesWeight() covers the weight from here.
+  if (IsFloatQnnDataType(plan.fc_act_data_type)) {
+    return Ort::Status();
+  }
+
+  if (plan.FixesUpOutput()) {
+    // Run the chain on the narrow output activation's grid re-expressed at FC's wider bit width, so
+    // the trailing Convert only drops bits and never rescales. FC still accumulates the bias at
+    // input_activation_scale * weight_scale, so the bias needs no requantization for this.
+    ScaleOffset output_encoding = {};
+    RETURN_IF_ERROR(plan.out_act.quant_param.GetPerTensorScaleOffset(output_encoding.scale,
+                                                                     output_encoding.offset));
+    ScaleOffset widened_output_encoding = {};
+    RETURN_IF_ERROR(utils::DeriveConvertQuantParams(out_type, plan.fc_act_data_type, output_encoding.offset,
+                                                    output_encoding.scale, /*output_symmetric*/ false,
+                                                    widened_output_encoding.scale,
+                                                    widened_output_encoding.offset));
+    plan.chain_quant_param = QnnQuantParamsWrapper::PerTensor(widened_output_encoding.scale,
+                                                              widened_output_encoding.offset);
+  } else {
+    // The chain produces the ONNX output tensor itself, so it carries its encoding.
+    plan.chain_quant_param = plan.out_act.quant_param.Copy();
+  }
+
+  return Ort::Status();
+}
+
+// Emits one link of the FC chain — the ops that turn FC's inputs into the node unit's output value:
+//
+//   plain             [FC]
+//   absorbed reshape  [FC] -> [Reshape]          (MatMulAddFusion's post-Gemm Reshape, see below)
+//   split bias        [FC] -> [ElementWiseAdd]   (bias QNN FC cannot fold in, see split_gemm)
+//
+// Every link's output carries the plan's FC data type and chain encoding, which differ from the ONNX
+// output's whenever an output fix-up follows. The node is named after the node unit so the QNN graph
+// traces back to the ONNX Gemm.
+Ort::Status AddFcChainLink(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
+                           const GemmPrecisionPlan& plan, const char* qnn_op_type,
+                           std::vector<std::string>&& input_names, const std::string& output_name,
+                           Qnn_TensorType_t output_tensor_type,
+                           const std::vector<uint32_t>& output_shape, bool do_op_validation) {
+  QnnTensorWrapper output_tensor(output_name, output_tensor_type, plan.fc_act_data_type,
+                                 plan.chain_quant_param.Copy(), std::vector<uint32_t>(output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)),
+                ("Failed to add Gemm FC-chain tensor " + output_name).c_str());
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, qnn_op_type),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW, qnn_op_type,
+                                                std::move(input_names), {output_name}, {}, do_op_validation),
+                ("Failed to add Gemm " + std::string(qnn_op_type) + " node.").c_str());
+  return Ort::Status();
+}
+
+// Requantizes the Gemm's int32 bias (input_names[2]) to `activation_scale`, the scale produced by the
+// widening Convert, replacing the tensor in place. The bias was quantized at
+// original_input_activation_scale * weight_scale, but HTP folds it into the FC accumulator at
+// activation_scale * weight_scale and ignores the declared encoding, so the data itself must move.
+Ort::Status RequantizeBias(QnnModelWrapper& qnn_model_wrapper, const GemmPrecisionPlan& plan,
+                           float activation_scale,
+                           /*in,out*/ std::vector<std::string>& input_names) {
+  const auto& bias_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(input_names[2]);
+  const Qnn_TensorType_t bias_tensor_type = bias_wrapper.GetTensorType();
+
+  // A NATIVE int32 bias is an intermediate from another op, which forces split_gemm: the bias lands
+  // on a separate ElementWiseAdd that honors its own encoding rather than being folded into the FC
+  // accumulator, so it needs no requantization.
+  if (bias_wrapper.GetTensorDataType() != QNN_DATATYPE_SFIXED_POINT_32 ||
+      bias_tensor_type == QNN_TENSOR_TYPE_NATIVE) {
+    return Ort::Status();
+  }
+
+  // Any other non-STATIC bias (i.e. a graph input) *is* handed to FC, which folds it at
+  // activation_scale * weight_scale and ignores the declared encoding — but it carries no client
+  // buffer to rescale. Reject instead of emitting a silently mis-scaled bias.
+  RETURN_IF_NOT(bias_tensor_type == QNN_TENSOR_TYPE_STATIC,
+                "QNN EP: mixed-precision (widening) Gemm requires a constant int32 bias; a graph-input "
+                "bias cannot be requantized for the converted activation scale.");
+  const auto& bias_qp = bias_wrapper.GetQnnQuantParams();
+  const auto& bias_dims = bias_wrapper.GetTensorDims();
+
+  std::vector<float> bias_scales;
+  RETURN_IF_ERROR(bias_qp.GetScales(bias_scales));
+  std::vector<int32_t> bias_offsets(bias_scales.size(), 0);
+
+  std::vector<float> weight_scales;
+  RETURN_IF_ERROR(plan.weight.quant_param.GetScales(weight_scales));
+
+  const Qnn_Tensor_t& qnn_bias = bias_wrapper.GetQnnTensor();
+  const Qnn_ClientBuffer_t& client_buf = GetQnnTensorClientBuf(qnn_bias);
+  std::vector<uint8_t> original_bias_data(
+      static_cast<const uint8_t*>(client_buf.data),
+      static_cast<const uint8_t*>(client_buf.data) + client_buf.dataSize);
+
+  std::vector<uint8_t> requantized_bias_data;
+  std::vector<float> new_bias_scales;
+  std::vector<int32_t> new_bias_offsets;
+  std::optional<int64_t> axis = bias_qp.IsPerChannel()
+                                    ? std::optional<int64_t>(0)
+                                    : std::nullopt;
+
+  RETURN_IF_ERROR(utils::RequantizeBiasTensor(
+      original_bias_data, bias_dims,
+      bias_scales, bias_offsets,
+      weight_scales, activation_scale,
+      QNN_DATATYPE_SFIXED_POINT_32,
+      requantized_bias_data, new_bias_scales, new_bias_offsets,
+      axis));
+
+  const std::string new_bias_name = utils::UniqueNameGenerator().New(input_names[2], "_requant");
+  QnnQuantParamsWrapper new_bias_qp;
+  if (bias_qp.IsPerChannel()) {
+    new_bias_qp = QnnQuantParamsWrapper::PerChannel(new_bias_scales, new_bias_offsets, /*axis*/ 0);
+  } else {
+    new_bias_qp = QnnQuantParamsWrapper::PerTensor(new_bias_scales[0], new_bias_offsets[0]);
+  }
+  QnnTensorWrapper new_bias_wrapper(new_bias_name, QNN_TENSOR_TYPE_STATIC,
+                                    QNN_DATATYPE_SFIXED_POINT_32,
+                                    std::move(new_bias_qp),
+                                    std::vector<uint32_t>(bias_dims),
+                                    std::move(requantized_bias_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(new_bias_wrapper)),
+                "Failed to add requantized bias tensor.");
+  input_names[2] = new_bias_name;
+  return Ort::Status();
+}
+
+// Re-expresses the input activation in the plan's FC data type, when the ONNX activation is not
+// already at it: a Convert to a wider quantized type, or a Dequantize to float. No-op otherwise, so
+// callers can invoke it unconditionally.
+Ort::Status FixUpInput(QnnModelWrapper& qnn_model_wrapper, const GemmPrecisionPlan& plan,
+                       /*in,out*/ std::vector<std::string>& input_names, bool do_op_validation) {
+  if (!plan.FixesUpInput()) {
+    return Ort::Status();
+  }
+
+  // input_names[0] is a Transpose output when transA=1, so its dims are the permuted ONNX dims.
+  // Read the shape from the staged wrapper rather than from the ONNX-side plan.in_act.
+  std::vector<uint32_t> fixed_up_shape = qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]).GetTensorDims();
+
+  if (IsFloatQnnDataType(plan.fc_act_data_type)) {
+    const std::string dq_output_name = utils::UniqueNameGenerator().New(input_names[0], "_dequantize");
+    RETURN_IF_ERROR(qnn_model_wrapper.AddDequantizeNode(input_names[0], dq_output_name, plan.fc_act_data_type,
+                                                        std::move(fixed_up_shape), do_op_validation));
+    input_names[0] = dq_output_name;
+    return Ort::Status();
+  }
+
+  ScaleOffset in_encoding = {};
+  RETURN_IF_ERROR(plan.in_act.quant_param.GetPerTensorScaleOffset(in_encoding.scale, in_encoding.offset));
+
+  const std::string convert_output_name =
+      utils::UniqueNameGenerator().New(input_names[0], "_convert_to_fc_type");
+  RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper, input_names[0], convert_output_name,
+                                         plan.in_act.qnn_data_type, plan.fc_act_data_type,
+                                         in_encoding.offset, in_encoding.scale,
+                                         fixed_up_shape, /*output_symmetric*/ false, do_op_validation));
+  input_names[0] = convert_output_name;
+
+  if (input_names.size() == 3) {
+    // The Convert re-expressed the same float range at FC's wider bit width, so the activation scale
+    // changed. FC folds the bias in at that derived scale, so the bias data must follow it. Mirrors
+    // InsertConvertOp's own derivation above.
+    ScaleOffset converted_in_encoding = {};
+    RETURN_IF_ERROR(utils::DeriveConvertQuantParams(plan.in_act.qnn_data_type, plan.fc_act_data_type,
+                                                    in_encoding.offset, in_encoding.scale,
+                                                    /*output_symmetric*/ false, converted_in_encoding.scale,
+                                                    converted_in_encoding.offset));
+    RETURN_IF_ERROR(RequantizeBias(qnn_model_wrapper, plan, converted_in_encoding.scale, input_names));
+  }
+  return Ort::Status();
+}
+
+// Replaces the quantized weight in input_names[1] with a statically dequantized float copy at the
+// plan's FC data type, so FC can run in float mode. No-op when FC runs quantized.
+Ort::Status DequantizeWeight(QnnModelWrapper& qnn_model_wrapper, const GemmPrecisionPlan& plan,
+                             /*in,out*/ std::vector<std::string>& input_names) {
+  if (!plan.DequantizesWeight()) {
+    return Ort::Status();
+  }
+
+  const Qnn_DataType_t fc_act_data_type = plan.fc_act_data_type;
+
+  const auto& weight_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]);
+  const Qnn_Tensor_t& qnn_weight = weight_wrapper.GetQnnTensor();
+  const Qnn_ClientBuffer_t& w_buf = GetQnnTensorClientBuf(qnn_weight);
+
+  // Use wrapper dims (post-transpose) and wrapper quant params (already transposed)
+  const auto& w_dims = weight_wrapper.GetTensorDims();
+  const auto& w_qp = weight_wrapper.GetQnnQuantParams();
+  std::vector<float> weight_scales;
+  RETURN_IF_ERROR(w_qp.GetScales(weight_scales));
+  std::vector<int32_t> weight_offsets(weight_scales.size(), 0);
+
+  size_t num_elements = 1;
+  for (auto d : w_dims) num_elements *= d;
+
+  std::vector<float> fp32_weights(num_elements);
+  std::optional<int64_t> axis = w_qp.IsPerChannel() ? std::optional<int64_t>(0) : std::nullopt;
+  RETURN_IF_ERROR(utils::DequantizePerChannel(
+      gsl::span<const uint8_t>(static_cast<const uint8_t*>(w_buf.data), w_buf.dataSize),
+      gsl::span<const uint32_t>(w_dims.data(), w_dims.size()),
+      weight_scales, weight_offsets,
+      fp32_weights, plan.weight.qnn_data_type, axis));
+
+  // Weights must match FC's float width, so they take the activation type: an fp16 FC's in[1] is
+  // fp16, an fp32 FC's is fp32 (see HtpOpDefSupplement, FullyConnected datatypes).
+  std::vector<uint8_t> float_bytes;
+  if (fc_act_data_type == QNN_DATATYPE_FLOAT_16) {
+    float_bytes.resize(num_elements * sizeof(uint16_t));
+    auto* fp16_dst = reinterpret_cast<uint16_t*>(float_bytes.data());
+    for (size_t i = 0; i < num_elements; ++i) {
+      const Ort::Float16_t fp16(fp32_weights[i]);
+      memcpy(&fp16_dst[i], &fp16.val, sizeof(uint16_t));
+    }
+  } else {
+    float_bytes.resize(num_elements * sizeof(float));
+    memcpy(float_bytes.data(), fp32_weights.data(), float_bytes.size());
+  }
+
+  const std::string float_weight_name = utils::UniqueNameGenerator().New(
+      input_names[1], fc_act_data_type == QNN_DATATYPE_FLOAT_16 ? "_fp16" : "_fp32");
+  QnnTensorWrapper float_weight_tensor(float_weight_name, QNN_TENSOR_TYPE_STATIC,
+                                       fc_act_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(w_dims.begin(), w_dims.end()),
+                                       std::move(float_bytes));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(float_weight_tensor)),
+                "Failed to add float weight tensor.");
+  input_names[1] = float_weight_name;
+  return Ort::Status();
+}
+
+// Re-encodes the FC chain's result into the ONNX output activation's type, when FC could not run at
+// that type directly. No-op otherwise, so callers can invoke it unconditionally.
+Ort::Status FixUpOutput(QnnModelWrapper& qnn_model_wrapper, const GemmPrecisionPlan& plan,
+                        const std::string& chain_output_name, const std::string& onnx_output_name,
+                        bool do_op_validation) {
+  if (!plan.FixesUpOutput()) {
+    return Ort::Status();
+  }
+
+  // The ONNX output is always the narrower of the two here: had it been float it would have set the FC
+  // precision itself and needed no fix-up. So the chain is either quantized (Convert, drop bits) or
+  // float (Quantize, back to the ONNX grid).
+  const char* qnn_op_type = IsFloatQnnDataType(plan.fc_act_data_type) ? QNN_OP_QUANTIZE : QNN_OP_CONVERT;
+  const Qnn_TensorType_t final_tensor_type = qnn_model_wrapper.GetTensorType(onnx_output_name);
+  QnnTensorWrapper final_output_tensor(onnx_output_name, final_tensor_type, plan.out_act.qnn_data_type,
+                                       plan.out_act.quant_param.Copy(),
+                                       std::vector<uint32_t>(plan.out_act.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_output_tensor)),
+                "Failed to add mixed-precision Gemm output tensor.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(onnx_output_name, qnn_op_type),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                qnn_op_type,
+                                                {chain_output_name},
+                                                {onnx_output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to add mixed-precision Gemm output node.");
+  return Ort::Status();
+}
+
 }  // namespace
 
 class GemmOpBuilder : public BaseOpBuilder {
@@ -71,6 +482,19 @@ class GemmOpBuilder : public BaseOpBuilder {
                                      const Ort::Logger& logger,
                                      std::vector<std::string>& input_names,
                                      bool do_op_validation) const ORT_MUST_USE_RESULT;
+
+  // Emits every node between the Gemm's inputs and `chain_output_name`: FC alone, FC+Reshape when the
+  // QDQ selector absorbed a post-Gemm Reshape, or FC+ElementWiseAdd when `split_gemm` says QNN FC
+  // cannot fold the bias in. Every link runs at the FC chain's type and encoding (see AddFcChainLink).
+  Ort::Status AddFcChain(QnnModelWrapper& qnn_model_wrapper,
+                         const OrtNodeUnit& node_unit,
+                         const OrtNodeAttrHelper& node_helper,
+                         const GemmPrecisionPlan& plan,
+                         std::vector<std::string>&& input_names,
+                         const std::string& chain_output_name,
+                         bool split_gemm,
+                         const Ort::Logger& logger,
+                         bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
 
 Ort::Status GemmOpBuilder::ExplictOpCheck(const OrtNodeUnit& node_unit) const {
@@ -199,6 +623,13 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                          std::move(input_shape), std::move(unpacked_tensor));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
   }
+
+  // Bring FC's inputs to the precision it runs at (see GemmPrecisionPlan); both helpers are no-ops
+  // when nothing needs fixing up. The output side is handled by ProcessAttributesAndOutputs.
+  GemmPrecisionPlan plan;
+  RETURN_IF_ERROR(MakeGemmPrecisionPlan(qnn_model_wrapper, node_unit, plan));
+  RETURN_IF_ERROR(DequantizeWeight(qnn_model_wrapper, plan, input_names));
+  RETURN_IF_ERROR(FixUpInput(qnn_model_wrapper, plan, input_names, do_op_validation));
 
   return Ort::Status();
 }
@@ -340,10 +771,11 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
     offsets_qnn = std::move(onnx_offsets);
   }
 
-  QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
-                                                                              gsl::span<const float>(offsets_qnn),
-                                                                              bitwidth,
-                                                                              gsl::span<const uint32_t>(block_size_arr));
+  QnnQuantParamsWrapper bq_quant_params =
+      QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
+                                          gsl::span<const float>(offsets_qnn),
+                                          bitwidth,
+                                          gsl::span<const uint32_t>(block_size_arr));
 
   // 2-D weight [N, K] with BW_FLOAT_BLOCK encoding.
   std::vector<uint32_t> weight_shape_2d = {static_cast<uint32_t>(N), static_cast<uint32_t>(K)};
@@ -418,6 +850,66 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
   return Ort::Status();
 }
 
+Ort::Status GemmOpBuilder::AddFcChain(QnnModelWrapper& qnn_model_wrapper,
+                                      const OrtNodeUnit& node_unit,
+                                      const OrtNodeAttrHelper& node_helper,
+                                      const GemmPrecisionPlan& plan,
+                                      std::vector<std::string>&& input_names,
+                                      const std::string& chain_output_name,
+                                      bool split_gemm,
+                                      const Ort::Logger& logger,
+                                      bool do_op_validation) const {
+  // APP_READ only when the chain ends on the node unit's own graph output; a generated name (the
+  // intermediate an output fix-up consumes, or a pre-bias FC result) is NATIVE.
+  const Qnn_TensorType_t chain_output_tensor_type = qnn_model_wrapper.GetTensorType(chain_output_name);
+
+  // MatMulAddFusion post-Gemm Reshape absorbed by the QDQ selector: FC (rank-2) followed by a QNN
+  // Reshape (rank-N). node_unit.Outputs()[0] already reflects the Reshape's rank-N shape and the
+  // terminal Q's encoding, so the output fix-up (if any) is appended after the Reshape.
+  if (node_unit.GetOutputReshapeNode() != nullptr) {
+    // Derive FC's rank-2 output shape [M, N] from the rank-2 input activation [M, K] and the
+    // weight [K, N] (transB=0 asserted for MatMulAddFusion pattern).
+    RETURN_IF_NOT(plan.in_act.shape.size() == 2,
+                  "QNN EP: absorbed-Reshape Gemm input activation must be rank-2 [M, K].");
+    RETURN_IF_NOT(plan.weight.shape.size() == 2, "QNN EP: absorbed-Reshape Gemm weight must be rank-2 [K, N].");
+    RETURN_IF_NOT(node_helper.Get("transB", static_cast<int64_t>(0)) == 0,
+                  "QNN EP: absorbed-Reshape Gemm only supports transB=0.");
+    RETURN_IF_NOT(node_helper.Get("transA", static_cast<int64_t>(0)) == 0,
+                  "QNN EP: absorbed-Reshape Gemm only supports transA=0.");
+    // fc_output_shape = [M, N]: with transA=0 the input activation is [M, K] so shape[0] == M.
+    const std::vector<uint32_t> fc_output_shape{plan.in_act.shape[0], plan.weight.shape[1]};
+
+    const std::string fc_output_name = utils::UniqueNameGenerator().New(chain_output_name, "_fc");
+    RETURN_IF_ERROR(AddFcChainLink(qnn_model_wrapper, node_unit, plan, QNN_OP_FULLY_CONNECTED,
+                                   std::move(input_names), fc_output_name, QNN_TENSOR_TYPE_NATIVE,
+                                   fc_output_shape, do_op_validation));
+    return AddFcChainLink(qnn_model_wrapper, node_unit, plan, QNN_OP_RESHAPE, {fc_output_name},
+                          chain_output_name, chain_output_tensor_type, plan.out_act.shape, do_op_validation);
+  }
+
+  if (split_gemm) {
+    // The pre-bias FC result carries the FC chain's type and encoding: a quantized intermediate
+    // needs a defined encoding, and the trailing ElementWiseAdd re-encodes to the same grid.
+    const std::string fc_output_name = utils::UniqueNameGenerator().New(chain_output_name, "_fc");
+    RETURN_IF_ERROR(AddFcChainLink(qnn_model_wrapper, node_unit, plan, QNN_OP_FULLY_CONNECTED,
+                                   {input_names[0], input_names[1]}, fc_output_name, QNN_TENSOR_TYPE_NATIVE,
+                                   plan.out_act.shape, do_op_validation));
+    return AddFcChainLink(qnn_model_wrapper, node_unit, plan, QNN_OP_ELEMENT_WISE_ADD,
+                          {fc_output_name, input_names[2]}, chain_output_name, chain_output_tensor_type,
+                          plan.out_act.shape, do_op_validation);
+  }
+
+  if (plan.FixesUpOutput()) {
+    // FC feeds the output fix-up, so it emits at the FC chain's type/encoding, not the ONNX output's.
+    return AddFcChainLink(qnn_model_wrapper, node_unit, plan, QNN_OP_FULLY_CONNECTED, std::move(input_names),
+                          chain_output_name, chain_output_tensor_type, plan.out_act.shape, do_op_validation);
+  }
+
+  // Nothing to fix up: the chain is a lone FC emitting the ONNX output tensor as-is.
+  return ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), {}, logger, do_op_validation,
+                        GetQnnOpType(node_unit.OpType()));
+}
+
 Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                        const OrtNodeUnit& node_unit,
                                                        std::vector<std::string>&& input_names,
@@ -464,67 +956,19 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     return Ort::Status();
   }
 
-  // MatMulAddFusion post-Gemm Reshape absorbed by the QDQ selector: FC (rank-2, encoded) followed
-  // by a QNN Reshape (rank-N, same encoding). node_unit.Outputs()[0] already reflects the Reshape's
-  // rank-N shape and the terminal Q's encoding.
-  const OrtNode* absorbed_reshape = node_unit.GetOutputReshapeNode();
-  if (absorbed_reshape != nullptr) {
-    const std::string& final_output_name = node_unit.Outputs()[0].name;
-    TensorInfo final_output_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], final_output_info));
+  GemmPrecisionPlan plan;
+  RETURN_IF_ERROR(MakeGemmPrecisionPlan(qnn_model_wrapper, node_unit, plan));
 
-    // Derive FC's rank-2 output shape [M, N] from the rank-2 activation input [M, K] and the
-    // weight [K, N] (transB=0 asserted for MatMulAddFusion pattern).
-    TensorInfo act_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], act_info));
-    TensorInfo weight_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], weight_info));
-    RETURN_IF_NOT(act_info.shape.size() == 2, "QNN EP: absorbed-Reshape Gemm activation must be rank-2 [M, K].");
-    RETURN_IF_NOT(weight_info.shape.size() == 2, "QNN EP: absorbed-Reshape Gemm weight must be rank-2 [K, N].");
-    const int64_t trans_b = node_helper.Get("transB", static_cast<int64_t>(0));
-    RETURN_IF_NOT(trans_b == 0, "QNN EP: absorbed-Reshape Gemm only supports transB=0.");
-    const int64_t trans_a = node_helper.Get("transA", static_cast<int64_t>(0));
-    RETURN_IF_NOT(trans_a == 0, "QNN EP: absorbed-Reshape Gemm only supports transA=0.");
-    // fc_output_shape = [M, N]: with transA=0 the activation is [M, K] so act_info.shape[0] == M.
-    std::vector<uint32_t> fc_output_shape{act_info.shape[0], weight_info.shape[1]};
+  const std::string& org_output_name = node_unit.Outputs()[0].name;
 
-    const bool final_is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
+  // With an output fix-up the FC chain feeds it under an intermediate name; without one the chain
+  // produces the ONNX output tensor itself.
+  const std::string fc_chain_output_name = plan.FixesUpOutput()
+                                               ? utils::UniqueNameGenerator().New(org_output_name, "_pre_convert")
+                                               : org_output_name;
 
-    // FC intermediate tensor: rank-2 shape, same encoding as the final output.
-    const std::string fc_output_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(final_output_name, "_fc");
-    QnnTensorWrapper fc_out_wrapper(fc_output_name, QNN_TENSOR_TYPE_NATIVE, final_output_info.qnn_data_type,
-                                    final_output_info.quant_param.Copy(), std::vector<uint32_t>(fc_output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_out_wrapper)),
-                  "Failed to add FC output tensor for absorbed-Reshape Gemm.");
-
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_FULLY_CONNECTED),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_FULLY_CONNECTED,
-                                                  std::move(input_names),
-                                                  {fc_output_name},
-                                                  {},
-                                                  do_op_validation),
-                  "Failed to add FullyConnected node (absorbed-Reshape path).");
-
-    // Final Reshape tensor: rank-N shape, same encoding.
-    Qnn_TensorType_t final_tensor_type = final_is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-    QnnTensorWrapper final_wrapper(final_output_name, final_tensor_type, final_output_info.qnn_data_type,
-                                   final_output_info.quant_param.Copy(),
-                                   std::vector<uint32_t>(final_output_info.shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_wrapper)),
-                  "Failed to add final Reshape output tensor for absorbed-Reshape Gemm.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_RESHAPE,
-                                                  {fc_output_name},
-                                                  {final_output_name},
-                                                  {},
-                                                  do_op_validation),
-                  "Failed to add Reshape node (absorbed-Reshape path).");
-    return Ort::Status();
-  }
-
-  // Non-BQ path: decompose Gemm into FullyConnected + Add when needed.
+  // QNN FC folds the bias in itself, except when the bias shape or tensor type rules it out; then the
+  // FC chain grows a trailing ElementWiseAdd.
   bool split_gemm = false;
   if (node_unit.Inputs().size() == 3 && beta != 0.0f) {
     auto& input_c = node_unit.Inputs()[2];
@@ -541,58 +985,10 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     split_gemm = split_gemm || qnn_model_wrapper.GetTensorType(input_c.name) == QNN_TENSOR_TYPE_NATIVE;
   }
 
-  if (split_gemm) {
-    // If split_gemm, input and output of Gemm must at least 2d.
-    const std::string& org_output_name = node_unit.Outputs()[0].name;
-    TensorInfo input_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
-    TensorInfo output_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
-    std::vector<uint32_t> output_shape = output_info.shape;
-    QnnQuantParamsWrapper op_output_quant_param = output_info.quant_param.Copy();
+  RETURN_IF_ERROR(AddFcChain(qnn_model_wrapper, node_unit, node_helper, plan, std::move(input_names),
+                             fc_chain_output_name, split_gemm, logger, do_op_validation));
 
-    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
-
-    // Create FullyConnected Node
-    std::vector<std::string> gemm_input_0_1;
-    gemm_input_0_1.push_back(input_names[0]);
-    gemm_input_0_1.push_back(input_names[1]);
-    const std::string fc_output_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(org_output_name, "_fc");
-    QnnTensorWrapper fully_connected_output(fc_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
-                                            QnnQuantParamsWrapper(), std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fully_connected_output)),
-                  "Failed to add FullyConnected output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_FULLY_CONNECTED),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_FULLY_CONNECTED,
-                                                  std::move(gemm_input_0_1),
-                                                  {fc_output_name},
-                                                  {},
-                                                  do_op_validation),
-                  "Failed to add FullyConnected node.");
-
-    // Create Add Node
-    Qnn_TensorType_t op_output_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-    QnnTensorWrapper op_output_tensor_wrapper(org_output_name, op_output_tensor_type, output_info.qnn_data_type,
-                                              op_output_quant_param.Copy(), std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(op_output_tensor_wrapper)),
-                  "Failed to add ElementWiseAdd output tensor.");
-    std::string bias_name = input_names[2];
-
-    std::string add_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_ADD);
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(add_node_name,
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_ELEMENT_WISE_ADD,
-                                                  {fc_output_name, bias_name},
-                                                  {org_output_name},
-                                                  {},
-                                                  do_op_validation),
-                  "Failed to add ElementWiseAdd node.");
-  } else {
-    RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), {},
-                                   logger, do_op_validation, GetQnnOpType(node_unit.OpType())));
-  }
-  return Ort::Status();
+  return FixUpOutput(qnn_model_wrapper, plan, fc_chain_output_name, org_output_name, do_op_validation);
 }
 
 void CreateGemmOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1689,6 +1689,30 @@ Ort::Status TransposeFromCnhwToHwcn(std::vector<int64_t>&& original_input_shape_
                             output_buffer);
 }
 
+Ort::Status DeriveConvertQuantParams(Qnn_DataType_t input_qnn_data_type,
+                                     Qnn_DataType_t output_qnn_data_type,
+                                     int32_t input_offset,
+                                     float input_scale,
+                                     bool output_symmetric,
+                                     float& output_scale,
+                                     int32_t& output_offset) {
+  // Decode the float range the input encoding represents, then re-derive an encoding for that same
+  // range in the target type. Going through the float range (rather than scaling by a power-of-two
+  // bit-width ratio) keeps this correct when the target differs in signedness or symmetry.
+  float qmin = 0.0f;
+  float qmax = 255.0f;
+  RETURN_IF_ERROR(qnn::utils::GetQminQmax(input_qnn_data_type, qmin, qmax));
+  double value_min = qnn::utils::Dequantize(input_offset, input_scale, qmin);
+  double value_max = qnn::utils::Dequantize(input_offset, input_scale, qmax);
+
+  return qnn::utils::GetQuantParams(static_cast<float>(value_min),
+                                    static_cast<float>(value_max),
+                                    output_qnn_data_type,
+                                    output_scale,
+                                    output_offset,
+                                    output_symmetric);
+}
+
 // Inserts a QNN Convert operator to convert from one quantization type (e.g., uint16) to another (e.g., uint8).
 // (OR) Convert from Asymmetric (e.g., UINT16) to Symmetric (e.g., INT16) quantization type
 Ort::Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
@@ -1702,19 +1726,10 @@ Ort::Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
                             bool output_symmetric,
                             bool do_op_validation) {
   // Assume input is already handled.
-  float qmin = 0.0f;
-  float qmax = 255.0f;
-  RETURN_IF_ERROR(qnn::utils::GetQminQmax(input_qnn_data_type, qmin, qmax));
-  double value_min = qnn::utils::Dequantize(input_offset, input_scale, qmin);
-  double value_max = qnn::utils::Dequantize(input_offset, input_scale, qmax);
   float scale = 0.0f;
   int32_t offset = 0;
-  RETURN_IF_ERROR(qnn::utils::GetQuantParams(static_cast<float>(value_min),
-                                             static_cast<float>(value_max),
-                                             output_qnn_data_type,
-                                             scale,
-                                             offset,
-                                             output_symmetric));
+  RETURN_IF_ERROR(DeriveConvertQuantParams(input_qnn_data_type, output_qnn_data_type, input_offset,
+                                           input_scale, output_symmetric, scale, offset));
 
   std::vector<uint32_t> output_shape_copy = output_shape;
   QnnTensorWrapper convert_output_tensorwrapper(convert_output_name,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -695,6 +695,17 @@ Ort::Status TwoDimensionTranspose(const std::vector<T>& data,
   return Ort::Status();
 }
 
+// Derives the per-tensor encoding that represents the same float range as (input_scale, input_offset)
+// in output_qnn_data_type. Use this when only the target encoding is needed; InsertConvertOp() below
+// applies the same derivation and also emits the Convert node.
+Ort::Status DeriveConvertQuantParams(Qnn_DataType_t input_qnn_data_type,
+                                     Qnn_DataType_t output_qnn_data_type,
+                                     int32_t input_offset,
+                                     float input_scale,
+                                     bool output_symmetric,
+                                     /*out*/ float& output_scale,
+                                     /*out*/ int32_t& output_offset);
+
 Ort::Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
                             const std::string& convert_input_name,
                             const std::string& convert_output_name,

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1185,35 +1185,24 @@ bool OrtGemmNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const OrtNode* redundant_clip_node,
                                      const std::vector<const OrtNode*>& dq_nodes,
                                      const std::vector<const OrtNode*>& q_nodes) const {
-  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, -1 /*num_dq_inputs*/,
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes,
+                     static_cast<int>(dq_nodes.size()) /*num_dq_inputs*/,
                      true /*is_empty_q_nodes_allowed*/)) {
     return false;
   }
 
-  // Check if we have at least 2 DQ nodes (A and B inputs)
-  if (dq_nodes.size() < 2) {
+  // At least 1 DQ node required (either activation or weight must be quantized) else its not a QDQ node group
+  if (dq_nodes.empty()) {
     return false;
   }
 
-  // Get input data types for A and B
-  auto dt_A = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
-  auto dt_B = GetNodeInputDataType(dq_nodes[1], ort_api, 0);
-
-  if (!dt_A.has_value() || !dt_B.has_value()) {
-    return false;
-  }
-
-  // If A is INT8, B must also be INT8
-  if (dt_A.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8) {
-    if (dt_A.value() != dt_B.value()) {  // if A is signed int, B must be signed int
-      return false;
-    }
-  }
-
-  // If there are Q nodes, check if activation and output have the same type
-  if (!q_nodes.empty()) {
-    auto dt_Y = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
-    if (!dt_Y.has_value() || dt_A.value() != dt_Y.value()) {  // activation and output must be same type
+  // Every available DQ input must have a resolvable type. Deliberately does NOT require
+  // dt_A == dt_B or dt_A == dt_Y: mixed-precision Gemm converts to a uniform activation
+  // bitwidth inside GemmOpBuilder (widening/narrowing QNN_OP_CONVERT), so the group is
+  // allowed to form with differing input/output quantization types.
+  for (size_t i = 0; i < dq_nodes.size(); ++i) {
+    auto dt = GetNodeInputDataType(dq_nodes[i], ort_api, 0);
+    if (!dt.has_value()) {
       return false;
     }
   }

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -247,12 +247,14 @@ TEST_F(QnnCPUBackendTests, ReshapeGemmFusion) {
 //
 
 // Returns a function that builds a model with a QDQ Gemm node.
-template <typename InputAQType, typename InputBQType>
-inline GetTestQDQModelFn<InputAQType> BuildQDQGemmTestCase(const std::vector<TestInputDef<float>>& input_defs,
+// OutputQType defaults to InputAQType; pass a different type to build a mixed-precision group
+// (e.g. u8 activation with u16 output), which QNN EP handles by inserting a Convert before the FC.
+template <typename InputAQType, typename InputBQType, typename OutputQType = InputAQType>
+inline GetTestQDQModelFn<OutputQType> BuildQDQGemmTestCase(const std::vector<TestInputDef<float>>& input_defs,
                                                            const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                                                            bool use_contrib_qdq = false) {
   return [input_defs, attrs, use_contrib_qdq](ModelTestBuilder& builder,
-                                              std::vector<QuantParams<InputAQType>>& output_qparams) {
+                                              std::vector<QuantParams<OutputQType>>& output_qparams) {
     const size_t num_inputs = input_defs.size();
     QNN_ASSERT(num_inputs == 2 || num_inputs == 3);
 
@@ -286,14 +288,14 @@ inline GetTestQDQModelFn<InputAQType> BuildQDQGemmTestCase(const std::vector<Tes
     builder.AddNode("gemm", "Gemm", gemm_inputs, {"Y"}, "", attributes);
 
     // Output: Y -> Q -> DQ -> output
-    AddQDQNodePairWithOutputAsGraphOutput<InputAQType>(
+    AddQDQNodePairWithOutputAsGraphOutput<OutputQType>(
         builder, "qdq_out", "Y", output_qparams[0].scale, output_qparams[0].zero_point, use_contrib_qdq);
   };
 }
 
 // Runs a QDQ Gemm model on the QNN (HTP) EP and the ORT CPU EP. Checks the graph node assignment and that inference
 // running the QDQ model on QNN EP is at least as accurate as on ORT CPU EP (compared to the baseline float32 model).
-template <typename InputAQType, typename InputBQType>
+template <typename InputAQType, typename InputBQType, typename OutputQType = InputAQType>
 static void RunQDQGemmTestOnHTP(const std::vector<TestInputDef<float>>& input_defs,
                                 const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                                 ExpectedEPNodeAssignment expected_ep_assignment,
@@ -306,8 +308,9 @@ static void RunQDQGemmTestOnHTP(const std::vector<TestInputDef<float>>& input_de
   provider_options["offload_graph_io_quantization"] = "0";
 
   auto f32_model_builder = BuildOpTestCase<float>("Gemm_node", "Gemm", input_defs, {}, attrs);
-  auto qdq_model_builder = BuildQDQGemmTestCase<InputAQType, InputBQType>(input_defs, attrs, use_contrib_qdq);
-  TestQDQModelAccuracy<InputAQType>(f32_model_builder,
+  auto qdq_model_builder =
+      BuildQDQGemmTestCase<InputAQType, InputBQType, OutputQType>(input_defs, attrs, use_contrib_qdq);
+  TestQDQModelAccuracy<OutputQType>(f32_model_builder,
                                     qdq_model_builder,
                                     provider_options,
                                     opset,
@@ -511,6 +514,108 @@ TEST_F(QnnHTPBackendTests, Gemm_TransAB_Static_B_And_Bias_U16Act_U8Weight) {
                                          ExpectedEPNodeAssignment::All,
                                          13,     // opset
                                          true);  // Use com.microsoft Q/DQ ops
+}
+
+// Mixed-precision (widening) QDQ Gemm with transA=1: u8 activation, u8 weight, u16 output.
+//
+// Covers the interaction between the transA Transpose and the widening Convert in GemmOpBuilder.
+// HTP FullyConnected requires in[0] and out[0] to share a quantized type, so the builder inserts
+// Convert(u8->u16) on the activation. With transA=1 the activation has already been transposed,
+// so input_names[0] is a Transpose output and the Convert's shape must be read from the staged
+// QNN tensor wrapper (post-permute dims) rather than from the ONNX-side input info. Reading the
+// ONNX dims here would give the Convert a [K, M] shape where the graph carries [M, K].
+//
+// The bias is also requantized, since the Convert changes the activation scale the FC accumulates at.
+TEST_F(QnnHTPBackendTests, Gemm_TransA_MixedPrecision_U8Act_U8Weight_U16Out) {
+  std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
+  std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
+  // A is [K, M] = [6, 1] because transA=1; B is [K, N] = [6, 4] with transB=0.
+  RunQDQGemmTestOnHTP<uint8_t, uint8_t, uint16_t>({TestInputDef<float>({6, 1}, false, input_a_data),
+                                                   TestInputDef<float>({6, 4}, true, input_b_data),
+                                                   TestInputDef<float>({1, 4}, true, input_c_data)},
+                                                  {test::MakeAttribute("transA", static_cast<int64_t>(1))},
+                                                  ExpectedEPNodeAssignment::All,
+                                                  21);  // opset 21 for native 16-bit Q/DQ
+}
+
+// Same widening path with transA=1 and transB=1, so both A and B carry a Transpose.
+//
+// A and B use smaller ranges than the transA-only test above (2.5/1.25 instead of 10/5). Both EPs
+// consume the same quantized inputs, so shrinking A and B does not change their quantization error
+// relative to each other — it shrinks the FC accumulator, and with it the absolute QNN-vs-CPU
+// difference, while the unchanged bias range keeps the output range from shrinking as fast. At
+// 10/5 this configuration lands at 0.409% of the output range, just over the 0.4% default
+// tolerance; the same-data 8-bit sibling Gemm_TransAB_Static_B_And_Bias_U8 is marginal for the
+// same reason (skipped on v79/v81 for exceeding it by 2.7%), so it is the input/double-transpose
+// combination rather than the widening path that sits near the limit.
+TEST_F(QnnHTPBackendTests, Gemm_TransAB_MixedPrecision_U8Act_U8Weight_U16Out) {
+  std::vector<float> input_a_data = GetFloatDataInRange(-2.5f, 2.5f, 6);
+  std::vector<float> input_b_data = GetFloatDataInRange(-1.25f, 1.25f, 24);
+  std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
+  RunQDQGemmTestOnHTP<uint8_t, uint8_t, uint16_t>({TestInputDef<float>({6, 1}, false, input_a_data),
+                                                   TestInputDef<float>({4, 6}, true, input_b_data),
+                                                   TestInputDef<float>({1, 4}, true, input_c_data)},
+                                                  {test::MakeAttribute("transA", static_cast<int64_t>(1)),
+                                                   test::MakeAttribute("transB", static_cast<int64_t>(1))},
+                                                  ExpectedEPNodeAssignment::All,
+                                                  21);  // opset 21 for native 16-bit Q/DQ
+}
+
+// Narrowing counterpart with transA=1: u16 activation, u8 weight, u8 output. Here the Convert is
+// inserted after the FC (ProcessAttributesAndOutputs) and the bias is deliberately NOT requantized,
+// since the FC still accumulates at the original u16 activation scale.
+TEST_F(QnnHTPBackendTests, Gemm_TransA_MixedPrecision_U16Act_U8Weight_U8Out) {
+  std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
+  std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
+  RunQDQGemmTestOnHTP<uint16_t, uint8_t, uint8_t>({TestInputDef<float>({6, 1}, false, input_a_data),
+                                                   TestInputDef<float>({6, 4}, true, input_b_data),
+                                                   TestInputDef<float>({1, 4}, true, input_c_data)},
+                                                  {test::MakeAttribute("transA", static_cast<int64_t>(1))},
+                                                  ExpectedEPNodeAssignment::All,
+                                                  21);  // opset 21 for native 16-bit Q/DQ
+}
+
+// Widening mixed-precision Gemm (u8 act, u16 out) whose int32 bias is a *graph input* rather than an
+// initializer: must be rejected, not silently mis-scaled.
+//
+// The widening Convert changes the scale FC accumulates at, so the int32 bias has to be rescaled from
+// old_act_scale * weight_scale to new_act_scale * weight_scale. HTP folds the bias into the FC
+// accumulator at that product and ignores the bias tensor's declared encoding, so re-declaring the
+// encoding alone is not enough — the stored integers must change, which requires a client buffer the
+// builder can rewrite. A graph-input bias has none, so ProcessInputs rejects the node.
+//
+// (A NATIVE int32 bias is deliberately *not* rejected: it forces split_gemm, where the bias lands on a
+// separate ElementWiseAdd that honors its own encoding. See GemmReshapeQ_Direct_NativeBias_NotAbsorbed.)
+TEST_F(QnnHTPBackendTests, Gemm_MixedPrecision_U8Act_U16Out_GraphInputBias_Unsupported) {
+  std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
+  std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
+  RunQDQGemmTestOnHTP<uint8_t, uint8_t, uint16_t>({TestInputDef<float>({1, 6}, false, input_a_data),
+                                                   TestInputDef<float>({6, 4}, true, input_b_data),
+                                                   // Dynamic bias => int32 graph input, no client buffer.
+                                                   TestInputDef<float>({1, 4}, false, input_c_data)},
+                                                  {},
+                                                  ExpectedEPNodeAssignment::None,
+                                                  21);  // opset 21 for native 16-bit Q/DQ
+}
+
+// Mixed-precision Gemm whose activation/output types differ but map to no supported sequence:
+// u8 activation with s8 output. Same bit width, so it is neither widening nor narrowing, and both
+// sides are quantized so it is neither quant-to-float nor float-to-quant. Emitting it anyway would
+// hand HTP FullyConnected mismatched in[0]/out[0] types, so GemmOpBuilder must reject the node
+// (GemmMixedPrecision::IsUnsupported) and let it fall back rather than build a bad graph.
+TEST_F(QnnHTPBackendTests, Gemm_MixedPrecision_U8Act_S8Out_Unsupported) {
+  std::vector<float> input_a_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::vector<float> input_b_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
+  std::vector<float> input_c_data = GetFloatDataInRange(-1.0f, 1.0f, 4);
+  RunQDQGemmTestOnHTP<uint8_t, uint8_t, int8_t>({TestInputDef<float>({1, 6}, false, input_a_data),
+                                                 TestInputDef<float>({6, 4}, true, input_b_data),
+                                                 TestInputDef<float>({1, 4}, true, input_c_data)},
+                                                {},
+                                                ExpectedEPNodeAssignment::None,
+                                                21);
 }
 
 // Broken on v79 and v81 devices:
@@ -784,7 +889,12 @@ namespace {
 // The activation is rank-3 so MatMulAddFusion inserts the Reshape wrappers around
 // the resulting rank-2 Gemm. The output Q is unsigned with zero_point == 0, so
 // encoding_min = scale * (qmin - zp) = 0 and the Relu fold is encoding-safe.
-template <typename ActQType, typename WtQType>
+//
+// OutQType defaults to ActQType. Passing a different type builds a mixed-precision group on top of
+// the absorbed Reshape, which makes GemmOpBuilder emit FC + Reshape + Convert. Note that the
+// trailing Reshape is only absorbed when include_relu is true — see the comment on
+// GemmMatMulAddFusion_MixedPrecision_U8Act_U8Weight_U16Out.
+template <typename ActQType, typename WtQType, typename OutQType = ActQType>
 GetTestModelFn BuildMatMulAddFusionQDQTestCase(int64_t M, int64_t K, int64_t N, bool include_relu) {
   return [M, K, N, include_relu](ModelTestBuilder& builder) {
     const std::vector<int64_t> act_shape{1, M, K};
@@ -828,8 +938,8 @@ GetTestModelFn BuildMatMulAddFusionQDQTestCase(int64_t M, int64_t K, int64_t N, 
     // Output Q(zp=0) makes the encoding safe for the Relu fold; ORT normally drops
     // Relu itself in this case, but we assert that even if the Relu survives (e.g.,
     // because L2 cleanup decides to keep it), the group forms and QNN accepts the FC.
-    QuantParams<ActQType> out_qp = QuantParams<ActQType>::Compute(0.0f, 8.0f, /*symmetric=*/false);
-    AddQDQNodePairWithOutputAsGraphOutput<ActQType>(builder, "out", post_activation,
+    QuantParams<OutQType> out_qp = QuantParams<OutQType>::Compute(0.0f, 8.0f, /*symmetric=*/false);
+    AddQDQNodePairWithOutputAsGraphOutput<OutQType>(builder, "out", post_activation,
                                                     out_qp.scale, out_qp.zero_point,
                                                     /*use_contrib_qdq=*/true);
   };
@@ -871,123 +981,37 @@ TEST_F(QnnHTPBackendTests, GemmMatMulAddFusion_U16Act_S16Weight_WithRelu) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
 }
 
-// Direct QDQ Gemm -> Reshape -> Q graphs (no MatMul+Add) — exercise the absorb-Reshape
-// selector's guard-rails on shapes; MatMulAddFusion never emits (transB=1, NATIVE bias).
-namespace {
-// activation: rank-2 [M, K] float -> Q(u16) -> DQ
-// weight:    rank-2 [K, N] (or [N, K] when trans_b=1) static -> DQ
-// bias (opt): rank-1 [N] INT32 static -> DQ
-// -> Gemm -> Reshape (rank-3 [1, M, N]) -> Q -> DQ -> output
-struct DirectGemmReshapeQConfig {
-  int64_t M = 4;
-  int64_t K = 8;
-  int64_t N = 6;
-  int64_t trans_b = 0;                  // 0 → weight [K,N]; 1 → weight [N,K]
-  bool include_bias = true;             // rank-1 bias by default
-  bool bias_from_intermediate = false;  // if true, bias is produced by an intermediate MatMul (NATIVE bias)
-};
-
-GetTestModelFn BuildDirectGemmReshapeQTestCase(const DirectGemmReshapeQConfig& cfg) {
-  return [cfg](ModelTestBuilder& builder) {
-    const std::vector<int64_t> act_shape{cfg.M, cfg.K};
-    const std::vector<int64_t> weight_shape = cfg.trans_b == 0
-                                                  ? std::vector<int64_t>{cfg.K, cfg.N}
-                                                  : std::vector<int64_t>{cfg.N, cfg.K};
-
-    MakeTestInput<float>(builder, "input", TestInputDef<float>(act_shape, false, -1.0f, 1.0f));
-    QuantParams<uint16_t> act_qp = QuantParams<uint16_t>::Compute(-1.0f, 1.0f, /*symmetric=*/false);
-    const std::string act_qdq = AddQDQNodePair<uint16_t>(builder, "act", "input", act_qp.scale,
-                                                         act_qp.zero_point, /*use_contrib_qdq=*/true);
-
-    QuantParams<uint8_t> wt_qp = QuantParams<uint8_t>::Compute(-0.5f, 0.5f, /*symmetric=*/true);
-    TestInputDef<float> wt_def(weight_shape, /*is_initializer=*/true,
-                               GetFloatDataInRange(-0.5f, 0.5f, static_cast<size_t>(cfg.K * cfg.N)));
-    std::vector<uint8_t> wt_quantized(static_cast<size_t>(cfg.K * cfg.N));
-    const std::vector<float> wt_scales{wt_qp.scale};
-    const std::vector<uint8_t> wt_zps{wt_qp.zero_point};
-    QuantizeValues<float, uint8_t>(wt_def.GetRawData(), wt_quantized, weight_shape,
-                                   wt_scales, wt_zps, std::nullopt);
-    builder.MakeInitializer<uint8_t>("weight_q", weight_shape, wt_quantized);
-    builder.AddDequantizeLinearNode<uint8_t>("weight_dq", "weight_q", wt_qp.scale,
-                                             wt_qp.zero_point, "weight_dq", /*use_contrib_qdq=*/true);
-
-    std::vector<std::string> gemm_inputs{act_qdq, "weight_dq"};
-    if (cfg.include_bias) {
-      if (cfg.bias_from_intermediate) {
-        // Build a NATIVE bias: MatMul produces the tensor consumed by Gemm as C. This is what
-        // MatMulAddFusion normally rewrites into Gemm(C=intermediate), but here we assemble
-        // the pattern by hand so the absorb-Reshape selector must reject it.
-        std::vector<int64_t> mm_a_shape{cfg.M, cfg.K};
-        std::vector<int64_t> mm_w_shape{cfg.K, cfg.N};
-        builder.MakeInput<float>("bias_mm_a", mm_a_shape, -1.0f, 1.0f);
-        builder.MakeInitializer<float>("bias_mm_w", mm_w_shape, -0.5f, 0.5f);
-        const std::string bias_mm_dq_a = AddQDQNodePair<uint16_t>(builder, "bias_mm_a_qdq",
-                                                                  "bias_mm_a", act_qp.scale,
-                                                                  act_qp.zero_point, /*use_contrib_qdq=*/true);
-        builder.AddNode("bias_mm", "MatMul", {bias_mm_dq_a, "bias_mm_w"}, {"bias_native"}, kOnnxDomain);
-        gemm_inputs.push_back("bias_native");
-      } else {
-        const std::vector<int64_t> bias_shape{cfg.N};
-        TestInputDef<float> bias_def(bias_shape, /*is_initializer=*/true,
-                                     GetFloatDataInRange(-0.2f, 0.2f, static_cast<size_t>(cfg.N)));
-        const std::string bias_dq = MakeTestQDQBiasInput(builder, "bias", bias_def,
-                                                         act_qp.scale * wt_qp.scale, /*use_contrib_qdq=*/true);
-        gemm_inputs.push_back(bias_dq);
-      }
-    }
-
-    std::vector<ONNX_NAMESPACE::AttributeProto> gemm_attrs;
-    gemm_attrs.push_back(test::MakeAttribute("transB", cfg.trans_b));
-    builder.AddNode("gemm", "Gemm", gemm_inputs, {"gemm_out"}, kOnnxDomain, gemm_attrs);
-
-    // Explicit Reshape rank-2 -> rank-3.
-    const std::vector<int64_t> reshape_target{1, cfg.M, cfg.N};
-    builder.Make1DInitializer<int64_t>("reshape_shape", reshape_target);
-    builder.AddNode("reshape", "Reshape", {"gemm_out", "reshape_shape"}, {"reshape_out"});
-
-    QuantParams<uint16_t> out_qp = QuantParams<uint16_t>::Compute(0.0f, 8.0f, /*symmetric=*/false);
-    AddQDQNodePairWithOutputAsGraphOutput<uint16_t>(builder, "out", "reshape_out",
-                                                    out_qp.scale, out_qp.zero_point,
-                                                    /*use_contrib_qdq=*/true);
-  };
-}
-
-ProviderOptions GetHtpProviderOptions() {
-  ProviderOptions opts;
-  opts["backend_type"] = "htp";
-  opts["offload_graph_io_quantization"] = "0";
-  return opts;
-}
-}  // namespace
-
-// Positive: direct Gemm -> Reshape -> Q with transB=0 and rank-1 static bias.
-// The selector absorbs the Reshape and the group is assigned to QNN EP.
-TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_TransB0_1DBias) {
-  DirectGemmReshapeQConfig cfg;
-  RunQnnModelTest(BuildDirectGemmReshapeQTestCase(cfg), GetHtpProviderOptions(), /*opset=*/21,
+// Mixed-precision (widening) on top of the absorbed Reshape: u8 activation, u8 weight, u16 output.
+//
+// Regression test for the absorbed-Reshape path skipping the mixed-precision output logic. The
+// widening Convert lands on the *activation* (ProcessInputs), so the FC receives u16 while the
+// absorbed path used to type its FC/Reshape intermediates off the ONNX-side u8 activation type —
+// giving HTP FullyConnected mismatched in[0]/out[0] types. The intermediates must carry the
+// effective FC type (u16 here), not the pre-Convert activation type.
+//
+// include_relu must be true to reach the absorbed path at all: ORT's QDQPropagationTransformer
+// pushes the trailing Q back across a bare Reshape, so `Gemm -> Reshape -> Q` becomes
+// `Gemm -> Q -> DQ -> Reshape -> Q` and the Reshape ends up as a standalone QNN op. It does not
+// propagate across Relu/Clip, so only `Gemm -> Reshape -> Relu -> Q` survives for the selector to
+// absorb (qnn_ep_utils.cc, TryAbsorbTrailingReshape gate 3b.3.2).
+TEST_F(QnnHTPBackendTests, GemmMatMulAddFusion_MixedPrecision_U8Act_U8Weight_U16Out) {
+  RunQnnModelTest(BuildMatMulAddFusionQDQTestCase<uint8_t, uint8_t, uint16_t>(
+                      /*M=*/8, /*K=*/16, /*N=*/12, /*include_relu=*/true),
+                  GetMatMulAddFusionProviderOptions(), /*opset=*/21,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
 }
 
-// Negative gate (M-1): direct Gemm(transB=1) -> Reshape -> Q must NOT be absorbed by the
-// absorb-Reshape selector — the builder's absorbed path hard-asserts transB=0. The graph
-// still runs on QNN EP via the split_gemm / regular Gemm path (Reshape is a separate node).
-TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_TransB1_NotAbsorbed) {
-  DirectGemmReshapeQConfig cfg;
-  cfg.trans_b = 1;
-  // Successful build proves the selector did not force the absorbed-Reshape path
-  // (which would abort at graph build with transB=1).
-  RunQnnModelTest(BuildDirectGemmReshapeQTestCase(cfg), GetHtpProviderOptions(), /*opset=*/21,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
-}
-
-// Negative gate (M-2): direct Gemm with a NATIVE bias (produced by an intermediate MatMul)
-// -> Reshape -> Q. The absorb-Reshape path must reject it (unsafe: NATIVE bias would have
-// forced split_gemm). The graph still runs via split_gemm.
-TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_NativeBias_NotAbsorbed) {
-  DirectGemmReshapeQConfig cfg;
-  cfg.bias_from_intermediate = true;
-  RunQnnModelTest(BuildDirectGemmReshapeQTestCase(cfg), GetHtpProviderOptions(), /*opset=*/21,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+// Narrowing counterpart on the absorbed Reshape: u16 activation, u8 weight, u8 output. Here the FC
+// chain (FC + Reshape) runs at u16 with the u8 output grid re-expressed at 16-bit, and a trailing
+// Convert re-encodes to u8 *after* the Reshape. Before the fix the absorbed path returned early and
+// never emitted that Convert, so the graph output kept the wrong encoding/type.
+//
+// include_relu is true for the same reason as the widening test above.
+TEST_F(QnnHTPBackendTests, GemmMatMulAddFusion_MixedPrecision_U16Act_U8Weight_U8Out) {
+  RunQnnModelTest(BuildMatMulAddFusionQDQTestCase<uint16_t, uint8_t, uint8_t>(
+                      /*M=*/8, /*K=*/16, /*N=*/12, /*include_relu=*/true),
+                  GetMatMulAddFusionProviderOptions(), /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(4e-2f)});
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -297,6 +297,103 @@ static GetTestQDQModelFn<OutputQType> BuildQDQBlockQuantMatMulTestCase(
   };
 }
 
+// Returns a function that creates a graph with MatMul + Add operators.
+// input0 --|
+//           MatMul -> Add -> output
+// input1 --|
+// bias ----------------|
+static GetTestModelFn BuildMatMulAddOpTestCase(const TestInputDef<float>& input0_def,
+                                               const TestInputDef<float>& input1_def,
+                                               const TestInputDef<float>& bias_def) {
+  return [input0_def, input1_def, bias_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input0", input0_def);
+    MakeTestInput<float>(builder, "input1", input1_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    builder.AddNode("MatMul", "MatMul", {"input0", "input1"}, {"matmul_out"}, kOnnxDomain);
+    builder.AddNode("Add", "Add", {"matmul_out", "bias"}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput("Y");
+  };
+}
+
+// Returns a function that creates a QDQ MatMul + Add graph with:
+//   - Per-tensor input Q->DQ
+//   - Per-channel weight (DQ-only, pre-quantized initializer)
+//   - Float bias (initializer, no quantization)
+//   - Per-tensor output Q->DQ
+//
+//   input[f32] -> Q -> DQ - |
+//                           MatMul -> Add -> Q -> DQ -> output[f32]
+//   weight[per-ch] -> DQ -- |        /
+//   bias[f32 initializer] ----------/
+template <typename InputQType, typename WeightQType, typename OutputQType>
+static GetTestQDQModelFn<OutputQType> BuildQDQPerChannelMatMulAddTestCase(
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weights_def,
+    const TestInputDef<float>& bias_def,
+    int64_t weight_quant_axis) {
+  return [input_def, weights_def, bias_def, weight_quant_axis](
+             ModelTestBuilder& builder, std::vector<QuantParams<OutputQType>>& output_qparams) {
+    QNN_ASSERT(weights_def.IsInitializer() && weights_def.IsRawData());
+    QNN_ASSERT(bias_def.IsInitializer() && bias_def.IsRawData());
+
+    // input
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // input -> Q -> DQ -> input_qdq
+    const QuantParams<InputQType> input_qparams = GetTestInputQuantParams<InputQType>(input_def);
+    const std::string input_qdq =
+        AddQDQNodePair<InputQType>(builder, "qdq_in", "input",
+                                   input_qparams.scale, input_qparams.zero_point);
+
+    // Quantized(weights) -> DQ -> weights_dq (per-channel, pre-quantized initializer)
+    auto weight_shape = weights_def.GetShape();
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zero_points;
+    int64_t pos_weight_quant_axis = weight_quant_axis;
+    if (pos_weight_quant_axis < 0) {
+      pos_weight_quant_axis += static_cast<int64_t>(weight_shape.size());
+    }
+
+    GetTestInputQuantParamsPerChannel<WeightQType>(weights_def, weight_scales, weight_zero_points,
+                                                   static_cast<size_t>(pos_weight_quant_axis), true);
+
+    std::vector<WeightQType> quantized_weights;
+    size_t num_weight_storage_elems = SizeOfShape(weight_shape);
+    if constexpr (std::is_same_v<WeightQType, Int4x2> || std::is_same_v<WeightQType, UInt4x2>) {
+      num_weight_storage_elems = Int4x2::CalcNumInt4Pairs(SizeOfShape(weight_shape));
+    }
+    quantized_weights.resize(num_weight_storage_elems);
+
+    QuantizeValues<float, WeightQType>(weights_def.GetRawData(), quantized_weights, weight_shape, weight_scales,
+                                       weight_zero_points, pos_weight_quant_axis);
+
+    builder.MakeInitializer<WeightQType>("weights", weights_def.GetShape(), quantized_weights);
+
+    builder.AddDequantizeLinearNode<WeightQType>(
+        "weights_dq",
+        "weights",
+        weight_scales,
+        weight_zero_points,
+        "weights_dq",
+        {builder.MakeScalarAttribute("axis", static_cast<int64_t>(weight_quant_axis))});
+
+    // bias as fp32 initializer (no quantization)
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    // MatMul(input_qdq, weights_dq) -> matmul_out
+    builder.AddNode("MatMul", "MatMul", {input_qdq, "weights_dq"}, {"matmul_out"}, kOnnxDomain);
+
+    // Add(matmul_out, bias) -> Y
+    builder.AddNode("Add", "Add", {"matmul_out", "bias"}, {"Y"}, kOnnxDomain);
+
+    // Y -> Q -> DQ -> (graph output)
+    AddQDQNodePairWithOutputAsGraphOutput<OutputQType>(builder, "qdq_out", "Y",
+                                                       output_qparams[0].scale,
+                                                       output_qparams[0].zero_point);
+  };
+}
+
 template <typename InputQType, typename WeightQType, typename OutputQType>
 static void RunQDQBlockQuantMatMulOpTest(
     const std::vector<int64_t>& shape_input,
@@ -325,6 +422,31 @@ static void RunQDQBlockQuantMatMulOpTest(
       BuildQDQBlockQuantMatMulTestCase<InputQType, WeightQType, OutputQType>(
           input_def, weight_def, block_size, weight_quant_axis, use_contrib_qdq),
       provider_options, opset, expected_ep_assignment, tolerance);
+}
+
+template <typename InputQType, typename WeightQType, typename OutputQType>
+static void RunQDQPerChannelMatMulAddOpTest(
+    const std::vector<int64_t>& shape_input, const std::vector<int64_t>& shape_weight,
+    const std::vector<int64_t>& bias_shape, int64_t weight_quant_axis,
+    QDQTolerance tolerance = QDQTolerance(),
+    ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All, int opset = 21) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  auto num_elements = [](const std::vector<int64_t>& shape) -> size_t {
+    return static_cast<size_t>(
+        std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>()));
+  };
+
+  TestInputDef<float> input_def(shape_input, false, GetFloatDataInRange(-0.1f, 0.1f, num_elements(shape_input)));
+  TestInputDef<float> weight_def(shape_weight, true, GetFloatDataInRange(-0.1f, 0.1f, num_elements(shape_weight)));
+  TestInputDef<float> bias_def(bias_shape, true, GetFloatDataInRange(-0.1f, 0.1f, num_elements(bias_shape)));
+
+  TestQDQModelAccuracy(BuildMatMulAddOpTestCase(input_def, weight_def, bias_def),
+                       BuildQDQPerChannelMatMulAddTestCase<InputQType, WeightQType, OutputQType>(
+                           input_def, weight_def, bias_def, weight_quant_axis),
+                       provider_options, opset, expected_ep_assignment, tolerance);
 }
 
 //
@@ -580,6 +702,213 @@ TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_Rank4Weight) {
                                         /*act_shape_override=*/{}, /*weight_shape_override=*/{1, 1, 16, 4}),
                   GetBQMatMulProviderOptions(), /*opset=*/21,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+}
+
+// Test QDQ MatMul + Add with per-channel int8 weight and int32 bias, uint16 output.
+// Pattern: input -> Q(u8) -> DQ -> MatMul -> Add -> Q(u16) -> DQ -> output
+//          weight[i8 per-ch] -> DQ ---|        |
+//          bias[i32 per-ch] -> DQ -------------|
+//
+// NOTE: Inputs must be rank-2 (2D). With rank>2 inputs, ORT's MatMulAddFusion optimizer
+// inserts Reshape nodes around Gemm (Reshape -> Gemm -> Reshape), which breaks the QDQ
+// pattern because QNN EP cannot form valid QDQ node units when Reshape sits between DQ and Gemm.
+//
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_U8_I8_U16) {
+  RunQDQPerChannelMatMulAddOpTest<uint8_t, int8_t, uint16_t>(
+      {2, 3}, {3, 2}, {2}, /*weight_quant_axis=*/-1, QDQTolerance(0.002f));
+  // Larger shape
+  RunQDQPerChannelMatMulAddOpTest<uint8_t, int8_t, uint16_t>(
+      {32, 32}, {32, 32}, {32}, /*weight_quant_axis=*/-1, QDQTolerance(0.002f));
+}
+
+// Test QDQ MatMul + Add with per-channel int8 weight, fp32 output (no QDQ on output).
+// Pattern: input -> Q -> DQ -> MatMul -> Add -> output(fp32)
+//     weight[i8 per-ch] -> DQ ---|        /
+//             bias[f32 initializer] -----/
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_U8_I8_FP32) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  auto num_elements = [](const std::vector<int64_t>& shape) -> size_t {
+    return static_cast<size_t>(
+        std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>()));
+  };
+
+  std::vector<int64_t> shape_input = {2, 3};
+  std::vector<int64_t> shape_weight = {3, 2};
+  std::vector<int64_t> bias_shape = {2};
+
+  TestInputDef<float> input_def(shape_input, false, GetFloatDataInRange(-0.1f, 0.1f, num_elements(shape_input)));
+  TestInputDef<float> weight_def(shape_weight, true, GetFloatDataInRange(-0.1f, 0.1f, num_elements(shape_weight)));
+  TestInputDef<float> bias_def(bias_shape, true, GetFloatDataInRange(-0.1f, 0.1f, num_elements(bias_shape)));
+
+  // Float reference model: MatMul -> Add -> output (f32)
+  auto f32_model_fn = BuildMatMulAddOpTestCase(input_def, weight_def, bias_def);
+
+  // QDQ model: QDQ(u8) -> MatMul -> Add -> output (f32)
+  auto qdq_model_fn = [input_def, weight_def, bias_def](
+                          ModelTestBuilder& builder, std::vector<QuantParams<uint8_t>>& output_qparams) {
+    QNN_TEST_UNUSED_PARAMETER(output_qparams);
+
+    // input -> Q -> DQ
+    MakeTestInput<float>(builder, "input", input_def);
+    const QuantParams<uint8_t> input_qparams = GetTestInputQuantParams<uint8_t>(input_def);
+    const std::string input_qdq =
+        AddQDQNodePair<uint8_t>(builder, "qdq_in", "input",
+                                input_qparams.scale, input_qparams.zero_point);
+
+    // weights as fp32 initializer
+    MakeTestInput<float>(builder, "weights", weight_def);
+
+    // bias as fp32 initializer
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    // MatMul -> Add
+    builder.AddNode("MatMul", "MatMul", {input_qdq, "weights"}, {"matmul_out"}, kOnnxDomain);
+    builder.AddNode("Add", "Add", {"matmul_out", "bias"}, {"Y"}, kOnnxDomain);
+
+    // Output is already fp32, no Cast needed
+    builder.MakeOutput("Y");
+  };
+
+  TestQDQModelAccuracy<uint8_t>(f32_model_fn,
+                                qdq_model_fn,
+                                provider_options, 21, ExpectedEPNodeAssignment::All);
+}
+template <typename InputQType = float, typename WeightQType = int8_t, typename OutputQType = float>
+static void RunMixedPrecisionPerChannelMatMulAddTest(
+    const std::vector<int64_t>& input_shape,
+    const std::vector<int64_t>& weight_shape,
+    const std::vector<int64_t>& bias_shape) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  auto num_elements = [](const std::vector<int64_t>& shape) -> size_t {
+    return static_cast<size_t>(
+        std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1), std::multiplies<int64_t>()));
+  };
+
+  TestInputDef<float> input_def(input_shape, false, GetFloatDataInRange(-0.1f, 0.1f, num_elements(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, true, GetFloatDataInRange(-0.1f, 0.1f, num_elements(weight_shape)));
+  TestInputDef<float> bias_def(bias_shape, true, GetFloatDataInRange(-0.1f, 0.1f, num_elements(bias_shape)));
+
+  auto f32_model_fn = BuildMatMulAddOpTestCase(input_def, weight_def, bias_def);
+
+  // Determine the quant type used for TestQDQModelAccuracy template param.
+  // Priority: OutputQType if quantized, else InputQType if quantized, else uint8_t fallback.
+  using TestQType = std::conditional_t<!std::is_same_v<OutputQType, float>, OutputQType,
+                                       std::conditional_t<!std::is_same_v<InputQType, float>, InputQType, uint8_t>>;
+
+  auto qdq_model_fn = [input_def, weight_def, bias_def](
+                          ModelTestBuilder& builder, std::vector<QuantParams<TestQType>>& output_qparams) {
+    QNN_TEST_UNUSED_PARAMETER(output_qparams);
+
+    MakeTestInput<float>(builder, "input", input_def);
+    std::string matmul_input_name;
+    if constexpr (std::is_same_v<InputQType, float>) {
+      matmul_input_name = "input";
+    } else {
+      const QuantParams<InputQType> input_qparams = GetTestInputQuantParams<InputQType>(input_def);
+      matmul_input_name =
+          AddQDQNodePair<InputQType>(builder, "qdq_in", "input",
+                                     input_qparams.scale, input_qparams.zero_point);
+    }
+
+    auto w_shape = weight_def.GetShape();
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zero_points;
+    GetTestInputQuantParamsPerChannel<WeightQType>(weight_def, weight_scales, weight_zero_points, 1, true);
+
+    std::vector<WeightQType> quantized_weights(SizeOfShape(w_shape));
+    QuantizeValues<float, WeightQType>(weight_def.GetRawData(), quantized_weights, w_shape,
+                                       weight_scales, weight_zero_points, 1);
+    builder.MakeInitializer<WeightQType>("weights", w_shape, quantized_weights);
+    builder.template AddDequantizeLinearNode<WeightQType>(
+        "weights_dq", "weights", weight_scales, weight_zero_points, "weights_dq",
+        {builder.MakeScalarAttribute("axis", static_cast<int64_t>(-1))});
+
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    builder.AddNode("MatMul", "MatMul", {matmul_input_name, "weights_dq"}, {"matmul_out"}, kOnnxDomain);
+    builder.AddNode("Add", "Add", {"matmul_out", "bias"}, {"Y"}, kOnnxDomain);
+
+    if constexpr (std::is_same_v<OutputQType, float>) {
+      builder.MakeOutput("Y");
+    } else {
+      AddQDQNodePairWithOutputAsGraphOutput<OutputQType>(builder, "qdq_out", "Y",
+                                                         output_qparams[0].scale,
+                                                         output_qparams[0].zero_point);
+    }
+  };
+
+  TestQDQModelAccuracy<TestQType>(f32_model_fn, qdq_model_fn,
+                                  provider_options, 21, ExpectedEPNodeAssignment::All);
+}
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_U8_I8_NoOutputQDQ) {
+  RunMixedPrecisionPerChannelMatMulAddTest<uint8_t, int8_t>({2, 3}, {3, 2}, {2});
+}
+
+// QDQ(u16) input, per-channel int16 weights, fp32 output (no output QDQ).
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_U16_I16_NoOutputQDQ) {
+  RunMixedPrecisionPerChannelMatMulAddTest<uint16_t, int16_t>({2, 3}, {3, 2}, {2});
+}
+
+// fp32 input, per-channel int8 weights, QDQ(u8) output (no input QDQ).
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_NoInputQDQ_U8) {
+  RunMixedPrecisionPerChannelMatMulAddTest<float, int8_t, uint8_t>({2, 3}, {3, 2}, {2});
+}
+
+// fp32 input, per-channel int8 weights, QDQ(u16) output (no input QDQ).
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_NoInputQDQ_U16) {
+  RunMixedPrecisionPerChannelMatMulAddTest<float, int8_t, uint16_t>({2, 3}, {3, 2}, {2});
+}
+// fp32 input, per-channel int8 weights, fp32 output (no input or output QDQ)
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_NoQDQ_FP32) {
+  RunMixedPrecisionPerChannelMatMulAddTest<float, int8_t, float>({2, 3}, {3, 2}, {2});
+}
+
+// The three tests below use a rank-2 [M, N] bias instead of rank-1 [N]. MatMulAddFusion still folds
+// MatMul+Add into a Gemm (C=[M, N] broadcasts unidirectionally), but QNN FullyConnected only accepts
+// a [N] / [1, N] bias, so GemmOpBuilder decomposes into FullyConnected + ElementWiseAdd ("split_gemm").
+// A rank-2 bias also falls outside ORT's WeightBiasQuantization (rank-1 only), so it stays fp32 —
+// which is why only the two float-FC mixed-precision sub-cases can reach the split path: a quantized
+// FC would need a quantized bias, and ExplictOpCheck rejects a quantized C with shape[0] != 1.
+//
+// Regression coverage for the split path: the FC intermediate used to be typed off the ONNX-side
+// activation type (wrong once ProcessInputs re-typed the activation ahead of FC), and the
+// mixed-precision output tail used to be emitted only on the non-split branches. Every rank-1-bias
+// test above takes the non-split path, so both bugs were invisible.
+
+// QDQ(u8) input, per-channel int8 weights, fp32 output, rank-2 bias.
+// quant-to-float + split_gemm: ProcessInputs inserts Dequantize on the activation and pre-dequantizes
+// the weights, so FC runs in fp32. The FC intermediate feeding the ElementWiseAdd must therefore be
+// FLOAT_32; typing it off the ONNX activation (UFIXED_8) hands FC mismatched in[0]/out[0] types.
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_U8_I8_NoOutputQDQ_2DBias) {
+  RunMixedPrecisionPerChannelMatMulAddTest<uint8_t, int8_t>({2, 3}, {3, 2}, {2, 2});
+}
+
+// fp32 input, per-channel int8 weights, QDQ(u16) output, rank-2 bias.
+// float-to-quant + split_gemm: FC and the ElementWiseAdd both run in fp32 and a Quantize tail
+// re-encodes to u16. The tail has to be appended after the Add, not after the FC — before the fix the
+// split branch emitted no tail at all, leaving the node unit's output tensor uncreated.
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_NoInputQDQ_U16_2DBias) {
+  RunMixedPrecisionPerChannelMatMulAddTest<float, int8_t, uint16_t>({2, 3}, {3, 2}, {2, 2});
+}
+
+// fp32 in/out with quantized weights and a rank-2 bias: split_gemm with no mixed-precision tail.
+// Pins the baseline so the two tests above isolate the mixed-precision handling.
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_NoQDQ_FP32_2DBias) {
+  RunMixedPrecisionPerChannelMatMulAddTest<float, int8_t, float>({2, 3}, {3, 2}, {2, 2});
+}
+
+TEST_F(QnnHTPBackendTests, MatMulAddOp_QDQ_PerChannel_U16_I8_U8) {
+  RunQDQPerChannelMatMulAddOpTest<uint16_t, int8_t, uint8_t>(
+      {2, 3}, {3, 2}, {2}, /*weight_quant_axis=*/-1);
+  // Larger shape
+  RunQDQPerChannelMatMulAddOpTest<uint8_t, int8_t, uint16_t>(
+      {32, 32}, {32, 32}, {32}, /*weight_quant_axis=*/-1);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulOp) {


### PR DESCRIPTION
TODO: 
- FP support (fp->u16/u8, u16/u8->fp)
- Move MP logic outside of single op-builder
- Remove unnecessary code from selectors
- Test using onnx files instead of adding the test in the file - makes the code easier to read and more scalable for Mixed precision testing 