### PR TITLE
Add constant folding for standalone post-partition Q/DQ

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -20,7 +20,7 @@ namespace qnn {
 
 namespace {
 
-// Fetch raw bytes from either a real initializer or a previously-folded STATIC tensor.
+// Accepts either a real initializer or a previously-folded STATIC tensor.
 Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
                                    const std::string& tensor_name,
                                    /*out*/ std::vector<uint8_t>& bytes) {
@@ -38,6 +38,60 @@ Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
     return Ort::Status();
   }
   return MAKE_EP_FAIL("Tensor is not a constant initializer or folded constant.");
+}
+
+// SafeInt guards against overflow from an adversarial shape before allocation.
+Ort::Status ComputeNumElements(gsl::span<const uint32_t> shape, /*out*/ size_t& num_elems) {
+  SafeInt<size_t> safe_num_elems = 1;
+  for (uint32_t d : shape) {
+    safe_num_elems *= d;
+  }
+  num_elems = safe_num_elems;
+  return Ort::Status();
+}
+
+Ort::Status UnpackQuantParams(QnnModelWrapper& qnn_model_wrapper,
+                              const OrtNodeUnitIODef::QuantParam& quant_param,
+                              /*out*/ std::vector<float>& scales,
+                              /*out*/ std::vector<int32_t>& offsets) {
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(quant_param.scale, scales));
+  if (quant_param.zero_point != nullptr) {
+    ONNXTensorElementDataType zp_type;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(quant_param.zero_point, offsets, zp_type));
+  } else {
+    // ONNX treats a missing zero_point as zero; match that for both per-tensor and per-channel.
+    offsets.assign(scales.size(), 0);
+  }
+  return Ort::Status();
+}
+
+Ort::Status ResolvePerChannelAxis(QnnModelWrapper& qnn_model_wrapper,
+                                  const OrtNodeUnitIODef& io_def,
+                                  /*out*/ std::optional<int64_t>& axis) {
+  bool is_per_chan = false;
+  int64_t per_chan_axis = 0;
+  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(io_def, is_per_chan, per_chan_axis));
+  axis = is_per_chan ? std::optional<int64_t>(per_chan_axis) : std::nullopt;
+  return Ort::Status();
+}
+
+// Marks the tensor as folded so downstream Q/DQ hops keep folding through the chain.
+Ort::Status RegisterFoldedStaticTensor(QnnModelWrapper& qnn_model_wrapper,
+                                       const std::string& name,
+                                       Qnn_DataType_t data_type,
+                                       QnnQuantParamsWrapper quant_param,
+                                       std::vector<uint32_t> shape,
+                                       std::vector<uint8_t> data,
+                                       const char* failure_msg) {
+  QnnTensorWrapper out_wrapper(name,
+                               QNN_TENSOR_TYPE_STATIC,
+                               data_type,
+                               std::move(quant_param),
+                               std::move(shape),
+                               std::move(data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)), failure_msg);
+  qnn_model_wrapper.MarkTensorAsFoldedConstant(name);
+  return Ort::Status();
 }
 
 // Only fp32 DQ output is supported; opset >= 21 fp16/bf16 outputs fall back to the normal op.
@@ -60,31 +114,15 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));
 
   std::vector<float> scales;
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(input_def.quant_param->scale, scales));
-
   std::vector<int32_t> offsets;
-  if (input_def.quant_param->zero_point != nullptr) {
-    ONNXTensorElementDataType zp_type;
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(input_def.quant_param->zero_point, offsets, zp_type));
-  } else {
-    offsets.assign(scales.size(), 0);
-  }
+  RETURN_IF_ERROR(UnpackQuantParams(qnn_model_wrapper, *input_def.quant_param, scales, offsets));
 
-  // SafeInt catches overflow from an adversarial shape before allocation.
-  SafeInt<size_t> safe_num_elems = 1;
-  for (uint32_t d : input_info.shape) {
-    safe_num_elems *= d;
-  }
-  const size_t num_elems = safe_num_elems;
+  size_t num_elems = 0;
+  RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(input_info.shape), num_elems));
   std::vector<float> fp32_data(num_elems);
 
-  std::optional<int64_t> axis = std::nullopt;
-  bool is_per_chan = false;
-  int64_t per_chan_axis = 0;
-  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(input_def, is_per_chan, per_chan_axis));
-  if (is_per_chan) {
-    axis = per_chan_axis;
-  }
+  std::optional<int64_t> axis;
+  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, input_def, axis));
 
   RETURN_IF_ERROR(utils::DequantizePerChannel(
       gsl::make_span(quant_bytes), gsl::make_span(input_info.shape),
@@ -94,16 +132,11 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   std::vector<uint8_t> output_bytes(fp32_data.size() * sizeof(float));
   std::memcpy(output_bytes.data(), fp32_data.data(), output_bytes.size());
 
-  QnnTensorWrapper out_wrapper(output_def.name,
-                               QNN_TENSOR_TYPE_STATIC,
-                               QNN_DATATYPE_FLOAT_32,
-                               QnnQuantParamsWrapper(),
-                               std::vector<uint32_t>(output_info.shape),
-                               std::move(output_bytes));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)),
-                "Failed to add folded DequantizeLinear output tensor.");
-  qnn_model_wrapper.MarkTensorAsFoldedConstant(output_def.name);
-  return Ort::Status();
+  return RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
+                                    QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
+                                    std::vector<uint32_t>(output_info.shape),
+                                    std::move(output_bytes),
+                                    "Failed to add folded DequantizeLinear output tensor.");
 }
 
 // Only fp32 Q input is supported; fp16/bf16 sources fall back to the normal op.
@@ -122,36 +155,21 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF(input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
             "Folded QuantizeLinear only supports float32 input.");
 
