### PR TITLE
[QNN EP] Ensure ORT Core is 1.24.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coloredlogs
 flatbuffers
 numpy >= 1.21.6
-onnxruntime >= 1.24.2
+onnxruntime == 1.24.4
 packaging
 protobuf
 sympy


### PR DESCRIPTION
This PR ensures we always build ORT QNN EP with the desired version of ORT Core for Python wheels

