### PR TITLE
Re-enable failed UT for Linux aarch64 running on qcs6490

### DIFF
--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -103,6 +103,9 @@ TEST_F(QnnCPUBackendTests, MaxPool_Global) {
 
 TEST_F(QnnCPUBackendTests, MaxPool_Rank3) {
   QNN_SKIP_TEST_ON_AARCH64("Test not supported on Linux ARM64");
+  // TODO: [AISW-163150] QNN CPU backend produces incorrect rank-3 MaxPool results on Linux
+  // aarch64 (qcs6490) — verified by running the same DLC with qnn-net-run + CPU backend.
+  // Re-enable once the QNN CPU team fixes the backend bug; ORT QNN EP itself is not at fault.
   RunPoolOpTest("MaxPool",
                 TestInputDef<float>({1, 16, 120}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
                 {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),

--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -103,7 +103,7 @@ TEST_F(QnnCPUBackendTests, MaxPool_Global) {
 
 TEST_F(QnnCPUBackendTests, MaxPool_Rank3) {
   QNN_SKIP_TEST_ON_AARCH64("Test not supported on Linux ARM64");
-  // TODO: [AISW-163150] QNN CPU backend produces incorrect rank-3 MaxPool results on Linux
+  // TODO: QNN CPU backend produces incorrect rank-3 MaxPool results on Linux
   // aarch64 (qcs6490) — verified by running the same DLC with qnn-net-run + CPU backend.
   // Re-enable once the QNN CPU team fixes the backend bug; ORT QNN EP itself is not at fault.
   RunPoolOpTest("MaxPool",

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -568,7 +568,7 @@ TEST_F(QnnCPUBackendTests, QnnSaver_OutputFiles) {
   // QnnSaver writes flat to cwd on Linux aarch64 and to ./saver_output/ on Windows.
   const auto cwd = std::filesystem::current_path();
   const auto saver_dir = cwd / "saver_output";
-  auto find_saver_file = [&](const std::string& filename) -> bool {
+  auto find_saver_file = [&cwd, &saver_dir](const std::string& filename) -> bool {
     return std::filesystem::exists(cwd / filename) ||
            std::filesystem::exists(saver_dir / filename);
   };

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -564,21 +564,19 @@ TEST_F(QnnCPUBackendTests, QnnSaver_OutputFiles) {
                      TestBackend::Cpu,
                      TestBackend::Saver);
 
-  // Accept saver_output.c / params.bin anywhere in cwd or one level of subdirectory.
+  // Accept saver_output.c / params.bin in flat cwd or in ./saver_output/ subdirectory.
   // QnnSaver writes flat to cwd on Linux aarch64 and to ./saver_output/ on Windows.
   const auto cwd = std::filesystem::current_path();
+  const auto saver_dir = cwd / "saver_output";
   auto find_saver_file = [&](const std::string& filename) -> bool {
-    if (std::filesystem::exists(cwd / filename)) return true;
-    for (const auto& entry : std::filesystem::directory_iterator(cwd)) {
-      if (entry.is_directory() && std::filesystem::exists(entry.path() / filename)) return true;
-    }
-    return false;
+    return std::filesystem::exists(cwd / filename) ||
+           std::filesystem::exists(saver_dir / filename);
   };
 
   EXPECT_TRUE(find_saver_file("saver_output.c"))
-      << "saver_output.c not found in cwd or any immediate subdirectory";
+      << "saver_output.c not found in cwd or ./saver_output/";
   EXPECT_TRUE(find_saver_file("params.bin"))
-      << "params.bin not found in cwd or any immediate subdirectory";
+      << "params.bin not found in cwd or ./saver_output/";
 }
 
 struct ModelAndBuilder {

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -551,21 +551,34 @@ TEST_F(QnnCPUBackendTests, TestNHWCResizeShapeInference_sizes_opset18) {
 }
 
 // Test that QNN Saver generates the expected files for a model meant to run on the QNN CPU backend.
-// TODO: [AISW-163150] ORT test failures on qcs6490
-TEST_F(QnnCPUBackendTests, DISABLED_QnnSaver_OutputFiles) {
-  const std::filesystem::path qnn_saver_output_dir = "saver_output";
-
-  // Remove pre-existing QNN Saver output files. Note that fs::remove_all() can handle non-existing paths.
-  std::filesystem::remove_all(qnn_saver_output_dir);
-  ASSERT_FALSE(std::filesystem::exists(qnn_saver_output_dir));
+// QnnSaver may write flat to cwd (Linux aarch64) or to a subdirectory (Windows); the test
+// accepts either location.
+TEST_F(QnnCPUBackendTests, QnnSaver_OutputFiles) {
+  // Clean up any pre-existing Saver output from prior runs, both flat in cwd and in the default
+  // subdirectory, so stale files don't cause a false pass.
+  std::filesystem::remove("saver_output.c");
+  std::filesystem::remove("params.bin");
+  std::filesystem::remove_all("saver_output");
 
   RunNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                     TestBackend::Cpu,     // backend
-                     TestBackend::Saver);  // serializer_backend
+                     TestBackend::Cpu,
+                     TestBackend::Saver);
 
-  // Check that QNN Saver output files exist.
-  EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "saver_output.c"));
-  EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "params.bin"));
+  // Accept saver_output.c / params.bin anywhere in cwd or one level of subdirectory.
+  // QnnSaver writes flat to cwd on Linux aarch64 and to ./saver_output/ on Windows.
+  const auto cwd = std::filesystem::current_path();
+  auto find_saver_file = [&](const std::string& filename) -> bool {
+    if (std::filesystem::exists(cwd / filename)) return true;
+    for (const auto& entry : std::filesystem::directory_iterator(cwd)) {
+      if (entry.is_directory() && std::filesystem::exists(entry.path() / filename)) return true;
+    }
+    return false;
+  };
+
+  EXPECT_TRUE(find_saver_file("saver_output.c"))
+      << "saver_output.c not found in cwd or any immediate subdirectory";
+  EXPECT_TRUE(find_saver_file("params.bin"))
+      << "params.bin not found in cwd or any immediate subdirectory";
 }
 
 struct ModelAndBuilder {

--- a/qcom/scripts/linux/appium/configs/linux-aarch64_oe_gcc11_2.jsonc
+++ b/qcom/scripts/linux/appium/configs/linux-aarch64_oe_gcc11_2.jsonc
@@ -45,8 +45,7 @@
 
     // Comma-separated list of ctest cases to skip
     // Default: null
-    // TODO: [AISW-163150] ORT test failures on qcs6490
-    "skip_ctests": "onnxruntime_provider_test",
+    "skip_ctests": "null",
 
     // Comma-separated list of model test suites cases to skip
     // Default: null

--- a/qcom/scripts/linux/appium/configs/linux-aarch64_oe_gcc11_2.jsonc
+++ b/qcom/scripts/linux/appium/configs/linux-aarch64_oe_gcc11_2.jsonc
@@ -45,7 +45,7 @@
 
     // Comma-separated list of ctest cases to skip
     // Default: null
-    "skip_ctests": "null",
+    "skip_ctests": null,
 
     // Comma-separated list of model test suites cases to skip
     // Default: null


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

#### Summary
Re-enable previously broadly-skipped tests on Linux aarch64 running on qcs6490 (test-linux-aarch64-oe-gcc11_2) for onnxruntime_provider_test.  
 
#### Background
PR #303 already skips most of the linux aarch64 V68-unsupported failures (FP16 / U16 quant cases)  — no code change needed in this PR for those cases.

#### Changes
  - maxpool_test.cc — QnnCPUBackendTests.MaxPool_Rank3 is already skipped via QNN_SKIP_TEST_ON_AARCH64. Added a TODO comment recording the root cause (QNN CPU backend produces incorrect rank-3 MaxPool results on Linux aarch64; responsibility lies with the QNN CPU team, not ORT QNN EP).                                                                                                                                              
  - qnn_basic_test.cc — QnnCPUBackendTests.QnnSaver_OutputFiles dropped the DISABLED_ prefix and now accepts saver output in either $cwd or $cwd/<subdir>/ layout (Linux aarch64 writes flat, Windows writes to a subdirectory).
  - linux-aarch64_oe_gcc11_2.jsonc — Removed "skip_ctests": "onnxruntime_provider_test", so the full ctest runs on qcs6490. skip_model_tests keeps "node" because the four strnormalizer cases are an image locale limitation (en_US.UTF-8 is not available on the Yocto/OE image), not a code bug.   



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


