### PR TITLE
Translate MatMul to Conv2D 1x1 for LPBQ encodings

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include <functional>
@@ -848,12 +848,8 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     param_tensor_names.push_back(dilation_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(dilation_param));
 
-    Qnn_Scalar_t group_scalar = QNN_SCALAR_INIT;
-    group_scalar.dataType = QNN_DATATYPE_UINT_32;
-    group_scalar.uint32Value = 1;
-    QnnParamWrapper group_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_GROUP, group_scalar);
-    param_tensor_names.push_back(group_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(group_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), 1,
+                                           QNN_OP_CONV_2D_PARAM_GROUP, param_tensor_names));
   } else if (use_fully_connected) {
     qnn_op_type = QNN_OP_FULLY_CONNECTED;
   } else {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include <functional>
@@ -106,11 +106,25 @@ Ort::Status FlattenLeadingDims(const std::vector<uint32_t>& shape, uint32_t& bat
   return Ort::Status();
 }
 
+// Determines which QNN op to lower the ONNX MatMul to.
+// Sets use_fully_connected=true  -> lower to QNN FullyConnected
+// Sets use_conv2d=true           -> lower to QNN Conv2D (LPBQ path)
+// Both false                     -> lower to QNN MatMul
 Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& input_def_0,
                         const OrtNodeUnitIODef& input_def_1, TensorInfo& input_info_0, TensorInfo& input_info_1,
-                        bool& use_fully_connected) {
+                        bool& use_fully_connected, bool& use_conv2d) {
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def_0, input_info_0));
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def_1, input_info_1));
+
+  // LPBQ weights require Conv2D lowering (1x1 filters) on NPU backends.
+  // QNN Conv2D supports LPBQ (blockwise expansion) on the filter channel axis (axis 3 in HWCN format).
+  // This check must come before the FullyConnected logic so that LPBQ weights are never routed to FC.
+  // input_0 must be rank >= 2 so that we can identify the M (width) and K (channel) dimensions.
+  use_conv2d = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+               input_info_1.quant_param.IsLPBQ() &&
+               input_info_1.shape.size() == 2 &&
+               input_info_1.is_initializer &&
+               input_info_0.shape.size() >= 2;
 
 #if QNN_API_VERSION_MAJOR >= 2 && QNN_API_VERSION_MINOR <= 20
   // Validation crashes if use QNN FullyConnected in QNN SDK versions 2.26 - 2.27
@@ -130,35 +144,51 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
                                                  !input_info_0.is_initializer &&
                                                  IsQuant16bit(input_info_1.qnn_data_type) &&
                                                  !input_info_1.is_initializer);
+  // Don't use FullyConnected for LPBQ weights
+  use_fully_connected = use_fully_connected && !use_conv2d;
 #endif
   return Ort::Status();
 }
 
-// Process input[0] for ONNX MatMul that can be translated to either a QNN MatMul or a QNN FullyConnected.
+// Process input[0] for ONNX MatMul lowered to QNN MatMul, FullyConnected, or Conv2D.
+// A Reshape node (or reshaped initializer) is inserted when any of the following is true:
+//   1. is_rank1:          input is rank-1 (reshaped to [1, K] for MatMul/FC compatibility).
+//   2. shape_mismatch:    target_shape is provided and differs from the current shape
+//                         (used by the Conv2D path to produce 4D NHWC layout).
+//   3. use_fully_connected && rank > 2: leading dims are flattened to a single batch dim
+//                         so QNN FullyConnected receives a 2D input.
+// Note: target_shape and use_fully_connected are mutually exclusive - the Conv2D path
+// always passes target_shape and never sets use_fully_connected.
 Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
                           const TensorInfo& input_0_info,
                           const std::string& original_input_0_name,
                           std::vector<std::string>& input_names,
                           const Ort::Logger& logger,
                           bool do_op_validation,
