### PR TITLE
Wire build_nuget and build_archive flags for all Windows architectures

### DIFF
--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -593,6 +593,8 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_nuget=self.__build_nuget,
+                    build_archive=self.__build_archive,
                 )
             )
 
@@ -626,6 +628,8 @@ class TaskLibrary:
                             self.__qairt_sdk_root,
                             "build",
                             build_as_x=True,
+                            build_nuget=self.__build_nuget,
+                            build_archive=self.__build_archive,
                         ),
                     ],
                 )
@@ -658,6 +662,8 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_nuget=self.__build_nuget,
+                    build_archive=self.__build_archive,
                 )
             )
 


### PR DESCRIPTION
## Summary

- `--build-nuget` and `--build-archive` CLI flags were only forwarded to the `arm64` build task in `build_ort_windows_arm64`. The `arm64ec`, `arm64x`, and `x86_64` targets silently dropped these flags, preventing NuGet package and archive generation for those architectures.
- This fix wires `self.__build_nuget` and `self.__build_archive` into `build_ort_windows_arm64ec`, the arm64ec slice of `build_ort_windows_arm64x`, and `build_ort_windows_x86_64`.

Fixes [AISW-181405](https://jira-dc.qualcomm.com/jira/browse/AISW-181405).

## Test plan

- [ ] Verify `--build-nuget` and `--build-archive` flags produce artifacts for arm64ec, arm64x, and x86_64 builds on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)