### PR TITLE
[QNN EP] Add framework op tracing feature

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -212,6 +212,19 @@ file(GLOB onnxruntime_test_framework_src CONFIGURE_DEPENDS
 list(REMOVE_ITEM onnxruntime_test_framework_src
      "${TEST_SRC_DIR}/providers/qnn/optimizer/transpose_optimizer_test.cc")
 
+# qnn_op_tracing_serialization.cc is compiled directly into the test binary so
+# that QnnFrameworkOpTraceUnit tests can call ComputeTraceSummary and
+# SerializeFrameworkOpTrace without linking against the EP library.
+# This translation unit intentionally does NOT include ort_api.h, avoiding
+# the ORT_API_MANUAL_INIT mismatch linker error on Windows.  It is needed in
+# both shared-lib builds (hidden symbol visibility prevents linking) and
+# static-lib builds (test binary has build-order dependency only, not a linker
+# dependency, on the EP).
+if(onnxruntime_USE_QNN AND NOT onnxruntime_MINIMAL_BUILD AND NOT onnxruntime_REDUCED_OPS_BUILD)
+  list(APPEND onnxruntime_test_framework_src
+       "${ONNXRUNTIME_ROOT}/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc")
+endif()
+
 #This is a small wrapper library that shouldn't use any onnxruntime internal symbols(except onnxruntime_common).
 #Because it could dynamically link to onnxruntime. Otherwise you will have two copies of onnxruntime in the same
 #process and you won't know which one you are testing.

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -217,6 +217,15 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 |---|---|
 |Directory path (string)|Directory path for dumping QNN IR DLC files. Only effective when `dump_qnn_ir_dlc` is enabled.|
 
+|`"enable_framework_op_trace"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Enable framework op tracing. Writes a JSON file that maps each ONNX operator (or fused group) to its corresponding QNN operator(s), records unsupported operators, and includes summary statistics. See `framework_op_trace_dir` to control the output location. The trace is produced from the QNN graph composition path: it is emitted on a fresh JIT compile and on AOT context-binary generation (when `ep.context_enable=1` writes a new EPContext model). It is **not** emitted when loading an existing EPContext model (cached run), because no graph composition occurs in that path; in that case an INFO log records that no trace file is written.|
+
+|`"framework_op_trace_dir"`|Description|
+|---|---|
+|Directory path (string)|Directory path for framework op trace JSON files. Only effective when `enable_framework_op_trace` is `'1'`. Defaults to the current working directory if not set. The directory is created automatically if it does not exist. If the directory cannot be created or written to (e.g. read-only mount, missing permissions), framework op tracing is disabled with a WARNING log and no trace file is produced. Trace files use the pattern `qnn_op_trace.json`.|
+
 |`"qnn_ir_backend_path"`|Description|
 |---|---|
 |Backend path (string)|Path to the QNN IR backend library. Defaults to 'libQnnIr.so' or 'QnnIr.dll'. Only effective when `dump_qnn_ir_dlc` is enabled.|

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.cc
@@ -1,0 +1,241 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
+
+#include <algorithm>
+#include <fstream>
+
+#include "nlohmann/json.hpp"
+
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// ---------------------------------------------------------------------------
+// OpTraceCollector
+// ---------------------------------------------------------------------------
+
+void OpTraceCollector::SetCurrentNodeGroup(const IQnnNodeGroup* node_group) {
+  current_node_group_ = node_group;
+}
+
+void OpTraceCollector::ClearCurrentNodeGroup() {
+  current_node_group_ = nullptr;
+}
+
+void OpTraceCollector::RecordOpMapping(const std::string& qnn_op_name, const std::string& qnn_op_type,
+                                       gsl::span<const std::string> output_tensor_names) {
+  // Guard: node group context is set by NodeGroupGuard around each AddToModelBuilder call.
+  // If nullptr, this QNN op was created outside that bracket (e.g. BF16
+  // conversion ops Cast added during ComposeQnnGraph postprocessing),
+  // which has no corresponding ONNX node group - skip it.
+  if (current_node_group_ == nullptr) {
+    return;
+  }
+
+  TraceMapping mapping;
+  mapping.dst_name = qnn_op_name;
+  mapping.dst_qnn_op_type = qnn_op_type;
+  mapping.node_group_type = std::string(current_node_group_->Type());
+
+  // Collect all raw nodes into a flat list. Inline capacity 8 covers the
+  // typical case (most node groups have <= 8 raw nodes; see
+  // qnn_execution_provider.cc).
+  InlinedVector<const OrtNode*, 8> all_nodes;
+  for (const OrtNodeUnit* node_unit : current_node_group_->GetNodeUnits()) {
+    for (const OrtNode* node : node_unit->GetAllNodesInGroup()) {
+      all_nodes.push_back(node);
+    }
+  }
+
+  // Build srcInfo chain:
+  //   op1, tensor_out1, op2, tensor_out2, ..., opN
+  // Each source op is followed by the output tensor that actually flows into
+  // the next op in the chain (found by intersecting node[i]'s outputs with
+  // node[i+1]'s inputs). Falls back to outputs[0] if no match is found.
+  for (size_t i = 0; i < all_nodes.size(); ++i) {
+    Ort::ConstNode const_node(all_nodes[i]);
+    // Node names are optional per ONNX spec. Fall back to OpType+position,
+    // mirroring UniqueNameGenerator::New(node_unit)'s OpType+Index fallback
+    // so that source names are structurally consistent with QNN op names
+    // in the 1:1 case. The position index `i` differs from the graph-global
+    // NodeUnit index used by UniqueNameGenerator, so the names may not match
+    // exactly for unnamed nodes — but they remain unique within this group and
+    // are typed as OP (not a tensor name masquerading as an OP source).
+    std::string node_name = std::string(const_node.GetName());
+    if (node_name.empty()) {
+      node_name = std::string(const_node.GetOperatorType()) + std::to_string(i);
+    }
+    mapping.sources.push_back({std::move(node_name), TraceTargetType::kOp});
+
+    // Add linking tensor for all nodes except the last.
+    if (i + 1 < all_nodes.size()) {
+      std::vector<Ort::ConstValueInfo> outputs = const_node.GetOutputs();
+      if (!outputs.empty()) {
+        // Collect this node's output names for O(1) lookup.
+        InlinedHashSet<std::string> output_names;
+        for (const Ort::ConstValueInfo& out : outputs) {
+          output_names.insert(std::string(out.GetName()));
+        }
+
+        // Find all outputs consumed by the next node in the chain.
+        // Note: Ort::ConstValueInfo wraps a nullable OrtValueInfo pointer;
+        // there is no operator bool(), so we extract the raw pointer to check.
+        InlinedVector<std::string, 8> linking_tensors;
+        Ort::ConstNode next_node(all_nodes[i + 1]);
+        for (const Ort::ConstValueInfo& in : next_node.GetInputs()) {
+          const OrtValueInfo* raw_in = in;
+          if (!raw_in) continue;  // optional input not provided
+          std::string in_name = std::string(in.GetName());
+          if (output_names.count(in_name)) {
+            linking_tensors.push_back(std::move(in_name));
+          }
+        }
+
+        // Fall back to outputs[0] if the intersection is empty (should not
+        // happen for a well-formed fusion, but avoids a missing entry).
+        if (linking_tensors.empty()) {
+          linking_tensors.push_back(std::string(outputs[0].GetName()));
+        }
+
+        for (std::string& t : linking_tensors) {
+          mapping.sources.push_back({std::move(t), TraceTargetType::kTensor});
+        }
+      }
+    }
+  }
+
+  if (mapping.sources.empty()) {
+    return;
+  }
+
+  // Record tensor mappings for each output tensor of this QNN op.
+  // Each output tensor carries the same srcInfo chain as the op
+  // (N:1 or N:M — same sources, different dst_name).
+  for (const auto& out_name : output_tensor_names) {
+    TraceMapping t;
+    t.dst_name = out_name;
+    t.sources = mapping.sources;  // shared sources, copy intentional
+    tensor_mappings_.push_back(std::move(t));
+    recorded_tensor_names_.insert(out_name);
+  }
+
+  op_mappings_.push_back(std::move(mapping));
+}
+
+void OpTraceCollector::Finalize(const std::string& graph_name, const QnnModelWrapper& wrapper, OpTraceInfo& out) {
+  // Records the direct ONNX<->QNN tensor correspondence when a tensor was
+  // renamed by an op builder (onnx_name != qnn_name).
+  //
+  // Identity mappings (onnx_name == qnn_name, e.g. graph inputs and
+  // initializers that flow through unchanged) are NOT recorded — they carry
+  // no information for downstream tools and would inflate the trace with
+  // zero-information entries for every graph input and weight tensor.
+  //
+  // Output tensors of QNN ops are recorded by RecordOpMapping (with the op's
+  // full srcInfo chain) and are therefore also excluded here to avoid duplicates.
+  //
+  // Two emission rules ensure each qnn_name appears at most once in
+  // tensor_mappings_:
+  //   * Option A (merge): when several wrappers resolve to the same qnn_name
+  //     for non-canonical reasons, all distinct internal source names are
+  //     merged into one entry's sources list.
+  //   * Option B (canonical): when qnn_name is an external override target
+  //     (i.e. produced by `offload_graph_io_quantization` aliasing a QNN
+  //     internal tensor back to its original ONNX graph-input/output name),
+  //     the trace records the canonical mapping {dst: qnn_name, sources:
+  //     [qnn_name]}. The intermediate internal names (q_*_out / dq_*_out)
+  //     are an artefact of the alias and carry no information for downstream
+  //     tools, so they are dropped.
+  const auto& tensors_map = wrapper.GetModelTensorsMap();
+
+  // First pass: group unique source names by qnn_name to deduplicate.
+  InlinedHashMap<std::string, InlinedVector<std::string, 8>> grouped;
+  for (const auto& [key, tensor_wrapper] : tensors_map) {
+    const std::string& onnx_name = tensor_wrapper.GetName();
+    const std::string& qnn_name = tensor_wrapper.GetResolvedTensorName();
+    if (onnx_name == qnn_name || recorded_tensor_names_.count(qnn_name)) {
+      continue;  // identity or already recorded by RecordOpMapping
+    }
+    auto& sources = grouped[qnn_name];
+    if (std::find(sources.begin(), sources.end(), onnx_name) == sources.end()) {
+      sources.push_back(onnx_name);
+    }
+  }
+
+  // Second pass: emit one entry per unique qnn_name, applying B or A.
+  for (auto& [qnn_name, sources] : grouped) {
+    TraceMapping mapping;
+    mapping.dst_name = qnn_name;
+    if (wrapper.IsExternalOverrideTarget(qnn_name)) {
+      // Option B: canonical mapping.
+      mapping.sources.push_back({qnn_name, TraceTargetType::kTensor});
+    } else {
+      // Option A: merged sources.
+      for (auto& src : sources) {
+        mapping.sources.push_back({std::move(src), TraceTargetType::kTensor});
+      }
+    }
+    tensor_mappings_.push_back(std::move(mapping));
+    recorded_tensor_names_.insert(qnn_name);
+  }
+
+  out.graph_name = graph_name;
+  out.op_mappings = std::move(op_mappings_);
+  out.tensor_mappings = std::move(tensor_mappings_);
+}
+
+bool WriteTraceToFile(const FrameworkOpTrace& trace,
+                      const std::filesystem::path& output_path,
+                      const Ort::Logger& logger) {
+  std::error_code ec;
+  auto parent = output_path.parent_path();
+  // parent is empty when output_path is a filename-only path (write to CWD).
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("Failed to create trace output directory: " + parent.string() +
+                   " error: " + ec.message())
+                      .c_str());
+      return false;
+    }
+  }
+
+  nlohmann::json j = SerializeFrameworkOpTrace(trace);
+
+  // Intentional overwrite: the trace file is a diagnostic artefact and the
+  // most recent run's data is always the most useful.  Log a warning so the
+  // developer is aware, but do not treat it as an error.
+  if (std::filesystem::exists(output_path)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("Overwriting existing framework op trace file: " + output_path.string()).c_str());
+  }
+
+  std::ofstream ofs(output_path);
+  if (!ofs.is_open()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("Could not open framework op trace file: " + output_path.string()).c_str());
+    return false;
+  }
+
+  ofs << j.dump(2);  // pretty-print with 2-space indent
+  ofs.close();
+  if (!ofs) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("Framework op trace write failed (disk full / I/O error): " + output_path.string()).c_str());
+    std::error_code rm_ec;
+    std::filesystem::remove(output_path, rm_ec);
+    return false;
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO,
+              ("Framework op trace written to: " + output_path.string()).c_str());
+  return true;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.h
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.h
@@ -1,0 +1,84 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+// EP-internal header: OpTraceCollector class definition and WriteTraceToFile.
+// Test TUs should include qnn_op_tracing_types.h (which also declares
+// SerializeFrameworkOpTrace via nlohmann/json_fwd.hpp) and add
+// nlohmann/json.hpp directly if they use the return value.
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/common/inlined_containers.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class IQnnNodeGroup;
+class QnnModelWrapper;
+
+// Collects ONNX-to-QNN op/tensor mappings during a single ComposeGraph() call.
+// Lifetime: stack-allocated in QnnModel::ComposeGraph(), pointer passed to QnnModelWrapper.
+class OpTraceCollector {
+ public:
+  OpTraceCollector() = default;
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(OpTraceCollector);
+
+  // Called from QnnModelWrapper::CreateQnnNode() when a QNN op is created.
+  // Also records a tensor mapping for each output tensor using the same sources.
+  void RecordOpMapping(const std::string& qnn_op_name, const std::string& qnn_op_type,
+                       gsl::span<const std::string> output_tensor_names);
+
+  // Finalize the subgraph trace: record tensor mappings from the wrapper and
+  // populate `out` with the collected op_mappings, tensor_mappings, and the
+  // graph name. Call once after ComposeQnnGraph().
+  void Finalize(const std::string& graph_name, const QnnModelWrapper& wrapper, OpTraceInfo& out);
+
+ private:
+  // Set/clear the current node group context. Only NodeGroupGuard may call these
+  // to preserve the set/clear pairing and exception-safety invariant.
+  friend class NodeGroupGuard;
+  void SetCurrentNodeGroup(const IQnnNodeGroup* node_group);
+  void ClearCurrentNodeGroup();
+
+  const IQnnNodeGroup* current_node_group_ = nullptr;
+  // Real subgraphs frequently exceed any small inline capacity (LLM subgraphs
+  // can have hundreds of ops/tensors), so use std::vector and let it grow on
+  // the heap. The trace path is debug-only, so the extra allocation is
+  // immaterial.
+  std::vector<TraceMapping> op_mappings_;
+  std::vector<TraceMapping> tensor_mappings_;
+  // Tracks QNN tensor names already recorded by RecordOpMapping so that
+  // Finalize can skip them and avoid duplicate entries.
+  InlinedHashSet<std::string> recorded_tensor_names_;
+};
+
+// RAII guard that brackets SetCurrentNodeGroup / ClearCurrentNodeGroup around one
+// AddToModelBuilder call so that ClearCurrentNodeGroup is always called even if
+// AddToModelBuilder returns early via an exception.
+class NodeGroupGuard {
+ public:
+  NodeGroupGuard(OpTraceCollector* c, const IQnnNodeGroup* g) : c_(c) {
+    if (c_) c_->SetCurrentNodeGroup(g);
+  }
+  ~NodeGroupGuard() {
+    if (c_) c_->ClearCurrentNodeGroup();
+  }
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(NodeGroupGuard);
+
+ private:
+  OpTraceCollector* c_;
+};
+
+// Write trace JSON to file. Returns true on success.
+bool WriteTraceToFile(const FrameworkOpTrace& trace,
+                      const std::filesystem::path& output_path,
+                      const Ort::Logger& logger);
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc
@@ -1,0 +1,144 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+// Implementations of ComputeTraceSummary and SerializeFrameworkOpTrace.
+//
+// This translation unit (.cc file) is compiled directly into the test binary
+// (via cmake) so that unit tests can call these functions without linking
+// against the EP library. It intentionally does NOT include ort_api.h (or any
+// header that pulls it in) to avoid the ORT_API_MANUAL_INIT mismatch linker
+// error on Windows.
+
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
+
+#include <unordered_set>
+
+#include "nlohmann/json.hpp"
+
+namespace onnxruntime {
+namespace qnn {
+
+void ComputeTraceSummary(FrameworkOpTrace& trace) {
+  TraceSummary& summary = trace.summary;
+  summary.unsupported_nodes = trace.unsupported_nodes.size();
+  summary.qnn_subgraphs = trace.subgraph_traces.size();
+  summary.total_qnn_ops = 0;
+  summary.fusion_count.clear();
+
+  // An ONNX node is "supported" if it appears as an OP-typed source on any QNN
+  // op_mapping. N:M fusions emit the same ONNX source set from multiple QNN op
+  // entries (e.g. ReshapeEinsumReshape: 3 ONNX ops referenced by 3 QNN op
+  // entries = 9 OP source occurrences but only 3 unique ONNX nodes), so we
+  // dedup by source name before counting.
+  std::unordered_set<std::string> supported_onnx_node_names;
+  for (const auto& subgraph : trace.subgraph_traces) {
+    summary.total_qnn_ops += subgraph.op_mappings.size();
+    for (const auto& mapping : subgraph.op_mappings) {
+      summary.fusion_count[mapping.node_group_type]++;
+      for (const auto& src : mapping.sources) {
+        if (src.type == TraceTargetType::kOp) {
+          supported_onnx_node_names.insert(src.name);
+        }
+      }
+    }
+  }
+
+  summary.supported_nodes = supported_onnx_node_names.size();
+  summary.total_onnx_nodes = summary.supported_nodes + summary.unsupported_nodes;
+}
+
+namespace detail {
+
+static nlohmann::json SerializeTraceSourcePair(const TraceSourcePair& pair) {
+  return {
+      {"name", pair.name},
+      {"type", pair.type == TraceTargetType::kOp ? "OP" : "TENSOR"},
+  };
+}
+
+static nlohmann::json SerializeTraceMapping(const TraceMapping& mapping) {
+  nlohmann::json j;
+  j["dst_name"] = mapping.dst_name;
+
+  if (!mapping.dst_qnn_op_type.empty()) {
+    j["dst_qnn_op_type"] = mapping.dst_qnn_op_type;
+  }
+
+  nlohmann::json sources = nlohmann::json::array();
+  for (const auto& src : mapping.sources) {
+    sources.push_back(SerializeTraceSourcePair(src));
+  }
+  j["sources"] = std::move(sources);
+
+  if (!mapping.node_group_type.empty()) {
+    j["node_group_type"] = mapping.node_group_type;
+  }
+
+  return j;
+}
+
+}  // namespace detail
+
+nlohmann::json SerializeFrameworkOpTrace(const FrameworkOpTrace& trace) {
+  nlohmann::json j;
+  j["model_name"] = trace.model_name;
+  j["backend_type"] = trace.backend_type;
+
+  nlohmann::json ct;
+  ct["htp_arch"] = trace.compilation_target.htp_arch;
+  ct["soc_model"] = trace.compilation_target.soc_model;
+  ct["device_id"] = trace.compilation_target.device_id;
+  j["compilation_target"] = std::move(ct);
+
+  nlohmann::json subgraphs = nlohmann::json::array();
+  for (const auto& sg : trace.subgraph_traces) {
+    nlohmann::json sg_json;
+    sg_json["graph_name"] = sg.graph_name;
+
+    nlohmann::json op_mappings = nlohmann::json::array();
+    for (const auto& m : sg.op_mappings) {
+      op_mappings.push_back(detail::SerializeTraceMapping(m));
+    }
+    sg_json["op_mappings"] = std::move(op_mappings);
+
+    nlohmann::json tensor_mappings = nlohmann::json::array();
+    for (const auto& m : sg.tensor_mappings) {
+      tensor_mappings.push_back(detail::SerializeTraceMapping(m));
+    }
+    sg_json["tensor_mappings"] = std::move(tensor_mappings);
+
+    subgraphs.push_back(std::move(sg_json));
+  }
+  j["subgraph_traces"] = std::move(subgraphs);
+
+  nlohmann::json unsupported = nlohmann::json::array();
+  for (const auto& un : trace.unsupported_nodes) {
+    unsupported.push_back({
+        {"node_name", un.node_name},
+        {"op_type", un.op_type},
+        {"node_index", un.node_index},
+        {"reason", un.reason},
+    });
+  }
+  j["unsupported_nodes"] = std::move(unsupported);
+
+  const auto& s = trace.summary;
+  nlohmann::json summary;
+  summary["total_onnx_nodes"] = s.total_onnx_nodes;
+  summary["supported_nodes"] = s.supported_nodes;
+  summary["unsupported_nodes"] = s.unsupported_nodes;
+  summary["qnn_subgraphs"] = s.qnn_subgraphs;
+  summary["total_qnn_ops"] = s.total_qnn_ops;
+
+  nlohmann::json fc;
+  for (const auto& [type, count] : s.fusion_count) {
+    fc[type] = count;
+  }
+  summary["fusion_count"] = std::move(fc);
+  j["summary"] = std::move(summary);
+
+  return j;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h
@@ -1,0 +1,103 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+// Data types and free-function declarations for the framework op tracing feature.
+//
+// This header is intentionally test-safe: it does not include qnn_def.h,
+// ort_api.h, or any other EP-internal header, so it can be included from test
+// translation units without pulling in large template libraries or causing
+// conflicts with ORT core public headers. nlohmann/json_fwd.hpp is included
+// only for the SerializeFrameworkOpTrace return-type declaration; the full
+// nlohmann/json.hpp is needed at call sites that actually use the return value.
+//
+// Implementations of ComputeTraceSummary and SerializeFrameworkOpTrace live
+// in qnn_op_tracing_serialization.cc.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json_fwd.hpp"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Source target type: matches the integer encoding used by the QNN SDK
+// (TENSOR = 0, OP = 1, defined in QnnInterface.h).
+enum class TraceTargetType : uint8_t {
+  kTensor = 0,
+  kOp = 1,
+};
+
+struct TraceSourcePair {
+  std::string name;
+  TraceTargetType type;
+};
+
+struct TraceMapping {
+  std::string dst_name;         // QNN op or tensor name
+  std::string dst_qnn_op_type;  // QNN op type string, empty for tensor mappings
+  std::vector<TraceSourcePair> sources;
+  // Populated from IQnnNodeGroup::Type(). These strings are part of the JSON
+  // schema and must remain stable across SDK versions; changing them is a
+  // breaking change for any consumer that keys on fusion_count entries.
+  std::string node_group_type;  // e.g., "DQQFusion", "OrtNodeUnit"
+};
+
+struct OpTraceInfo {
+  std::string graph_name;
+  std::vector<TraceMapping> op_mappings;
+  std::vector<TraceMapping> tensor_mappings;
+};
+
+struct UnsupportedNodeInfo {
+  std::string node_name;
+  std::string op_type;
+  size_t node_index;
+  std::string reason;
+};
+
+struct TraceSummary {
+  size_t total_onnx_nodes = 0;
+  // Count of unique ONNX source nodes that appear as OP-typed sources across
+  // all op_mappings. Deduplicated by source name so an N:M fusion (which
+  // emits the same ONNX sources from multiple QNN op entries) is counted
+  // once per ONNX node rather than once per QNN op entry.
+  size_t supported_nodes = 0;
+  size_t unsupported_nodes = 0;
+  size_t qnn_subgraphs = 0;
+  size_t total_qnn_ops = 0;
+  // std::map keeps keys in sorted order, which produces deterministic JSON
+  // output and makes trace files diff-friendly across runs.
+  std::map<std::string, size_t> fusion_count;
+};
+
+struct CompilationTarget {
+  std::string htp_arch;
+  uint32_t soc_model = 0;
+  uint32_t device_id = 0;
+};
+
+struct FrameworkOpTrace {
+  std::string model_name;
+  std::string backend_type;
+  CompilationTarget compilation_target;
+  std::vector<OpTraceInfo> subgraph_traces;
+  std::vector<UnsupportedNodeInfo> unsupported_nodes;
+  TraceSummary summary;
+};
+
+// Compute summary statistics for a FrameworkOpTrace.
+// Defined in qnn_op_tracing_serialization.cc.
+void ComputeTraceSummary(FrameworkOpTrace& trace);
+
+// Serialize a FrameworkOpTrace to JSON.
+// Defined in qnn_op_tracing_serialization.cc.  Call sites that use the return value must
+// include nlohmann/json.hpp separately.
+nlohmann::json SerializeFrameworkOpTrace(const FrameworkOpTrace& trace);
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -256,6 +256,8 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   QnnHtpDevice_Arch_t GetHtpArch() { return htp_arch_internal_; }
 
+  uint32_t GetSocModel() const { return soc_model_; }
+
   // Get backend library directory by adopting identical logic as in LoadLib.
   std::string GetBackendLibDir() {
     auto backend_path = std::filesystem::path(backend_path_);

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.cc
@@ -647,5 +647,28 @@ bool IsQpuBackend(QnnBackendType backend_type) {
   return IsNpuBackend(backend_type) || IsGpuBackend(backend_type);
 }
 
+std::string QnnBackendTypeToString(QnnBackendType backend_type) {
+  switch (backend_type) {
+    case QnnBackendType::CPU:
+      return "cpu";
+    case QnnBackendType::GPU:
+      return "gpu";
+    case QnnBackendType::DSP:
+      return "dsp";
+    case QnnBackendType::HTP:
+      return "htp";
+    case QnnBackendType::HTP_FP16:
+      return "htp_fp16";
+    case QnnBackendType::SERIALIZER:
+      return "ir";
+  }
+  // Unreachable for well-formed enum values; -Wswitch ensures every enumerator
+  // above is handled. The fallback exists only for defensive runtime safety
+  // (e.g. ill-formed enum value via reinterpret_cast). ORT_THROW is intentionally
+  // not used here because GetStackTrace is a local symbol in libonnxruntime.so
+  // and is not available to plugin EPs at runtime - see common/qnn_safeint.h.
+  return "unknown";
+}
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -128,6 +128,8 @@ bool IsGpuBackend(QnnBackendType backend_type);
 
 bool IsQpuBackend(QnnBackendType backend_type);
 
+std::string QnnBackendTypeToString(QnnBackendType backend_type);
+
 // constexpr config values
 constexpr const int kSleepMinLatency = 40;
 constexpr const int kSleepLowLatency = 100;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -12,6 +12,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_profile_serializer.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -238,6 +239,13 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
   const auto& graph_name = Ort::ConstNode(&fused_node).GetName();
   RETURN_IF_ERROR(SetGraphInputOutputInfo(context));
 
+  // Framework op trace: create collector before QnnModelWrapper so it can be
+  // passed at construction time. nullptr when tracing is disabled.
+  std::unique_ptr<OpTraceCollector> trace_collector;
+  if (context.op_trace_output) {
+    trace_collector = std::make_unique<OpTraceCollector>();
+  }
+
   QnnModelWrapper qnn_model_wrapper = QnnModelWrapper(ort_graph, api_ptrs_, logger,
                                                       qnn_backend_manager_->GetQnnInterface(),
                                                       qnn_backend_manager_->GetQnnBackendHandle(),
@@ -247,7 +255,8 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
                                                       graph_outputs_,
                                                       qnn_backend_manager_->GetQnnBackendType(),
                                                       *context.model_settings,
-                                                      context.tensor_name_overrides);
+                                                      context.tensor_name_overrides,
+                                                      trace_collector.get());
 
   qnn::profile::ProfilingInfo profiling_info;
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
@@ -280,6 +289,8 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
                                         node_unit_holder.size(), logger));
 
   for (const std::unique_ptr<qnn::IQnnNodeGroup>& qnn_node_group : qnn_node_groups) {
+    NodeGroupGuard guard(trace_collector.get(), qnn_node_group.get());
+
     Ort::Status status = qnn_node_group->AddToModelBuilder(qnn_model_wrapper, logger);
 
     if (!status.IsOK()) {
@@ -294,6 +305,11 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
 
   const bool build_json_graph = !context.json_qnn_graph_path.empty();
   RETURN_IF_NOT(qnn_model_wrapper.ComposeQnnGraph(build_json_graph), "Failed to compose Qnn graph.");
+
+  // Collect framework op trace after graph composition
+  if (trace_collector) {
+    trace_collector->Finalize(graph_name, qnn_model_wrapper, *context.op_trace_output);
+  }
 
   LogTensorDetails(qnn_model_wrapper, graph_name, context.json_qnn_graph_path, logger);
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -9,6 +9,7 @@
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_backend_manager.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/rpcmem_library.h"
 
@@ -37,6 +38,9 @@ struct QnnModelContext {
   // Used by offload_graph_io_quantization to map internal QNN names to ONNX names.
   std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr;
   std::string json_qnn_graph_path;
+
+  // Non-null when tracing is enabled; ComposeGraph writes one OpTraceInfo here.
+  OpTraceInfo* op_trace_output = nullptr;
 };
 
 class QnnModel {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/qnn_graph_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -512,6 +513,12 @@ bool QnnModelWrapper::CreateQnnNode(const std::string& qnn_node_name,
     QnnOpProperty qnn_op(qnn_node_name, package_name, qnn_node_type,
                          std::move(input_names), std::move(output_names), std::move(param_tensor_names));
     qnn_op_property_list_.push_back(std::move(qnn_op));
+
+    if (op_trace_collector_) {
+      op_trace_collector_->RecordOpMapping(qnn_node_name, qnn_node_type,
+                                           qnn_op_property_list_.back().GetOutputNames());
+    }
+
     return true;
   }
 }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -22,6 +22,7 @@ namespace qnn {
 
 // Forward declarations
 class BF16ConversionGuard;
+class OpTraceCollector;
 
 // Stores information about an ONNX input or output tensor.
 // Filled out by QnnModelWrapper::GetTensorInfo()
@@ -55,7 +56,8 @@ class QnnModelWrapper {
                   const GraphInputOutputInfo& graph_outputs,
                   QnnBackendType qnn_backend_type,
                   const ModelSettings& model_settings,
-                  std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr)
+                  std::unordered_map<std::string, std::string>* tensor_name_overrides = nullptr,
+                  OpTraceCollector* op_trace_collector = nullptr)
       : ort_graph_(ort_graph),
         logger_(logger),
         qnn_interface_(qnn_interface),
@@ -67,7 +69,8 @@ class QnnModelWrapper {
         qnn_backend_type_(qnn_backend_type),
         model_settings_(model_settings),
         api_ptrs_(ApiPtrs{api_ptrs.ort_api, api_ptrs.ep_api, api_ptrs.model_editor_api}),
-        tensor_name_overrides_(tensor_name_overrides) {
+        tensor_name_overrides_(tensor_name_overrides),
+        op_trace_collector_(op_trace_collector) {
     // Invariant: validator interface and handle must both be set or both be null.
     // They are populated together by QnnBackendManager::LoadQnnSerializerBackend() (QnnIr flow).
     assert((validator_backend_handle == nullptr) ==
@@ -360,6 +363,10 @@ class QnnModelWrapper {
 
   const OrtGraph& GetOrtGraph() const { return ort_graph_; }
 
+  const std::unordered_map<std::string, QnnTensorWrapper>& GetModelTensorsMap() const {
+    return model_tensors_map_;
+  }
+
   const OrtApi& GetOrtApi() const { return api_ptrs_.ort_api; }
 
   // Unpack scales from initializer (1 scale for per-tensor, > 1 for per-axis or per-block).
@@ -518,6 +525,11 @@ class QnnModelWrapper {
 
   // Tensor names produced by compile-time Q/DQ folds; chained across hops.
   std::unordered_set<std::string> folded_constant_tensors_;
+
+  // Non-owning pointer to the trace collector. Lifetime is managed by
+  // QnnModel::ComposeGraph (stack-allocated unique_ptr).
+  // Null when tracing is disabled.
+  OpTraceCollector* op_trace_collector_ = nullptr;
 };  // QnnModelWrapper
 
 template <typename T>

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.h
@@ -46,6 +46,11 @@ class IQnnNodeGroup {
   virtual const OrtNodeUnit* GetTargetNodeUnit() const = 0;
 
   // Returns a string representation of the IQnnNodeGroup's type.
+  // The returned string is used as a JSON key in the framework op trace
+  // (FrameworkOpTrace::summary::fusion_count). Changing it is a breaking
+  // change for any consumer that keys on fusion_count entries in the trace JSON.
+  // The canonical set of return values is the fusion registration map in
+  // qnn_node_group.cc (the kType string constant of each IQnnNodeGroup subclass).
   virtual std::string_view Type() const = 0;
 };
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -25,6 +26,7 @@
 #include "core/providers/qnn/qnn_provider_factory.h"
 #include "core/providers/qnn/shared_context.h"
 #include "core/providers/qnn/qnn_allocator.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_backend_manager.h"
 #include "core/providers/qnn/genie/genie_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_cache_compatibility_manager.h"
@@ -986,6 +988,63 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     }
   }
 
+  // Framework op trace options
+  static constexpr const char* kEnableFrameworkOpTrace = "enable_framework_op_trace";
+  static constexpr const char* kFrameworkOpTraceDir = "framework_op_trace_dir";
+
+  enable_framework_op_trace_ = ParseBoolOption(ort_api,
+                                               session_options_,
+                                               FormatEPConfigKey(kEnableFrameworkOpTrace),
+                                               false,
+                                               logger_);
+
+  std::string trace_dir_str;
+  GetSessionConfigEntryOrDefault(ort_api,
+                                 session_options_,
+                                 FormatEPConfigKey(kFrameworkOpTraceDir),
+                                 "",
+                                 trace_dir_str);
+  if (!trace_dir_str.empty()) {
+    framework_op_trace_dir_ = trace_dir_str;
+  }
+
+  if (enable_framework_op_trace_) {
+    if (framework_op_trace_dir_.empty()) {
+      framework_op_trace_dir_ = std::filesystem::current_path().string();
+    }
+    // Probe writability up-front. A non-writable path (read-only Android mount,
+    // read-only network share, missing parent permissions) would otherwise only
+    // surface as a WARNING after the entire compile + in-memory trace build
+    // finishes. Disabling tracing here lets us skip all the per-graph collection
+    // work when the trace can never be written.
+    std::filesystem::path probe_dir(framework_op_trace_dir_);
+    std::error_code ec;
+    std::filesystem::create_directories(probe_dir, ec);
+    bool probe_ok = !ec;
+    if (probe_ok) {
+      std::filesystem::path probe_file = probe_dir / ".qnn_op_trace_probe";
+      {
+        std::ofstream ofs(probe_file);
+        probe_ok = ofs.is_open() && (ofs << "1").good();
+      }
+      std::filesystem::remove(probe_file, ec);
+    }
+    if (!probe_ok) {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                  ("Framework op trace directory not writable: " + probe_dir.string() +
+                   "; framework op tracing will be disabled.")
+                      .c_str());
+      enable_framework_op_trace_ = false;
+    } else {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+                  ("Framework op tracing enabled. Output dir: " + framework_op_trace_dir_).c_str());
+    }
+  } else if (!framework_op_trace_dir_.empty()) {
+    ORT_CXX_LOG(logger_,
+                ORT_LOGGING_LEVEL_WARNING,
+                "Provided a directory for framework op trace, but did not enable framework op tracing.");
+  }
+
   static const std::string QNN_HTP_EXTENDED_UDMA_MODE = "extended_udma";
   enable_htp_extended_udma_mode_ = ParseBoolOption(ort_api,
                                                    session_options_,
@@ -1153,7 +1212,8 @@ static void LogNodeSupport(const Ort::Logger& logger,
 OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
                                     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                     const size_t node_unit_size,
-                                    std::vector<const OrtNode*>& supported_nodes) const {
+                                    std::vector<const OrtNode*>& supported_nodes,
+                                    std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes) const {
   size_t num_graph_inputs = 0;
   size_t num_graph_outputs = 0;
   RETURN_IF_NOT_NULL(ort_api.Graph_GetNumInputs(graph, &num_graph_inputs));
@@ -1221,6 +1281,24 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
         for (const OrtNode* node : node_unit->GetAllNodesInGroup()) {
           supported_nodes.push_back(node);
         }
+      }
+    } else if (enable_framework_op_trace_) {
+      std::vector<qnn::UnsupportedNodeInfo> batch;
+      for (const OrtNodeUnit* node_unit : qnn_node_group->GetNodeUnits()) {
+        for (const OrtNode* node : node_unit->GetAllNodesInGroup()) {
+          Ort::ConstNode const_node(node);
+          batch.push_back({
+              std::string(const_node.GetName()),
+              std::string(const_node.GetOperatorType()),
+              const_node.GetId(),
+              std::string(support_status.GetErrorMessage()),
+          });
+        }
+      }
+      if (!batch.empty()) {
+        unsupported_nodes.insert(unsupported_nodes.end(),
+                                 std::make_move_iterator(batch.begin()),
+                                 std::make_move_iterator(batch.end()));
       }
     }
   }
@@ -1625,7 +1703,8 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
 
   // Analyze nodes for QNN support
   std::vector<const OrtNode*> supported_nodes;
-  ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(), supported_nodes);
+  ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(), supported_nodes,
+                        ep->trace_.unsupported_nodes);
 
   // Helper function that returns a string that lists all unsupported nodes.
   // Ex: { name: mul_123, type: Mul }, {}, ...
@@ -1650,6 +1729,13 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
 
   // If no supported nodes, return empty
   if (supported_nodes.empty()) {
+    // ORT does not invoke CompileImpl when no nodes are supported, so the
+    // unsupported list collected in GetSupportedNodes would otherwise be
+    // discarded. Flush a trace here so the diagnostic record (why every node
+    // was rejected) is preserved.
+    if (ep->enable_framework_op_trace_ && !ep->trace_.unsupported_nodes.empty()) {
+      ep->CollectAndWriteFrameworkOpTrace(graph);
+    }
     return nullptr;
   }
 
@@ -1704,6 +1790,12 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
                                       const OrtNode** fused_nodes,
                                       size_t count,
                                       OrtNodeComputeInfo** node_compute_infos) {
+  if (enable_framework_op_trace_) {
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+                "Framework op tracing requested but graph is loaded from EPContext "
+                "(no fresh ComposeGraph) - no trace file will be written.");
+  }
+
   // Collect graph and fused nodes names.
   std::vector<std::pair<std::string, std::string>> names;
   names.reserve(count);
@@ -1943,6 +2035,12 @@ OrtStatus* QnnEp::CompileDlcContextModel(OrtEp* this_ptr,
                                          size_t count,
                                          OrtNodeComputeInfo** node_compute_infos) {
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
+  if (ep->enable_framework_op_trace_) {
+    ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                "Framework op tracing requested but graph is loaded from EPContext "
+                "(no fresh ComposeGraph) - no trace file will be written.");
+  }
+
   std::basic_string<ORTCHAR_T> model_path = GetModelPathString(graphs[0], ep->ort_api);
   std::basic_string<ORTCHAR_T> context_model_path;
   GetContextOnnxModelFilePath(ep->context_cache_path_cfg_, model_path, context_model_path);
@@ -1971,6 +2069,40 @@ OrtStatus* QnnEp::CompileDlcContextModel(OrtEp* this_ptr,
     node_compute_infos[graph_idx] = node_compute_info.release();
   }
   return nullptr;
+}
+
+void QnnEp::CollectAndWriteFrameworkOpTrace(const OrtGraph* primary_graph) {
+  trace_.model_name = std::filesystem::path(GetModelPathString(primary_graph, ort_api)).filename().u8string();
+  if (trace_.model_name.empty()) {
+    trace_.model_name = "<in-memory>";
+  }
+  trace_.backend_type = qnn::QnnBackendTypeToString(qnn_backend_manager_->GetQnnBackendType());
+  trace_.compilation_target.device_id = device_id_;
+
+  if (qnn::IsNpuBackend(qnn_backend_manager_->GetQnnBackendType())) {
+    uint32_t soc_model = qnn_backend_manager_->GetSocModel();
+    if (soc_model != QNN_SOC_MODEL_UNKNOWN) {
+      trace_.compilation_target.soc_model = soc_model;
+    }
+    QnnHtpDevice_Arch_t htp_arch = qnn_backend_manager_->GetHtpArch();
+    if (htp_arch != QNN_HTP_DEVICE_ARCH_NONE) {
+      trace_.compilation_target.htp_arch = "V" + std::to_string(htp_arch);
+    }
+  }
+
+  qnn::ComputeTraceSummary(trace_);
+
+  // Write when either compiled subgraphs or unsupported nodes are present.
+  // The unsupported-only branch covers the "entire model is unsupported"
+  // case, where ORT may not invoke CompileImpl at all but the trace still
+  // has diagnostic value (it records why every node was rejected).
+  // A wholly empty trace can still occur on EPContext cached runs
+  // - skip the file write there.
+  if (!trace_.subgraph_traces.empty() || !trace_.unsupported_nodes.empty()) {
+    qnn::WriteTraceToFile(trace_,
+                          std::filesystem::path(framework_op_trace_dir_) / "qnn_op_trace.json",
+                          logger_);
+  }
 }
 
 OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
@@ -2074,6 +2206,12 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
         /*tensor_name_overrides=*/&ep->tensor_name_overrides_,
         /*json_qnn_graph_path=*/std::string{}};
 
+    // Each ComposeGraph writes its mappings into a slot in ep->trace_.subgraph_traces.
+    if (ep->enable_framework_op_trace_) {
+      ep->trace_.subgraph_traces.push_back(qnn::OpTraceInfo{});
+      context.op_trace_output = &ep->trace_.subgraph_traces.back();
+    }
+
     if (ep->dump_json_qnn_graph_) {
       namespace fs = std::filesystem;
       context.json_qnn_graph_path =
@@ -2144,6 +2282,12 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   // Clean up transient GetCapability→Compile state.
   ep->onnx_graph_io_names_.reset();
   ep->tensor_name_overrides_.clear();
+
+  // Framework op trace: serialize and write JSON.
+  // When multiple graphs are compiled, all subgraph traces are collected into a single file.
+  if (ep->enable_framework_op_trace_) {
+    ep->CollectAndWriteFrameworkOpTrace(graphs[0]);
+  }
 
   if (ep->context_cache_enabled_) {
     RETURN_IF_NOT_NULL(ep->CreateEPContextNodes(graphs[0], fused_nodes, count, ep_context_nodes));

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -18,6 +18,7 @@
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 #include "core/providers/qnn/builder/onnx_ctx_model_helper.h"
 #include "core/providers/qnn/qnn_telemetry.h"
 #include "core/providers/qnn/rpcmem_library.h"
@@ -93,7 +94,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
   OrtStatus* GetSupportedNodes(const OrtGraph* graph,
                                const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                const size_t node_unit_size,
-                               std::vector<const OrtNode*>& supported_nodes) const;
+                               std::vector<const OrtNode*>& supported_nodes,
+                               std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes) const;
 
   void PartitionCtxModel(const OrtGraph* graph, OrtEpGraphSupportInfo* graph_support_info);
 
@@ -118,6 +120,11 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // std::string MakeMetadefName(const OrtGraph* graph);
   void ParseHtpGraphFinalizationOptimizationMode(const std::string& htp_graph_finalization_opt_mode_string,
                                                  const Ort::Logger& logger);
+
+  // Framework op trace helpers. trace_ is populated incrementally during
+  // GetCapability (unsupported_nodes) and Compile (subgraph_traces); this
+  // function finalizes summary fields and writes the JSON file.
+  void CollectAndWriteFrameworkOpTrace(const OrtGraph* primary_graph);
 
   bool IsHtpSharedMemoryAllocatorAvailable() const { return rpcmem_library_ != nullptr; }
 
@@ -205,6 +212,15 @@ class QnnEp : public OrtEp, public ApiPtrs {
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";
+
+  // === Framework op trace ===
+  bool enable_framework_op_trace_ = false;
+  std::string framework_op_trace_dir_;
+  // Accumulates the trace state for this session: unsupported nodes are pushed
+  // by GetSupportedNodes, per-subgraph mappings are pushed by CompileImpl, and
+  // CollectAndWriteFrameworkOpTrace finalizes/serializes.
+  qnn::FrameworkOpTrace trace_;
+
   bool enable_htp_extended_udma_mode_ = false;
 
   // Whether this is set depends on a session option enabling it and if the RPCMEM dynamic library is available.

--- a/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
+++ b/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
@@ -1,0 +1,1418 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_set>
+
+#include "nlohmann/json.hpp"
+#include "gtest/gtest.h"
+
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+
+// Defined in test_main.cc
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+namespace test {
+
+namespace fs = std::filesystem;
+
+// ===================== Test Helpers =====================
+
+class ScopedTempDir {
+ public:
+  ScopedTempDir() {
+    auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    auto sanitize = [](std::string s) {
+      for (char& c : s) {
+        if (c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' ||
+            c == '"' || c == '<' || c == '>' || c == '|') {
+          c = '_';
+        }
+      }
+      return s;
+    };
+    path_ = fs::temp_directory_path() /
+            (sanitize(info->test_suite_name()) + "_" + sanitize(info->name()));
+    // Remove any stale state left by a previous crashed test run before
+    // creating a fresh directory.
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+    fs::create_directories(path_);
+  }
+
+  ~ScopedTempDir() {
+    std::error_code ec;
+    fs::remove_all(path_, ec);
+  }
+
+  const fs::path& path() const { return path_; }
+
+ private:
+  fs::path path_;
+};
+
+static fs::path FindTraceFile(const fs::path& dir) {
+  if (!fs::exists(dir)) return {};
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    if (entry.path().extension() == ".json" &&
+        entry.path().stem().string().find("_op_trace") != std::string::npos) {
+      return entry.path();
+    }
+  }
+  return {};
+}
+
+static nlohmann::json ReadTraceJson(const fs::path& path) {
+  std::ifstream ifs(path);
+  EXPECT_TRUE(ifs.is_open()) << "Failed to open: " << path;
+  if (!ifs.is_open()) return {};
+  auto j = nlohmann::json::parse(ifs, nullptr, false);
+  EXPECT_FALSE(j.is_discarded()) << "Failed to parse JSON: " << path;
+  return j;
+}
+
+static nlohmann::json RunModelWithTracing(const GetTestModelFn& build_fn,
+                                          const fs::path& trace_dir,
+                                          const std::string& backend = "cpu",
+                                          int opset = 13) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend;
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_framework_op_trace"] = "1";
+  provider_options["framework_op_trace_dir"] = trace_dir.string();
+
+  // These tests verify tracing behavior, not numeric exactness. HTP uses float16
+  // internally, so fp32 comparisons require a relaxed tolerance on all platforms.
+  float fp32_abs_err = (backend == "htp") ? 5e-3f : 1e-5f;
+#if defined(__linux__) && !defined(__aarch64__)
+  if (backend == "htp") {
+    provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+  }
+#endif
+
+  RunQnnModelTest(build_fn, provider_options, opset,
+                  ExpectedEPNodeAssignment::All, fp32_abs_err);
+
+  // GTEST_SKIP() in RunQnnModelTest (e.g. arch guard) sets the skip flag and
+  // returns from that function but does not propagate to our caller.  Bail out
+  // now so we don't assert on a trace file that was never written.
+  if (::testing::UnitTest::GetInstance()->current_test_info()->result()->Skipped()) {
+    return {};
+  }
+
+  auto trace_file = FindTraceFile(trace_dir);
+  EXPECT_FALSE(trace_file.empty()) << "No trace file found in " << trace_dir;
+  if (trace_file.empty()) return {};
+  return ReadTraceJson(trace_file);
+}
+
+static void ValidateTraceStructure(const nlohmann::json& j) {
+  ASSERT_TRUE(j.contains("backend_type"));
+  ASSERT_TRUE(j.contains("subgraph_traces"));
+  ASSERT_TRUE(j.contains("compilation_target"));
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  ASSERT_TRUE(j.contains("summary"));
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  EXPECT_GT(j["summary"]["total_qnn_ops"].get<size_t>(), 0u);
+}
+
+// ========================= Unit Tests =========================
+
+// Pure unit tests for qnn_op_tracing.h/.cc — no QNN backend required.
+class QnnFrameworkOpTraceUnit : public ::testing::Test {};
+
+TEST_F(QnnFrameworkOpTraceUnit, SerializeDeserializeRoundTrip) {
+  qnn::FrameworkOpTrace trace;
+  trace.model_name = "test_model.onnx";
+  trace.backend_type = "cpu";
+  trace.compilation_target = {"V73", 60, 0};
+
+  qnn::OpTraceInfo sg;
+  sg.graph_name = "QnnEP_graph_0";
+  sg.op_mappings.push_back({"Add_0",
+                            "QNN_OP_ELEMENT_WISE_ADD",
+                            {{"/add/Add", qnn::TraceTargetType::kOp}},
+                            "OrtNodeUnit"});
+  sg.op_mappings.push_back({"Conv_1",
+                            "QNN_OP_CONV_2D",
+                            {{"/dq_node", qnn::TraceTargetType::kOp},
+                             {"_out_dq", qnn::TraceTargetType::kTensor},
+                             {"/conv_node", qnn::TraceTargetType::kOp},
+                             {"_out_conv", qnn::TraceTargetType::kTensor},
+                             {"/q_node", qnn::TraceTargetType::kOp}},
+                            "DQQFusion"});
+  sg.tensor_mappings.push_back({"input_0", "", {{"/input_0", qnn::TraceTargetType::kTensor}}, ""});
+  trace.subgraph_traces.push_back(std::move(sg));
+  trace.unsupported_nodes.push_back({"custom_op_1", "CustomOp", 42, "No op builder registered"});
+  qnn::ComputeTraceSummary(trace);
+
+  nlohmann::json j = qnn::SerializeFrameworkOpTrace(trace);
+  EXPECT_EQ(j["model_name"], "test_model.onnx");
+  EXPECT_EQ(j["compilation_target"]["htp_arch"], "V73");
+  EXPECT_EQ(j["compilation_target"]["soc_model"], 60);
+  EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][0]["dst_name"], "Add_0");
+  EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][0]["sources"][0]["type"], "OP");
+  // Verify mixed OP+TENSOR sources in Conv_1 (DQ_Q_Fusion)
+  EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][1]["dst_name"], "Conv_1");
+  EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][1]["sources"][0]["type"], "OP");
+  EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][1]["sources"][1]["type"], "TENSOR");
+  EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][1]["sources"][1]["name"], "_out_dq");
+  EXPECT_EQ(j["unsupported_nodes"][0]["node_name"], "custom_op_1");
+}
+
+TEST_F(QnnFrameworkOpTraceUnit, ComputeTraceSummary) {
+  qnn::FrameworkOpTrace trace;
+
+  qnn::OpTraceInfo sg1;
+  sg1.graph_name = "graph_0";
+  sg1.op_mappings.push_back({"op0", "A", {{"s0", qnn::TraceTargetType::kOp}}, "FusionA"});
+  sg1.op_mappings.push_back({"op1", "A", {{"s1", qnn::TraceTargetType::kOp}}, "FusionA"});
+  // Mixed OP+TENSOR sources — summary should only count OP entries (1 OP, not 2 total)
+  sg1.op_mappings.push_back({"op2",
+                             "B",
+                             {{"s2", qnn::TraceTargetType::kOp},
+                              {"_out_s2", qnn::TraceTargetType::kTensor}},
+                             "FusionB"});
+  trace.subgraph_traces.push_back(std::move(sg1));
+
+  qnn::OpTraceInfo sg2;
+  sg2.graph_name = "graph_1";
+  // N:1 fusion with interleaved OP+TENSOR — 2 OPs, 1 TENSOR
+  sg2.op_mappings.push_back({"op3",
+                             "C",
+                             {{"s3", qnn::TraceTargetType::kOp},
+                              {"_out_s3", qnn::TraceTargetType::kTensor},
+                              {"s4", qnn::TraceTargetType::kOp}},
+                             "FusionC"});
+  sg2.op_mappings.push_back({"op4", "A", {{"s5", qnn::TraceTargetType::kOp}}, "FusionA"});
+  // N:M fusion: 2 ONNX source nodes (s_nm0, s_nm1) emitted by 2 QNN op entries.
+  // Without deduplication this would inflate supported_nodes by 2 extra entries.
+  sg2.op_mappings.push_back({"op5",
+                             "D",
+                             {{"s_nm0", qnn::TraceTargetType::kOp},
+                              {"s_nm1", qnn::TraceTargetType::kOp}},
+                             "FusionD"});
+  sg2.op_mappings.push_back({"op6",
+                             "D",
+                             {{"s_nm0", qnn::TraceTargetType::kOp},
+                              {"s_nm1", qnn::TraceTargetType::kOp}},
+                             "FusionD"});
+  trace.subgraph_traces.push_back(std::move(sg2));
+
+  trace.unsupported_nodes.push_back({"u0", "Bad", 0, "r"});
+  trace.unsupported_nodes.push_back({"u1", "Bad", 1, "r"});
+
+  qnn::ComputeTraceSummary(trace);
+
+  EXPECT_EQ(trace.summary.qnn_subgraphs, 2u);
+  EXPECT_EQ(trace.summary.total_qnn_ops, 7u);
+  EXPECT_EQ(trace.summary.unsupported_nodes, 2u);
+  // supported_nodes counts unique ONNX node names: {s0, s1, s2, s3, s4, s5, s_nm0, s_nm1} = 8.
+  // The N:M FusionD entries (op5, op6) reference the same {s_nm0, s_nm1} pair, so they
+  // contribute 2 unique names rather than 4 source occurrences.
+  EXPECT_EQ(trace.summary.supported_nodes, 8u);
+  EXPECT_EQ(trace.summary.total_onnx_nodes, 10u);
+  EXPECT_EQ(trace.summary.fusion_count["FusionA"], 3u);
+  EXPECT_EQ(trace.summary.fusion_count["FusionB"], 1u);
+  EXPECT_EQ(trace.summary.fusion_count["FusionC"], 1u);
+  EXPECT_EQ(trace.summary.fusion_count["FusionD"], 2u);
+}
+
+// Verify that mixed OP+TENSOR srcInfo is serialized correctly.
+TEST_F(QnnFrameworkOpTraceUnit, SrcInfoMixedOpTensor) {
+  // Simulate N:1 SpaceToDepth fusion: 3 ops, 2 intermediate tensors
+  qnn::FrameworkOpTrace trace;
+  trace.model_name = "mixed_test.onnx";
+  trace.backend_type = "cpu";
+
+  qnn::OpTraceInfo sg;
+  sg.graph_name = "QnnEP_graph_0";
+  // N:1: Reshape→Transpose→Reshape → SpaceToDepth
+  sg.op_mappings.push_back({
+      "SpaceToDepth_0",
+      "QNN_OP_SPACE_TO_DEPTH",
+      {{"Reshape_6D", qnn::TraceTargetType::kOp},
+       {"_out_Reshape_6D", qnn::TraceTargetType::kTensor},
+       {"Transpose_6D", qnn::TraceTargetType::kOp},
+       {"_out_Transpose_6D", qnn::TraceTargetType::kTensor},
+       {"Reshape_4D", qnn::TraceTargetType::kOp}},
+      "SpaceToDepthFusion",
+  });
+  // 1:1: single op, no intermediate tensor
+  sg.op_mappings.push_back({
+      "Relu_0",
+      "QNN_OP_RELU",
+      {{"Relu_node", qnn::TraceTargetType::kOp}},
+      "OrtNodeUnit",
+  });
+  trace.subgraph_traces.push_back(std::move(sg));
+  qnn::ComputeTraceSummary(trace);
+
+  // Verify summary counts unique ONNX OP source names
+  EXPECT_EQ(trace.summary.supported_nodes, 4u);  // Reshape_6D + Transpose_6D + Reshape_4D + Relu_node
+
+  // Verify N:1 srcInfo chain: OP, TENSOR, OP, TENSOR, OP
+  const auto& sources = trace.subgraph_traces[0].op_mappings[0].sources;
+  ASSERT_EQ(sources.size(), 5u);
+  EXPECT_EQ(sources[0].type, qnn::TraceTargetType::kOp);
+  EXPECT_EQ(sources[0].name, "Reshape_6D");
+  EXPECT_EQ(sources[1].type, qnn::TraceTargetType::kTensor);
+  EXPECT_EQ(sources[1].name, "_out_Reshape_6D");
+  EXPECT_EQ(sources[2].type, qnn::TraceTargetType::kOp);
+  EXPECT_EQ(sources[2].name, "Transpose_6D");
+  EXPECT_EQ(sources[3].type, qnn::TraceTargetType::kTensor);
+  EXPECT_EQ(sources[3].name, "_out_Transpose_6D");
+  EXPECT_EQ(sources[4].type, qnn::TraceTargetType::kOp);
+  EXPECT_EQ(sources[4].name, "Reshape_4D");
+
+  // Verify JSON serialization preserves OP/TENSOR type strings
+  nlohmann::json j = qnn::SerializeFrameworkOpTrace(trace);
+  const auto& jsources = j["subgraph_traces"][0]["op_mappings"][0]["sources"];
+  ASSERT_EQ(jsources.size(), 5u);
+  EXPECT_EQ(jsources[0]["type"], "OP");
+  EXPECT_EQ(jsources[1]["type"], "TENSOR");
+  EXPECT_EQ(jsources[2]["type"], "OP");
+  EXPECT_EQ(jsources[3]["type"], "TENSOR");
+  EXPECT_EQ(jsources[4]["type"], "OP");
+
+  // Verify 1:1 srcInfo: single OP, no TENSOR
+  const auto& relu_sources = trace.subgraph_traces[0].op_mappings[1].sources;
+  ASSERT_EQ(relu_sources.size(), 1u);
+  EXPECT_EQ(relu_sources[0].type, qnn::TraceTargetType::kOp);
+}
+
+// ========================= CPU Backend Integration Tests =========================
+
+// Test trace disabled by default — even with a trace dir set, no file should be written.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_DisabledByDefault) {
+  ScopedTempDir tmp;
+  ProviderOptions opts;
+  opts["backend_type"] = "cpu";
+  opts["offload_graph_io_quantization"] = "0";
+  // Explicitly set trace dir but do NOT enable tracing (enable_framework_op_trace defaults to false)
+  opts["framework_op_trace_dir"] = tmp.path().string();
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  RunQnnModelTest(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      opts, 13, ExpectedEPNodeAssignment::All);
+
+  EXPECT_TRUE(FindTraceFile(tmp.path()).empty()) << "No trace file when tracing disabled";
+}
+
+// Test single op 1:1 mapping.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_SingleOp_OneToOne) {
+  ScopedTempDir tmp;
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  auto j = RunModelWithTracing(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      tmp.path(), "cpu");
+  if (j.empty()) return;
+
+  EXPECT_EQ(j["backend_type"], "cpu");
+  ValidateTraceStructure(j);
+
+  // Verify the 1:1 property: for an OrtNodeUnit op mapping (single op, no fusion),
+  // the single source must be an OP entry.  Note: dst_name (the QNN op name, generated by
+  // UniqueNameGenerator which deduplicates across the process) is NOT required
+  // to equal sources[0].name (the raw ONNX node name); they only match on the
+  // first use of a given name within a process-level test run.
+  bool found_single_node_entry = false;
+  for (const auto& m : j["subgraph_traces"][0]["op_mappings"]) {
+    if (m.value("node_group_type", "") != "OrtNodeUnit") continue;
+    found_single_node_entry = true;
+    ASSERT_EQ(m["sources"].size(), 1u) << "OrtNodeUnit mapping must have exactly one source";
+    EXPECT_EQ(m["sources"][0]["type"].get<std::string>(), "OP");
+    EXPECT_FALSE(m["sources"][0]["name"].get<std::string>().empty());
+  }
+  EXPECT_TRUE(found_single_node_entry) << "Expected at least one OrtNodeUnit op_mapping entry";
+}
+
+// Test unsupported op recorded with reason.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_UnsupportedNodeReport) {
+  ScopedTempDir tmp;
+  auto build_model = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, 2, 3}, GetFloatDataInRange(-1.0f, 1.0f, 6));
+    builder.AddNode("abs_node", "Abs", {"input"}, {"abs_out"});
+    builder.MakeOutput("Y");
+    builder.AddNode("nonzero_node", "NonZero", {"abs_out"}, {"Y"});
+  };
+
+  ProviderOptions opts;
+  opts["backend_type"] = "cpu";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+
+  RunQnnModelTest(build_model, opts, 13, ExpectedEPNodeAssignment::Some);
+
+  auto trace_file = FindTraceFile(tmp.path());
+  if (trace_file.empty()) return;
+  auto j = ReadTraceJson(trace_file);
+
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  ASSERT_GT(j["unsupported_nodes"].size(), 0u) << "NonZero should be recorded in unsupported_nodes";
+  for (const auto& un : j["unsupported_nodes"]) {
+    EXPECT_FALSE(un["node_name"].get<std::string>().empty());
+    EXPECT_FALSE(un["op_type"].get<std::string>().empty());
+    EXPECT_FALSE(un["reason"].get<std::string>().empty());
+  }
+  EXPECT_GT(j["summary"]["unsupported_nodes"].get<size_t>(), 0u);
+}
+
+// Test trace is written when the entire model is unsupported.
+// In this case ORT does not invoke CompileImpl, so the trace must be flushed
+// from the GetCapability path; otherwise the unsupported list is silently
+// discarded.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_AllUnsupportedModel_StillWritesTrace) {
+  ScopedTempDir tmp;
+  // NonZero is unsupported on QNN CPU; build a model containing only NonZero
+  // so QNN reports zero supported nodes.
+  auto build_model = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, 2, 3}, GetFloatDataInRange(-1.0f, 1.0f, 6));
+    builder.MakeOutput("Y");
+    builder.AddNode("nonzero_node", "NonZero", {"input"}, {"Y"});
+  };
+
+  ProviderOptions opts;
+  opts["backend_type"] = "cpu";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+
+  RunQnnModelTest(build_model, opts, 13, ExpectedEPNodeAssignment::None);
+
+  auto trace_file = FindTraceFile(tmp.path());
+  ASSERT_FALSE(trace_file.empty())
+      << "Trace file must be written even when no nodes are supported";
+  auto j = ReadTraceJson(trace_file);
+
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  ASSERT_GT(j["unsupported_nodes"].size(), 0u);
+  bool found_nonzero = false;
+  for (const auto& un : j["unsupported_nodes"]) {
+    if (un["op_type"].get<std::string>() == "NonZero") {
+      found_nonzero = true;
+      EXPECT_FALSE(un["reason"].get<std::string>().empty());
+    }
+  }
+  EXPECT_TRUE(found_nonzero) << "NonZero must appear in unsupported_nodes";
+
+  ASSERT_TRUE(j.contains("subgraph_traces"));
+  EXPECT_TRUE(j["subgraph_traces"].empty())
+      << "subgraph_traces must be empty when nothing was supported";
+  EXPECT_EQ(j["summary"]["supported_nodes"].get<size_t>(), 0u);
+  EXPECT_GT(j["summary"]["unsupported_nodes"].get<size_t>(), 0u);
+}
+
+// Test tensor mappings recorded.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_TensorMappings) {
+  ScopedTempDir tmp;
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  auto j = RunModelWithTracing(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      tmp.path(), "cpu");
+  if (j.empty()) return;
+
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  const auto& tm = j["subgraph_traces"][0]["tensor_mappings"];
+  // Each output tensor of a compiled QNN op produces a tensor_mappings entry
+  // whose sources mirror the op's srcInfo chain (same nodes, same types).
+  for (const auto& m : tm) {
+    EXPECT_FALSE(m["dst_name"].get<std::string>().empty());
+    ASSERT_GE(m["sources"].size(), 1u);
+    for (const auto& s : m["sources"]) {
+      EXPECT_FALSE(s["name"].get<std::string>().empty());
+      const auto& t = s["type"].get<std::string>();
+      EXPECT_TRUE(t == "OP" || t == "TENSOR") << "unexpected source type: " << t;
+    }
+  }
+}
+
+// Test multiple QNN subgraphs.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_MultipleSubgraphs) {
+  ScopedTempDir tmp;
+  auto build_model = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("in0", {1, 2, 3}, GetFloatDataInRange(-1.0f, 1.0f, 6));
+    builder.MakeInput<float>("in1", {1, 2, 3}, GetFloatDataInRange(-1.0f, 1.0f, 6));
+    builder.AddNode("add_node", "Add", {"in0", "in1"}, {"add_out"});
+    builder.AddNode("nonzero_node", "NonZero", {"add_out"}, {"nz_out"});
+    ONNX_NAMESPACE::AttributeProto to_attr;
+    to_attr.set_name("to");
+    to_attr.set_type(ONNX_NAMESPACE::AttributeProto::INT);
+    to_attr.set_i(1);  // FLOAT
+    builder.AddNode("cast_node", "Cast", {"nz_out"}, {"cast_out"}, kOnnxDomain, {to_attr});
+    builder.MakeOutput("Y");
+    builder.AddNode("relu_node", "Relu", {"cast_out"}, {"Y"});
+  };
+
+  ProviderOptions opts;
+  opts["backend_type"] = "cpu";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+
+  RunQnnModelTest(build_model, opts, 13, ExpectedEPNodeAssignment::Some);
+
+  auto trace_file = FindTraceFile(tmp.path());
+  if (trace_file.empty()) return;
+  auto j = ReadTraceJson(trace_file);
+  ASSERT_TRUE(j.contains("subgraph_traces"));
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  ASSERT_TRUE(j.contains("summary"));
+}
+
+// Builds the fan-out QDQ model: a single graph input feeds two
+// independent Q->DQ pairs whose DQ outputs are summed by an Add. With
+// `offload_graph_io_quantization=1`, both Q nodes stay on CPU and both DQ
+// outputs are registered as QNN graph inputs sharing the override name "input".
+// Used by the trace test below to exercise duplicate-override handling in
+// QnnModelWrapper::GetModelTensorsMap during framework op trace recording.
+static GetTestModelFn BuildOffloadFanoutQDQModelForTrace() {
+  return [](ModelTestBuilder& builder) {
+    builder.graph_->set_name("trace_offload_fanout_qdq");
+
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({1, 3}, false, {0.1f, 0.2f, 0.3f}));
+    builder.MakeInitializer<float>("scale", {}, {1.0f / 255.0f});
+    builder.MakeInitializer<uint8_t>("zp", {}, {0});
+
+    builder.AddNode("q_a", "QuantizeLinear", {"input", "scale", "zp"}, {"q_a_out"}, kOnnxDomain);
+    builder.AddNode("dq_a", "DequantizeLinear", {"q_a_out", "scale", "zp"}, {"dq_a_out"}, kOnnxDomain);
+    builder.AddNode("q_b", "QuantizeLinear", {"input", "scale", "zp"}, {"q_b_out"}, kOnnxDomain);
+    builder.AddNode("dq_b", "DequantizeLinear", {"q_b_out", "scale", "zp"}, {"dq_b_out"}, kOnnxDomain);
+    builder.AddNode("add", "Add", {"dq_a_out", "dq_b_out"}, {"add_out"}, kOnnxDomain);
+    builder.AddNode("q_out", "QuantizeLinear", {"add_out", "scale", "zp"}, {"q_out_out"}, kOnnxDomain);
+    builder.AddNode("dq_out", "DequantizeLinear", {"q_out_out", "scale", "zp"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+}
+
+// Exercises the framework op trace path for the `offload_graph_io_quantization=1`
+// + graph-input fan-out QDQ scenario.
+// Validates the dedup contract in OpTraceCollector::Finalize:
+//   * Option A: each qnn_name appears at most once in tensor_mappings.
+//   * Option B: when qnn_name is an external override target (e.g. the graph
+//     input "input" aliased back from an internal QNN name under
+//     offload_graph_io_quantization), the entry's sources contain exactly one
+//     element whose name equals the dst_name (the canonical ONNX name).
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_OffloadGraphIoQuantization_FanoutQDQ) {
+  ScopedTempDir tmp;
+
+  ProviderOptions opts;
+  opts["backend_type"] = "cpu";
+  opts["offload_graph_io_quantization"] = "1";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+
+  // Q nodes stay on CPU when offloading is enabled; DQ + Add land on QNN.
+  RunQnnModelTest(BuildOffloadFanoutQDQModelForTrace(), opts, /*opset*/ 18,
+                  ExpectedEPNodeAssignment::Some);
+
+  if (::testing::UnitTest::GetInstance()->current_test_info()->result()->Skipped()) {
+    return;
+  }
+
+  auto trace_file = FindTraceFile(tmp.path());
+  ASSERT_FALSE(trace_file.empty()) << "No trace file written for offload fanout QDQ model";
+
+  auto j = ReadTraceJson(trace_file);
+  ASSERT_TRUE(j.contains("subgraph_traces"));
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  ASSERT_TRUE(j["subgraph_traces"][0].contains("tensor_mappings"));
+  ASSERT_TRUE(j.contains("summary"));
+
+  // Option A: dst_name uniqueness across tensor_mappings.
+  std::unordered_set<std::string> seen_dst_names;
+  for (const auto& sg : j["subgraph_traces"]) {
+    for (const auto& m : sg["tensor_mappings"]) {
+      const auto dst = m["dst_name"].get<std::string>();
+      EXPECT_TRUE(seen_dst_names.insert(dst).second)
+          << "tensor_mappings has duplicate dst_name: " << dst;
+    }
+  }
+
+  // Option B: the override-target entry for the canonical graph input "input"
+  // must have exactly one source whose name equals "input".
+  bool found_canonical_input = false;
+  for (const auto& sg : j["subgraph_traces"]) {
+    for (const auto& m : sg["tensor_mappings"]) {
+      if (m["dst_name"].get<std::string>() != "input") continue;
+      found_canonical_input = true;
+      ASSERT_EQ(m["sources"].size(), 1u)
+          << "override-target entry must collapse to a single canonical source";
+      EXPECT_EQ(m["sources"][0]["name"].get<std::string>(), "input");
+      EXPECT_EQ(m["sources"][0]["type"].get<std::string>(), "TENSOR");
+    }
+  }
+  EXPECT_TRUE(found_canonical_input)
+      << "expected a tensor_mappings entry for the canonical override target 'input'";
+}
+
+// Test custom output directory.
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_CustomOutputDir) {
+  ScopedTempDir tmp;
+  fs::path custom_dir = tmp.path() / "nested" / "custom_trace";
+  ASSERT_FALSE(fs::exists(custom_dir));
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  RunModelWithTracing(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      custom_dir, "cpu");
+
+  EXPECT_TRUE(fs::exists(custom_dir));
+  EXPECT_FALSE(FindTraceFile(custom_dir).empty());
+}
+
+// Test compilation_target metadata (CPU).
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_CompilationTargetMetadata) {
+  ScopedTempDir tmp;
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  auto j = RunModelWithTracing(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      tmp.path(), "cpu");
+  if (j.empty()) return;
+  ASSERT_TRUE(j.contains("compilation_target"));
+  EXPECT_TRUE(j["compilation_target"].contains("htp_arch"));
+  EXPECT_TRUE(j["compilation_target"].contains("soc_model"));
+  EXPECT_TRUE(j["compilation_target"].contains("device_id"));
+}
+
+// Test explicit output directory (simulates Android non-writable CWD).
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_ExplicitOutputDir_NonWritableCWD) {
+  ScopedTempDir tmp;
+  fs::path explicit_dir = tmp.path() / "explicit_output";
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  RunModelWithTracing(
+      BuildOpTestCase<float>("relu_node", "Relu",
+                             {TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      explicit_dir, "cpu");
+  EXPECT_TRUE(fs::exists(explicit_dir));
+  EXPECT_FALSE(FindTraceFile(explicit_dir).empty());
+}
+
+// ========================= HTP Backend Integration Tests =========================
+
+// Test HTP backend basic trace.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_BasicHTP) {
+  ScopedTempDir tmp;
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  auto j = RunModelWithTracing(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      tmp.path(), "htp");
+  if (j.empty()) return;
+
+  EXPECT_EQ(j["backend_type"], "htp");
+  ValidateTraceStructure(j);
+}
+
+// Test QDQ fusion N:1 mapping on HTP.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_QDQFusion_ManyToOne) {
+  ScopedTempDir tmp;
+
+  auto build_qdq_conv = [](ModelTestBuilder& builder) {
+    // Use uint8 input directly so DequantizeLinear receives a quantized tensor.
+    builder.MakeInput<uint8_t>("input", {1, 1, 5, 5}, std::vector<uint8_t>(25, 128));
+    builder.MakeInitializer<uint8_t>("weight", {1, 1, 3, 3}, std::vector<uint8_t>(9, 128));
+    builder.AddDequantizeLinearNode<uint8_t>("dq_input_node", "input", 0.004f, static_cast<uint8_t>(128), "dq_input");
+    builder.AddDequantizeLinearNode<uint8_t>("dq_weight_node", "weight", 0.003f, static_cast<uint8_t>(128), "dq_weight");
+    builder.AddNode("conv_node", "Conv", {"dq_input", "dq_weight"}, {"conv_output"});
+    builder.MakeOutput("output");
+    builder.AddQuantizeLinearNode<uint8_t>("q_output_node", "conv_output", 0.005f, static_cast<uint8_t>(128), "output");
+  };
+
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+
+  RunQnnModelTest(build_qdq_conv, opts, 13, ExpectedEPNodeAssignment::All);
+
+  auto trace_file = FindTraceFile(tmp.path());
+  if (trace_file.empty()) return;
+  auto j = ReadTraceJson(trace_file);
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+
+  bool found_multi = false;
+  bool found_tensor_src = false;
+  for (const auto& m : j["subgraph_traces"][0]["op_mappings"]) {
+    if (m["sources"].size() > 1) {
+      found_multi = true;
+      for (const auto& s : m["sources"]) {
+        if (s["type"] == "TENSOR") {
+          found_tensor_src = true;
+          break;
+        }
+      }
+      break;
+    }
+  }
+  EXPECT_TRUE(found_multi) << "HTP QDQ fusion should produce multi-source mapping";
+  EXPECT_TRUE(found_tensor_src) << "HTP QDQ fusion sources should contain TENSOR entries (intermediate outputs)";
+}
+
+// Test Gelu fusion on HTP.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_GeluFusion) {
+#if defined(_WIN32) && !defined(_M_ARM64)
+  GTEST_SKIP() << "GeluFusion not supported on Windows x86 HTP simulation";
+#endif
+  ScopedTempDir tmp;
+  // Use the ONNX Gelu decomposition pattern (Mul/Div/Erf/Add) so the
+  // GeluFusion node group fires. kMSDomain Gelu fails to finalize on HTP.
+  auto build_gelu = [](ModelTestBuilder& builder) {
+    constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float half = 0.5f;
+    constexpr float one = 1.0f;
+    builder.MakeInput<float>("input", {1, 2, 8}, GetFloatDataInRange(-3.0f, 3.0f, 16));
+    builder.MakeScalarInitializer<float>("half_const", half);
+    builder.AddNode("Mul_half", "Mul", {"input", "half_const"}, {"mul_half_out"});
+    builder.MakeScalarInitializer<float>("sqrt2_const", sqrt_2);
+    builder.AddNode("Div_sqrt2", "Div", {"input", "sqrt2_const"}, {"div_out"});
+    builder.AddNode("Erf_node", "Erf", {"div_out"}, {"erf_out"});
+    builder.MakeScalarInitializer<float>("one_const", one);
+    builder.AddNode("Add_one", "Add", {"erf_out", "one_const"}, {"add_out"});
+    builder.AddNode("Mul_out", "Mul", {"add_out", "mul_half_out"}, {"Y"});
+    builder.MakeOutput("Y");
+  };
+
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  // HTP executes float ops via float16 hardware precision, so fp32 comparison
+  // requires a relaxed tolerance. 5e-3f covers observed rounding on both
+  // simulation (x86) and real ARM64 hardware.
+  RunQnnModelTest(build_gelu, opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+
+  auto trace_file = FindTraceFile(tmp.path());
+  if (trace_file.empty()) return;
+  auto j = ReadTraceJson(trace_file);
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  EXPECT_GT(j["subgraph_traces"][0]["op_mappings"].size(), 0u);
+}
+
+// Test 1:N mapping on HTP.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_OneToMany) {
+  ScopedTempDir tmp;
+  auto build_split = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, 6, 2}, GetFloatDataInRange(-1.0f, 1.0f, 12));
+    builder.MakeOutput("Y0");
+    builder.MakeOutput("Y1");
+    ONNX_NAMESPACE::AttributeProto axis_attr;
+    axis_attr.set_name("axis");
+    axis_attr.set_type(ONNX_NAMESPACE::AttributeProto::INT);
+    axis_attr.set_i(1);
+    builder.AddNode("split_node", "Split", {"input"}, {"Y0", "Y1"}, kOnnxDomain, {axis_attr});
+  };
+
+  auto j = RunModelWithTracing(build_split, tmp.path(), "htp", 13);
+  if (j.empty()) return;
+  EXPECT_EQ(j["backend_type"], "htp");
+  ValidateTraceStructure(j);
+}
+
+// Test HTP compilation_target metadata.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_HTP_CompilationTarget) {
+  ScopedTempDir tmp;
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  auto j = RunModelWithTracing(
+      BuildOpTestCase<float>("relu_node", "Relu",
+                             {TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      tmp.path(), "htp");
+  if (j.empty()) return;
+
+  EXPECT_EQ(j["backend_type"], "htp");
+  ASSERT_TRUE(j.contains("compilation_target"));
+  EXPECT_TRUE(j["compilation_target"].contains("device_id"));
+}
+
+// ========================= AOT Path Integration Tests =========================
+
+static std::string BuildModelData(const GetTestModelFn& build_fn, int opset_version = 13) {
+  const std::unordered_map<std::string, int> domain_to_version = {{"", opset_version}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  build_fn(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+  return model_data;
+}
+
+// Test AOT Phase 1 — trace JSON written to framework_op_trace_dir.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase1_TraceWritten) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path trace_dir = tmp.path() / "trace";
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_framework_op_trace"] = "1";
+  provider_options["framework_op_trace_dir"] = trace_dir.string();
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", provider_options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  // Verify context model was generated
+  EXPECT_TRUE(fs::exists(ctx_file)) << "Context model not generated";
+
+  // Verify trace JSON was written to framework_op_trace_dir
+  auto trace_file = FindTraceFile(trace_dir);
+  ASSERT_FALSE(trace_file.empty()) << "No trace file in framework_op_trace_dir";
+
+  auto j = ReadTraceJson(trace_file);
+  ValidateTraceStructure(j);
+  EXPECT_EQ(j["backend_type"], "htp");
+
+  // Phase 1 writes only to framework_op_trace_dir; no sidecar alongside the context model.
+  fs::path sidecar_path = ctx_file.parent_path() / "model_ctx_op_trace.json";
+  EXPECT_FALSE(fs::exists(sidecar_path)) << "No sidecar should be written alongside context model";
+}
+
+// Test AOT Phase 1 — no trace output when tracing disabled.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase1_DisabledNoTrace) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path trace_dir = tmp.path() / "trace";
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  // Tracing NOT enabled (default: enable_framework_op_trace = false)
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", provider_options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  // Context model should exist
+  EXPECT_TRUE(fs::exists(ctx_file));
+
+  // No trace file should exist (no trace_dir created, no sidecar)
+  EXPECT_TRUE(FindTraceFile(trace_dir).empty()) << "Trace file should not be generated when tracing disabled";
+  fs::path sidecar_path = ctx_file.parent_path() / "model_ctx_op_trace.json";
+  EXPECT_FALSE(fs::exists(sidecar_path)) << "Sidecar should not be written when tracing disabled";
+}
+
+// Test AOT Phase 1 trace content matches JIT trace content for same model.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase1_MatchesJIT) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path jit_trace_dir = tmp.path() / "jit";
+  fs::path aot_trace_dir = tmp.path() / "aot";
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  auto build_fn = BuildOpTestCase<float>(
+      "add_node", "Add",
+      {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+      {}, {}, kOnnxDomain);
+
+  // JIT path: run with tracing
+  auto jit_j = RunModelWithTracing(build_fn, jit_trace_dir, "htp");
+  if (jit_j.empty()) return;
+
+  // AOT Phase 1: run with tracing + context generation
+  std::string model_data = BuildModelData(build_fn);
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_framework_op_trace"] = "1";
+  provider_options["framework_op_trace_dir"] = aot_trace_dir.string();
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", provider_options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  auto aot_trace_file = FindTraceFile(aot_trace_dir);
+  ASSERT_FALSE(aot_trace_file.empty()) << "No AOT trace file generated";
+  auto aot_j = ReadTraceJson(aot_trace_file);
+
+  // Compare: same backend, same op_mappings structure
+  EXPECT_EQ(jit_j["backend_type"], aot_j["backend_type"]);
+  ASSERT_GE(jit_j["subgraph_traces"].size(), 1u);
+  ASSERT_GE(aot_j["subgraph_traces"].size(), 1u);
+
+  const auto& jit_ops = jit_j["subgraph_traces"][0]["op_mappings"];
+  const auto& aot_ops = aot_j["subgraph_traces"][0]["op_mappings"];
+  ASSERT_EQ(jit_ops.size(), aot_ops.size());
+
+  for (size_t i = 0; i < jit_ops.size(); ++i) {
+    EXPECT_EQ(jit_ops[i]["dst_name"], aot_ops[i]["dst_name"]);
+    EXPECT_EQ(jit_ops[i]["dst_qnn_op_type"], aot_ops[i]["dst_qnn_op_type"]);
+    EXPECT_EQ(jit_ops[i]["sources"], aot_ops[i]["sources"]);
+    EXPECT_EQ(jit_ops[i]["node_group_type"], aot_ops[i]["node_group_type"]);
+  }
+
+  // Summary should match
+  EXPECT_EQ(jit_j["summary"]["total_qnn_ops"], aot_j["summary"]["total_qnn_ops"]);
+  EXPECT_EQ(jit_j["summary"]["supported_nodes"], aot_j["summary"]["supported_nodes"]);
+}
+
+// ========================= Mixed EPContext Model Integration Tests =========================
+
+// Test phase 1 trace for model that produces mixed EPContext:
+// unsupported_nodes contains the ops that become non-EPContext.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_Phase1UnsupportedNodesCaptured) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path trace_dir = tmp.path() / "trace";
+  fs::path ctx_file = tmp.path() / "mixed_ctx.onnx";
+
+  // Build model with supported (Abs) + unsupported (NonZero) ops
+  auto build_mixed = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, 2, 3}, GetFloatDataInRange(-1.0f, 1.0f, 6));
+    builder.AddNode("abs_node", "Abs", {"input"}, {"abs_out"});
+    builder.MakeOutput("Y");
+    builder.AddNode("nonzero_node", "NonZero", {"abs_out"}, {"Y"});
+  };
+
+  std::string model_data = BuildModelData(build_mixed);
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_framework_op_trace"] = "1";
+  provider_options["framework_op_trace_dir"] = trace_dir.string();
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", provider_options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  auto trace_file = FindTraceFile(trace_dir);
+  ASSERT_FALSE(trace_file.empty()) << "No trace file generated for mixed model";
+  auto j = ReadTraceJson(trace_file);
+
+  // Unsupported nodes should capture the NonZero op
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  bool found_nonzero = false;
+  for (const auto& un : j["unsupported_nodes"]) {
+    if (un["op_type"] == "NonZero") {
+      found_nonzero = true;
+      EXPECT_FALSE(un["reason"].get<std::string>().empty()) << "Unsupported reason should not be empty";
+      break;
+    }
+  }
+  EXPECT_TRUE(found_nonzero) << "NonZero should appear in unsupported_nodes";
+  EXPECT_GT(j["summary"]["unsupported_nodes"].get<size_t>(), 0u);
+}
+
+// Test mixed EPContext model Phase 2 — no new trace file produced.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_NoTraceInPhase2) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "mixed_ctx.onnx";
+
+  // Phase 1: Generate context model from mixed model
+  auto build_mixed = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, 2, 3}, GetFloatDataInRange(-1.0f, 1.0f, 6));
+    builder.AddNode("abs_node", "Abs", {"input"}, {"abs_out"});
+    builder.MakeOutput("Y");
+    builder.AddNode("nonzero_node", "NonZero", {"abs_out"}, {"Y"});
+  };
+
+  std::string model_data = BuildModelData(build_mixed);
+
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file)) << "Context model not generated in Phase 1";
+
+  // Phase 2: Load context model with tracing enabled, but no new trace should appear
+  fs::path phase2_trace_dir = tmp.path() / "phase2_trace";
+  fs::create_directories(phase2_trace_dir);
+
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = phase2_trace_dir.string();
+    opts["disable_file_mapped_weights"] = "1";  // avoid DMA path crash with App Verifier
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, ctx_file.c_str(), so);
+  }
+
+  // No trace file in Phase 2 trace dir (Phase 2 has no trace behavior)
+  EXPECT_TRUE(FindTraceFile(phase2_trace_dir).empty())
+      << "Phase 2 should not produce a trace file";
+}
+
+// Test mixed EPContext model Phase 2 — inference succeeds with tracing enabled.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_Phase2InferenceSucceeds) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "mixed_ctx.onnx";
+
+  // Phase 1: Generate context model from a simple supported-only model
+  // (Mixed model inference is harder to set up; use all-supported model to verify Phase 2 doesn't crash)
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file));
+
+  // Phase 2: Load context model with tracing enabled and run inference
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = tmp.path().string();
+    opts["disable_file_mapped_weights"] = "1";  // avoid DMA path crash with App Verifier
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, ctx_file.c_str(), so);
+
+    // Run inference — just verify it doesn't crash
+    auto input_names = session.GetInputNames();
+    auto output_names = session.GetOutputNames();
+
+    std::vector<float> input_data(6, 1.0f);
+    std::vector<int64_t> input_shape = {1, 2, 3};
+
+    Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    std::vector<Ort::Value> inputs;
+    for (size_t i = 0; i < input_names.size(); ++i) {
+      inputs.push_back(Ort::Value::CreateTensor<float>(
+          mem_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size()));
+    }
+
+    std::vector<const char*> input_name_ptrs;
+    for (const auto& name : input_names) input_name_ptrs.push_back(name.c_str());
+    std::vector<const char*> output_name_ptrs;
+    for (const auto& name : output_names) output_name_ptrs.push_back(name.c_str());
+
+    auto outputs = session.Run(Ort::RunOptions{nullptr},
+                               input_name_ptrs.data(), inputs.data(), inputs.size(),
+                               output_name_ptrs.data(), output_name_ptrs.size());
+    EXPECT_GT(outputs.size(), 0u) << "Inference should produce output";
+  }
+}
+
+// ========================= HTP Mixed EPContext Model Tests =========================
+
+// Build a QDQ model with FusedGemm (unsupported on HTP) + quantized Add (supported).
+// This produces a mixed EPContext model: FusedGemm becomes non-EPContext, Add becomes EPContext.
+static GetTestModelFn BuildHTPMixedModel() {
+  return [](ModelTestBuilder& builder) {
+    // FusedGemm (kMSDomain) — unsupported on HTP backend
+    std::vector<float> data(12 * 12, 1.0f);
+    MakeTestInput(builder, "input1", TestInputDef<float>({12, 12}, false, data));
+    MakeTestInput(builder, "gemm_weight", TestInputDef<float>({12, 12}, true, data));
+    std::vector<ONNX_NAMESPACE::AttributeProto> fusedgemm_attrs;
+    fusedgemm_attrs.push_back(builder.MakeStringAttribute("activation", "Relu"));
+    builder.AddNode("FusedGemm_node0", "FusedGemm", {"input1", "gemm_weight"}, {"gemm_out"},
+                    kMSDomain, fusedgemm_attrs);
+
+    // Quantized Add — supported via QDQ fusion on HTP
+    gsl::span<float> data_range = gsl::make_span(data);
+    QuantParams<uint8_t> q_params = GetDataQuantParams<uint8_t>(data_range);
+    std::string add_in1_qdq = AddQDQNodePair<uint8_t>(builder, "add_in1_qdq", "gemm_out",
+                                                      q_params.scale, q_params.zero_point);
+    MakeTestInput(builder, "add_input2", TestInputDef<float>({12, 12}, true, data));
+    std::string add_in2_qdq = AddQDQNodePair<uint8_t>(builder, "add_in2_qdq", "add_input2",
+                                                      q_params.scale, q_params.zero_point);
+    builder.AddNode("Add_node0", "Add", {add_in1_qdq, add_in2_qdq}, {"add_out"});
+    AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, "qdq_out", "add_out",
+                                                   q_params.scale, q_params.zero_point);
+  };
+}
+
+// Test (HTP): Phase 1 trace captures unsupported FusedGemm with reason.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_HTP_Phase1UnsupportedNodesCaptured) {
+  ScopedTempDir tmp;
+  fs::path trace_dir = tmp.path() / "trace";
+  fs::path ctx_file = tmp.path() / "mixed_ctx.onnx";
+
+  std::string model_data = BuildModelData(BuildHTPMixedModel());
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_framework_op_trace"] = "1";
+  provider_options["framework_op_trace_dir"] = trace_dir.string();
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", provider_options);
+  Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+
+  auto trace_file = FindTraceFile(trace_dir);
+  ASSERT_FALSE(trace_file.empty()) << "No trace file generated for HTP mixed model";
+  auto j = ReadTraceJson(trace_file);
+
+  // Unsupported nodes should capture FusedGemm
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  bool found_fusedgemm = false;
+  for (const auto& un : j["unsupported_nodes"]) {
+    if (un["op_type"] == "FusedGemm") {
+      found_fusedgemm = true;
+      EXPECT_FALSE(un["reason"].get<std::string>().empty()) << "Unsupported reason should not be empty";
+      break;
+    }
+  }
+  EXPECT_TRUE(found_fusedgemm) << "FusedGemm should appear in unsupported_nodes";
+  EXPECT_EQ(j["backend_type"], "htp");
+  EXPECT_GT(j["summary"]["unsupported_nodes"].get<size_t>(), 0u);
+}
+
+// Test (HTP): Mixed EPContext model Phase 2 — no trace file produced.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_HTP_NoTraceInPhase2) {
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "mixed_ctx.onnx";
+
+  std::string model_data = BuildModelData(BuildHTPMixedModel());
+
+  // Phase 1: Generate context model
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file)) << "Context model not generated in Phase 1";
+
+  // Phase 2: Load context model with tracing enabled
+  fs::path phase2_trace_dir = tmp.path() / "phase2_trace";
+  fs::create_directories(phase2_trace_dir);
+
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = phase2_trace_dir.string();
+    opts["disable_file_mapped_weights"] = "1";  // avoid DMA path crash with App Verifier
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, ctx_file.c_str(), so);
+  }
+
+  EXPECT_TRUE(FindTraceFile(phase2_trace_dir).empty())
+      << "Phase 2 should not produce a trace file";
+}
+
+// Test (HTP): Mixed EPContext model Phase 2 — inference succeeds with tracing enabled.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_HTP_Phase2InferenceSucceeds) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "mixed_ctx.onnx";
+
+  // Phase 1: Use a simple all-supported HTP model for inference verification
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file));
+
+  // Phase 2: Load context model with tracing enabled and run inference
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = tmp.path().string();
+    opts["disable_file_mapped_weights"] = "1";  // avoid DMA path crash with App Verifier
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, ctx_file.c_str(), so);
+
+    auto input_names = session.GetInputNames();
+    auto output_names = session.GetOutputNames();
+
+    std::vector<float> input_data(6, 1.0f);
+    std::vector<int64_t> input_shape = {1, 2, 3};
+
+    Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    std::vector<Ort::Value> inputs;
+    for (size_t i = 0; i < input_names.size(); ++i) {
+      inputs.push_back(Ort::Value::CreateTensor<float>(
+          mem_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size()));
+    }
+
+    std::vector<const char*> input_name_ptrs;
+    for (const auto& name : input_names) input_name_ptrs.push_back(name.c_str());
+    std::vector<const char*> output_name_ptrs;
+    for (const auto& name : output_names) output_name_ptrs.push_back(name.c_str());
+
+    auto outputs = session.Run(Ort::RunOptions{nullptr},
+                               input_name_ptrs.data(), inputs.data(), inputs.size(),
+                               output_name_ptrs.data(), output_name_ptrs.size());
+    EXPECT_GT(outputs.size(), 0u) << "Inference should produce output";
+  }
+}
+
+// ========================= N:M Fusion Integration Test =========================
+
+// Test N:1 fusion — multiple ONNX nodes → single QNN Gelu op sharing same source chain.
+// Uses ONNX Gelu decomposition pattern (Mul/Div/Erf/Add) which gets fused by GeluFusion on HTP.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_GeluFusion) {
+#if defined(_WIN32) && !defined(_M_ARM64)
+  GTEST_SKIP() << "GeluFusion not supported on Windows x86 HTP simulation";
+#endif
+  ScopedTempDir tmp;
+  // ONNX Gelu decomposition pattern: GeluFusion maps 5 ONNX ops → 1 QNN Gelu op.
+  auto build_gelu = [](ModelTestBuilder& builder) {
+    constexpr float sqrt_2 = 1.4142135381698608f;
+    constexpr float half = 0.5f;
+    constexpr float one = 1.0f;
+    builder.MakeInput<float>("input", {1, 2, 8}, GetFloatDataInRange(-3.0f, 3.0f, 16));
+    builder.MakeScalarInitializer<float>("half_const", half);
+    builder.AddNode("Mul_half", "Mul", {"input", "half_const"}, {"mul_half_out"});
+    builder.MakeScalarInitializer<float>("sqrt2_const", sqrt_2);
+    builder.AddNode("Div_sqrt2", "Div", {"input", "sqrt2_const"}, {"div_out"});
+    builder.AddNode("Erf_node", "Erf", {"div_out"}, {"erf_out"});
+    builder.MakeScalarInitializer<float>("one_const", one);
+    builder.AddNode("Add_one", "Add", {"erf_out", "one_const"}, {"add_out"});
+    builder.AddNode("Mul_out", "Mul", {"add_out", "mul_half_out"}, {"Y"});
+    builder.MakeOutput("Y");
+  };
+
+  auto j = [&]() -> nlohmann::json {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+    opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+    // HTP executes float ops via float16 hardware precision, so fp32 comparison
+    // requires a relaxed tolerance. 5e-3f covers observed rounding on both
+    // simulation (x86) and real ARM64 hardware.
+    RunQnnModelTest(build_gelu, opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+    auto trace_file = FindTraceFile(tmp.path());
+    if (trace_file.empty()) return {};
+    return ReadTraceJson(trace_file);
+  }();
+  if (j.empty()) return;
+
+  ValidateTraceStructure(j);
+
+  // Verify fusion pattern: multiple QNN ops should share the same source chain
+  // indicating N:M mapping (Gelu fuses multiple ONNX ops into potentially multiple QNN ops)
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  const auto& op_mappings = j["subgraph_traces"][0]["op_mappings"];
+  EXPECT_GT(op_mappings.size(), 0u);
+
+  // Check that at least one op has a non-OrtNodeUnit node_group_type (indicating fusion)
+  bool found_fusion = false;
+  for (const auto& m : op_mappings) {
+    if (m.contains("node_group_type") && m["node_group_type"] != "OrtNodeUnit") {
+      found_fusion = true;
+      // Fusion ops should have multiple sources
+      EXPECT_GT(m["sources"].size(), 1u) << "Fused op should have multiple source entries";
+      break;
+    }
+  }
+  // Gelu is decomposed into multiple ops by ONNX optimizer, which may then be fused by QNN EP
+  // If no fusion found, at least verify the trace is valid
+  if (!found_fusion) {
+    EXPECT_GT(op_mappings.size(), 0u) << "Should have at least one op mapping";
+  }
+}
+
+// Test N:M trace for ReshapeEinsumReshape fusion (3 ONNX ops → 3 QNN ops).
+// The fusion maps Reshape→Einsum→Reshape to Reshape+DepthToSpace+Transpose in QNN.
+// Each QNN op entry in op_mappings should share the same 3 ONNX op sources, proving
+// that the trace correctly records the N:M relationship.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_ReshapeEinsumReshape) {
+#if defined(_WIN32) && !defined(_M_ARM64)
+  GTEST_SKIP() << "ReshapeEinsumReshape fusion not supported on Windows x86 HTP simulation";
+#endif
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+
+  // Reshape(1024,32)→(1,32,32,2,2,8) + Einsum("nhwpqc->nchpwq") + Reshape→(1,8,64,64)
+  // This pattern triggers ReshapeEinsumReshapeNodeGroup which emits 3 QNN ops:
+  //   Reshape, DepthToSpace, Transpose
+  auto build_fn = [](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({1024, 32}, false, -10.0f, 10.0f));
+    builder.Make1DInitializer<int64_t>("reshape1_shape", {1, 32, 32, 2, 2, 8});
+    builder.AddNode("reshape1", "Reshape", {"input", "reshape1_shape"}, {"reshape1_out"}, kOnnxDomain);
+    ONNX_NAMESPACE::AttributeProto eq_attr;
+    eq_attr.set_name("equation");
+    eq_attr.set_type(ONNX_NAMESPACE::AttributeProto::STRING);
+    eq_attr.set_s("nhwpqc->nchpwq");
+    builder.AddNode("einsum", "Einsum", {"reshape1_out"}, {"einsum_out"}, kOnnxDomain, {eq_attr});
+    builder.Make1DInitializer<int64_t>("reshape2_shape", {1, 8, 64, 64});
+    builder.AddNode("reshape2", "Reshape", {"einsum_out", "reshape2_shape"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(build_fn, opts, 13, ExpectedEPNodeAssignment::All, 1e-2f);
+
+  auto trace_file = FindTraceFile(tmp.path());
+  ASSERT_FALSE(trace_file.empty()) << "No trace file generated for ReshapeEinsumReshape model";
+  auto j = ReadTraceJson(trace_file);
+  ValidateTraceStructure(j);
+
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  const auto& op_mappings = j["subgraph_traces"][0]["op_mappings"];
+
+  // Collect all op_mapping entries attributed to the ReshapeEinsumReshape fusion.
+  std::vector<nlohmann::json> rer_entries;
+  for (const auto& m : op_mappings) {
+    if (m.contains("node_group_type") && m["node_group_type"] == "ReshapeEinsumReshapeNodeGroup") {
+      rer_entries.push_back(m);
+    }
+  }
+
+  // N:M: 3 ONNX ops → 3 QNN ops, so there must be at least 2 fusion entries
+  // (3 is the expected exact count: Reshape + DepthToSpace + Transpose).
+  ASSERT_GE(rer_entries.size(), 2u)
+      << "ReshapeEinsumReshape N:M fusion should produce at least 2 QNN op trace entries "
+         "(expected Reshape + DepthToSpace + Transpose)";
+
+  // Each QNN op entry must reference all 3 source ONNX ops.
+  for (const auto& entry : rer_entries) {
+    int op_source_count = 0;
+    for (const auto& s : entry["sources"]) {
+      if (s["type"] == "OP") op_source_count++;
+    }
+    EXPECT_GE(op_source_count, 3)
+        << "Each N:M fusion entry should reference all 3 ONNX source ops "
+           "(reshape1, einsum, reshape2)";
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description

- New session options: qnn.enable_framework_op_trace, qnn.framework_op_trace_dir
- Collect unsupported node info with rejection reasons in GetSupportedNodes
- Record op/tensor mappings via OpTraceCollector hook in CreateQnnNode during ComposeGraph, and tensor mappings from QnnModelWrapper after composition
- Serialize trace to JSON file in CompileImpl
- Add unit tests


### Motivation and Context
Add framework op tracing feature