-                          bool use_fully_connected) {
+                          bool use_fully_connected,
+                          const std::vector<uint32_t>* target_shape = nullptr) {
+  // use_fully_connected and target_shape (conv2d path) are mutually exclusive
+  assert(!(use_fully_connected && target_shape != nullptr));
   const bool is_rank1 = input_0_info.shape.size() == 1;
-  const bool reshape_input_0 = is_rank1 || (use_fully_connected && input_0_info.shape.size() > 2);
+  const bool shape_mismatch = (target_shape != nullptr && input_0_info.shape != *target_shape);
+  const bool reshape_input_0 = is_rank1 || shape_mismatch || (use_fully_connected && input_0_info.shape.size() > 2);
   std::string actual_input_0_name = original_input_0_name;
 
   if (reshape_input_0) {
     actual_input_0_name = utils::UniqueNameGenerator().New(original_input_0_name, "_reshape");
-    std::vector<uint32_t> shape_2d;
-    if (is_rank1) {
-      shape_2d = {1, input_0_info.shape[0]};
+    std::vector<uint32_t> reshape_target;
+    if (shape_mismatch) {
+      reshape_target = *target_shape;
+    } else if (is_rank1) {
+      reshape_target = {1, input_0_info.shape[0]};
     } else {
       uint32_t batch = 0;
       RETURN_IF_ERROR(FlattenLeadingDims(input_0_info.shape, batch));
-      shape_2d = {batch, input_0_info.shape.back()};
+      reshape_target = {batch, input_0_info.shape.back()};
     }
-    QnnQuantParamsWrapper quant_param_2d = input_0_info.quant_param.Copy();
-    if (is_rank1) {
-      RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_0_info.shape, shape_2d));
+    QnnQuantParamsWrapper quant_param_reshaped = input_0_info.quant_param.Copy();
+    if (is_rank1 || shape_mismatch) {
+      RETURN_IF_ERROR(quant_param_reshaped.HandleUnsqueeze<uint32_t>(input_0_info.shape, reshape_target));
     }
 
     // If input_0 is initializer, unpack it and add the tensor with new quantization parameter and shape.
@@ -167,13 +197,13 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
       std::vector<uint8_t> unpacked_tensor;
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_0_info.initializer_tensor, unpacked_tensor));
       QnnTensorWrapper input_tensorwrapper(actual_input_0_name, QNN_TENSOR_TYPE_STATIC, input_0_info.qnn_data_type,
-                                           std::move(quant_param_2d), std::move(shape_2d), std::move(unpacked_tensor));
+                                           std::move(quant_param_reshaped), std::move(reshape_target), std::move(unpacked_tensor));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
     } else {
       RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(original_input_0_name, actual_input_0_name,
-                                                       input_0_info.shape, shape_2d,
+                                                       input_0_info.shape, reshape_target,
                                                        input_0_info.qnn_data_type, input_0_info.quant_param,
-                                                       quant_param_2d, do_op_validation,
+                                                       quant_param_reshaped, do_op_validation,
                                                        qnn_model_wrapper.IsGraphInput(original_input_0_name), false));
     }
   } else {
@@ -192,12 +222,13 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
 }  // namespace
 
 /**
- * An ONNX MatMul can be translated to either a QNN MatMul or a QNN FullyConnected.
+ * An ONNX MatMul can be translated to either a QNN MatMul, a QNN FullyConnected, or a QNN Conv2D.
  * ONNX's MatMul supports inputs of rank 1, but neither QNN's MatMul nor FullyConnected support two rank 1 inputs.
  * So, we need to add Reshape Ops if necessary.
  * In two cases, FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op:
  * 1. input_1 is a rank 2 initializer.
  * 2. input_1 is a rank 1 tensor.
+ * For LPBQ-quantized weights on NPU backends, Conv2D with 1x1 filters is used instead of MatMul.
  */
 class MatMulOpBuilder : public BaseOpBuilder {
  public:
@@ -230,6 +261,13 @@ class MatMulOpBuilder : public BaseOpBuilder {
                                                 const Ort::Logger& logger,
                                                 std::vector<std::string>& input_names,
                                                 bool do_op_validation) const ORT_MUST_USE_RESULT;
+  Ort::Status ProcessInputsForQnnConv2D(QnnModelWrapper& qnn_model_wrapper,
+                                        const OrtNodeUnit& node_unit,
+                                        const TensorInfo& input_info_0,
+                                        const TensorInfo& input_info_1,
+                                        const Ort::Logger& logger,
+                                        std::vector<std::string>& input_names,
+                                        bool do_op_validation) const ORT_MUST_USE_RESULT;
   // Block-quantized (BW_FLOAT_BLOCK) weight path. Translates to a QNN MatMul whose weight carries a
   // per-block float scale; activation is dequantized to FP16 and the FP16 output is re-quantized to INT16.
   Ort::Status ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
@@ -240,7 +278,7 @@ class MatMulOpBuilder : public BaseOpBuilder {
 };
 
 // Process operator inputs. Dispatches to other processing functions depending on whether we're
-// translating an ONNX MatMul to a QNN MatMul or a QNN FullyConnected.
+// translating an ONNX MatMul to a QNN MatMul, a QNN FullyConnected, or a QNN Conv2D.
 Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
                                            const Ort::Logger& logger, std::vector<std::string>& input_names,
                                            bool do_op_validation) const {
@@ -249,15 +287,25 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
   TensorInfo input_info_0{};
   TensorInfo input_info_1{};
   bool use_fully_connected = false;
+  bool use_conv2d = false;
   RETURN_IF_ERROR(
-      CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1, use_fully_connected));
+      CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1,
+                  use_fully_connected, use_conv2d));
 
   // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight.
   if (IsBQWeight(qnn_model_wrapper, inputs[1]) && !input_info_1.quant_param.IsLPBQ()) {
     return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
   }
 
-  if (use_fully_connected) {
+  if (use_conv2d) {
+    return ProcessInputsForQnnConv2D(qnn_model_wrapper,
+                                     node_unit,
+                                     input_info_0,
+                                     input_info_1,
+                                     logger,
+                                     input_names,
+                                     do_op_validation);
+  } else if (use_fully_connected) {
     return ProcessInputsForQnnFullyConnected(qnn_model_wrapper,
                                              node_unit,
                                              input_info_0,
@@ -265,14 +313,15 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
                                              logger,
                                              input_names,
                                              do_op_validation);
+  } else {
+    return ProcessInputsForQnnMatMul(qnn_model_wrapper,
+                                     node_unit,
+                                     input_info_0,
+                                     input_info_1,
+                                     logger,
+                                     input_names,
+                                     do_op_validation);
   }
-  return ProcessInputsForQnnMatMul(qnn_model_wrapper,
-                                   node_unit,
-                                   input_info_0,
-                                   input_info_1,
-                                   logger,
-                                   input_names,
-                                   do_op_validation);
 }
 
 Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_model_wrapper,
@@ -500,6 +549,91 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   return Ort::Status();
 }
 
