### PR TITLE
[QNN EP] Migrating from ARM64 NuGet package to ARM64 (ARM64x) NuGet package

### DIFF
--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -151,8 +151,6 @@ jobs:
       test_wheel: false
       # For each arch, upload the test archive with the first Python version we encounter
       upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
-      build_nuget: false
-      upload_nuget: false
       build_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       # For each arch, build and upload a PDB archive with the first python version we encounter
@@ -165,19 +163,10 @@ jobs:
     with:
       nightly_build: ${{ inputs.nightly_build }}
       version_suffix: ${{ inputs.version_suffix }}
-      target_os: windows
       target_arch: arm64x
       target_py_vsn: ${{ fromJSON(inputs.windows_target_py_vsns)[0] }}
       build_runner_arch: ARM64
-      build_test_same_runner: true
-      test_runner_arch: ARM64
       run_tests: false
-      test_wheel: false
-      upload_test_archive: false
       upload_wheel: false
       build_nuget: true
       upload_nuget: true
-      build_archive: false
-      upload_archive: false
-      build_pdb_archive: false
-      upload_pdb_archive: false

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -159,7 +159,7 @@ jobs:
       build_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
 
-  build-windows-arm64x-nuget:
+  build-windows-arm64x:
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -37,19 +37,15 @@ on:
       linux_aarch64_manylinux_2_34_target_py_vsns:
         description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
         type: string
-        default: "['3.10','3.11','3.12','3.13']"
+        default: "['3.11','3.12','3.13','3.14']"
       windows_target_archs:
         description: "JSON list of Windows architectures to build"
         type: string
-        default: "['arm64', 'arm64x']"
+        default: "['arm64', 'arm64ec', 'x86_64']"
       windows_target_py_vsns:
         description: "JSON list of Python versions to build for Windows"
         type: string
         default: "['3.11','3.12','3.13','3.14']"
-      windows_arm64_build_nuget:
-        description: "If true, build a NuGet package with the first ARM64 build."
-        type: boolean
-        default: true
       windows_arm64_build_archive:
         description: "If true, build an archive with the first ARM64 build."
         type: boolean
@@ -155,11 +151,33 @@ jobs:
       test_wheel: false
       # For each arch, upload the test archive with the first Python version we encounter
       upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