-  SafeInt<size_t> safe_num_elems = 1;
-  for (uint32_t d : input_info.shape) {
-    safe_num_elems *= d;
-  }
-  const size_t num_elems = safe_num_elems;
+  size_t num_elems = 0;
+  RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(input_info.shape), num_elems));
   RETURN_IF(input_bytes.size() != SafeInt<size_t>(num_elems) * sizeof(float),
             "QuantizeLinear input byte size mismatch with shape.");
   gsl::span<const float> fp32_input(reinterpret_cast<const float*>(input_bytes.data()), num_elems);
 
   std::vector<float> scales;
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(output_def.quant_param->scale, scales));
-
   std::vector<int32_t> offsets;
-  if (output_def.quant_param->zero_point != nullptr) {
-    ONNXTensorElementDataType zp_type;
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(output_def.quant_param->zero_point, offsets, zp_type));
-  } else {
-    offsets.assign(scales.size(), 0);
-  }
+  RETURN_IF_ERROR(UnpackQuantParams(qnn_model_wrapper, *output_def.quant_param, scales, offsets));
 
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output_def, output_info));
 
-  std::optional<int64_t> axis = std::nullopt;
-  bool is_per_chan = false;
-  int64_t per_chan_axis = 0;
-  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(output_def, is_per_chan, per_chan_axis));
-  if (is_per_chan) {
-    axis = per_chan_axis;
-  }
+  std::optional<int64_t> axis;
+  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, output_def, axis));
 
   // Needed over GetElementSizeByType to correctly size sub-byte dtypes (e.g. int4).
   const size_t total_bytes = utils::GetQnnTensorDataSizeInBytes(num_elems, output_info.qnn_data_type);
@@ -162,16 +180,12 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
       gsl::make_span(scales), gsl::make_span(offsets),
       gsl::make_span(quant_bytes), output_info.qnn_data_type, axis));
 
-  QnnTensorWrapper out_wrapper(output_def.name,
-                               QNN_TENSOR_TYPE_STATIC,
-                               output_info.qnn_data_type,
-                               std::move(output_info.quant_param),
-                               std::vector<uint32_t>(output_info.shape),
-                               std::move(quant_bytes));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)),
-                "Failed to add folded QuantizeLinear output tensor.");
-  qnn_model_wrapper.MarkTensorAsFoldedConstant(output_def.name);
-  return Ort::Status();
+  return RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
+                                    output_info.qnn_data_type,
+                                    std::move(output_info.quant_param),
+                                    std::vector<uint32_t>(output_info.shape),
+                                    std::move(quant_bytes),
+                                    "Failed to add folded QuantizeLinear output tensor.");
 }
 
 }  // namespace

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -20,9 +20,7 @@ namespace qnn {
 
 namespace {
 
-// Fetch raw bytes of a constant input tensor. Works whether the tensor is a real
-// graph initializer or a previously folded constant tensor we placed in the
-// model wrapper.
+// Fetch raw bytes from either a real initializer or a previously-folded STATIC tensor.
 Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
                                    const std::string& tensor_name,
                                    /*out*/ std::vector<uint8_t>& bytes) {
@@ -42,13 +40,7 @@ Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
   return MAKE_EP_FAIL("Tensor is not a constant initializer or folded constant.");
 }
 
-// Constant-fold a standalone DequantizeLinear whose input is effectively constant.
-// Computes the dequantized fp32 data at compile time and emits a STATIC fp32
-// tensor for the DQ output. The DQ op itself is not added to the QNN graph.
-//
-// Note: only fp32 DQ output is supported. ONNX opset >= 21 also allows fp16
-// (and other) DQ outputs; those are rejected here so the caller falls back to
-// emitting a normal QNN op.
+// Only fp32 DQ output is supported; opset >= 21 fp16/bf16 outputs fall back to the normal op.
 Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit) {
   const auto& input_def = node_unit.Inputs()[0];
@@ -78,9 +70,7 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
     offsets.assign(scales.size(), 0);
   }
 
-  // Use SafeInt to detect a malicious model whose shape product overflows size_t.
-  // The downstream allocation would fail anyway, but explicit bounds turn silent
-  // wrap into an immediate, attributable error.
+  // SafeInt catches overflow from an adversarial shape before allocation.
   SafeInt<size_t> safe_num_elems = 1;
   for (uint32_t d : input_info.shape) {
     safe_num_elems *= d;
@@ -116,13 +106,7 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// Constant-fold a standalone QuantizeLinear whose input is effectively constant.
-// Computes the quantized data at compile time and emits a STATIC quantized
-// tensor for the Q output. The Q op itself is not added to the QNN graph.
-//
-// Note: only fp32 input is supported. fp16 sources would require an additional
-// fp16 -> fp32 conversion step before quantization; not needed by current
-// targets.
+// Only fp32 Q input is supported; fp16/bf16 sources fall back to the normal op.
 Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
                                        const OrtNodeUnit& node_unit) {
   const auto& input_def = node_unit.Inputs()[0];
@@ -169,8 +153,7 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
     axis = per_chan_axis;
   }
 
-  // GetQnnTensorDataSizeInBytes correctly accounts for sub-byte dtypes (e.g. int4),
-  // unlike GetElementSizeByType which rounds up to a byte per element.
+  // Needed over GetElementSizeByType to correctly size sub-byte dtypes (e.g. int4).
   const size_t total_bytes = utils::GetQnnTensorDataSizeInBytes(num_elems, output_info.qnn_data_type);
   std::vector<uint8_t> quant_bytes(total_bytes);
 
