### PR TITLE
Support negative and int64 indices for ScatterElements

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -100,7 +100,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateSimpleOpBuilder("QuantizeLinear", *this);
   CreateSimpleOpBuilder("Relu", *this);
   CreateSimpleOpBuilder("Round", *this);
-  CreateSimpleOpBuilder("ScatterElements", *this);
+  CreateScatterElementsOpBuilder("ScatterElements", *this);
   CreateScatterNDOpBuilder("ScatterND", *this);
   CreateSimpleOpBuilder("Sigmoid", *this);
   CreateSimpleOpBuilder("Sign", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -96,6 +96,7 @@ void CreateResizeOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreateRMSNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateRoiAlignOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateRotaryEmbeddingOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateScatterElementsOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateScatterNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSimpleOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSliceOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.cc
@@ -24,7 +24,8 @@ namespace utils {
 template <typename SrcType>
 bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
-                           std::vector<uint8_t>& qnn_bytes) {
+                           std::vector<uint8_t>& qnn_bytes,
+                           bool& has_negative_indices) {
   const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
   const auto onnx_indices = gsl::span<const SrcType>{
       reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
@@ -38,10 +39,10 @@ bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
     // int64 prevents wraparound on int32 idx + axis_dim >= 2^31.
     int64_t idx = static_cast<int64_t>(onnx_indices[i]);
     if (idx < 0) {
+      has_negative_indices = true;
       idx += axis_dim;
     }
-    // ORT core validates shapes/dtypes; value-range is the actual safeguard
-    // because ONNX allows out-of-range ints to ship in user models.
+    // ORT does not reject out-of-range initializer values; guard here.
     if (idx < 0 || idx >= axis_dim ||
         idx > static_cast<int64_t>(std::numeric_limits<int32_t>::max())) {
       return false;
@@ -52,14 +53,12 @@ bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
   return true;
 }
 
+template bool NormalizeIndicesBytes<int32_t>(
+    gsl::span<const uint8_t>, const std::function<int64_t(size_t)>&,
+    std::vector<uint8_t>&, bool&);
 template bool NormalizeIndicesBytes<int64_t>(
     gsl::span<const uint8_t>, const std::function<int64_t(size_t)>&,
-    std::vector<uint8_t>&);
-
-namespace {
-
-constexpr const char* kOutOfRangeMsg =
-    "QNN does not support negative or out-of-range index values for ScatterND-style ops";
+    std::vector<uint8_t>&, bool&);
 
 Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
                                        TensorInfo indices_info,
@@ -104,48 +103,6 @@ Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
   }
   input_names.push_back(indices_casted_name);
   return Ort::Status();
-}
-
-}  // namespace
-
-Ort::Status NormalizeIndicesForScatterND(QnnModelWrapper& qnn_model_wrapper,
-                                         const OrtNodeUnitIODef& indices_input,
-                                         const std::vector<uint32_t>& data_shape,
-                                         const Ort::Logger& logger,
-                                         std::vector<std::string>& input_names,
-                                         bool do_op_validation) {
-  std::string indices_tensor_name = indices_input.name;
-
-  TensorInfo indices_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
-
-  // ORT core validates ONNX schema (rank>=1, last-dim <= rank(data), int64 dtype).
-  const uint32_t index_tuple_size = indices_info.shape.back();
-
-  const auto axis_dim_for_element = [index_tuple_size, &data_shape](size_t element_index) -> int64_t {
-    const size_t col = element_index % static_cast<size_t>(index_tuple_size);
-    return static_cast<int64_t>(data_shape[col]);
-  };
-
-  std::vector<uint8_t> qnn_indices_bytes;
-
-  if (indices_info.is_initializer) {
-    std::vector<uint8_t> onnx_indices_bytes;
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor,
-                                                            onnx_indices_bytes));
-
-    RETURN_IF_NOT(NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
-                                                 qnn_indices_bytes),
-                  kOutOfRangeMsg);
-    indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
-
-    // Rename so a sibling op reusing the same ONNX initializer under a different
-    // axis bound cannot alias our rewritten copy.
-    indices_tensor_name = UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
-  }
-
-  return AddNormalizedIndicesTensor(qnn_model_wrapper, std::move(indices_info), indices_tensor_name,
-                                    std::move(qnn_indices_bytes), logger, input_names, do_op_validation);
 }
 
 }  // namespace utils

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
@@ -15,12 +15,11 @@
 
 #include <gsl/gsl>
 
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/ort_api.h"
 
 namespace onnxruntime {
 namespace qnn {
-
-class QnnModelWrapper;
 
 namespace utils {
 
@@ -30,16 +29,18 @@ namespace utils {
 template <typename SrcType>
 bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            const std::function<int64_t(size_t)>& axis_dim_for_element,
-                           std::vector<uint8_t>& qnn_bytes);
+                           std::vector<uint8_t>& qnn_bytes,
+                           bool& has_negative_indices);
 
-// ScatterND: indices' last dim is tuple depth; column c bounds `data_shape[c]`.
-Ort::Status NormalizeIndicesForScatterND(
-    QnnModelWrapper& qnn_model_wrapper,
-    const OrtNodeUnitIODef& indices_input,
-    const std::vector<uint32_t>& data_shape,
-    const Ort::Logger& logger,
-    std::vector<std::string>& input_names,
-    bool do_op_validation);
+// Registers the indices tensor; for dynamic INT_64 inputs, inserts a
+// runtime Cast(INT_32) so downstream QNN ops see INT_32.
+Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,
+                                       TensorInfo indices_info,
+                                       const std::string& indices_tensor_name,
+                                       std::vector<uint8_t>&& qnn_indices_bytes,
+                                       const Ort::Logger& logger,
+                                       std::vector<std::string>& input_names,
+                                       bool do_op_validation);
 
 }  // namespace utils
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
@@ -1,0 +1,185 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+constexpr std::array<std::string_view, 4> kSupportedReductions = {"none", "add", "mul", "max"};
+
+Ort::Status ProcessScatterElementsIndices(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnitIODef& indices_input,
+                                          const std::vector<uint32_t>& data_shape,
+                                          int64_t axis,
+                                          const Ort::Logger& logger,
+                                          std::vector<std::string>& input_names,
+                                          bool do_op_validation) {
+  std::string indices_tensor_name = indices_input.name;
+
+  TensorInfo indices_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
+
+  const int64_t axis_dim = static_cast<int64_t>(data_shape[static_cast<size_t>(axis)]);
+  // Uniform bound -- element_index unused (contrast with ScatterND's per-column closure).
+  const auto axis_dim_for_element = [axis_dim](size_t /*element_index*/) -> int64_t {
+    return axis_dim;
+  };
+
+  std::vector<uint8_t> qnn_indices_bytes;
+  bool has_negative_indices = false;
+
+  if (indices_info.is_initializer) {
+    std::vector<uint8_t> onnx_indices_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor,
+                                                            onnx_indices_bytes));
+
+    // `Tind` is {int32, int64}; reject anything else rather than reinterpret bytes.
+    if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
+      RETURN_IF_NOT(utils::NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
+                                                          qnn_indices_bytes, has_negative_indices),
+                    "QNN does not support out-of-range index values for ScatterElements.");
+      indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
+    } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
+      RETURN_IF_NOT(utils::NormalizeIndicesBytes<int32_t>(onnx_indices_bytes, axis_dim_for_element,
+                                                          qnn_indices_bytes, has_negative_indices),
+                    "QNN does not support out-of-range index values for ScatterElements.");
+      if (!has_negative_indices) {
+        // No per-axis remapping happened; reuse the original bytes unchanged.
+        qnn_indices_bytes = std::move(onnx_indices_bytes);
+      }
+    } else {
+      return MAKE_EP_FAIL("ScatterElements indices must be INT_32 or INT_64.");
+    }
+
+    if (has_negative_indices) {
+      // Remapped bytes depend on axis_dim; rename so siblings under a different axis can't alias.
+      indices_tensor_name = utils::UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
+    }
+  }
+
+  return utils::AddNormalizedIndicesTensor(qnn_model_wrapper, std::move(indices_info),
+                                           indices_tensor_name, std::move(qnn_indices_bytes),
+                                           logger, input_names, do_op_validation);
+}
+
+}  // namespace
+
+// Op builder for ONNX ScatterElements (https://onnx.ai/onnx/operators/onnx__ScatterElements.html).
+// ONNX allows negative and INT_64 indices; QNN accepts only non-negative INT_32. Static
+// indices are normalized at partition time; dynamic INT_64 indices get a runtime Cast.
+class ScatterElementsOpBuilder : public BaseOpBuilder {
+ public:
+  ScatterElementsOpBuilder() : BaseOpBuilder("ScatterElementsOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ScatterElementsOpBuilder);
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status ScatterElementsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                                    const OrtNodeUnit& node_unit,
+                                                    const Ort::Logger& logger,
+                                                    std::vector<std::string>& input_names,
+                                                    bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  RETURN_IF(inputs.size() != 3, "QNN EP: ScatterElements operator must have three inputs.");
+
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+
+  // QNN rejects negative indices; rewrite statics to keep the node on QNN.
+  TensorInfo data_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], data_info));
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  int64_t axis = node_helper.Get("axis", static_cast<int64_t>(0));
+  const int64_t rank = static_cast<int64_t>(data_info.shape.size());
+  if (axis < 0) {
+    axis += rank;
+  }
+  RETURN_IF_NOT(axis >= 0 && axis < rank, "ScatterElements axis out of range.");
+
+  RETURN_IF_ERROR(ProcessScatterElementsIndices(qnn_model_wrapper, inputs[1], data_info.shape, axis,
+                                                logger, input_names, do_op_validation));
+
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));
+  return Ort::Status();
+}
+
+Ort::Status ScatterElementsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                                  const OrtNodeUnit& node_unit,
+                                                                  std::vector<std::string>&& input_names,
+                                                                  const Ort::Logger& logger,
+                                                                  bool do_op_validation) const {
+  if (input_names.empty()) {
+    return Ort::Status();
+  }
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  const std::string reduction = node_helper.Get("reduction", "none");
+  RETURN_IF_NOT(utils::ArrayHasString(kSupportedReductions, reduction),
+                ("ScatterElements does not support reduction " + reduction).c_str());
+
+  std::vector<std::string> param_tensor_names;
+
+  int32_t axis_value = 0;
+  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
+  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
+                             QNN_OP_SCATTER_ELEMENTS_PARAM_AXIS, axis_qnn_scalar);
+  param_tensor_names.push_back(axis_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+  Qnn_Scalar_t reduction_scalar = QNN_SCALAR_INIT;
+  reduction_scalar.dataType = QNN_DATATYPE_UINT_32;
+  if (reduction == "none") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_NONE;
+  } else if (reduction == "add") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_ADD;
+  } else if (reduction == "mul") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MUL;
+  } else if (reduction == "max") {
+    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MAX;
+  } else {
+    return MAKE_EP_FAIL(("Unexpected ScatterElements reduction: " + reduction).c_str());
+  }
+
+  QnnParamWrapper reduction_param(node_unit.Index(), node_unit.Name(),
+                                  QNN_OP_SCATTER_ELEMENTS_PARAM_REDUCTION, reduction_scalar);
+  param_tensor_names.push_back(reduction_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
+
+  return ProcessOutputs(qnn_model_wrapper, node_unit,
+                        std::move(input_names),
+                        std::move(param_tensor_names),
+                        logger, do_op_validation, GetQnnOpType(node_unit.OpType()));
+}
+
+void CreateScatterElementsOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<ScatterElementsOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
@@ -17,7 +17,53 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
+
 constexpr std::array<std::string_view, 3> kSupportedReductions = {"none", "add", "mul"};