-      # On ARM64, build NuGet/Archive with the first python version we encounter
-      build_nuget: ${{ inputs.windows_arm64_build_nuget && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
-      upload_nuget: ${{ inputs.windows_arm64_build_nuget && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+      build_nuget: false
+      upload_nuget: false
       build_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_archive: ${{ inputs.windows_arm64_build_archive && matrix.target_arch == 'arm64' && matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       # For each arch, build and upload a PDB archive with the first python version we encounter
       build_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
       upload_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
+
+  build-windows-arm64x-nuget:
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: windows
+      target_arch: arm64x
+      target_py_vsn: ${{ fromJSON(inputs.windows_target_py_vsns)[0] }}
+      build_runner_arch: ARM64
+      build_test_same_runner: true
+      test_runner_arch: ARM64
+      run_tests: false
+      test_wheel: false
+      upload_test_archive: false
+      upload_wheel: false
+      build_nuget: true
+      upload_nuget: true
+      build_archive: false
+      upload_archive: false
+      build_pdb_archive: false
+      upload_pdb_archive: false

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -42,9 +42,11 @@ jobs:
       build_android_aarch64: true
       build_android_aarch64_aar: true
       build_linux_aarch64_oe_gcc11_2: true
+      build_linux_x86_64: true
       linux_aarch64_manylinux_2_34_target_py_vsns: "['3.11','3.12','3.13','3.14']"
       windows_target_archs: "['arm64', 'arm64ec', 'x86_64']"
       windows_target_py_vsns: "['3.11','3.12','3.13','3.14']"
+      windows_arm64_build_archive: true
 
   publish-wheel-workflow:
     name: "Publish distribution to PyPI"
@@ -256,10 +258,10 @@ jobs:
         with:
           name: android-aarch64-pom
 
-      - name: Download ARM64 Windows NuGet Package from Artifactory
+      - name: Download ARM64 (ARM64x) Windows NuGet Package from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
-          name: windows-arm64-py3.11-nuget
+          name: windows-arm64x-py3.11-nuget
 
       - name: Download ARM64 Windows Zip Package
         uses: ./.github/actions/download-ci-artifact

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -19,6 +19,10 @@ on:
         description: "Version suffix for released package. If set, the specified suffix will be appended to the version string."
         type: string
         default: ""
+      linux_aarch64_manylinux_2_34_target_py_vsns:
+        description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
+        type: string
+        default: "['3.11','3.12','3.13','3.14']"
       windows_target_archs:
         description: "JSON list of Windows architectures to build"
         type: string
@@ -40,15 +44,16 @@ jobs:
     uses: ./.github/workflows/qualcomm-internal-build-artifacts.yml
     secrets: inherit
     with:
-      build_linux_x86_64: false
-      build_android_aarch64_aar: true
-      linux_aarch64_manylinux_2_34_target_py_vsns: "['3.11','3.12','3.13','3.14']"
-      windows_target_archs: ${{ inputs.windows_target_archs }}
-      windows_target_py_vsns: ${{ inputs.windows_target_py_vsns }}
-      windows_arm64_build_nuget: true
-      windows_arm64_build_archive: true
       nightly_build: ${{ inputs.nightly_build }}
       version_suffix: ${{ inputs.version_suffix }}
+      build_android_aarch64: false
+      build_android_aarch64_aar: true
+      build_linux_aarch64_oe_gcc11_2: false
+      build_linux_x86_64: false
+      linux_aarch64_manylinux_2_34_target_py_vsns: ${{ inputs.linux_aarch64_manylinux_2_34_target_py_vsns }}
+      windows_target_archs: ${{ inputs.windows_target_archs }}
+      windows_target_py_vsns: ${{ inputs.windows_target_py_vsns }}
+      windows_arm64_build_archive: true
 
   upload-wheel-workflow:
     name: "Upload python wheel artifacts to Artifactory"
@@ -226,7 +231,7 @@ jobs:
       - name: Download NuGet from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
-          name: windows-arm64-py3.11-nuget
+          name: windows-arm64x-py3.11-nuget
 
       - name: Verify NuGet artifact
         shell: powershell

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -257,7 +257,7 @@ jobs:
           uv pip install -r .\qcom\requirements.txt
 
           . ".\qcom\scripts\upleveling\upload_nupkg_to_artifactory.ps1" `
-            -InputDir "${{ github.workspace }}\build\windows-arm64\Release"
+            -InputDir "${{ github.workspace }}\build\windows-arm64x\Release"
 
   upload-zip-workflow:
     name: "Upload zip artifacts to Artifactory"

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -626,6 +626,7 @@ class TaskLibrary:
                             self.__qairt_sdk_root,
                             "build",
                             build_as_x=True,
+                            build_nuget=self.__build_nuget,
                         ),
                     ],
                 )


### PR DESCRIPTION
This PR migrates the NuGet package build target from `ARM64` to `ARM64 (ARM64x)` package. The change involves:

- **Disabling NuGet builds in the matrix job:** The build-windows job (which handles arm64, arm64ec, and x86_64) now has `build_nuget: false` and `upload_nuget: false`
- **Creating a dedicated ARM64X build job:** A new build-windows-arm64x job exclusively builds the NuGet package for ARM64X on ARM64 runners. Only the NuGet is built for ARM64 (ARM64x), no wheels and zip are produced.
- **Updating release workflow:** The release workflow downloads the `ARM64 (ARM64x) NuGet` package instead of `ARM64 NuGet`. Made changes to ensure Python versions for Linux ARM64 wheels are manually configurable. 
- **Workflow Inputs**: Updated and reorder workflow inputs to reflect default values for easy tracking.



