### PR TITLE
Implement graph checker with public GetEpGraphAssignmentInfo API

### DIFF
--- a/onnxruntime/test/providers/qnn/averagepool_test.cc
+++ b/onnxruntime/test/providers/qnn/averagepool_test.cc
@@ -275,9 +275,16 @@ TEST_F(QnnHTPBackendTests, AveragePool1DFusedQnnNodePresent) {
   ProviderOptions options;
   options["backend_type"] = "htp";
 
-  std::function<void(const Graph&)> check_num_nodes = [](const Graph& graph) {
-    int number_of_nodes = graph.NumberOfNodes();
-    EXPECT_EQ(number_of_nodes, 1) << "Expected 1 fused QNN node for AveragePool rank-3 input.";
+  std::function<void(const Ort::Session&)> check_num_nodes = [](const Ort::Session& session) {
+    // The Reshape -> Pool -> Reshape gets fused to a single QNN node, so there should be
+    // exactly 1 QNN EP subgraph.
+    size_t num_qnn_subgraphs = 0;
+    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
+      if (subgraph.GetEpName() == kQnnExecutionProvider) {
+        num_qnn_subgraphs++;
+      }
+    }
+    EXPECT_EQ(num_qnn_subgraphs, 1u) << "Expected 1 fused QNN node for AveragePool rank-3 input.";
   };
 
   RunQnnModelTest(build_test_case,

--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -243,10 +243,16 @@ TEST_F(QnnHTPBackendTests, MaxPool1D_ReshapeNodesPresent) {
   ProviderOptions options;
   options["backend_type"] = "htp";
 
-  std::function<void(const Graph&)> check_num_nodes = [](const Graph& graph) {
-    int number_of_nodes = graph.NumberOfNodes();
-    // The Reshape -> Pool -> Reshape gets fused to a single QNN node
-    EXPECT_EQ(number_of_nodes, 1) << "Expected 1 QNN fused node for MaxPool rank-3 input.";
+  std::function<void(const Ort::Session&)> check_num_nodes = [](const Ort::Session& session) {
+    // The Reshape -> Pool -> Reshape gets fused to a single QNN node, so there should be
+    // exactly 1 QNN EP subgraph.
+    size_t num_qnn_subgraphs = 0;
+    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
+      if (subgraph.GetEpName() == kQnnExecutionProvider) {
+        num_qnn_subgraphs++;
+      }
+    }
+    EXPECT_EQ(num_qnn_subgraphs, 1u) << "Expected 1 QNN fused node for MaxPool rank-3 input.";
   };
 
   RunQnnModelTest(build_test_case,

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1350,11 +1350,9 @@ TEST_F(QnnHTPBackendTests, EPRejectsDynamicShapesF32) {
       for (const auto& node : subgraph.GetNodes()) {
         std::string op_type = node.GetOperatorType();
         if (op_type == "Reshape" || op_type == "Softmax") {
-          EXPECT_NE(ep_name, kQnnExecutionProvider)
-              << op_type << " should NOT be assigned to QNN EP";
+          EXPECT_EQ(ep_name, kCpuExecutionProvider) << op_type << " should be assigned to CPU EP";
         } else {
-          EXPECT_EQ(ep_name, kQnnExecutionProvider)
-              << op_type << " should be assigned to QNN EP";
+          EXPECT_EQ(ep_name, kQnnExecutionProvider) << op_type << " should be assigned to QNN EP";
         }
       }
     }
@@ -1441,10 +1439,22 @@ TEST_F(QnnHTPBackendTests, EPOffloadsGraphIOQuantDequant) {
     return [offload_graph_io_quantization](const Ort::Session& session) {
       // The public API returns pre-fusion nodes grouped by EP subgraph.
       // We verify:
-      //   offload=0: exactly 1 QNN subgraph (all nodes fused), 0 CPU nodes
-      //   offload=1: exactly 1 QNN subgraph (inner DQ+Op+Q fused), 2 CPU nodes (boundary Q + DQ)
+      //   offload=0: exactly 1 QNN subgraph (all QNN-eligible ops grouped), 0 CPU nodes
+      //   offload=1: exactly 1 QNN subgraph (all QNN-eligible ops grouped), 2 CPU nodes (boundary Q + DQ)
       size_t num_qnn_subgraphs = 0;
       size_t num_cpu_nodes = 0;
+      std::vector<std::string> cpu_op_types;
+
+      // For offload=1 verify the CPU Q/DQ are the graph-IO boundary nodes, not interior ones.
+      // ConstEpAssignedNode exposes only GetName/GetDomain/GetOperatorType — no input/output
+      // tensor name accessors — so we proxy the boundary check via the node names assigned by
+      // AddQDQNodePair / AddQDQNodePairWithOutputAsGraphOutput in BuildQDQOpTestCase:
+      //   input-side boundary Q   → "qdq_in0_q"  (consumes graph input "quant_input_defs_0")
+      //   output-side boundary DQ → "qdq_out_dq" (produces graph output "qdq_out_dq_out")
+      // Interior counterparts are "qdq_in0_dq" and "qdq_out_q"; ending up on CPU would mean
+      // the partitioner sent the wrong nodes to the CPU EP.
+      bool found_boundary_q = false;
+      bool found_boundary_dq = false;
 
       std::vector<Ort::ConstEpAssignedSubgraph> subgraphs = session.GetEpGraphAssignmentInfo();
       for (const auto& subgraph : subgraphs) {
@@ -1454,21 +1464,37 @@ TEST_F(QnnHTPBackendTests, EPOffloadsGraphIOQuantDequant) {
         } else {
           // CPU EP should only receive Q/DQ boundary nodes when offloading is enabled.
           for (const auto& node : subgraph.GetNodes()) {
+            std::string op_type = node.GetOperatorType();
+            std::string node_name = node.GetName();
+            cpu_op_types.push_back(op_type);
             if (offload_graph_io_quantization) {
-              std::string op_type = node.GetOperatorType();
               EXPECT_TRUE(op_type == "QuantizeLinear" || op_type == "DequantizeLinear")
                   << op_type << " should not be on CPU EP when IO quantization offloading is enabled";
+              if (op_type == "QuantizeLinear") {
+                found_boundary_q = (node_name == "qdq_in0_q");
+              } else if (op_type == "DequantizeLinear") {
+                found_boundary_dq = (node_name == "qdq_out_dq");
+              }
             }
             num_cpu_nodes++;
           }
         }
       }
 
-      EXPECT_EQ(num_qnn_subgraphs, 1u) << "Expected all QNN-assigned nodes fused into 1 subgraph";
+      EXPECT_EQ(num_qnn_subgraphs, 1u) << "Expected all QNN-assigned nodes grouped into 1 subgraph";
       if (offload_graph_io_quantization) {
+        const std::vector<std::string> graph_inputs = session.GetInputNames();
+        const std::vector<std::string> graph_outputs = session.GetOutputNames();
         EXPECT_EQ(num_cpu_nodes, 2u) << "Expected 2 boundary Q/DQ nodes offloaded to CPU EP";
+        EXPECT_TRUE(found_boundary_q)
+            << "Expected input-side boundary Q (qdq_in0_q) on CPU EP consuming a graph input; "
+            << "graph inputs: " << testing::PrintToString(graph_inputs);
+        EXPECT_TRUE(found_boundary_dq)
+            << "Expected output-side boundary DQ (qdq_out_dq) on CPU EP producing a graph output; "
+            << "graph outputs: " << testing::PrintToString(graph_outputs);
       } else {
-        EXPECT_EQ(num_cpu_nodes, 0u) << "Expected no CPU nodes when IO quantization offloading is disabled";
+        EXPECT_EQ(num_cpu_nodes, 0u) << "Expected no CPU nodes when IO quantization offloading is disabled, "
+                                     << "got: " << testing::PrintToString(cpu_op_types);
       }
     };
   };

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1343,14 +1343,19 @@ TEST_F(QnnHTPBackendTests, EPRejectsDynamicShapesF32) {
   };
 
   // Local function that checks that the nodes with dynamic shape I/O were assigned to CPU EP.
-  std::function<void(const Graph&)> ep_graph_checker = [](const Graph& graph) {
-    for (const Node& node : graph.Nodes()) {
-      const std::string& ep_name = node.GetExecutionProviderType();
-      const std::string& op_type = node.OpType();
-      if (op_type == "Reshape" || op_type == "Softmax") {
-        EXPECT_EQ(ep_name, kCpuExecutionProvider);
-      } else {
-        EXPECT_TRUE((ep_name == kQnnExecutionProvider) || (ep_name == onnxruntime::kQnnExecutionProvider));
+  std::function<void(const Ort::Session&)> ep_graph_checker = [](const Ort::Session& session) {
+    std::vector<Ort::ConstEpAssignedSubgraph> subgraphs = session.GetEpGraphAssignmentInfo();
+    for (const auto& subgraph : subgraphs) {
+      std::string ep_name = subgraph.GetEpName();
+      for (const auto& node : subgraph.GetNodes()) {
+        std::string op_type = node.GetOperatorType();
+        if (op_type == "Reshape" || op_type == "Softmax") {
+          EXPECT_NE(ep_name, kQnnExecutionProvider)
+              << op_type << " should NOT be assigned to QNN EP";
+        } else {
+          EXPECT_EQ(ep_name, kQnnExecutionProvider)
+              << op_type << " should be assigned to QNN EP";
+        }
       }
     }
   };
@@ -1432,35 +1437,39 @@ TEST_F(QnnHTPBackendTests, DumpJsonQNNGraph) {
 TEST_F(QnnHTPBackendTests, EPOffloadsGraphIOQuantDequant) {
   // Returns a function that checks that the Q/DQ ops at the graph IO boundary are offloaded to CPU
   // if the corresponding provider option is enabled.
-  auto graph_checker_builder = [](bool offload_graph_io_quantization) -> std::function<void(const Graph&)> {
-    return [offload_graph_io_quantization](const Graph& graph) {
-      size_t num_q = 0;
-      size_t num_dq = 0;
-      size_t num_qnn_fused_node = 0;
+  auto graph_checker_builder = [](bool offload_graph_io_quantization) -> std::function<void(const Ort::Session&)> {
+    return [offload_graph_io_quantization](const Ort::Session& session) {
+      // The public API returns pre-fusion nodes grouped by EP subgraph.
+      // We verify:
+      //   offload=0: exactly 1 QNN subgraph (all nodes fused), 0 CPU nodes
+      //   offload=1: exactly 1 QNN subgraph (inner DQ+Op+Q fused), 2 CPU nodes (boundary Q + DQ)
+      size_t num_qnn_subgraphs = 0;
+      size_t num_cpu_nodes = 0;
 
-      for (const Node& node : graph.Nodes()) {
-        const std::string& ep_name = node.GetExecutionProviderType();
-        const std::string& op_type = node.OpType();
-
-        if (offload_graph_io_quantization && op_type == "QuantizeLinear") {
-          const bool consumes_graph_input = graph.IsInputsIncludingInitializers(node.InputDefs()[0]);
-          EXPECT_EQ(ep_name, kCpuExecutionProvider);
-          EXPECT_TRUE(consumes_graph_input);
-          num_q += 1;
-        } else if (offload_graph_io_quantization && op_type == "DequantizeLinear") {
-          const bool produces_graph_output = graph.IsOutput(node.OutputDefs()[0]);
-          EXPECT_EQ(ep_name, kCpuExecutionProvider);
-          EXPECT_TRUE(produces_graph_output);
-          num_dq += 1;
+      std::vector<Ort::ConstEpAssignedSubgraph> subgraphs = session.GetEpGraphAssignmentInfo();
+      for (const auto& subgraph : subgraphs) {
+        std::string ep_name = subgraph.GetEpName();
+        if (ep_name == kQnnExecutionProvider) {
+          num_qnn_subgraphs++;
         } else {
-          EXPECT_TRUE((ep_name == kQnnExecutionProvider) || (ep_name == onnxruntime::kQnnExecutionProvider));
-          num_qnn_fused_node += 1;
+          // CPU EP should only receive Q/DQ boundary nodes when offloading is enabled.
+          for (const auto& node : subgraph.GetNodes()) {
+            if (offload_graph_io_quantization) {
+              std::string op_type = node.GetOperatorType();
+              EXPECT_TRUE(op_type == "QuantizeLinear" || op_type == "DequantizeLinear")
+                  << op_type << " should not be on CPU EP when IO quantization offloading is enabled";
+            }
+            num_cpu_nodes++;
+          }
         }
       }
 
-      EXPECT_EQ(num_q, static_cast<size_t>(offload_graph_io_quantization));
-      EXPECT_EQ(num_dq, static_cast<size_t>(offload_graph_io_quantization));
-      EXPECT_EQ(num_qnn_fused_node, 1);
+      EXPECT_EQ(num_qnn_subgraphs, 1u) << "Expected all QNN-assigned nodes fused into 1 subgraph";
+      if (offload_graph_io_quantization) {
+        EXPECT_EQ(num_cpu_nodes, 2u) << "Expected 2 boundary Q/DQ nodes offloaded to CPU EP";
+      } else {
+        EXPECT_EQ(num_cpu_nodes, 0u) << "Expected no CPU nodes when IO quantization offloading is disabled";
+      }
     };
   };
 

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -18,7 +18,6 @@
 #include "core/framework/error_code_helper.h"
 #include "core/graph/ep_api_types.h"
 #include "core/graph/constants.h"
-#include "core/graph/graph.h"
 #include "core/session/abi_devices.h"
 #include "core/session/abi_ep_types.h"
 #include "core/session/onnxruntime_cxx_api.h"
@@ -275,9 +274,8 @@ void RegisterQnnEpLibrary(RegisteredEpDeviceUniquePtr& registered_ep_device,
 void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions provider_options,
                      int opset_version, ExpectedEPNodeAssignment expected_ep_assignment,
                      float fp32_abs_err, OrtLoggingLevel log_severity, bool verify_outputs,
-                     std::function<void(const Graph&)>* ep_graph_checker) {
+                     std::function<void(const Ort::Session&)>* ep_graph_checker) {
   CONDITIONAL_SKIP_TEST_ON_LINUX_ARM64(provider_options, QNN_HTP_DEVICE_ARCH_V68, "FP16");
-
   std::filesystem::path output_dir;
   if (QNNTestEnvironment::GetInstance().dump_onnx() ||
       QNNTestEnvironment::GetInstance().dump_json() ||
@@ -413,7 +411,7 @@ void InferenceModel(const std::string& model_data,
                     OrtLoggingLevel log_severity,
                     const std::unordered_map<std::string, std::string>& session_option_pairs,
                     std::optional<GraphOptimizationLevel> graph_optimization_level,
-                    std::function<void(const Graph&)>* graph_checker [[maybe_unused]]) {
+                    std::function<void(const Ort::Session&)>* graph_checker) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   const std::string& registration_name = "QNNExecutionProvider";
   Ort::SessionOptions session_options;
@@ -442,11 +440,9 @@ void InferenceModel(const std::string& model_data,
   Ort::Session session(*GetOrtEnv(), model_data.data(), model_data.size(), session_options);
   ASSERT_NO_FATAL_FAILURE(VerifyEPNodeAssignment(session, provider_type, expected_ep_assignment));
 
-  // TODO: Implement graph_checker once public API for ep partition is ready
-  // const auto& graph = ort_session.GetGraph();
-  // if (graph_checker) {
-  //   (*graph_checker)(graph);
-  // }
+  if (graph_checker) {
+    (*graph_checker)(session);
+  }
 
   RunWithEP(session, ort_run_options, feeds, output_vals);
 }

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -600,7 +600,7 @@ void InferenceModel(const std::string& model_data,
                     OrtLoggingLevel log_severity = OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                     const std::unordered_map<std::string, std::string>& session_option_pairs = {},
                     std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt,
-                    std::function<void(const Graph&)>* graph_checker = nullptr);
+                    std::function<void(const Ort::Session&)>* graph_checker = nullptr);
 
 /**
  * If the ORT_UNIT_TEST_ENABLE_QNN_SAVER environment variable is enabled (set to 1), this function modifies
@@ -836,8 +836,8 @@ void VerifyQDQOutput(const std::vector<Ort::Value>& cpu_qdq_outputs,
  * \param tolerance The percent tolerance (as fraction) QNN EP results are allowed to differ from the QDQ model
  *                  on CPU EP. This tolerance is a percentage of the output range.
  * \param log_severity The logger's severity setting.
- * \param ep_graph_checker Function called on the Graph generated for the QNN EP's session. Used to check node
- *                         EP assignment.
+ * \param ep_graph_checker Function called on the Session after EP assignment. Used to check node
+ *                         EP assignment via public API.
  */
 
 // Helper macro to check if QuantType is a supported QDQ type
@@ -875,9 +875,8 @@ inline void TestQDQModelAccuracy(const GetTestModelFn& f32_model_fn,
                                  const std::string& qnn_ctx_model_path = "",
                                  const std::unordered_map<std::string, std::string>& session_option_pairs = {},
                                  std::optional<GraphOptimizationLevel> graph_optimization_level = std::nullopt,
-                                 std::function<void(const Graph&)>* qnn_ep_graph_checker = nullptr) {
+                                 std::function<void(const Ort::Session&)>* qnn_ep_graph_checker = nullptr) {
   CONDITIONAL_SKIP_TEST_ON_LINUX_ARM64(qnn_options, QNN_HTP_DEVICE_ARCH_V68, "QDQ", QuantType);
-
   std::filesystem::path output_dir;
   if (QNNTestEnvironment::GetInstance().dump_onnx() ||
       QNNTestEnvironment::GetInstance().dump_dlc() ||
@@ -1573,15 +1572,15 @@ inline GetTestQDQModelFn<QuantType> BuildQDQOpTestCase(
  * \param fp32_abs_err The acceptable error between CPU EP and QNN EP.
  * \param log_severity The logger's minimum severity level.
  * \param verify_outputs True to verify that the outputs match (within tolerance).
- * \param ep_graph_checker Function called on the Graph generated for the EP's session. Used to check node
- *                         EP assignment.
+ * \param ep_graph_checker Function called on the Session after EP assignment. Used to check node
+ *                         EP assignment via public API.
  */
 void RunQnnModelTest(const GetTestModelFn& build_test_case, ProviderOptions provider_options,
                      int opset_version, ExpectedEPNodeAssignment expected_ep_assignment,
                      float fp32_abs_err = 1e-5f,
                      OrtLoggingLevel log_severity = OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                      bool verify_outputs = true,
-                     std::function<void(const Graph&)>* ep_graph_checker = nullptr);
+                     std::function<void(const Ort::Session&)>* ep_graph_checker = nullptr);
 
 enum class BackendSupport {
   SUPPORT_UNKNOWN,

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -21,7 +21,6 @@
 #include "test/util/include/inference_session_wrapper.h"
 
 namespace onnxruntime {
-class Graph;
 struct SessionOptions;
 
 namespace test {
@@ -43,8 +42,8 @@ struct EPVerificationParams {
   // Set this only if this is necessary
   float fp32_abs_err = 1e-5f;
 
-  // optional graph verification function
-  const std::function<void(const Graph&)>* graph_verifier{nullptr};
+  // optional graph verification function (uses public ORT Session API)
+  const std::function<void(const Ort::Session&)>* graph_verifier{nullptr};
 };
 
 // Verify equality of two output tensors.

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -9,6 +9,7 @@
 #include "core/graph/onnx_protobuf.h"
 #include "core/session/inference_session.h"
 #include "core/session/onnxruntime_cxx_api.h"
+#include "core/session/onnxruntime_session_options_config_keys.h"
 #include "core/framework/tensorprotoutils.h"
 
 #include "test/util/include/asserts.h"
@@ -265,6 +266,10 @@ void RunAndVerifyOutputsWithEP(ModelPathOrBytes model_path_or_bytes,
 
   std::vector<Ort::Value> expected_fetches;
   RunWithEP(cpu_session, cpu_run_options, feeds, expected_fetches);
+
+  if (params.graph_verifier) {
+    ort_so.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
+  }
 
   // Run with EP and verify the result
   Ort::Session ort_session(*GetOrtEnv(), model_data.data(), static_cast<int>(model_data.size()), ort_so);

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -281,15 +281,14 @@ void RunAndVerifyOutputsWithEP(ModelPathOrBytes model_path_or_bytes,
     VerifyOutputs(output_names, expected_fetches, fetches, params);
   }
 
-  // TODO: graph_verifier requires internal graph access, commented out for public API migration
-  // if (params.graph_verifier) {
-  //   (*params.graph_verifier)(ort_session.GetGraph());
-  // }
+  if (params.graph_verifier) {
+    (*params.graph_verifier)(ort_session);
+  }
 }
 
 void TestModelLoad(ModelPathOrBytes model_path_or_bytes,
                    std::unique_ptr<IExecutionProvider>, /* execution_provider */
-                   const std::function<void(const Graph&)>& /* check_graph */) {
+                   const std::function<void(const Ort::Session&)>& check_graph) {
   std::vector<std::byte> model_data_buffer{};
   const auto model_data = GetModelBytes(model_path_or_bytes, model_data_buffer);
 
@@ -299,10 +298,9 @@ void TestModelLoad(ModelPathOrBytes model_path_or_bytes,
   // These are not available in the public API, so we just test model loading
   OrtSessionWrapper session_object(*GetOrtEnv(), model_data.data(), static_cast<int>(model_data.size()), ort_so);
 
-  // Note: check_graph callback requires internal graph access, commented out for public API migration
-  // if (check_graph) {
-  //   check_graph(session_object.GetGraph());
-  // }
+  if (check_graph) {
+    check_graph(session_object);
+  }
 }
 
 void CheckShapeEquality(const ONNX_NAMESPACE::TensorShapeProto* shape1,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- `EPVerificationParams::graph_verifier` in `test_utils.h` now accepts const `Ort::Session&` instead of `const Graph&`
- `RunQnnModelTest`, `TestQDQModelAccuracy`, and `InferenceModel` signatures updated             accordingly
- The previously dead-code checker invocation (commented out with a TODO) is now active
- TestModelLoad's check_graph callback similarly updated
- All three test-side checkers (AveragePool1DFusedQnnNodePresent,  MaxPool1D_ReshapeNodesPresent, EPOffloadsGraphIOQuantDequant, EPRejectsDynamicShapesF32) rewritten using `Session::GetEpGraphAssignmentInfo() → ConstEpAssignedSubgraph / ConstEpAssignedNode`
- Removed `#include "core/graph/graph.h"` from `qnn_test_utils.cc`

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The QNN EP tests were depending on `core/graph/graph.h` (an ORT-internal header) via `std::function<void(const Graph&)> callbacks`. This creates a coupling to internal ORT types that should be avoided as the EP API moves toward a fully public interface.                                                                                                    
- The checker callbacks were also entirely non-functional — the call site in
  `RunAndVerifyOutputsWithEP` had been commented out with a TODO: Implement graph_checker      once public API for ep partition is ready. With `Session::GetEpGraphAssignmentInfo()` now available in the public C++ API, we have everything needed to implement the same verification without internal headers.