+
+// Bounds each tuple column by the matching `data_shape[c]`.
+Ort::Status ProcessScatterNDIndices(QnnModelWrapper& qnn_model_wrapper,
+                                    const OrtNodeUnitIODef& indices_input,
+                                    const std::vector<uint32_t>& data_shape,
+                                    const Ort::Logger& logger,
+                                    std::vector<std::string>& input_names,
+                                    bool do_op_validation) {
+  std::string indices_tensor_name = indices_input.name;
+
+  TensorInfo indices_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(indices_input, indices_info));
+
+  // ONNX ScatterND rank>=1 is not enforced by shape inference; rely on a well-formed graph.
+  const uint32_t index_tuple_size = indices_info.shape.back();
+
+  const auto axis_dim_for_element = [index_tuple_size, &data_shape](size_t element_index) -> int64_t {
+    const size_t col = element_index % static_cast<size_t>(index_tuple_size);
+    return static_cast<int64_t>(data_shape[col]);
+  };
+
+  std::vector<uint8_t> qnn_indices_bytes;
+  bool has_negative_indices = false;
+
+  if (indices_info.is_initializer) {
+    std::vector<uint8_t> onnx_indices_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor,
+                                                            onnx_indices_bytes));
+
+    // ONNX ScatterND `indices` is hard-typed tensor(int64) (unlike ScatterElements).
+    RETURN_IF_NOT(utils::NormalizeIndicesBytes<int64_t>(onnx_indices_bytes, axis_dim_for_element,
+                                                        qnn_indices_bytes, has_negative_indices),
+                  "QNN does not support out-of-range index values for ScatterND.");
+    indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
+
+    // Rename so a sibling op reusing the same ONNX initializer under a different
+    // axis bound cannot alias our rewritten copy.
+    indices_tensor_name = utils::UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
+  }
+
+  return utils::AddNormalizedIndicesTensor(qnn_model_wrapper, std::move(indices_info),
+                                           indices_tensor_name, std::move(qnn_indices_bytes),
+                                           logger, input_names, do_op_validation);
+}
+
 }  // namespace
 
 class ScatterNDOpBuilder : public BaseOpBuilder {
@@ -52,9 +98,8 @@ Ort::Status ScatterNDOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper
   // QNN rejects negative/INT_64 indices; rewrite statics to keep the node on QNN.
   TensorInfo data_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], data_info));
