### PR TITLE
Add provider options for GPU custom config settings

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -244,6 +244,28 @@ Warning: Enabling HTP Monolithic LSTM may improve session creation time, but thi
 |'0'|Default. Disabled.|
 |'1'|Enable HTP extended UDMA mode for better performance on supported hardware.|
 
+|`"gpu_precision_mode"`|Description|
+|---|---|
+|'0'|Sets the precision mode to floating point 32-bit (FP32).|
+|'1'|Sets the precision mode to floating point 16-bit (FP16).|
+|'2'|Sets the precision mode to FP16 for storage and FP32 for calculations.|
+|'3'|Default. Uses the tensor data type provided by the user.|
+
+|`"disable_gpu_memory_optimizations"`|Description|
+|---|---|
+|'0'|Default. QNN GPU memory optimizations enabled.|
+|'1'|Disable QNN GPU memory optimizations.|
+
+|`"disable_gpu_node_optimizations"`|Description|
+|---|---|
+|'0'|Default. QNN GPU node optimizations enabled.|
+|'1'|Disable QNN GPU node optimizations.|
+
+|`"disable_gpu_queue_recording"`|Description|
+|---|---|
+|'0'|Default. QNN GPU recordable command queue (RCQ) enabled.|
+|'1'|Disable the QNN GPU recordable command queue (RCQ).|
+
 |`"op_packages"`|Description|
 |---|---|
 |Op package config (string)|Register custom op packages. Format: `<OpType>:<PackagePath>:<InterfaceSymbolName>[:<Target>]`. Multiple packages can be separated by commas.|

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -24,6 +24,7 @@
 #endif
 
 #include "HTP/QnnHtpGraph.h"
+#include "GPU/QnnGpuGraph.h"
 
 #include "core/providers/qnn/common/qnn_graph_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -973,6 +974,54 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     }
   }
 
+  // GPU precision mode
+  std::string gpu_precision_mode_str;
+  GetSessionConfigEntryOrDefault(ort_api,
+                                 session_options_,
+                                 FormatEPConfigKey("gpu_precision_mode"),
+                                 "3",  // user-provided
+                                 gpu_precision_mode_str);
+  if (gpu_precision_mode_str == "0") {
+    gpu_precision_mode_ = QNN_GPU_PRECISION_FP32;
+  } else if (gpu_precision_mode_str == "1") {
+    gpu_precision_mode_ = QNN_GPU_PRECISION_FP16;
+  } else if (gpu_precision_mode_str == "2") {
+    gpu_precision_mode_ = QNN_GPU_PRECISION_HYBRID;
+  } else if (gpu_precision_mode_str == "3") {
+    gpu_precision_mode_ = QNN_GPU_PRECISION_USER_PROVIDED;
+  } else {
+    ORT_CXX_LOG(logger_,
+                ORT_LOGGING_LEVEL_ERROR,
+                ("Invalid value for gpu_precision_mode: " +
+                 gpu_precision_mode_str +
+                 " only 0, 1, 2, or 3 allowed. Falling back to default (3, user-provided).")
+                    .c_str());
+  }
+  ORT_CXX_LOG(logger_,
+              ORT_LOGGING_LEVEL_VERBOSE,
+              ("User specified gpu_precision_mode: " + gpu_precision_mode_str).c_str());
+
+  // GPU memory optimizations. Default false: optimizations enabled.
+  gpu_disable_memory_optimizations_ = ParseBoolOption(ort_api,
+                                                      session_options_,
+                                                      FormatEPConfigKey("disable_gpu_memory_optimizations"),
+                                                      false,
+                                                      logger_);
+
+  // GPU node optimizations. Default false: optimizations enabled.
+  gpu_disable_node_optimizations_ = ParseBoolOption(ort_api,
+                                                    session_options_,
+                                                    FormatEPConfigKey("disable_gpu_node_optimizations"),
+                                                    false,
+                                                    logger_);
+
+  // GPU recordable command queue (RCQ). Default false: RCQ enabled.
+  gpu_disable_rcq_ = ParseBoolOption(ort_api,
+                                     session_options_,
+                                     FormatEPConfigKey("disable_gpu_queue_recording"),
+                                     false,
+                                     logger_);
+
   // Parallel graph prepare.
   std::string num_graph_prepare_threads_str;
   GetSessionConfigEntryOrDefault(ort_api,
@@ -1732,6 +1781,47 @@ void QnnEp::InitQnnHtpGraphConfigs(
   }
 }
 