+// Lowers an ONNX MatMul with LPBQ-quantized weight to a QNN Conv2D with 1x1 filters.
+//
+// Activation reshape:
+//   2D: [M, K]       -> [1, 1, M, K]  (NHWC)
+//   3D: [B, M, K]    -> [B, 1, M, K]  (NHWC)
+//   4D: [B, C, M, K] -> no change
+// Weight unsqueeze:
+//   [K, N] -> [1, 1, K, N]  (HWCN; LPBQ axis 1->3)
+// Conv2D params: stride=[1,1], pad_amount=[[0,0],[0,0]].
+Ort::Status MatMulOpBuilder::ProcessInputsForQnnConv2D(QnnModelWrapper& qnn_model_wrapper,
+                                                       const OrtNodeUnit& node_unit,
+                                                       const TensorInfo& input_info_0,
+                                                       const TensorInfo& input_info_1,
+                                                       const Ort::Logger& logger,
+                                                       std::vector<std::string>& input_names,
+                                                       bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  const std::string& org_input_0_name = inputs[0].name;
+  const std::string& org_input_1_name = inputs[1].name;
+
+  // Reshape input[0] to 4D NHWC based on input rank.
+  //   2D: [M, K]       -> [1, 1, M, K]
+  //   3D: [B, M, K]    -> [B, 1, M, K]
+  //   4D: [B, C, M, K] -> no change
+  {
+    const auto& shape = input_info_0.shape;
+    std::vector<uint32_t> conv_input_shape;
+    if (shape.size() == 2) {
+      conv_input_shape = {1, 1, shape[0], shape[1]};
+    } else if (shape.size() == 3) {
+      conv_input_shape = {shape[0], 1, shape[1], shape[2]};
+    } else if (shape.size() == 4) {
+      conv_input_shape = shape;
+    } else {
+      return MAKE_EP_FAIL("LPBQ Conv2D lowering only supports activation rank 2, 3, or 4.");
+    }
+    RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_info_0, org_input_0_name, input_names,
+                                  logger, do_op_validation, /*use_fully_connected=*/false, &conv_input_shape));
+  }
+
+  // Unsqueeze input[1] [K, N] -> [1, 1, K, N] (HWCN)
+  // The LPBQ encoding axis is on the N (output-channel) dimension:
+  // Axis 1 in [K, N]  ->  axis 3 in [1, 1, K, N]
+  {
+    // CheckInputs already checks the rank for input[1] for Conv2D. This check is just for any future refactoring guard.
+    RETURN_IF_NOT(input_info_1.shape.size() == 2, "LPBQ Conv2D lowering requires weight to be rank-2 [K, N]");
+    const uint32_t K = input_info_1.shape[0];
+    const uint32_t N = input_info_1.shape[1];
+
+    std::vector<uint32_t> conv_weight_shape = {1, 1, K, N};
+    QnnQuantParamsWrapper conv_weight_quant = input_info_1.quant_param.Copy();
+    RETURN_IF_ERROR(conv_weight_quant.HandleUnsqueeze<uint32_t>(input_info_1.shape, conv_weight_shape));
+
+    const std::string conv_weight_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
+
+    RETURN_IF_NOT(input_info_1.is_initializer, "LPBQ Conv2D lowering requires weight to be static initializer");
+    std::vector<uint8_t> unpacked_tensor;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info_1.initializer_tensor, unpacked_tensor));
+
+    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(org_input_1_name);
+    QnnTensorWrapper weight_tensorwrapper(conv_weight_name, tensor_type, input_info_1.qnn_data_type,
+                                          std::move(conv_weight_quant), std::move(conv_weight_shape),
+                                          std::move(unpacked_tensor));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensorwrapper)),
+                  "Failed to add Conv2D weight tensor.");
+    input_names.emplace_back(conv_weight_name);
+  }
+
+#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 16 && QNN_API_VERSION_MINOR <= 18)
+  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    // Bias is implicit. QNN SDK 2.23/2.24/2.25 (QNN API version 2.16/2.17/2.18) has a validation bug for
+    // implicit bias inputs, so provide an explicit bias of all 0 (quantized int32).
+
+    if (input_info_0.quant_param.IsPerTensor(/*include_bw*/ true) && input_info_1.quant_param.IsQuantized()) {
+      const std::string bias_name = qnn::utils::UniqueNameGenerator().New(node_unit, "_implicit_bias");
+      std::vector<uint32_t> bias_shape = {input_info_1.shape[0]};
+      RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, input_info_0.quant_param, input_info_1.quant_param,
+                                       std::move(bias_shape), bias_name, logger, input_names));
+    }
+  }
+#endif
+
+  return Ort::Status();
+}
+
 Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
                                                       const OrtNodeUnit& node_unit,
                                                       const Ort::Logger& logger,
@@ -680,8 +814,11 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   TensorInfo input_info_0{};
   TensorInfo input_info_1{};
   bool use_fully_connected = false;
+  bool use_conv2d = false;
+  std::string qnn_op_type;
   RETURN_IF_ERROR(
-      CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1, use_fully_connected));
+      CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1,
+                  use_fully_connected, use_conv2d));
 
   // A block-quantized weight is always emitted as a QNN MatMul (see ProcessInputsForBQMatMul), even
   // when CheckInputs would otherwise route a rank-2 initializer weight to FullyConnected. Force the
@@ -692,12 +829,35 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   bool reshape_input_0 = input_info_0.shape.size() == 1;
   bool reshape_input_1 = input_info_1.shape.size() == 1;
-  bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2);
+  bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2) ||
+                        (use_conv2d && input_info_0.shape.size() < 4);
 
-  // For QNN MatMul: set the input transpose parameters to their default values of 0. These parameters should be
-  // optional, but older versions of QNN SDK failed validation if not explicitly provided.
   std::vector<std::string> param_tensor_names;
-  if (!use_fully_connected) {
+  if (use_conv2d) {
+    qnn_op_type = QNN_OP_CONV_2D;
+    // Conv2D params: stride=[1,1], pad_amount=[[0,0],[0,0]], dilation=[1,1], group=1
+    QnnParamWrapper stride_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_STRIDE, {2}, {1, 1});
+    param_tensor_names.push_back(stride_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(stride_param));
+
+    QnnParamWrapper pad_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, {2, 2}, {0, 0, 0, 0});
+    param_tensor_names.push_back(pad_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(pad_param));
+
+    QnnParamWrapper dilation_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_DILATION, {2}, {1, 1});
+    param_tensor_names.push_back(dilation_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(dilation_param));
+
+    Qnn_Scalar_t group_scalar = QNN_SCALAR_INIT;
+    group_scalar.dataType = QNN_DATATYPE_UINT_32;
+    group_scalar.uint32Value = 1;
+    QnnParamWrapper group_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_GROUP, group_scalar);
+    param_tensor_names.push_back(group_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(group_param));
+  } else if (use_fully_connected) {
+    qnn_op_type = QNN_OP_FULLY_CONNECTED;
+  } else {
+    qnn_op_type = QNN_OP_MAT_MUL;
     RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
                                        QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, param_tensor_names));
     RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
