### PR TITLE
[QNN EP] Fix memory leak in OrtTensorTypeAndShapeInfo in ExecuteGraph

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1081,6 +1081,8 @@ void QnnBackendManager::ProcessContextFromBinListAsync(Qnn_ContextHandle_t conte
   auto s = AddQnnContextHandle(context);
   if (!s.IsOK()) {
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING, ("Unable to add context " + context_ss.str()).c_str());
+  } else {
+    context_created_ = true;
   }
 }
 
@@ -1395,6 +1397,7 @@ Ort::Status QnnBackendManager::ReleaseContext() {
   // release QNN context handles
   contexts_.clear();
   context_map_.clear();
+  ep_context_handle_map_.clear();
 
   context_created_ = false;
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -428,14 +428,17 @@ Ort::Status QnnModel::ExecuteGraph(OrtKernelContext* context,
     size_t length;
     tensor_status = ort_api.GetTensorShapeElementCount(tensor_type_and_shape, &length);
     if (tensor_status != nullptr) {
+      ort_api.ReleaseTensorTypeAndShapeInfo(tensor_type_and_shape);
       return 0;  // Return 0 on error, will be handled by caller
     }
     ONNXTensorElementDataType element_type;
     tensor_status = ort_api.GetTensorElementType(tensor_type_and_shape, &element_type);
     if (tensor_status != nullptr) {
+      ort_api.ReleaseTensorTypeAndShapeInfo(tensor_type_and_shape);
       return 0;  // Return 0 on error, will be handled by caller
     }
     size_t element_size = GetElementSizeByType(element_type);
+    ort_api.ReleaseTensorTypeAndShapeInfo(tensor_type_and_shape);
     return element_size * length;
   };
 


### PR DESCRIPTION


### Description
- Release OrtTensorTypeAndShapeInfo in TensorDataSize lambda
- Set context_created_ after async AddQnnContextHandle
- Clear ep_context_handle_map_ in ReleaseContext


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