@@ -195,8 +178,7 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
 
 bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
                         const OrtNodeUnit& node_unit) {
-  // Only standalone Q/DQ. QDQGroup-typed units have a non-Q/DQ target node and would
-  // already be handled by the corresponding op builder.
+  // QDQGroup units are owned by the target op builder; only standalone Q/DQ are foldable here.
   if (node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
     return false;
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
+
+#include <cstring>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <SafeInt.hpp>
+
+#include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+// Fetch raw bytes of a constant input tensor. Works whether the tensor is a real
+// graph initializer or a previously folded constant tensor we placed in the
+// model wrapper.
+Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
+                                   const std::string& tensor_name,
+                                   /*out*/ std::vector<uint8_t>& bytes) {
+  if (qnn_model_wrapper.IsConstantInput(tensor_name)) {
+    const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(tensor_name);
+    RETURN_IF(init == nullptr, "Constant initializer not found for tensor.");
+    return qnn_model_wrapper.UnpackInitializerData(init, bytes);
+  }
+  if (qnn_model_wrapper.IsFoldedConstant(tensor_name) &&
+      qnn_model_wrapper.IsQnnTensorWrapperExist(tensor_name)) {
+    const QnnTensorWrapper& wrapper = qnn_model_wrapper.GetQnnTensorWrapper(tensor_name);
+    const Qnn_ClientBuffer_t& buf = GetQnnTensorClientBuf(wrapper.GetQnnTensor());
+    const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(buf.data);
+    bytes.assign(data_ptr, data_ptr + buf.dataSize);
+    return Ort::Status();
+  }
+  return MAKE_EP_FAIL("Tensor is not a constant initializer or folded constant.");
+}
+
+// Constant-fold a standalone DequantizeLinear whose input is effectively constant.
+// Computes the dequantized fp32 data at compile time and emits a STATIC fp32
+// tensor for the DQ output. The DQ op itself is not added to the QNN graph.
+//
+// Note: only fp32 DQ output is supported. ONNX opset >= 21 also allows fp16
+// (and other) DQ outputs; those are rejected here so the caller falls back to
+// emitting a normal QNN op.
+Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
+                                         const OrtNodeUnit& node_unit) {
+  const auto& input_def = node_unit.Inputs()[0];
+  const auto& output_def = node_unit.Outputs()[0];
+
+  RETURN_IF(!input_def.quant_param.has_value(), "DQ input has no quant param.");
+
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output_def, output_info));
+  RETURN_IF(output_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
+            "Folded DequantizeLinear only supports float32 output.");
+
+  std::vector<uint8_t> quant_bytes;
+  RETURN_IF_ERROR(GetConstantTensorBytes(qnn_model_wrapper, input_def.name, quant_bytes));
+
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));
+
+  std::vector<float> scales;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(input_def.quant_param->scale, scales));
+
+  std::vector<int32_t> offsets;
+  if (input_def.quant_param->zero_point != nullptr) {
+    ONNXTensorElementDataType zp_type;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(input_def.quant_param->zero_point, offsets, zp_type));
+  } else {
+    offsets.assign(scales.size(), 0);
+  }
+
+  // Use SafeInt to detect a malicious model whose shape product overflows size_t.
+  // The downstream allocation would fail anyway, but explicit bounds turn silent
+  // wrap into an immediate, attributable error.
+  SafeInt<size_t> safe_num_elems = 1;
+  for (uint32_t d : input_info.shape) {
+    safe_num_elems *= d;
+  }
+  const size_t num_elems = safe_num_elems;
+  std::vector<float> fp32_data(num_elems);
+
+  std::optional<int64_t> axis = std::nullopt;
+  bool is_per_chan = false;
+  int64_t per_chan_axis = 0;
+  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(input_def, is_per_chan, per_chan_axis));
+  if (is_per_chan) {
+    axis = per_chan_axis;
+  }
+
+  RETURN_IF_ERROR(utils::DequantizePerChannel(
+      gsl::make_span(quant_bytes), gsl::make_span(input_info.shape),
+      gsl::make_span(scales), gsl::make_span(offsets),
+      gsl::make_span(fp32_data), input_info.qnn_data_type, axis));
+
+  std::vector<uint8_t> output_bytes(fp32_data.size() * sizeof(float));
+  std::memcpy(output_bytes.data(), fp32_data.data(), output_bytes.size());
+
+  QnnTensorWrapper out_wrapper(output_def.name,
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_FLOAT_32,
+                               QnnQuantParamsWrapper(),
+                               std::vector<uint32_t>(output_info.shape),
+                               std::move(output_bytes));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)),
+                "Failed to add folded DequantizeLinear output tensor.");
+  qnn_model_wrapper.MarkTensorAsFoldedConstant(output_def.name);
+  return Ort::Status();
+}
+
+// Constant-fold a standalone QuantizeLinear whose input is effectively constant.
+// Computes the quantized data at compile time and emits a STATIC quantized
+// tensor for the Q output. The Q op itself is not added to the QNN graph.
+//
+// Note: only fp32 input is supported. fp16 sources would require an additional
+// fp16 -> fp32 conversion step before quantization; not needed by current
+// targets.
+Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit) {
+  const auto& input_def = node_unit.Inputs()[0];
+  const auto& output_def = node_unit.Outputs()[0];
+
+  RETURN_IF(!output_def.quant_param.has_value(), "Q output has no quant param.");
+
+  std::vector<uint8_t> input_bytes;
+  RETURN_IF_ERROR(GetConstantTensorBytes(qnn_model_wrapper, input_def.name, input_bytes));
+
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));
+  RETURN_IF(input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
+            "Folded QuantizeLinear only supports float32 input.");
+
+  SafeInt<size_t> safe_num_elems = 1;
+  for (uint32_t d : input_info.shape) {
+    safe_num_elems *= d;
+  }
+  const size_t num_elems = safe_num_elems;
+  RETURN_IF(input_bytes.size() != SafeInt<size_t>(num_elems) * sizeof(float),
+            "QuantizeLinear input byte size mismatch with shape.");
+  gsl::span<const float> fp32_input(reinterpret_cast<const float*>(input_bytes.data()), num_elems);
+
+  std::vector<float> scales;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(output_def.quant_param->scale, scales));
+
+  std::vector<int32_t> offsets;
+  if (output_def.quant_param->zero_point != nullptr) {
+    ONNXTensorElementDataType zp_type;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(output_def.quant_param->zero_point, offsets, zp_type));
+  } else {
+    offsets.assign(scales.size(), 0);
+  }
+
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output_def, output_info));
+
+  std::optional<int64_t> axis = std::nullopt;
+  bool is_per_chan = false;
+  int64_t per_chan_axis = 0;
+  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(output_def, is_per_chan, per_chan_axis));
+  if (is_per_chan) {
+    axis = per_chan_axis;
+  }
+
+  // GetQnnTensorDataSizeInBytes correctly accounts for sub-byte dtypes (e.g. int4),
+  // unlike GetElementSizeByType which rounds up to a byte per element.
+  const size_t total_bytes = utils::GetQnnTensorDataSizeInBytes(num_elems, output_info.qnn_data_type);
+  std::vector<uint8_t> quant_bytes(total_bytes);
+
+  RETURN_IF_ERROR(utils::QuantizeData(
+      fp32_input, gsl::make_span(input_info.shape),
+      gsl::make_span(scales), gsl::make_span(offsets),
+      gsl::make_span(quant_bytes), output_info.qnn_data_type, axis));
+
+  QnnTensorWrapper out_wrapper(output_def.name,
+                               QNN_TENSOR_TYPE_STATIC,
+                               output_info.qnn_data_type,
+                               std::move(output_info.quant_param),
+                               std::vector<uint32_t>(output_info.shape),
+                               std::move(quant_bytes));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)),
+                "Failed to add folded QuantizeLinear output tensor.");
+  qnn_model_wrapper.MarkTensorAsFoldedConstant(output_def.name);
+  return Ort::Status();
+}
+
+}  // namespace
+
+bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
+                        const OrtNodeUnit& node_unit) {
+  // Only standalone Q/DQ. QDQGroup-typed units have a non-Q/DQ target node and would
+  // already be handled by the corresponding op builder.
+  if (node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return false;
+  }
+  const std::string& op_type = node_unit.OpType();
+  if (op_type != "DequantizeLinear" && op_type != "QuantizeLinear") {
+    return false;
+  }
+  if (node_unit.Inputs().empty()) {
+    return false;
+  }
+  return qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
+}
+
+Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
+                               const OrtNodeUnit& node_unit) {
+  const std::string& op_type = node_unit.OpType();
+  if (op_type == "DequantizeLinear") {
+    return FoldConstantDequantizeLinear(qnn_model_wrapper, node_unit);
+  }
+  if (op_type == "QuantizeLinear") {
+    return FoldConstantQuantizeLinear(qnn_model_wrapper, node_unit);
+  }
+  return MAKE_EP_FAIL("TryFoldConstantQDQ called on a non-Q/DQ node.");
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// Returns true if `node_unit` is a standalone DequantizeLinear or QuantizeLinear
+// whose only data input is effectively a compile-time constant (a real graph
+// initializer or a previously folded constant). Such nodes can be evaluated at
+// build time and emitted as QNN STATIC tensors instead of producing a runtime
+// QNN op + APP_WRITE input.
+bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
+                        const OrtNodeUnit& node_unit);
+
+// Constant-fold a standalone DequantizeLinear / QuantizeLinear node whose input
+// is effectively constant. On success, the node's output is registered as a
+// QNN_TENSOR_TYPE_STATIC tensor wrapper and is marked as a folded constant so
+// that downstream Q/DQ hops can continue folding. The Q/DQ op itself is not
+// added to the QNN graph.
+//
+// Caller MUST first verify with `CanFoldConstantQdq`. Behavior on a non-fold
+// candidate is an error status.
+Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
+                               const OrtNodeUnit& node_unit) ORT_MUST_USE_RESULT;
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -10,22 +10,13 @@ namespace qnn {
 
 class QnnModelWrapper;
 
-// Returns true if `node_unit` is a standalone DequantizeLinear or QuantizeLinear
-// whose only data input is effectively a compile-time constant (a real graph
-// initializer or a previously folded constant). Such nodes can be evaluated at
-// build time and emitted as QNN STATIC tensors instead of producing a runtime
-// QNN op + APP_WRITE input.
+// True if `node_unit` is a standalone Q/DQ with an effectively-constant input
+// (real initializer or previously-folded tensor) eligible for compile-time folding.
 bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
                         const OrtNodeUnit& node_unit);
 