@@ -712,11 +872,16 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   QnnQuantParamsWrapper op_output_quant_param = output_info.quant_param.Copy();
   if (reshape_output) {
     op_output_name = utils::UniqueNameGenerator().New(org_output_name, "_reshape");
-    if (use_fully_connected && input_info_0.shape.size() > 2) {
+    if (use_conv2d) {
+      op_output_shape.insert(op_output_shape.end() - 2, 1);
+      if (op_output_shape.size() < 4)
+        op_output_shape.insert(op_output_shape.begin(), 1);
+      RETURN_IF_ERROR(op_output_quant_param.HandleUnsqueeze<uint32_t>(output_info.shape, op_output_shape));
+    } else if (use_fully_connected && input_info_0.shape.size() > 2) {
       uint32_t batch = 0;
       RETURN_IF_ERROR(FlattenLeadingDims(input_info_0.shape, batch));
       op_output_shape = {batch, reshape_input_1 ? 1 : input_info_1.shape.back()};
-      RETURN_IF(op_output_quant_param.IsPerChannel(), "QNN MatMul output does not support per-channel quant.");
+      RETURN_IF(op_output_quant_param.IsPerChannel(), "QNN FC output does not support per-channel quant.");
     } else {
       // If both inputs are 1D tensors, the output shape is [1] instead of scalar. So if both inputs are 1D tensors,
       // we only need to add one "1" to the op_output_shape.
@@ -791,8 +956,8 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                               op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(op_output_tensor_wrapper)),
                   "Failed to add output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit), QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  use_fully_connected ? QNN_OP_FULLY_CONNECTED : QNN_OP_MAT_MUL,
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW, qnn_op_type,
                                                   std::move(input_names), {op_output_name},
                                                   std::move(param_tensor_names), do_op_validation),
                   "Failed to add fused Matmul node.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include <functional>

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include <functional>

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -780,7 +780,6 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_BlockQuant) {
   RunQDQBlockQuantMatMulOpTest<int16_t, Int4x2, int16_t>({4, 128}, {128, 64}, 64, 0, QDQTolerance(0.05f));
   RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({2, 4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
   RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({2, 3, 4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
-  RunQDQBlockQuantMatMulOpTest<uint16_t, int8_t, uint16_t>({4, 32}, {32, 16}, 16, 0, QDQTolerance(), ExpectedEPNodeAssignment::None);
 }
 
 #endif  // defined(__linux__)

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -310,6 +310,7 @@ static void RunQDQBlockQuantMatMulOpTest(
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_block_quant_weight_optimization"] = "1";
 
   const size_t num_input_elems = static_cast<size_t>(
       std::accumulate(shape_input.begin(), shape_input.end(), static_cast<int64_t>(1), std::multiplies<int64_t>()));

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -782,7 +782,7 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_BlockQuant) {
   RunQDQBlockQuantMatMulOpTest<uint16_t, int8_t, uint16_t>({4, 32}, {32, 16}, 16, 0, QDQTolerance(), ExpectedEPNodeAssignment::None);
 }
 
-#endif // defined(__linux__)
+#endif  // defined(__linux__)
 
 #if defined(_M_ARM64)
 //

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -224,6 +224,108 @@ static void RunQDQPerChannelMatMulOpTest(
                        provider_options, opset, expected_ep_assignment, tolerance);
 }
 
+/// Returns a function that creates a graph with a block-quantized (BQ) weight MatMul operator.
+template <typename Input0QType, typename WeightQType, typename OutputQType>
+static GetTestQDQModelFn<OutputQType> BuildQDQBlockQuantMatMulTestCase(
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weights_def,
+    int64_t block_size,
+    int64_t weight_quant_axis,
+    bool use_contrib_qdq = false) {
+  return [input_def, weights_def, block_size, weight_quant_axis, use_contrib_qdq](
+             ModelTestBuilder& builder, std::vector<QuantParams<OutputQType>>& output_qparams) {
+    QNN_ASSERT(weights_def.IsInitializer() && weights_def.IsRawData());
+
+    // input -> Q/DQ -> input_qdq
+    MakeTestInput<float>(builder, "input", input_def);
+    const QuantParams<Input0QType> input_qparams = GetTestInputQuantParams<Input0QType>(input_def);
+    const std::string input_qdq = AddQDQNodePair<Input0QType>(
+        builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point, use_contrib_qdq);
+
+    // Compute per-block quantization parameters (symmetric)
+    const auto& weight_shape = weights_def.GetShape();
+    int64_t pos_weight_quant_axis = weight_quant_axis;
+    if (pos_weight_quant_axis < 0) {
+      pos_weight_quant_axis += static_cast<int64_t>(weight_shape.size());
+    }
+
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zero_points;
+    GetTestInputQuantParamsBlockQuant<WeightQType>(weights_def, weight_scales, weight_zero_points,
+                                                   block_size, pos_weight_quant_axis, true);
+
+    // Quantize weight data with per-block params
+    const size_t num_weight_elems = SizeOfShape(weight_shape);
+    size_t num_weight_storage_elems = num_weight_elems;
+    if constexpr (std::is_same_v<WeightQType, Int4x2> || std::is_same_v<WeightQType, UInt4x2>) {
+      num_weight_storage_elems = Int4x2::CalcNumInt4Pairs(num_weight_elems);
+    }
+    std::vector<WeightQType> quantized_weights(num_weight_storage_elems);
+    QuantizeValuesBlockQuant<float, WeightQType>(
+        weights_def.GetRawData(), quantized_weights, weight_shape,
+        weight_scales, weight_zero_points, block_size, pos_weight_quant_axis);
+
+    builder.MakeInitializer<WeightQType>("weights", weight_shape, quantized_weights);
+
+    // Compute 2D scale shape: [num_blocks, non_axis_dim] for axis=0
+    //                          [non_axis_dim, num_blocks] for axis=1
+    const int64_t axis_dim = weight_shape[static_cast<size_t>(pos_weight_quant_axis)];
+    const int64_t non_axis_dim = weight_shape[static_cast<size_t>(1 - pos_weight_quant_axis)];
+    const int64_t num_blocks = (axis_dim + block_size - 1) / block_size;
+    const std::vector<int64_t> scale_shape = (pos_weight_quant_axis == 0)
+                                                 ? std::vector<int64_t>{num_blocks, non_axis_dim}
+                                                 : std::vector<int64_t>{non_axis_dim, num_blocks};
+
+    builder.MakeInitializer<float>("weights_scale", scale_shape, weight_scales);
+    builder.MakeInitializer<WeightQType>("weights_zp", scale_shape, weight_zero_points);
+
+    // weights -> DQ -> weights_dq (with block_size and axis attributes)
+    builder.AddNode("weights_dq", "DequantizeLinear",
+                    {"weights", "weights_scale", "weights_zp"},
+                    {"weights_dq"},
+                    "",
+                    {builder.MakeScalarAttribute("axis", weight_quant_axis),
+                     builder.MakeScalarAttribute("block_size", block_size)});
+
+    // MatMul(input_qdq, weights_dq) -> Y
+    builder.AddNode("MatMul", "MatMul", {input_qdq, "weights_dq"}, {"Y"}, kOnnxDomain);
+
+    // Y -> Q -> DQ -> (graph output)
+    AddQDQNodePairWithOutputAsGraphOutput<OutputQType>(builder, "qdq_out", "Y",
+                                                       output_qparams[0].scale, output_qparams[0].zero_point,
+                                                       use_contrib_qdq);
+  };
+}
+
+template <typename InputQType, typename WeightQType, typename OutputQType>
+static void RunQDQBlockQuantMatMulOpTest(
+    const std::vector<int64_t>& shape_input,
+    const std::vector<int64_t>& shape_weight,
+    int64_t block_size,
+    int64_t weight_quant_axis,
+    QDQTolerance tolerance = QDQTolerance(),
+    ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
+    int opset = 21,
+    bool use_contrib_qdq = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  const size_t num_input_elems = static_cast<size_t>(
+      std::accumulate(shape_input.begin(), shape_input.end(), static_cast<int64_t>(1), std::multiplies<int64_t>()));
+  const size_t num_weight_elems = static_cast<size_t>(
+      std::accumulate(shape_weight.begin(), shape_weight.end(), static_cast<int64_t>(1), std::multiplies<int64_t>()));
+
+  TestInputDef<float> input_def(shape_input, false, GetFloatDataInRange(-0.1f, 0.1f, num_input_elems));
+  TestInputDef<float> weight_def(shape_weight, true, GetFloatDataInRange(-0.1f, 0.1f, num_weight_elems));
+
+  TestQDQModelAccuracy(
+      BuildMatMulOpTestCase(input_def, weight_def),
+      BuildQDQBlockQuantMatMulTestCase<InputQType, WeightQType, OutputQType>(
+          input_def, weight_def, block_size, weight_quant_axis, use_contrib_qdq),
+      provider_options, opset, expected_ep_assignment, tolerance);
+}
+
 //
 // CPU tests:
 //
@@ -666,6 +768,21 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_static_weight) {
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+#if defined(__linux__)
+
+// Tests MatMul with ONNX block-quantized (BQ) weight using the BQ -> QNN LPBQ conversion path.
+// Currently BQ -> LPBQ conversion is only supported on Linux. It will be later enabled for windows as well.
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_BlockQuant) {
+  RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
+  RunQDQBlockQuantMatMulOpTest<int16_t, Int4x2, int16_t>({4, 128}, {128, 64}, 32, 0, QDQTolerance(0.05f));
+  RunQDQBlockQuantMatMulOpTest<int16_t, Int4x2, int16_t>({4, 128}, {128, 64}, 64, 0, QDQTolerance(0.05f));
+  RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({2, 4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
+  RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({2, 3, 4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
+  RunQDQBlockQuantMatMulOpTest<uint16_t, int8_t, uint16_t>({4, 32}, {32, 16}, 16, 0, QDQTolerance(), ExpectedEPNodeAssignment::None);
+}
+
+#endif // defined(__linux__)
 
 #if defined(_M_ARM64)
 //

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -656,30 +656,30 @@ static void GetTestInputQuantParamsBlockQuant(
 }
 
 // Specialization for Int4x2/UInt4x2: zero_points are packed
-#define DEF_GET_INPUT_QPARAMS_BLOCK_QUANT_INT4_FUNC(INT4x2_TYPE)                                                  \
-  template <>                                                                                                     \
-  inline void GetTestInputQuantParamsBlockQuant<INT4x2_TYPE>(const TestInputDef<float>& input_def,                \
-                                                             std::vector<float>& scales,                          \
-                                                             std::vector<INT4x2_TYPE>& zero_points,               \
-                                                             int64_t block_size, int64_t axis, bool symmetric) {  \
-    using UnpackedType = typename INT4x2_TYPE::UnpackedType;                                                      \
-    const auto f32_ranges = input_def.GetRangePerBlock(block_size, axis);                                         \
-    const size_t num_ranges = f32_ranges.size();                                                                  \
-                                                                                                                  \
-    scales.resize(num_ranges);                                                                                    \
-    zero_points.resize(INT4x2_TYPE::CalcNumInt4Pairs(num_ranges));                                                \
-                                                                                                                  \
-    for (size_t i = 0; i < num_ranges; i++) {                                                                     \
-      const auto& range = f32_ranges[i];                                                                          \
-      QuantParams<UnpackedType> params = QuantParams<UnpackedType>::Compute(range.first, range.second,            \
-                                                                            INT4x2_TYPE::min_val,                 \
-                                                                            INT4x2_TYPE::max_val, symmetric);     \
-      scales[i] = params.scale;                                                                                   \
-                                                                                                                  \
-      size_t r = i >> 1;                                                                                          \
-      size_t c = i & 0x1;                                                                                         \
-      zero_points[r].SetElem(c, params.zero_point);                                                               \
-    }                                                                                                             \
+#define DEF_GET_INPUT_QPARAMS_BLOCK_QUANT_INT4_FUNC(INT4x2_TYPE)                                                 \
+  template <>                                                                                                    \
+  inline void GetTestInputQuantParamsBlockQuant<INT4x2_TYPE>(const TestInputDef<float>& input_def,               \
+                                                             std::vector<float>& scales,                         \
+                                                             std::vector<INT4x2_TYPE>& zero_points,              \
+                                                             int64_t block_size, int64_t axis, bool symmetric) { \
+    using UnpackedType = typename INT4x2_TYPE::UnpackedType;                                                     \
+    const auto f32_ranges = input_def.GetRangePerBlock(block_size, axis);                                        \
+    const size_t num_ranges = f32_ranges.size();                                                                 \
+                                                                                                                 \
+    scales.resize(num_ranges);                                                                                   \
+    zero_points.resize(INT4x2_TYPE::CalcNumInt4Pairs(num_ranges));                                               \
+                                                                                                                 \
+    for (size_t i = 0; i < num_ranges; i++) {                                                                    \
+      const auto& range = f32_ranges[i];                                                                         \
+      QuantParams<UnpackedType> params = QuantParams<UnpackedType>::Compute(range.first, range.second,           \
+                                                                            INT4x2_TYPE::min_val,                \
+                                                                            INT4x2_TYPE::max_val, symmetric);    \
+      scales[i] = params.scale;                                                                                  \
+                                                                                                                 \
+      size_t r = i >> 1;                                                                                         \
+      size_t c = i & 0x1;                                                                                        \
+      zero_points[r].SetElem(c, params.zero_point);                                                              \
+    }                                                                                                            \
   }
 
 DEF_GET_INPUT_QPARAMS_BLOCK_QUANT_INT4_FUNC(Int4x2)
@@ -766,7 +766,7 @@ inline void QuantizeValuesBlockQuant<float, Int4x2>(
 
       const float q_unclamped = RoundHalfToEven(val / scale) + static_cast<float>(zp);
       const float q_clamped = std::min(static_cast<float>(Int4x2::max_val),
-                                        std::max(static_cast<float>(Int4x2::min_val), q_unclamped));
+                                       std::max(static_cast<float>(Int4x2::min_val), q_unclamped));
       const auto [out_pair_idx, out_elem_idx] = Int4x2::GetTensorElemIndices(elem_idx);
       output[out_pair_idx].SetElem(out_elem_idx, static_cast<int8_t>(q_clamped));
     }
@@ -814,7 +814,7 @@ inline void QuantizeValuesBlockQuant<float, UInt4x2>(
 
       const float q_unclamped = RoundHalfToEven(val / scale) + static_cast<float>(zp);
       const float q_clamped = std::min(static_cast<float>(UInt4x2::max_val),
-                                        std::max(static_cast<float>(UInt4x2::min_val), q_unclamped));
+                                       std::max(static_cast<float>(UInt4x2::min_val), q_unclamped));
       const auto [out_pair_idx, out_elem_idx] = UInt4x2::GetTensorElemIndices(elem_idx);
       output[out_pair_idx].SetElem(out_elem_idx, static_cast<uint8_t>(q_clamped));
     }

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -352,6 +352,49 @@ struct TestInputDef {
     return per_axis_ranges;
   }
 
+  std::vector<std::pair<T, T>> GetRangePerBlock(int64_t block_size, int64_t axis) const {
+    QNN_ASSERT(shape_.size() >= 2);
+    QNN_ASSERT(axis == 0 || axis == 1);
+    QNN_ASSERT(block_size > 0);
+
+    const int64_t axis_dim = shape_[static_cast<size_t>(axis)];
+    const int64_t non_axis_dim = shape_[static_cast<size_t>(1 - axis)];
+    const int64_t num_blocks = (axis_dim + block_size - 1) / block_size;
+    const size_t num_ranges = static_cast<size_t>(num_blocks * non_axis_dim);
+
+    // Random data: all blocks share the same range.
+    if (data_info_.index() == 1) {
+      RandomData rand_info = std::get<RandomData>(data_info_);
+      return std::vector<std::pair<T, T>>(num_ranges, std::pair<T, T>(rand_info.min, rand_info.max));
+    }
+
+    // Raw data: compute min/max per (block, channel) pair.
+    const std::vector<T>& raw_data = std::get<RawData>(data_info_).data;
+    const int64_t N = shape_[1];  // stride for row-major 2D indexing
+    std::pair<T, T> init_range(std::numeric_limits<T>::max(), std::numeric_limits<T>::lowest());
+    std::vector<std::pair<T, T>> per_block_ranges(num_ranges, init_range);
+
+    for (int64_t b = 0; b < num_blocks; ++b) {
+      const int64_t block_start = b * block_size;
+      const int64_t block_end = std::min(block_start + block_size, axis_dim);
+
+      for (int64_t c = 0; c < non_axis_dim; ++c) {
+        const int64_t range_idx = (axis == 0) ? (b * non_axis_dim + c) : (c * num_blocks + b);
+        std::pair<T, T>& range = per_block_ranges[static_cast<size_t>(range_idx)];
+
+        for (int64_t i = block_start; i < block_end; ++i) {
+          const int64_t row = (axis == 0) ? i : c;
+          const int64_t col = (axis == 0) ? c : i;
+          T val = raw_data[static_cast<size_t>(row * N + col)];
+          range.first = std::min(range.first, val);
+          range.second = std::max(range.second, val);
+        }
+      }
+    }
+
+    return per_block_ranges;
+  }
+
   bool IsOptional() const {
     return is_optional_;
   }
@@ -589,6 +632,193 @@ inline void QuantizeValues<float, UInt4x2>(gsl::span<const float> input,
     }
   }
   QNN_ASSERT(i == (block_count * broadcast_dim * block_size));
+}
+
+// Computes per-block quantization parameters for a weight tensor.
+template <typename QType>
+static void GetTestInputQuantParamsBlockQuant(
+    const TestInputDef<float>& input_def,
+    std::vector<float>& scales,
+    std::vector<QType>& zero_points,
+    int64_t block_size,
+    int64_t axis,
+    bool symmetric = true) {
+  const auto f32_ranges = input_def.GetRangePerBlock(block_size, axis);
+
+  scales.reserve(f32_ranges.size());
+  zero_points.reserve(f32_ranges.size());
+
+  for (const auto& range : f32_ranges) {
+    QuantParams<QType> params = QuantParams<QType>::Compute(range.first, range.second, symmetric);
+    scales.push_back(params.scale);
+    zero_points.push_back(params.zero_point);
+  }
+}
+
+// Specialization for Int4x2/UInt4x2: zero_points are packed
+#define DEF_GET_INPUT_QPARAMS_BLOCK_QUANT_INT4_FUNC(INT4x2_TYPE)                                                  \
+  template <>                                                                                                     \
+  inline void GetTestInputQuantParamsBlockQuant<INT4x2_TYPE>(const TestInputDef<float>& input_def,                \
+                                                             std::vector<float>& scales,                          \
+                                                             std::vector<INT4x2_TYPE>& zero_points,               \
+                                                             int64_t block_size, int64_t axis, bool symmetric) {  \
+    using UnpackedType = typename INT4x2_TYPE::UnpackedType;                                                      \
+    const auto f32_ranges = input_def.GetRangePerBlock(block_size, axis);                                         \
+    const size_t num_ranges = f32_ranges.size();                                                                  \
+                                                                                                                  \
+    scales.resize(num_ranges);                                                                                    \
+    zero_points.resize(INT4x2_TYPE::CalcNumInt4Pairs(num_ranges));                                                \
+                                                                                                                  \
+    for (size_t i = 0; i < num_ranges; i++) {                                                                     \
+      const auto& range = f32_ranges[i];                                                                          \
+      QuantParams<UnpackedType> params = QuantParams<UnpackedType>::Compute(range.first, range.second,            \
+                                                                            INT4x2_TYPE::min_val,                 \
+                                                                            INT4x2_TYPE::max_val, symmetric);     \
+      scales[i] = params.scale;                                                                                   \
+                                                                                                                  \
+      size_t r = i >> 1;                                                                                          \
+      size_t c = i & 0x1;                                                                                         \
+      zero_points[r].SetElem(c, params.zero_point);                                                               \
+    }                                                                                                             \
+  }
+
+DEF_GET_INPUT_QPARAMS_BLOCK_QUANT_INT4_FUNC(Int4x2)
+DEF_GET_INPUT_QPARAMS_BLOCK_QUANT_INT4_FUNC(UInt4x2)
+
+// Quantizes a weight tensor using per-block scales.
+template <typename FloatType, typename QType>
+static void QuantizeValuesBlockQuant(
+    gsl::span<const FloatType> input,
+    std::vector<QType>& output,
+    const std::vector<int64_t>& shape,
+    const std::vector<float>& scales,
+    const std::vector<QType>& zero_points,
+    int64_t block_size,
+    int64_t axis) {
+  QNN_ASSERT(shape.size() >= 2);
+  QNN_ASSERT(axis == 0 || axis == 1);
+
+  const int64_t K = shape[0];
+  const int64_t N = shape[1];
+  const int64_t axis_dim = shape[static_cast<size_t>(axis)];
+  const int64_t non_axis_dim = shape[static_cast<size_t>(1 - axis)];
+  const int64_t num_blocks = (axis_dim + block_size - 1) / block_size;
+
+  const size_t num_elems = static_cast<size_t>(K * N);
+  QNN_ASSERT(input.size() == num_elems);
+  output.resize(num_elems);
+
+  const float qmin = static_cast<float>(std::numeric_limits<QType>::min());
+  const float qmax = static_cast<float>(std::numeric_limits<QType>::max());
+
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      const float val = static_cast<float>(input[static_cast<size_t>(k * N + n)]);
+      const int64_t b = (axis == 0) ? (k / block_size) : (n / block_size);
+      const int64_t c = (axis == 0) ? n : k;
+      const int64_t scale_idx = (axis == 0) ? (b * non_axis_dim + c) : (c * num_blocks + b);
+      const float scale = scales[static_cast<size_t>(scale_idx)];
+      const QType zp = zero_points.empty() ? static_cast<QType>(0) : zero_points[static_cast<size_t>(scale_idx)];
+      const float q_unclamped = RoundHalfToEven(val / scale) + static_cast<float>(zp);
+      output[static_cast<size_t>(k * N + n)] = static_cast<QType>(std::min(qmax, std::max(qmin, q_unclamped)));
+    }
+  }
+}
+
+// Specialization for Int4x2: packed output, max_val = 7, min_val = -8.
+template <>
+inline void QuantizeValuesBlockQuant<float, Int4x2>(
+    gsl::span<const float> input,
+    std::vector<Int4x2>& output,
+    const std::vector<int64_t>& shape,
+    const std::vector<float>& scales,
+    const std::vector<Int4x2>& zero_points,
+    int64_t block_size,
+    int64_t axis) {
+  QNN_ASSERT(shape.size() >= 2);
+  QNN_ASSERT(axis == 0 || axis == 1);
+
+  const int64_t K = shape[0];
+  const int64_t N = shape[1];
+  const int64_t axis_dim = shape[static_cast<size_t>(axis)];
+  const int64_t non_axis_dim = shape[static_cast<size_t>(1 - axis)];
+  const int64_t num_blocks = (axis_dim + block_size - 1) / block_size;
+
+  const size_t num_elems = static_cast<size_t>(K * N);
+  QNN_ASSERT(input.size() == num_elems);
+  output.resize(Int4x2::CalcNumInt4Pairs(num_elems));
+  std::fill(output.begin(), output.end(), Int4x2{});
+
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      const size_t elem_idx = static_cast<size_t>(k * N + n);
+      const float val = input[elem_idx];
+      const int64_t b = (axis == 0) ? (k / block_size) : (n / block_size);
+      const int64_t c = (axis == 0) ? n : k;
+      const int64_t scale_idx = (axis == 0) ? (b * non_axis_dim + c) : (c * num_blocks + b);
+      const float scale = scales[static_cast<size_t>(scale_idx)];
+
+      int8_t zp = 0;
+      if (!zero_points.empty()) {
+        const auto [zp_pair_idx, zp_elem_idx] = Int4x2::GetTensorElemIndices(static_cast<size_t>(scale_idx));
+        zp = zero_points[zp_pair_idx].GetElem(zp_elem_idx);
+      }
+
+      const float q_unclamped = RoundHalfToEven(val / scale) + static_cast<float>(zp);
+      const float q_clamped = std::min(static_cast<float>(Int4x2::max_val),
+                                        std::max(static_cast<float>(Int4x2::min_val), q_unclamped));
+      const auto [out_pair_idx, out_elem_idx] = Int4x2::GetTensorElemIndices(elem_idx);
+      output[out_pair_idx].SetElem(out_elem_idx, static_cast<int8_t>(q_clamped));
+    }
+  }
+}
+
+// Specialization for UInt4x2: packed output, max_val = 15, min_val = 0.
+template <>
+inline void QuantizeValuesBlockQuant<float, UInt4x2>(
+    gsl::span<const float> input,
+    std::vector<UInt4x2>& output,
+    const std::vector<int64_t>& shape,
+    const std::vector<float>& scales,
+    const std::vector<UInt4x2>& zero_points,
+    int64_t block_size,
+    int64_t axis) {
+  QNN_ASSERT(shape.size() >= 2);
+  QNN_ASSERT(axis == 0 || axis == 1);
+
+  const int64_t K = shape[0];
+  const int64_t N = shape[1];
+  const int64_t axis_dim = shape[static_cast<size_t>(axis)];
+  const int64_t non_axis_dim = shape[static_cast<size_t>(1 - axis)];
+  const int64_t num_blocks = (axis_dim + block_size - 1) / block_size;
+
+  const size_t num_elems = static_cast<size_t>(K * N);
+  QNN_ASSERT(input.size() == num_elems);
+  output.resize(UInt4x2::CalcNumInt4Pairs(num_elems));
+  std::fill(output.begin(), output.end(), UInt4x2{});
+
+  for (int64_t k = 0; k < K; ++k) {
+    for (int64_t n = 0; n < N; ++n) {
+      const size_t elem_idx = static_cast<size_t>(k * N + n);
+      const float val = input[elem_idx];
+      const int64_t b = (axis == 0) ? (k / block_size) : (n / block_size);
+      const int64_t c = (axis == 0) ? n : k;
+      const int64_t scale_idx = (axis == 0) ? (b * non_axis_dim + c) : (c * num_blocks + b);
+      const float scale = scales[static_cast<size_t>(scale_idx)];
+
+      uint8_t zp = 0;
+      if (!zero_points.empty()) {
+        const auto [zp_pair_idx, zp_elem_idx] = UInt4x2::GetTensorElemIndices(static_cast<size_t>(scale_idx));
+        zp = zero_points[zp_pair_idx].GetElem(zp_elem_idx);
+      }
+
+      const float q_unclamped = RoundHalfToEven(val / scale) + static_cast<float>(zp);
+      const float q_clamped = std::min(static_cast<float>(UInt4x2::max_val),
+                                        std::max(static_cast<float>(UInt4x2::min_val), q_unclamped));
+      const auto [out_pair_idx, out_elem_idx] = UInt4x2::GetTensorElemIndices(elem_idx);
+      output[out_pair_idx].SetElem(out_elem_idx, static_cast<uint8_t>(q_clamped));
+    }
+  }
 }
 
 // Refer to test_autoep_utils.h for leveraging unique pointer to unregister plugin EP.


### PR DESCRIPTION
### Description
Onnx MatMul op is lowered down into QNN Conv2D op with 1x1 weights when LPBQ encodings are present.



### Motivation and Context
HTP supports Conv2D with 1x1 weights for LPBQ encodings. The Matmul and FC op are either not fully supported or not performant on HTP. Hence, we are translating the Matmuls into Convolutions.

This PR depends on https://github.com/onnxruntime/onnxruntime-qnn/pull/307
