### PR TITLE
Wire build_nuget and build_archive flags for all Windows architectures

### DIFF
--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -456,6 +456,7 @@ class TaskLibrary:
                         self.__qairt_sdk_root,
                         "build",
                         extra_args=extra_args,
+                        build_archive=self.__build_archive,
                     )
                 )
             else:
@@ -492,6 +493,7 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_archive=self.__build_archive,
                 )
             )
 
@@ -523,6 +525,7 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_archive=self.__build_archive,
                 )
             )
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -593,6 +593,8 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_nuget=self.__build_nuget,
+                    build_archive=self.__build_archive,
                 )
             )
 
@@ -626,6 +628,8 @@ class TaskLibrary:
                             self.__qairt_sdk_root,
                             "build",
                             build_as_x=True,
+                            build_nuget=self.__build_nuget,
+                            build_archive=self.__build_archive,
                         ),
                     ],
                 )
@@ -658,6 +662,8 @@ class TaskLibrary:
                     self.__ort_prebuilt_root,
                     self.__qairt_sdk_root,
                     "build",
+                    build_nuget=self.__build_nuget,
+                    build_archive=self.__build_archive,
                 )
             )
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Wire build_nuget and build_archive flags for all Windows architectures to reduce gaps


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The --build-nuget and --build-archive CLI flags were only forwarded to the arm64 build task. arm64ec, arm64x, and x86_64 targets silently ignored them, preventing artifact generation for those architectures.