-// Constant-fold a standalone DequantizeLinear / QuantizeLinear node whose input
-// is effectively constant. On success, the node's output is registered as a
-// QNN_TENSOR_TYPE_STATIC tensor wrapper and is marked as a folded constant so
-// that downstream Q/DQ hops can continue folding. The Q/DQ op itself is not
-// added to the QNN graph.
-//
-// Caller MUST first verify with `CanFoldConstantQdq`. Behavior on a non-fold
-// candidate is an error status.
+// Fold the Q/DQ statically and register its output as a STATIC tensor. Caller
+// MUST first verify with `CanFoldConstantQdq`.
 Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
                                const OrtNodeUnit& node_unit) ORT_MUST_USE_RESULT;
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -3,6 +3,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
@@ -83,7 +84,10 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     bool is_per_chan_quant = false;
     int64_t quant_axis = 0;
     RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_chan_quant, quant_axis));
-    RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone DQ op with per-channel quantization");
+    // Per-channel standalone DQ is allowed only if the input is a compile-time constant;
+    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
+    RETURN_IF(is_per_chan_quant && !is_input_const,
+              "QNN EP does not support a standalone DQ op with per-channel quantization");
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name)) {
@@ -106,7 +110,10 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     bool is_per_chan_quant = false;
     int64_t quant_axis = 0;
     RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Outputs()[0], is_per_chan_quant, quant_axis));
