### PR TITLE
Add SimplifiedLayerNormalization to QDQ node group selector

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1739,7 +1739,8 @@ void OrtSelectorManager::CreateSelectors() {
 
   // Register rmsnormalization ops
   OrtOpVersionsAndSelector::OpVersionsMap rmsnorm_ops = {
-      {"RMSNormalization", {}}};
+      {"RMSNormalization", {}},
+      {"SimplifiedLayerNormalization", {}}};
   ort_selectors_.RegisterSelector(rmsnorm_ops, std::make_unique<OrtRMSNormalizationNodeGroupSelector>());
 }
 


### PR DESCRIPTION
### Description
Add `SimplifiedLayerNormalization` to the RMSNorm QDQ node group selector registration.

The QNN EP's op builder factory and op type mapping already support `SimplifiedLayerNormalization` (mapping it to QNN RMSNorm op), but the QDQ node group selector only registered `RMSNormalization` ONNX op.


### Motivation and Context
`DQ` -> `SimplifiedLayerNormalization` -> `Q` patterns were never grouped into QDQ NodeUnits, and the op was forced to execute in float with explicit Dequantize/Quantize conversion nodes. This caused significant slowdowns on a quanitized model we were testing on HTP backend, affecting not only RMSNorm operations but neighboring operations as well (possibly suboptimal fusion).

