### PR TITLE
[QNN EP] Update workflow to run nightly on most recent release branch

### DIFF
--- a/.github/workflows/qualcomm-internal-release-nightly.yml
+++ b/.github/workflows/qualcomm-internal-release-nightly.yml
@@ -11,6 +11,7 @@ permissions:
 on:
   schedule:
     - cron: "0 9 * * *"  # Every day at 2am in San Diego/PDT (9am UTC)
+      branches: [main, rel-2.3.0]
 
 jobs:
   publish-artifacts:


### PR DESCRIPTION
This PR makes the change to run nightly on the most recent release branch