-    RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone Q op with per-channel quantization");
+    // Per-channel standalone Q is allowed only if the input is a compile-time constant;
+    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
+    RETURN_IF(is_per_chan_quant && !is_input_const,
+              "QNN EP does not support a standalone Q op with per-channel quantization");
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
@@ -321,6 +328,16 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
       }
     }
 #endif
+  }
+
+  // Constant-fold standalone DQ/Q on constant inputs. Avoid emitting a QNN op for them so
+  // their fp32 (DQ) or quantized (Q) output appears as a STATIC tensor in the graph rather
+  // than as an APP_WRITE input crossing the partition boundary.
+  if (CanFoldConstantQdq(qnn_model_wrapper, node_unit)) {
+    Ort::Status fold_status = TryFoldConstantQDQ(qnn_model_wrapper, node_unit);
+    if (fold_status.IsOK()) {
+      return Ort::Status();
+    }
   }
 
   std::vector<std::string> param_tensor_names;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -330,9 +330,7 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 #endif
   }
 
-  // Constant-fold standalone DQ/Q on constant inputs. Avoid emitting a QNN op for them so
-  // their fp32 (DQ) or quantized (Q) output appears as a STATIC tensor in the graph rather
-  // than as an APP_WRITE input crossing the partition boundary.
+  // Emit a STATIC tensor instead of an APP_WRITE input for standalone Q/DQ on constant inputs.
   if (CanFoldConstantQdq(qnn_model_wrapper, node_unit)) {
     Ort::Status fold_status = TryFoldConstantQDQ(qnn_model_wrapper, node_unit);
     if (fold_status.IsOK()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -195,8 +195,6 @@ class QnnModelWrapper {
     return is_constant_initializer;
   }
 
-  // Mark a tensor as a compile-time-folded constant (e.g. output of a Q/DQ on a constant
-  // initializer that we statically computed). Used by op builders to chain folds.
   void MarkTensorAsFoldedConstant(const std::string& tensor_name) {
     folded_constant_tensors_.insert(tensor_name);
   }
@@ -205,7 +203,7 @@ class QnnModelWrapper {
     return folded_constant_tensors_.count(tensor_name) > 0;
   }
 
-  // Effectively constant = real graph initializer OR a tensor we already folded.
+  // Real graph initializer OR a tensor produced by a previous compile-time fold.
   bool IsEffectivelyConstantInput(const std::string& tensor_name) const {
     return IsConstantInput(tensor_name) || IsFoldedConstant(tensor_name);
   }
@@ -505,9 +503,7 @@ class QnnModelWrapper {
 
   std::unordered_map<std::string, std::string>* tensor_name_overrides_ = nullptr;
 
-  // Set of tensor names whose data was folded at compile time and that should be
-  // treated as constant by downstream op builders. Used to chain constant-folding
-  // across multiple Q/DQ ops on a constant initializer.
+  // Tensor names produced by compile-time Q/DQ folds; chained across hops.
   std::unordered_set<std::string> folded_constant_tensors_;
 };  // QnnModelWrapper
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "nlohmann/json.hpp"
@@ -194,6 +195,21 @@ class QnnModelWrapper {
     return is_constant_initializer;
   }
 
+  // Mark a tensor as a compile-time-folded constant (e.g. output of a Q/DQ on a constant
+  // initializer that we statically computed). Used by op builders to chain folds.
+  void MarkTensorAsFoldedConstant(const std::string& tensor_name) {
+    folded_constant_tensors_.insert(tensor_name);
+  }
+
+  bool IsFoldedConstant(const std::string& tensor_name) const {
+    return folded_constant_tensors_.count(tensor_name) > 0;
+  }
+
+  // Effectively constant = real graph initializer OR a tensor we already folded.
+  bool IsEffectivelyConstantInput(const std::string& tensor_name) const {
+    return IsConstantInput(tensor_name) || IsFoldedConstant(tensor_name);
+  }
+
   // static bool GetOnnxShape(const NodeArg& node_arg, std::vector<uint32_t>& shape);
   static bool GetOnnxShape(const std::optional<std::vector<int64_t>>& onnx_shape, std::vector<uint32_t>& shape);
 
@@ -212,7 +228,7 @@ class QnnModelWrapper {
   }
 
   Qnn_TensorType_t GetTensorType(const std::string& tensor_name) const {
-    if (IsConstantInput(tensor_name)) {
+    if (IsConstantInput(tensor_name) || IsFoldedConstant(tensor_name)) {
       return QNN_TENSOR_TYPE_STATIC;
     } else if (IsGraphInput(tensor_name)) {
       return QNN_TENSOR_TYPE_APP_WRITE;
@@ -488,6 +504,11 @@ class QnnModelWrapper {
   const ApiPtrs api_ptrs_;
 
   std::unordered_map<std::string, std::string>* tensor_name_overrides_ = nullptr;
+
+  // Set of tensor names whose data was folded at compile time and that should be
+  // treated as constant by downstream op builders. Used to chain constant-folding
+  // across multiple Q/DQ ops on a constant initializer.
+  std::unordered_set<std::string> folded_constant_tensors_;
 };  // QnnModelWrapper
 
 template <typename T>

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -934,14 +934,9 @@ TEST_F(QnnCPUBackendTests, ConvTranspose1Df32_DynamicWeights_DefaultBias) {
                 ExpectedEPNodeAssignment::All);
 }
 
-// Regression test for chained Q/DQ on a per-channel constant Conv weight:
-//   weight_q0 initializer -> DQ -> Q -> DQ -> Conv
-// Without folded-constant propagation, the chain stops folding after the first hop and the
-// final DQ output can leak into the QNN graph as an extra runtime input.
-//
-// `scale1`/`zp1` configure the second Q/DQ hop. When they differ from `scale0`/`zp0`, the
-// fold path must perform real quant arithmetic on the intermediate STATIC tensor instead
-// of round-tripping bytes verbatim. Caller picks tolerance accordingly.
+// Builds: weight_q0 (int8 init) -> DQ -> Q -> DQ -> Conv.
+// Used to regression-test chained folding; differing scale0/scale1 exercises real requant
+// on the intermediate STATIC tensor rather than a byte round-trip.
 static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
     const std::vector<float>& scale0,
     const std::vector<int8_t>& zp0,
@@ -953,7 +948,6 @@ static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
     const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
     const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
 
-    // Float dynamic activation input.
     builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
 
     builder.MakeInitializer<int8_t>("weight_q0", weight_shape, std::vector<int8_t>{1, 2, 3, 4, 5, 6});
@@ -972,7 +966,6 @@ static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
     builder.AddNode("WeightDQ1", "DequantizeLinear", {"weight_q1", "scale1", "zp1"}, {"weight_dq1"},
                     kOnnxDomain, axis_attrs);
 
-    // Float Conv consuming the dequantized constant weight directly.
     builder.MakeOutput("output");
     std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
     conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
@@ -985,8 +978,6 @@ static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
   };
 }
 
-// Identity-scale chain: structural regression. Asserts the chain folds and the final DQ
-// output does not leak into the QNN graph as an APP_WRITE input.
 TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";
@@ -1001,9 +992,6 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
                   /*fp32_abs_err*/ 1e-4f);
 }
 
