### PR TITLE
Workaround QNN rank-5 matmul rejection

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <functional>
+#include <limits>
 #include <numeric>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -58,6 +60,17 @@ inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
   return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
 }
 
+// Flattens the leading dims of `shape` (all but the last) into a single uint32_t batch value.
+Ort::Status FlattenLeadingDims(const std::vector<uint32_t>& shape, uint32_t& batch) {
+  const int64_t batch_i64 = std::accumulate(shape.begin(), shape.end() - 1,
+                                            static_cast<int64_t>(1), std::multiplies<int64_t>());
+  RETURN_IF(batch_i64 <= 0 ||
+                batch_i64 > static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
+            "MatMul: flattened batch dimension product overflows uint32_t.");
+  batch = static_cast<uint32_t>(batch_i64);
+  return Ort::Status();
+}
+
 Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& input_def_0,
                         const OrtNodeUnitIODef& input_def_1, TensorInfo& input_info_0, TensorInfo& input_info_1,
                         bool& use_fully_connected) {
@@ -104,8 +117,8 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
     if (is_rank1) {
       shape_2d = {1, input_0_info.shape[0]};
     } else {
-      const uint32_t batch = std::accumulate(input_0_info.shape.begin(), input_0_info.shape.end() - 1,
-                                             static_cast<uint32_t>(1), std::multiplies<uint32_t>());
+      uint32_t batch = 0;
+      RETURN_IF_ERROR(FlattenLeadingDims(input_0_info.shape, batch));
       shape_2d = {batch, input_0_info.shape.back()};
     }
     QnnQuantParamsWrapper quant_param_2d = input_0_info.quant_param.Copy();
@@ -439,9 +452,9 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   if (reshape_output) {
     op_output_name = utils::UniqueNameGenerator().New(org_output_name, "_reshape");
     if (use_fully_connected && input_info_0.shape.size() > 2) {
-      op_output_shape = {std::accumulate(input_info_0.shape.begin(), input_info_0.shape.end() - 1,
-                                         static_cast<uint32_t>(1), std::multiplies<uint32_t>()),
-                         reshape_input_1 ? 1 : input_info_1.shape.back()};
+      uint32_t batch = 0;
+      RETURN_IF_ERROR(FlattenLeadingDims(input_info_0.shape, batch));
+      op_output_shape = {batch, reshape_input_1 ? 1 : input_info_1.shape.back()};
       RETURN_IF(op_output_quant_param.IsPerChannel(), "QNN MatMul output does not support per-channel quant.");
     } else {
       // If both inputs are 1D tensors, the output shape is [1] instead of scalar. So if both inputs are 1D tensors,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <numeric>
+
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
@@ -90,15 +92,26 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
                           const std::string& original_input_0_name,
                           std::vector<std::string>& input_names,
                           const Ort::Logger& logger,
-                          bool do_op_validation) {
-  bool reshape_input_0 = input_0_info.shape.size() == 1;
+                          bool do_op_validation,
+                          bool use_fully_connected) {
+  const bool is_rank1 = input_0_info.shape.size() == 1;
+  const bool reshape_input_0 = is_rank1 || (use_fully_connected && input_0_info.shape.size() > 2);
   std::string actual_input_0_name = original_input_0_name;
 
   if (reshape_input_0) {
     actual_input_0_name = utils::UniqueNameGenerator().New(original_input_0_name, "_reshape");
-    std::vector<uint32_t> shape_2d{1, input_0_info.shape[0]};
+    std::vector<uint32_t> shape_2d;
+    if (is_rank1) {
+      shape_2d = {1, input_0_info.shape[0]};
+    } else {
+      const uint32_t batch = std::accumulate(input_0_info.shape.begin(), input_0_info.shape.end() - 1,
+                                             static_cast<uint32_t>(1), std::multiplies<uint32_t>());
+      shape_2d = {batch, input_0_info.shape.back()};
+    }
     QnnQuantParamsWrapper quant_param_2d = input_0_info.quant_param.Copy();
-    RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_0_info.shape, shape_2d));
+    if (is_rank1) {
+      RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_0_info.shape, shape_2d));
+    }
 
     // If input_0 is initializer, unpack it and add the tensor with new quantization parameter and shape.
     // Otherwise, add a Reshape node.
@@ -172,7 +185,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
 
   const std::string& org_input_0_name = inputs[0].name;
   RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_info_0, org_input_0_name, input_names,
-                                logger, do_op_validation));
+                                logger, do_op_validation, /*use_fully_connected=*/false));
 
   // Process input 1.
   const std::string& org_input_1_name = inputs[1].name;
@@ -291,7 +304,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
 
   const std::string& org_input_0_name = inputs[0].name;
   RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_info_0, org_input_0_name, input_names,
-                                logger, do_op_validation));
+                                logger, do_op_validation, /*use_fully_connected=*/true));
 
   // Process input 1.
   const std::string& org_input_1_name = inputs[1].name;

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -249,7 +249,9 @@ TEST_F(QnnCPUBackendTests, MatMulOp) {
   RunMatMulOpTest({3}, {3, 3, 2}, true, false);
   RunMatMulOpTest({2, 3}, {3}, false, false);
   RunMatMulOpTest({2, 3}, {3}, true, false);
+  RunMatMulOpTest({2, 3, 4}, {4, 2}, false, true);
   RunMatMulOpTest({2, 3, 3, 3}, {3}, false, false);
+  RunMatMulOpTest({1, 1, 2, 2, 4}, {4, 2}, false, true);
 
   // Failed randomly on Linux
   // Expected: contains 36 values, where each value and its corresponding value in 16-byte object

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -286,7 +286,9 @@ TEST_F(QnnHTPBackendTests, MatMulOp) {
   RunMatMulOpTest({3}, {3, 3, 2}, true, false, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
   RunMatMulOpTest({2, 3}, {3}, false, false, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
   RunMatMulOpTest({2, 3}, {3}, true, false, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
+  RunMatMulOpTest({2, 3, 4}, {4, 2}, false, true, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
   RunMatMulOpTest({2, 3, 3, 3}, {3}, false, false, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
+  RunMatMulOpTest({1, 1, 2, 2, 4}, {4, 2}, false, true, ExpectedEPNodeAssignment::All, "htp", 18, 1e-2f);
 
   // Failed randomly on Linux
   // Expected: contains 18 values, where each value and its corresponding value in 16-byte object


### PR DESCRIPTION
QNN Rejects rank 5 matmul: 

```Failed to validate op /model/blocks.5/proj/MatMul incorrect Rank 5. ```

Workaround by flatten input 0.