### PR TITLE
Standardize archive asset invocation across platforms

### DIFF
--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -212,6 +212,11 @@ if ($env:ORT_VERSION_SUFFIX) {
     $VersionSuffixArg += "--version_suffix", "$env:ORT_VERSION_SUFFIX"
 }
 
+$BuildArchiveArgs = @()
+if ($BuildArchive) {
+    $BuildArchiveArgs += "--build_archive_asset"
+}
+
 switch ($Mode) {
     "build" {
         if ($BuildIsDirty) {
@@ -272,6 +277,7 @@ else {
     if ($GenerateBuild -or $DoBuild) {
         try {
             python.exe "$RepoRoot\qcom\scripts\all\fetch_cmake_deps.py"
+            $BuildBatPath = (Join-Path $RepoRoot "build.bat")
 
             if ($GenerateBuild) {
                 if (-not (Test-Path $BuildVEnv)) {
@@ -284,15 +290,17 @@ else {
                     Assert-Success { python.exe -m pip install uv }
                     Assert-Success { uv.exe pip install -r "$RepoRoot\tools\ci_build\github\windows\python\requirements.txt" --native-tls }
                     Assert-Success -ErrorMessage "Failed to generate build" {
-                        .\build.bat --update $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg
+                        & $BuildBatPath --update $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg
                     }
                 }
             }
 
             if ($DoBuild) {
                 $BuildOutputDir = (Join-Path $BuildDir $Config)
-                Assert-Success -ErrorMessage "Failed to build" {
-                    & cmake --build $BuildOutputDir --config $Config
+                Use-PyVenv -PyVenv $BuildVEnv {
+                    Assert-Success -ErrorMessage "Failed to build" {
+                        & $BuildBatPath --build --skip_tests $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg $BuildArchiveArgs
+                    }
                 }
 
                 if ($CMakeGenerator -in @("Visual Studio 17 2022", "Visual Studio 18 2026")) {
@@ -327,7 +335,6 @@ else {
                 if ($BuildNuget) {
                     Use-PyVenv -PyVenv $BuildVEnv {
                         Use-WorkingDir -Path $BuildOutputDir {
-                            $BuildBatPath = (Join-Path $RepoRoot "build.bat")
                             Assert-Success -ErrorMessage "Failed to build nuget" {
                                 & $BuildBatPath --skip_tests $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg
 
@@ -338,24 +345,6 @@ else {
                                 foreach ($Pkg in (Get-ChildItem -File -Recurse -Path $BinDir -Filter "Qualcomm.ML.OnnxRuntime.QNN*.nupkg")) {
                                     Copy-Item -Path $Pkg.FullName -Destination $DistDir
                                 }
-                            }
-                        }
-                    }
-                }
-                if ($BuildArchive) {
-                    Use-PyVenv -PyVenv $BuildVEnv {
-                        Use-WorkingDir -Path $BuildOutputDir {
-                            $PkgAssetsArgs = @(
-                                "--source", $RepoRoot,
-                                "--build_dir", $BuildDir,
-                                "--config", $Config,
-                                "--verbose"
-                            )
-                            if ($CMakeGenerator -eq "Ninja") {
-                                $PkgAssetsArgs += "--use_ninja"
-                            }
-                            Assert-Success -ErrorMessage "Failed to build archive" {
-                                python.exe (Join-Path $RepoRoot "tools\ci_build\pkg_assets.py") @PkgAssetsArgs $VersionSuffixArg
                             }
                         }
                     }

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -299,7 +299,7 @@ else {
                 $BuildOutputDir = (Join-Path $BuildDir $Config)
                 Use-PyVenv -PyVenv $BuildVEnv {
                     Assert-Success -ErrorMessage "Failed to build" {
-                        & $BuildBatPath --build --skip_tests $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg $BuildArchiveArgs
+                        & $BuildBatPath --build $ArchArgs $CommonArgs $QnnArgs $PlatformArgs $VersionSuffixArg $BuildArchiveArgs
                     }
                 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Pass --build_archive_asset to the existing build.bat
- Remove the direct pkg_assets.py call
- Fix build.ps1 for better maintainability


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Linux already invokes build_archive_asset() via build.py using `--build_archive_asset`. Windows called pkg_assets.py directly, bypassing build.py