-// Non-identity Q/DQ chain: stresses real quant arithmetic on the intermediate fold output.
-// scale1 != scale0 and zp1 != 0, so the fold path must dequant->requant the intermediate
-// STATIC tensor; a buggy implementation that re-uses input bytes verbatim would fail.
 TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Regression) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -934,6 +934,90 @@ TEST_F(QnnCPUBackendTests, ConvTranspose1Df32_DynamicWeights_DefaultBias) {
                 ExpectedEPNodeAssignment::All);
 }
 
+// Regression test for chained Q/DQ on a per-channel constant Conv weight:
+//   weight_q0 initializer -> DQ -> Q -> DQ -> Conv
+// Without folded-constant propagation, the chain stops folding after the first hop and the
+// final DQ output can leak into the QNN graph as an extra runtime input.
+//
+// `scale1`/`zp1` configure the second Q/DQ hop. When they differ from `scale0`/`zp0`, the
+// fold path must perform real quant arithmetic on the intermediate STATIC tensor instead
+// of round-tripping bytes verbatim. Caller picks tolerance accordingly.
+static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
+    const std::vector<float>& scale0,
+    const std::vector<int8_t>& zp0,
+    const std::vector<float>& scale1,
+    const std::vector<int8_t>& zp1) {
+  return [scale0, zp0, scale1, zp1](ModelTestBuilder& builder) {
+    constexpr int64_t out_ch = 2;
+    constexpr int64_t in_ch = 3;
+    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
+    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
+
+    // Float dynamic activation input.
+    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
+
+    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, std::vector<int8_t>{1, 2, 3, 4, 5, 6});
+    builder.MakeInitializer<float>("scale0", {out_ch}, scale0);
+    builder.MakeInitializer<int8_t>("zp0", {out_ch}, zp0);
+    builder.MakeInitializer<float>("scale1", {out_ch}, scale1);
+    builder.MakeInitializer<int8_t>("zp1", {out_ch}, zp1);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
+    axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+
+    builder.AddNode("WeightDQ0", "DequantizeLinear", {"weight_q0", "scale0", "zp0"}, {"weight_dq0"},
+                    kOnnxDomain, axis_attrs);
+    builder.AddNode("WeightQ1", "QuantizeLinear", {"weight_dq0", "scale1", "zp1"}, {"weight_q1"},
+                    kOnnxDomain, axis_attrs);
+    builder.AddNode("WeightDQ1", "DequantizeLinear", {"weight_q1", "scale1", "zp1"}, {"weight_dq1"},
+                    kOnnxDomain, axis_attrs);
+
+    // Float Conv consuming the dequantized constant weight directly.
+    builder.MakeOutput("output");
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+
+    builder.AddNode("Conv", "Conv", {"input", "weight_dq1"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+}
+
+// Identity-scale chain: structural regression. Asserts the chain folds and the final DQ
+// output does not leak into the QNN graph as an APP_WRITE input.
+TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
+                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
+                      /*scale1*/ {0.1f, 0.2f}, /*zp1*/ {0, 0}),
+                  provider_options,
+                  /*opset*/ 13,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err*/ 1e-4f);
+}
+
+// Non-identity Q/DQ chain: stresses real quant arithmetic on the intermediate fold output.
+// scale1 != scale0 and zp1 != 0, so the fold path must dequant->requant the intermediate
+// STATIC tensor; a buggy implementation that re-uses input bytes verbatim would fail.
+TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Regression) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
+                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
+                      /*scale1*/ {0.05f, 0.4f}, /*zp1*/ {-2, 3}),
+                  provider_options,
+                  /*opset*/ 13,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err*/ 1e-4f);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // The bug is from a QDQ model, and Conv node gets processed before it's producer Mul node
@@ -1025,6 +1109,34 @@ TEST_F(QnnHTPBackendTests, DISABLED_Test_QDQConvWithDynamicWeightsFromMul) {
                   provider_options,
                   13,
                   ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
+                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
+                      /*scale1*/ {0.1f, 0.2f}, /*zp1*/ {0, 0}),
+                  provider_options,
+                  /*opset*/ 13,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err*/ 1e-4f);
+}
+
+TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Regression) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
+                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
+                      /*scale1*/ {0.05f, 0.4f}, /*zp1*/ {-2, 3}),
+                  provider_options,
+                  /*opset*/ 13,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err*/ 1e-3f);
 }
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1110,7 +1110,7 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
                   provider_options,
                   /*opset*/ 13,
                   ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err*/ 1e-4f);