+void QnnEp::InitQnnGpuGraphConfigs(
+    qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnGpuGraph_CustomConfigV2_t>& configs_builder) const {
+  if (IsGpuBackend(qnn_backend_manager_->GetQnnBackendType())) {
+    gsl::not_null<QnnGpuGraph_CustomConfigV2_t*> gpu_graph_precision_config = configs_builder.PushCustomConfig();
+    gpu_graph_precision_config->handshake = QNN_GPU_GRAPH_V2_HANDSHAKE_FLAG;
+    gpu_graph_precision_config->option = QNN_GPU_GRAPH_CONFIG_OPTION_PRECISION;
+    gpu_graph_precision_config->precision = gpu_precision_mode_;
+
+    gsl::not_null<QnnGraph_Config_t*> graph_precision_config = configs_builder.PushConfig();
+    graph_precision_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_precision_config->customConfig = gpu_graph_precision_config;
+
+    gsl::not_null<QnnGpuGraph_CustomConfigV2_t*> gpu_graph_mem_opt_config = configs_builder.PushCustomConfig();
+    gpu_graph_mem_opt_config->handshake = QNN_GPU_GRAPH_V2_HANDSHAKE_FLAG;
+    gpu_graph_mem_opt_config->option = QNN_GPU_GRAPH_CONFIG_OPTION_DISABLE_MEMORY_OPTIMIZATIONS;
+    gpu_graph_mem_opt_config->disableMemoryOptimizations = gpu_disable_memory_optimizations_;
+
+    gsl::not_null<QnnGraph_Config_t*> graph_mem_opt_config = configs_builder.PushConfig();
+    graph_mem_opt_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_mem_opt_config->customConfig = gpu_graph_mem_opt_config;
+
+    gsl::not_null<QnnGpuGraph_CustomConfigV2_t*> gpu_graph_node_opt_config = configs_builder.PushCustomConfig();
+    gpu_graph_node_opt_config->handshake = QNN_GPU_GRAPH_V2_HANDSHAKE_FLAG;
+    gpu_graph_node_opt_config->option = QNN_GPU_GRAPH_CONFIG_OPTION_DISABLE_NODE_OPTIMIZATIONS;
+    gpu_graph_node_opt_config->disableNodeOptimizations = gpu_disable_node_optimizations_;
+
+    gsl::not_null<QnnGraph_Config_t*> graph_node_opt_config = configs_builder.PushConfig();
+    graph_node_opt_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_node_opt_config->customConfig = gpu_graph_node_opt_config;
+
+    gsl::not_null<QnnGpuGraph_CustomConfigV2_t*> gpu_graph_rcq_config = configs_builder.PushCustomConfig();
+    gpu_graph_rcq_config->handshake = QNN_GPU_GRAPH_V2_HANDSHAKE_FLAG;
+    gpu_graph_rcq_config->option = QNN_GPU_GRAPH_CONFIG_OPTION_DISABLE_QUEUE_RECORDING;
+    gpu_graph_rcq_config->disableQueueRecording = gpu_disable_rcq_;
+
+    gsl::not_null<QnnGraph_Config_t*> graph_rcq_config = configs_builder.PushConfig();
+    graph_rcq_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_rcq_config->customConfig = gpu_graph_rcq_config;
+  }
+}
+
 static bool EpSharedContextsHasAllGraphs(const OrtGraph* graph, const OrtApi& ort_api, const Ort::Logger& logger) {
   size_t num_nodes = 0;
   if (ort_api.Graph_GetNumNodes(graph, &num_nodes) != nullptr) {
@@ -2265,12 +2355,23 @@ OrtStatus* QnnEp::CompileOnnxModel(const OrtGraph** graphs,
         QNN_GRAPH_CONFIG_INIT, QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT);
     InitQnnHtpGraphConfigs(htp_graph_configs, htp_graph_configs_builder);
 
+    qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnGpuGraph_CustomConfigV2_t> gpu_graph_configs_builder(
+        QNN_GRAPH_CONFIG_INIT, {});
+    InitQnnGpuGraphConfigs(gpu_graph_configs_builder);
+
     std::vector<const QnnGraph_Config_t*> all_graph_configs;
     const QnnGraph_Config_t** htp_configs = htp_graph_configs_builder.GetQnnConfigs();
     if (htp_configs) {
       // Reserve enough for configs + nullptr
       all_graph_configs.reserve(htp_graph_configs_builder.GetSize() + 1);
       for (const QnnGraph_Config_t** config = htp_configs; *config; ++config) {
+        all_graph_configs.push_back(*config);
+      }
+    }
+
+    const QnnGraph_Config_t** gpu_configs = gpu_graph_configs_builder.GetQnnConfigs();
+    if (gpu_configs) {
+      for (const QnnGraph_Config_t** config = gpu_configs; *config; ++config) {
         all_graph_configs.push_back(*config);
       }
     }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "HTP/QnnHtpGraph.h"
+#include "GPU/QnnGpuGraph.h"
 
 #include "core/providers/qnn/ort_api.h"
 #include "core/providers/qnn/builder/qnn_configs_helper.h"
@@ -156,6 +157,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
   void InitQnnHtpGraphConfigs(
       const qnn::HtpGraphConfigs_t& configs,
       qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t>& configs_builder) const;
+  void InitQnnGpuGraphConfigs(
+      qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnGpuGraph_CustomConfigV2_t>& configs_builder) const;
 
   std::unique_ptr<qnn::QnnSerializerConfig> InitQnnSerializerConfig() const;
 
@@ -249,6 +252,12 @@ class QnnEp : public OrtEp, public ApiPtrs {
   uint32_t dynamic_rpc_polling_time_ = 0;
   qnn::ModelSettings model_settings_ = {};
   qnn::HtpGraphConfigs_t htp_graph_configs_;
+
+  // Configurations for GPU backend.
+  QnnGpu_Precision_t gpu_precision_mode_ = QNN_GPU_PRECISION_USER_PROVIDED;
+  bool gpu_disable_memory_optimizations_ = false;
+  bool gpu_disable_node_optimizations_ = false;
+  bool gpu_disable_rcq_ = false;
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";

--- a/onnxruntime/test/providers/qnn/unit/qnn_execution_provider_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_execution_provider_test.cc
@@ -667,6 +667,72 @@ TEST_F(QnnUnit_ExecutionProviderTest, Ctor_EnableHtpMonolithicLstmInvalid_LogsVe
                "Invalid value for ep.qnnexecutionprovider.enable_htp_monolithic_lstm");
 }
 
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_GpuPrecisionModeValidValues_Succeed) {
+  // 0=FP32, 1=FP16, 2=HYBRID, 3=USER_PROVIDED (default).
+  for (const char* mode : {"0", "1", "2", "3"}) {
+    EpStubContext ctx;
+    ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+    ctx.session_config[EPKey("gpu_precision_mode")] = mode;
+    auto factory = MakeFactory(ctx);
+    EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); }) << "gpu_precision_mode=" << mode;
+    ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
+                 std::string("User specified gpu_precision_mode: ") + mode);
+  }
+}
+
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_GpuPrecisionModeInvalid_LogsError) {
+  EpStubContext ctx;
+  ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+  ctx.session_config[EPKey("gpu_precision_mode")] = "4";
+  auto factory = MakeFactory(ctx);
+  EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); });
+  ExpectLogged(ctx, ORT_LOGGING_LEVEL_ERROR, "Invalid value for gpu_precision_mode: 4");
+}
+
+// The gpu_precision_mode string values are a public contract mapped onto
+// QnnGpu_Precision_t. Pin the mapping so an SDK enum renumbering shows up as a
+// local test failure rather than a silent behaviour change on device.
+TEST_F(QnnUnit_ExecutionProviderTest, GpuPrecisionEnumValues_MatchDocumentedOrder) {
+  EXPECT_EQ(QNN_GPU_PRECISION_FP32, static_cast<QnnGpu_Precision_t>(0));
+  EXPECT_EQ(QNN_GPU_PRECISION_FP16, static_cast<QnnGpu_Precision_t>(1));
+  EXPECT_EQ(QNN_GPU_PRECISION_HYBRID, static_cast<QnnGpu_Precision_t>(2));
+  EXPECT_EQ(QNN_GPU_PRECISION_USER_PROVIDED, static_cast<QnnGpu_Precision_t>(3));
+}
+
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_DisableGpuFlagsValidValues_Succeed) {
+  for (const char* key : {"disable_gpu_memory_optimizations",
+                          "disable_gpu_node_optimizations",
+                          "disable_gpu_queue_recording"}) {
+    for (const char* value : {"0", "1"}) {
+      EpStubContext ctx;
+      ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+      ctx.session_config[EPKey(key)] = value;
+      auto factory = MakeFactory(ctx);
+      EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); }) << key << "=" << value;
+      // ParseBoolOption echoes the parsed result, which also pins the documented
+      // polarity: "1" disables the optimization, "0" (default) leaves it enabled.
+      ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
+                   "User specified " + EPKey(key) + ": " + value);
+    }
+  }
+}
+
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_DisableGpuFlagsInvalid_LogVerbose) {
+  // Parsed by ParseBoolOption, which logs VERBOSE and keeps the default
+  // (false → optimizations enabled) for unrecognised values.
+  for (const char* key : {"disable_gpu_memory_optimizations",
+                          "disable_gpu_node_optimizations",
+                          "disable_gpu_queue_recording"}) {
+    EpStubContext ctx;
+    ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+    ctx.session_config[EPKey(key)] = "true";
+    auto factory = MakeFactory(ctx);
+    EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); }) << key;
+    ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE, "Invalid value for " + EPKey(key));
+    ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE, "User specified " + EPKey(key) + ": 0");
+  }
+}
+
 TEST_F(QnnUnit_ExecutionProviderTest, Ctor_EmbedModeInvalidValue_Succeeds) {
   EpStubContext ctx;
   ctx.session_config["ep.context_embed_mode"] = "2";


### PR DESCRIPTION
### Description
* Add  `"gpu_precision_mode"`, `"disable_gpu_memory_optimizations"`,
  `"disable_gpu_node_optimizations"`, and `"disable_gpu_queue_recording"` provider options.

### Motivation and Context
* Make GPU custom config options accessible through ORT.
* `"gpu_precision_mode"` is useful for e.g. running in hybrid precision or testing out fp16 precision without having to reexport model weights to fp16. The other options can be helpful when debugging.