-  RETURN_IF_ERROR(utils::NormalizeIndicesForScatterND(
-      qnn_model_wrapper, inputs[1], data_info.shape,
-      logger, input_names, do_op_validation));
+  RETURN_IF_ERROR(ProcessScatterNDIndices(qnn_model_wrapper, inputs[1], data_info.shape,
+                                          logger, input_names, do_op_validation));
 
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names));
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -40,7 +40,6 @@ class SimpleOpBuilder : public BaseOpBuilder {
 
   static constexpr std::array<std::string_view, 3> gridsample_supported_modes = {"bilinear", "nearest", "linear"};
   static constexpr std::array<std::string_view, 3> gridsample_supported_padding_modes = {"zeros", "border", "reflection"};
-  static constexpr std::array<std::string_view, 4> scatterelements_supported_reduction = {"none", "add", "mul", "max"};
 };
 
 Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const {
@@ -131,14 +130,6 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
     RETURN_IF(input_info.shape.size() > 4,
               "QNN EP does not support Softplus with input rank > 4.");
-  }
-
-  // QNN ScatterElements doesn't support MIN reduction
-  if (op_type == "ScatterElements") {
-    OrtNodeAttrHelper node_helper(node_unit);
-    std::string reduction = node_helper.Get("reduction", "none");
-    RETURN_IF_NOT(utils::ArrayHasString(scatterelements_supported_reduction, reduction),
-                  ("ScatterElements does not support reduction " + reduction).c_str());
   }
 
   return Ort::Status();