+                  /*fp32_abs_err*/ 1e-3f);
 }
 
 TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Regression) {

--- a/onnxruntime/test/providers/qnn/qnn_model_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_model_wrapper_test.cc
@@ -214,19 +214,9 @@ TEST(QnnModelWrapperTest, AddTensorWrapper_EmptyName_ReturnsFalse) {
   EXPECT_FALSE(wrapper->AddTensorWrapper(std::move(tensor)));
 }
 
-// ---------------------------------------------------------------------------
-// Folded-constant tensor tracking.
-//
-// These tests cover the API used by simple_op_builder.cc to constant-fold
-// standalone Q/DQ nodes whose inputs are constant initializers. Folded outputs
-// must be queryable as "effectively constant" so that downstream op builders
-// emit them as QNN STATIC tensors instead of APP_WRITE (runtime) graph inputs.
-// Regression coverage for: per-channel constant DequantizeLinear feeding Conv
-// weight pattern that previously leaked the DQ output as a graph input.
-// ---------------------------------------------------------------------------
+// Folded-constant tracking: regression coverage for per-channel constant DQ feeding
+// Conv weight that previously leaked the DQ output as a graph input.
 
-// By default, an unknown / never-marked tensor is not a folded constant, and
-// therefore not effectively constant either.
 TEST(QnnModelWrapperTest, FoldedConstant_DefaultIsFalse) {
   QnnModelWrapperTestContext ctx;
   ModelSettings settings{};
@@ -236,8 +226,6 @@ TEST(QnnModelWrapperTest, FoldedConstant_DefaultIsFalse) {
   EXPECT_FALSE(wrapper->IsEffectivelyConstantInput("not_marked"));
 }
 
-// Marking a tensor as folded makes IsFoldedConstant and IsEffectivelyConstantInput
-// return true for that tensor only.
 TEST(QnnModelWrapperTest, FoldedConstant_MarkMakesTensorFolded) {
   QnnModelWrapperTestContext ctx;
   ModelSettings settings{};
@@ -247,13 +235,10 @@ TEST(QnnModelWrapperTest, FoldedConstant_MarkMakesTensorFolded) {
 
   EXPECT_TRUE(wrapper->IsFoldedConstant("weight_dq"));
   EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("weight_dq"));
-
-  // Other tensor names are unaffected.
   EXPECT_FALSE(wrapper->IsFoldedConstant("other_tensor"));
   EXPECT_FALSE(wrapper->IsEffectivelyConstantInput("other_tensor"));
 }
 
-// Marking the same tensor twice is idempotent (set semantics).
 TEST(QnnModelWrapperTest, FoldedConstant_MarkIsIdempotent) {
   QnnModelWrapperTestContext ctx;
   ModelSettings settings{};
@@ -266,7 +251,6 @@ TEST(QnnModelWrapperTest, FoldedConstant_MarkIsIdempotent) {
   EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("weight_dq"));
 }
 
-// Multiple folded tensors can coexist; each is tracked independently.
 TEST(QnnModelWrapperTest, FoldedConstant_MultipleTensorsTrackedIndependently) {
   QnnModelWrapperTestContext ctx;
   ModelSettings settings{};
@@ -284,9 +268,7 @@ TEST(QnnModelWrapperTest, FoldedConstant_MultipleTensorsTrackedIndependently) {
   EXPECT_FALSE(wrapper->IsEffectivelyConstantInput("c"));
 }
 
-// Folded-constant marking is independent of the tensor wrapper registry: marking a
-// name that has not been added via AddTensorWrapper still flips the predicates.
-// (Op builders mark fold names before/after creating the static tensor wrapper.)
+// Marking is independent of AddTensorWrapper so op builders can mark before or after.
 TEST(QnnModelWrapperTest, FoldedConstant_DoesNotRequireTensorWrapper) {
   QnnModelWrapperTestContext ctx;
   ModelSettings settings{};
@@ -299,17 +281,13 @@ TEST(QnnModelWrapperTest, FoldedConstant_DoesNotRequireTensorWrapper) {
   EXPECT_FALSE(wrapper->IsQnnTensorWrapperExist("phantom_tensor"));
 }
 
-// GetTensorType must report STATIC for folded-constant outputs. They are emitted
-// as STATIC tensors at build time and must never be classified as NATIVE (which
-// would let later code treat them as runtime-produced intermediates).
+// Folded-constant outputs MUST map to STATIC (not NATIVE) so they aren't treated as runtime intermediates.
 TEST(QnnModelWrapperTest, FoldedConstant_GetTensorTypeIsStatic) {
   QnnModelWrapperTestContext ctx;
   ModelSettings settings{};
   auto wrapper = ctx.CreateWrapper(settings);
 
-  // Sanity: an unmarked tensor (and not a graph in/out, not an initializer) is NATIVE.
   EXPECT_EQ(wrapper->GetTensorType("unmarked"), QNN_TENSOR_TYPE_NATIVE);
-
   wrapper->MarkTensorAsFoldedConstant("folded");
   EXPECT_EQ(wrapper->GetTensorType("folded"), QNN_TENSOR_TYPE_STATIC);
 }

--- a/onnxruntime/test/providers/qnn/qnn_model_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_model_wrapper_test.cc
@@ -214,6 +214,106 @@ TEST(QnnModelWrapperTest, AddTensorWrapper_EmptyName_ReturnsFalse) {
   EXPECT_FALSE(wrapper->AddTensorWrapper(std::move(tensor)));
 }
 
+// ---------------------------------------------------------------------------
+// Folded-constant tensor tracking.
+//
+// These tests cover the API used by simple_op_builder.cc to constant-fold
+// standalone Q/DQ nodes whose inputs are constant initializers. Folded outputs
+// must be queryable as "effectively constant" so that downstream op builders
+// emit them as QNN STATIC tensors instead of APP_WRITE (runtime) graph inputs.
+// Regression coverage for: per-channel constant DequantizeLinear feeding Conv
+// weight pattern that previously leaked the DQ output as a graph input.
+// ---------------------------------------------------------------------------
+
+// By default, an unknown / never-marked tensor is not a folded constant, and
+// therefore not effectively constant either.
+TEST(QnnModelWrapperTest, FoldedConstant_DefaultIsFalse) {
+  QnnModelWrapperTestContext ctx;
+  ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  EXPECT_FALSE(wrapper->IsFoldedConstant("not_marked"));
+  EXPECT_FALSE(wrapper->IsEffectivelyConstantInput("not_marked"));
+}
+
+// Marking a tensor as folded makes IsFoldedConstant and IsEffectivelyConstantInput
+// return true for that tensor only.
+TEST(QnnModelWrapperTest, FoldedConstant_MarkMakesTensorFolded) {
+  QnnModelWrapperTestContext ctx;
+  ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  wrapper->MarkTensorAsFoldedConstant("weight_dq");
+
+  EXPECT_TRUE(wrapper->IsFoldedConstant("weight_dq"));
+  EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("weight_dq"));
+
+  // Other tensor names are unaffected.
+  EXPECT_FALSE(wrapper->IsFoldedConstant("other_tensor"));
+  EXPECT_FALSE(wrapper->IsEffectivelyConstantInput("other_tensor"));
+}
+
+// Marking the same tensor twice is idempotent (set semantics).
+TEST(QnnModelWrapperTest, FoldedConstant_MarkIsIdempotent) {
+  QnnModelWrapperTestContext ctx;
+  ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  wrapper->MarkTensorAsFoldedConstant("weight_dq");
+  wrapper->MarkTensorAsFoldedConstant("weight_dq");
+
+  EXPECT_TRUE(wrapper->IsFoldedConstant("weight_dq"));
+  EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("weight_dq"));
+}
+
+// Multiple folded tensors can coexist; each is tracked independently.
+TEST(QnnModelWrapperTest, FoldedConstant_MultipleTensorsTrackedIndependently) {
+  QnnModelWrapperTestContext ctx;
+  ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  wrapper->MarkTensorAsFoldedConstant("a");
+  wrapper->MarkTensorAsFoldedConstant("b");
+
+  EXPECT_TRUE(wrapper->IsFoldedConstant("a"));
+  EXPECT_TRUE(wrapper->IsFoldedConstant("b"));
+  EXPECT_FALSE(wrapper->IsFoldedConstant("c"));
+
+  EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("a"));
+  EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("b"));
+  EXPECT_FALSE(wrapper->IsEffectivelyConstantInput("c"));
+}
+
+// Folded-constant marking is independent of the tensor wrapper registry: marking a
+// name that has not been added via AddTensorWrapper still flips the predicates.
+// (Op builders mark fold names before/after creating the static tensor wrapper.)
+TEST(QnnModelWrapperTest, FoldedConstant_DoesNotRequireTensorWrapper) {
+  QnnModelWrapperTestContext ctx;
+  ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  wrapper->MarkTensorAsFoldedConstant("phantom_tensor");
+
+  EXPECT_TRUE(wrapper->IsFoldedConstant("phantom_tensor"));
+  EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("phantom_tensor"));
+  EXPECT_FALSE(wrapper->IsQnnTensorWrapperExist("phantom_tensor"));
+}
+
+// GetTensorType must report STATIC for folded-constant outputs. They are emitted
+// as STATIC tensors at build time and must never be classified as NATIVE (which
+// would let later code treat them as runtime-produced intermediates).
+TEST(QnnModelWrapperTest, FoldedConstant_GetTensorTypeIsStatic) {
+  QnnModelWrapperTestContext ctx;
+  ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  // Sanity: an unmarked tensor (and not a graph in/out, not an initializer) is NATIVE.
+  EXPECT_EQ(wrapper->GetTensorType("unmarked"), QNN_TENSOR_TYPE_NATIVE);
+
+  wrapper->MarkTensorAsFoldedConstant("folded");
+  EXPECT_EQ(wrapper->GetTensorType("folded"), QNN_TENSOR_TYPE_STATIC);
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
Introduce constant folding for standalone Q/DQ ops Track folded constants in QnnModelWrapper.

For model such as, Qwen3-0.6B, some constant weights follow this pattern:

`initializer -> DequantizeLinear -> QuantizeLinear -> DequantizeLinear -> op`

QNN EP folded only the first hop. After that, the intermediate Q/DQ output was no longer recognized as effectively constant, so later folded weight tensors were emitted as QNN `APP_WRITE` graph inputs instead of `STATIC` tensors. In the reproduced Qwen DLC, the ONNX graph had 60 real runtime inputs, but the generated QNN graph had 284 inputs: 224 leaked `v_proj_sha.*.weight_qdq` tensors.

Our fix helped by teaching QNN EP to remember tensors produced by successful constant Q/DQ folding. QnnModelWrapper now marks folded outputs as folded constants, and simple_op_builder/the extracted QDQ folding helper treat those outputs as constant inputs for the next Q/DQ hop. That lets the whole initializer → DQ → Q → DQ chain keep folding through to the final consumer.

Result: those chained constant weights become QNN STATIC tensors instead of runtime APP_WRITE graph inputs, so the generated DLC exposes only the real model inputs and context-binary linking no longer sees a bloated input signature.
