### PR TITLE
remove warning-as-error for aarch64 manylinux

### DIFF
--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -217,7 +217,7 @@ static void RunOpTest(const std::string& op_type,
                       const std::string& op_domain = kOnnxDomain,
                       float fp32_abs_err = 1e-5f,
                       bool enable_htp_fp16_precision = false,
-                      std::optional<std::string> soc_model = std::nullopt) {
+                      [[maybe_unused]] std::optional<std::string> soc_model = std::nullopt) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -244,7 +244,6 @@ class TaskLibrary:
     def _build_ort_linux_aarch64_manylinux_2_34(self, plan: Plan) -> str:
         """In-container build steps for aarch64-manylinux_2_34. Not to be used outside of Docker."""
         extra_args = [
-            "--no-warnings-as-errors",
             "--qnn-arch-abi=aarch64-oe-linux-gcc11.2",
         ]
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- remove warning-as-error for aarch64 manylinux


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- consistency of Linux build workflow