@@ -294,33 +285,6 @@ Ort::Status ProcessGridSampleAttributes(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// Process Reduction attribute of ScatterElements op
-Ort::Status ProcessReductionAttribute(QnnModelWrapper& qnn_model_wrapper,
-                                      const OrtNodeUnit& node_unit,
-                                      std::vector<std::string>& param_tensor_names) {
-  OrtNodeAttrHelper node_helper(node_unit);
-  std::string reduction = node_helper.Get("reduction", "none");
-  Qnn_Scalar_t reduction_qnn_scalar = QNN_SCALAR_INIT;
-  reduction_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-  if ("none" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_NONE;
-  } else if ("add" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_ADD;
-  } else if ("mul" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MUL;
-  } else if ("max" == reduction) {
-    reduction_qnn_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MAX;
-  } else {
-    return MAKE_EP_FAIL("ScatterElements support only reduction:{none, add, mul, max}.");
-  }
-  QnnParamWrapper reduction_param(node_unit.Index(), node_unit.Name(), QNN_OP_SCATTER_ELEMENTS_PARAM_REDUCTION,
-                                  reduction_qnn_scalar);
-  param_tensor_names.push_back(reduction_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
-
-  return Ort::Status();
-}
-
 Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                          const OrtNodeUnit& node_unit,
                                                          std::vector<std::string>&& input_names,
@@ -449,19 +413,6 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   if (op_type == "GridSample") {
     RETURN_IF_ERROR(ProcessGridSampleAttributes(qnn_model_wrapper, node_unit, param_tensor_names));
-  }
-
-  if (op_type == "ScatterElements") {
-    // Process axis attribute
-    int32_t default_axis = 0;
-    Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SCATTER_ELEMENTS_PARAM_AXIS, axis_qnn_scalar);
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
-
-    // Process reduction attribute
-    RETURN_IF_ERROR(ProcessReductionAttribute(qnn_model_wrapper, node_unit, param_tensor_names));
   }
 
   return ProcessOutputs(qnn_model_wrapper, node_unit,

--- a/onnxruntime/test/providers/qnn/scatterelements_test.cc
+++ b/onnxruntime/test/providers/qnn/scatterelements_test.cc
@@ -1,0 +1,240 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "onnxruntime_c_api.h"
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "core/graph/node_attr_utils.h"
+
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+// HTP backend is only enumerable on NPU or Linux x86_64 simulator; excludes
+// Windows x86_64, matching the guard in simple_op_test.cc / scatternd_test.cc.
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+ProviderOptions MakeHtpProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return provider_options;
+}
+
+}  // namespace
+
+TEST_F(QnnHTPBackendTests, ScatterElementsNegativeIndexDefaultAxis) {
+  constexpr int64_t kLen = 8;
+
+  auto build_model = [=](ModelTestBuilder& builder) {
+    // `data` must be a runtime input -- otherwise ORT constant-folds
+    // ScatterElements away before the QNN EP sees it.
+    std::vector<int32_t> data(kLen, 0);
+    builder.MakeInput<int32_t>("data", {kLen}, data);
+
+    std::vector<int64_t> indices = {-1};  // -> kLen - 1 after normalize
+    builder.MakeInitializer<int64_t>("indices", {1}, indices);
+
+    std::vector<int32_t> updates = {42};
+    builder.MakeInitializer<int32_t>("updates", {1}, updates);
+
+    builder.AddNode("scatter", "ScatterElements", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain);
+    builder.AddNode("cast", "Cast", {"scatter_out"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, ScatterElementsNegativeIndexNonDefaultAxis) {
+  constexpr int64_t kRows = 3;
+  constexpr int64_t kCols = 5;
+
+  auto build_model = [=](ModelTestBuilder& builder) {
+    std::vector<int32_t> data(kRows * kCols, 0);
+    builder.MakeInput<int32_t>("data", {kRows, kCols}, data);
+
+    std::vector<int64_t> indices = {-1, -kCols, 2, 0, 1, 3};  // shape [3, 2]
+    builder.MakeInitializer<int64_t>("indices", {kRows, 2}, indices);
+
+    std::vector<int32_t> updates = {11, 12, 13, 14, 15, 16};
+    builder.MakeInitializer<int32_t>("updates", {kRows, 2}, updates);
+
+    builder.AddNode("scatter", "ScatterElements", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(1))});
+    builder.AddNode("cast", "Cast", {"scatter_out"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Negative axis attribute (count-from-end) must resolve before bounds check.
+TEST_F(QnnHTPBackendTests, ScatterElementsNegativeIndexNegativeAxis) {
+  constexpr int64_t kRows = 2;
+  constexpr int64_t kCols = 6;
+
+  auto build_model = [=](ModelTestBuilder& builder) {
+    std::vector<int32_t> data(kRows * kCols, 0);
+    builder.MakeInput<int32_t>("data", {kRows, kCols}, data);
+
+    // axis=-1 == axis=1; index -2 -> kCols-2.
+    std::vector<int64_t> indices = {-2, 0};
+    builder.MakeInitializer<int64_t>("indices", {kRows, 1}, indices);
+
+    std::vector<int32_t> updates = {7, 9};
+    builder.MakeInitializer<int32_t>("updates", {kRows, 1}, updates);
+
+    builder.AddNode("scatter", "ScatterElements", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(-1))});
+    builder.AddNode("cast", "Cast", {"scatter_out"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// ScatterElements(-1) embedded between producer/consumer ops must compile
+// through QNN finalization without CPU fallback.
+TEST_F(QnnHTPBackendTests, ScatterElementsEndToEndNegativeIndexInGraph) {
+  constexpr int64_t kRows = 2;
+  constexpr int64_t kCols = 32;
+
+  auto build_model = [=](ModelTestBuilder& builder) {
+    std::vector<float> data(kRows * kCols);
+    for (int64_t i = 0; i < kRows * kCols; ++i) {
+      data[i] = static_cast<float>(i) * 0.01f;
+    }
+    builder.MakeInput<float>("data_src", {kRows, kCols}, data);
+
+    std::vector<float> bias(kRows * kCols, 0.5f);
+    builder.MakeInitializer<float>("bias", {kRows, kCols}, bias);
+    builder.AddNode("pre_add", "Add", {"data_src", "bias"}, {"data"}, kOnnxDomain);
+
+    std::vector<int64_t> indices = {-1, -2, 0, 1};
+    builder.MakeInitializer<int64_t>("indices", {kRows, 2}, indices);
+
+    std::vector<float> updates = {10.0f, 20.0f, 30.0f, 40.0f};
+    builder.MakeInitializer<float>("updates", {kRows, 2}, updates);
+
+    builder.AddNode("scatter", "ScatterElements", {"data", "indices", "updates"},
+                    {"scatter_out"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(-1))});
+
+    std::vector<float> scale(kRows * kCols, 2.0f);
+    builder.MakeInitializer<float>("scale", {kRows, kCols}, scale);
+    builder.AddNode("post_mul", "Mul", {"scatter_out", "scale"}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput("Y");
+  };
+
+  // HTP fp16 path -- loosen tolerance vs. CPU fp32 reference.
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// Same axis bound -- rewritten bytes are identical; both nodes land on QNN.
+TEST_F(QnnHTPBackendTests, ScatterElementsSharedNegativeIndicesInitializer) {
+  constexpr int64_t kLen = 12;
+
+  auto build_model = [=](ModelTestBuilder& builder) {
+    std::vector<int32_t> data_a(kLen, 0);
+    std::vector<int32_t> data_b(kLen, 0);
+    builder.MakeInput<int32_t>("dataA", {kLen}, data_a);
+    builder.MakeInput<int32_t>("dataB", {kLen}, data_b);
+
+    std::vector<int64_t> indices = {-1};
+    builder.MakeInitializer<int64_t>("indices", {1}, indices);
+
+    std::vector<int32_t> updates_a = {11};
+    std::vector<int32_t> updates_b = {22};
+    builder.MakeInitializer<int32_t>("updatesA", {1}, updates_a);
+    builder.MakeInitializer<int32_t>("updatesB", {1}, updates_b);
+
+    builder.AddNode("scatterA", "ScatterElements", {"dataA", "indices", "updatesA"},
+                    {"outA_i32"}, kOnnxDomain);
+    builder.AddNode("scatterB", "ScatterElements", {"dataB", "indices", "updatesB"},
+                    {"outB_i32"}, kOnnxDomain);
+    builder.AddNode("castA", "Cast", {"outA_i32"}, {"YA"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.AddNode("castB", "Cast", {"outB_i32"}, {"YB"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("YA");
+    builder.MakeOutput("YB");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Different axis bounds -- indices `[-1]` resolves to `kRows-1` for scatterA
+// and `kCols-1` for scatterB. The `_qnn_idx` rename prevents the two
+// per-axis rewrites from aliasing.
+TEST_F(QnnHTPBackendTests, ScatterElementsSharedNegativeIndicesDifferentAxes) {
+  constexpr int64_t kRows = 3;
+  constexpr int64_t kCols = 7;  // != kRows so rewritten bytes differ.
+
+  auto build_model = [=](ModelTestBuilder& builder) {
+    std::vector<int32_t> data_a(kRows * kCols, 0);
+    std::vector<int32_t> data_b(kRows * kCols, 0);
+    builder.MakeInput<int32_t>("dataA", {kRows, kCols}, data_a);
+    builder.MakeInput<int32_t>("dataB", {kRows, kCols}, data_b);
+
+    std::vector<int64_t> indices = {-1, -1, -1};
+    builder.MakeInitializer<int64_t>("indices", {kRows, 1}, indices);
+
+    std::vector<int32_t> updates_a = {10, 20, 30};
+    std::vector<int32_t> updates_b = {40, 50, 60};
+    builder.MakeInitializer<int32_t>("updatesA", {kRows, 1}, updates_a);
+    builder.MakeInitializer<int32_t>("updatesB", {kRows, 1}, updates_b);
+
+    builder.AddNode("scatterA", "ScatterElements", {"dataA", "indices", "updatesA"},
+                    {"outA_i32"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))});
+    builder.AddNode("scatterB", "ScatterElements", {"dataB", "indices", "updatesB"},
+                    {"outB_i32"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(1))});
+    builder.AddNode("castA", "Cast", {"outA_i32"}, {"YA"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.AddNode("castB", "Cast", {"outB_i32"}, {"YB"}, kOnnxDomain,
+                    {test::MakeAttribute("to",
+                                         static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+    builder.MakeOutput("YA");
+    builder.MakeOutput("YB");
+  };
+
+  RunQnnModelTest(build_model, MakeHtpProviderOptions(), 17,
+                  ExpectedEPNodeAssignment::All);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
keep ScatterElements on QNN when indices are negative or int64

Extends the prior ScatterND fix (#311) to ONNX ScatterElements. Same class of bug: QNN rejects negative and INT_64 indices, causing silent CPU fallback during partitioning.