### PR TITLE
[QNN-EP] Add dump_onnx_subgraph for per-partition debugging

### DIFF
--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -39,7 +39,22 @@
   endif()
 
   onnxruntime_add_shared_library_module(onnxruntime_providers_qnn ${onnxruntime_providers_qnn_all_srcs})
-  onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json onnx onnx_proto)
+  onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json)
+
+  # ONNX + protobuf headers are needed by builder/onnx_subgraph_dumper.cc, but they trip
+  # third-party warnings (e.g. -Wshorten-64-to-32 from protobuf's parse_context.h on the
+  # aarch64_oe_gcc11_2 clang toolchain that builds with -Werror). Bring them in as SYSTEM
+  # includes so warnings from those headers don't break the build.
+  foreach(onnx_dep_target onnx onnx_proto)
+    get_target_property(_onnx_inc_dirs ${onnx_dep_target} INTERFACE_INCLUDE_DIRECTORIES)
+    if(_onnx_inc_dirs)
+      target_include_directories(onnxruntime_providers_qnn SYSTEM PRIVATE ${_onnx_inc_dirs})
+    endif()
+    get_target_property(_onnx_compile_defs ${onnx_dep_target} INTERFACE_COMPILE_DEFINITIONS)
+    if(_onnx_compile_defs)
+      target_compile_definitions(onnxruntime_providers_qnn PRIVATE ${_onnx_compile_defs})
+    endif()
+  endforeach()
 
   target_link_libraries(onnxruntime_providers_qnn PRIVATE ${ABSEIL_LIBS} onnx onnx_proto)
 

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -39,9 +39,9 @@
   endif()
 
   onnxruntime_add_shared_library_module(onnxruntime_providers_qnn ${onnxruntime_providers_qnn_all_srcs})
-  onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json)
+  onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json onnx onnx_proto)
 
-  target_link_libraries(onnxruntime_providers_qnn PRIVATE ${ABSEIL_LIBS})
+  target_link_libraries(onnxruntime_providers_qnn PRIVATE ${ABSEIL_LIBS} onnx onnx_proto)
 
   add_dependencies(onnxruntime_providers_qnn ort_core_target)
 

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -39,22 +39,7 @@
   endif()
 
   onnxruntime_add_shared_library_module(onnxruntime_providers_qnn ${onnxruntime_providers_qnn_all_srcs})
-  onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json)
-
-  # ONNX + protobuf headers are needed by builder/onnx_subgraph_dumper.cc, but they trip
-  # third-party warnings (e.g. -Wshorten-64-to-32 from protobuf's parse_context.h on the
-  # aarch64_oe_gcc11_2 clang toolchain that builds with -Werror). Bring them in as SYSTEM
-  # includes so warnings from those headers don't break the build.
-  foreach(onnx_dep_target onnx onnx_proto)
-    get_target_property(_onnx_inc_dirs ${onnx_dep_target} INTERFACE_INCLUDE_DIRECTORIES)
-    if(_onnx_inc_dirs)
-      target_include_directories(onnxruntime_providers_qnn SYSTEM PRIVATE ${_onnx_inc_dirs})
-    endif()
-    get_target_property(_onnx_compile_defs ${onnx_dep_target} INTERFACE_COMPILE_DEFINITIONS)
-    if(_onnx_compile_defs)
-      target_compile_definitions(onnxruntime_providers_qnn PRIVATE ${_onnx_compile_defs})
-    endif()
-  endforeach()
+  onnxruntime_add_include_to_target(onnxruntime_providers_qnn ${GSL_TARGET} safeint_interface nlohmann_json::nlohmann_json onnx onnx_proto)
 
   target_link_libraries(onnxruntime_providers_qnn PRIVATE ${ABSEIL_LIBS} onnx onnx_proto)
 

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -208,7 +208,7 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 |`"dump_onnx_subgraph"`|Description|
 |---|---|
 |'0'|Default. Disabled.|
-|'1'|Enable dumping each QNN-claimed partition as a self-contained, runnable ONNX model. The dump fires inside `Compile`, immediately before QNN op-builders translate the partition's ONNX ops into `QNN_OP_*` — so the dumped graph contains only raw ONNX ops. Each partition produces two files: `<fused_node_name>.onnx` (model proto) and `<fused_node_name>.onnx.data` (initializer bytes referenced via ONNX's standard `external_data` mechanism). The external-data layout is required to handle large models (e.g. gpt-oss-class) whose per-partition weight totals would exceed protobuf's 2 GB single-message serialization ceiling. Filenames match the QNN graph name shown in profiling and `dump_json_qnn_graph` output for direct 1:1 correlation. Useful for HTP debug: each dumped file can be loaded as a fresh model and (because every node was QNN-supported by construction) should be claimed by the QNN EP as a single all-HTP partition with zero CPU fallback. The dump is a no-op when loading a precompiled EPContext / DLC context model. Subgraph attributes (If/Loop bodies) are not supported in v1; affected partitions return an error and are skipped with a warning. For strict reproducibility when reloading a dumped model, set `graph_optimization_level=ORT_DISABLE_ALL` to prevent ORT from re-running graph optimizations.|
+|'1'|Dumps each QNN-claimed partition as a self-contained, runnable ONNX model (`<fused_node_name>.onnx` + `.onnx.data` sidecar). Filename matches the QNN graph name in profiling output. No-op on EPContext / DLC-context load paths.|
 
 |`"onnx_subgraph_dir"`|Description|
 |---|---|

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -205,6 +205,15 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 |---|---|
 |Directory path (string)|Directory path for dumping QNN JSON graphs. Only effective when `dump_json_qnn_graph` is enabled.|
 
+|`"dump_onnx_subgraph"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Enable dumping each QNN-claimed partition as a self-contained, runnable ONNX model. The dump fires inside `Compile`, immediately before QNN op-builders translate the partition's ONNX ops into `QNN_OP_*` — so the dumped graph contains only raw ONNX ops. Each partition produces two files: `<fused_node_name>.onnx` (model proto) and `<fused_node_name>.onnx.data` (initializer bytes referenced via ONNX's standard `external_data` mechanism). The external-data layout is required to handle large models (e.g. gpt-oss-class) whose per-partition weight totals would exceed protobuf's 2 GB single-message serialization ceiling. Filenames match the QNN graph name shown in profiling and `dump_json_qnn_graph` output for direct 1:1 correlation. Useful for HTP debug: each dumped file can be loaded as a fresh model and (because every node was QNN-supported by construction) should be claimed by the QNN EP as a single all-HTP partition with zero CPU fallback. The dump is a no-op when loading a precompiled EPContext / DLC context model. Subgraph attributes (If/Loop bodies) are not supported in v1; affected partitions return an error and are skipped with a warning. For strict reproducibility when reloading a dumped model, set `graph_optimization_level=ORT_DISABLE_ALL` to prevent ORT from re-running graph optimizations.|
+
+|`"onnx_subgraph_dir"`|Description|
+|---|---|
+|Directory path (string)|Directory path for dumping ONNX subgraphs. Only effective when `dump_onnx_subgraph` is enabled. Both the `.onnx` and the `.onnx.data` sidecar are written to this directory.|
+
 |`"dump_qnn_ir_dlc"`|Description|
 |---|---|
 |'0'|Default. Disabled.|

--- a/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.cc
@@ -1,0 +1,566 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/onnx_subgraph_dumper.h"
+
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "onnx/onnx_pb.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+size_t ElementSizeBytes(ONNXTensorElementDataType type) {
+  switch (type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL:
+      return 1;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+Ort::Status FillTensorTypeAndShape(const OrtApi& ort_api,
+                                   const OrtTensorTypeAndShapeInfo& info,
+                                   ONNX_NAMESPACE::TypeProto_Tensor* out_tensor_type) {
+  ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorElementType(&info, &elem_type));
+  out_tensor_type->set_elem_type(static_cast<int>(elem_type));
+
+  size_t num_dims = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetDimensionsCount(&info, &num_dims));
+
+  auto* shape_proto = out_tensor_type->mutable_shape();
+  if (num_dims == 0) {
+    return Ort::Status{nullptr};
+  }
+
+  std::vector<int64_t> dims(num_dims, 0);
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetDimensions(&info, dims.data(), num_dims));
+
+  std::vector<const char*> sym_dims(num_dims, nullptr);
+  bool have_symbolic = (ort_api.GetSymbolicDimensions(&info, sym_dims.data(), num_dims) == nullptr);
+
+  for (size_t i = 0; i < num_dims; ++i) {
+    auto* dim_proto = shape_proto->add_dim();
+    if (dims[i] >= 0) {
+      dim_proto->set_dim_value(dims[i]);
+    } else if (have_symbolic && sym_dims[i] != nullptr && sym_dims[i][0] != '\0') {
+      dim_proto->set_dim_param(sym_dims[i]);
+    }
+  }
+  return Ort::Status{nullptr};
+}
+
+Ort::Status ConvertValueInfoToProto(const OrtApi& ort_api,
+                                    const OrtValueInfo* vi,
+                                    ONNX_NAMESPACE::ValueInfoProto* out_proto) {
+  const char* name = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetValueInfoName(vi, &name));
+  out_proto->set_name(name ? name : "");
+
+  const OrtTypeInfo* type_info = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetValueInfoTypeInfo(vi, &type_info));
+
+  const OrtTensorTypeAndShapeInfo* tt_info = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.CastTypeInfoToTensorInfo(type_info, &tt_info));
+  if (tt_info == nullptr) {
+    return MAKE_EP_FAIL(("ValueInfo " + std::string(name ? name : "?") +
+                         " is not a tensor type; non-tensor I/O is unsupported for ONNX subgraph dump.")
+                            .c_str());
+  }
+
+  auto* tensor_type = out_proto->mutable_type()->mutable_tensor_type();
+  RETURN_IF_ERROR(FillTensorTypeAndShape(ort_api, *tt_info, tensor_type));
+  return Ort::Status{nullptr};
+}
+
+// Sink for ONNX external_data writes. Each partition gets one of these so all of its
+// initializer bytes are streamed sequentially into a single sidecar file. Avoids protobuf's
+// 2 GB single-message ceiling that fires when inlining gpt-oss-sized weight tensors as raw_data.
+struct ExternalDataSink {
+  std::ofstream ofs;
+  std::string relative_filename;  // basename only — stored in TensorProto.external_data["location"]
+  uint64_t offset = 0;
+};
+
+Ort::Status ConvertInitializerToTensorProto(const OrtApi& ort_api,
+                                            const OrtValueInfo* vi,
+                                            ONNX_NAMESPACE::TensorProto* out_proto,
+                                            ExternalDataSink& sink) {
+  const char* name = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetValueInfoName(vi, &name));
+  out_proto->set_name(name ? name : "");
+
+  const OrtValue* tensor_value = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.ValueInfo_GetInitializerValue(vi, &tensor_value));
+  if (tensor_value == nullptr) {
+    return MAKE_EP_FAIL(("Initializer " + std::string(name ? name : "?") +
+                         " has no underlying OrtValue.")
+                            .c_str());
+  }
+
+  OrtTensorTypeAndShapeInfo* tt_info_raw = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorTypeAndShape(tensor_value, &tt_info_raw));
+  std::unique_ptr<OrtTensorTypeAndShapeInfo, FuncDeleter<OrtTensorTypeAndShapeInfo>> tt_guard(
+      tt_info_raw, FuncDeleter<OrtTensorTypeAndShapeInfo>{ort_api.ReleaseTensorTypeAndShapeInfo});
+
+  ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorElementType(tt_info_raw, &elem_type));
+  out_proto->set_data_type(static_cast<int>(elem_type));
+
+  size_t num_dims = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetDimensionsCount(tt_info_raw, &num_dims));
+  std::vector<int64_t> dims(num_dims, 0);
+  if (num_dims > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetDimensions(tt_info_raw, dims.data(), num_dims));
+  }
+  for (auto d : dims) {
+    out_proto->add_dims(d);
+  }
+
+  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
+    return MAKE_EP_FAIL(("String initializer " + std::string(name ? name : "?") +
+                         " is unsupported for ONNX subgraph dump.")
+                            .c_str());
+  }
+
+  size_t element_size = ElementSizeBytes(elem_type);
+  if (element_size == 0) {
+    return MAKE_EP_FAIL(("Unsupported initializer element type " + std::to_string(static_cast<int>(elem_type)) +
+                         " for " + std::string(name ? name : "?") + ".")
+                            .c_str());
+  }
+
+  size_t element_count = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorShapeElementCount(tt_info_raw, &element_count));
+  size_t bytes = element_count * element_size;
+  if (bytes == 0) {
+    return Ort::Status{nullptr};  // empty tensor: shape + dtype suffice, no data needed
+  }
+
+  void* data_ptr = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorMutableData(const_cast<OrtValue*>(tensor_value), &data_ptr));
+
+  // Stream the bytes into the per-partition sidecar file and reference them via external_data.
+  // This sidesteps the 2 GB protobuf serialization limit on the model proto and avoids a second
+  // copy of the weight bytes that the inline raw_data path would otherwise force.
+  const uint64_t this_offset = sink.offset;
+  sink.ofs.write(static_cast<const char*>(data_ptr), static_cast<std::streamsize>(bytes));
+  if (!sink.ofs.good()) {
+    return MAKE_EP_FAIL(("Failed to write " + std::to_string(bytes) +
+                         " bytes for initializer '" + std::string(name ? name : "?") +
+                         "' to external-data sidecar.")
+                            .c_str());
+  }
+  sink.offset += bytes;
+
+  out_proto->set_data_location(ONNX_NAMESPACE::TensorProto::EXTERNAL);
+  auto* loc = out_proto->add_external_data();
+  loc->set_key("location");
+  loc->set_value(sink.relative_filename);
+  auto* off = out_proto->add_external_data();
+  off->set_key("offset");
+  off->set_value(std::to_string(this_offset));
+  auto* len = out_proto->add_external_data();
+  len->set_key("length");
+  len->set_value(std::to_string(bytes));
+
+  return Ort::Status{nullptr};
+}
+
+Ort::Status ConvertAttributeToProto(const OrtApi& ort_api,
+                                    const OrtOpAttr* attr,
+                                    ONNX_NAMESPACE::AttributeProto* out_proto) {
+  const char* attr_name = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.OpAttr_GetName(attr, &attr_name));
+  std::string name = attr_name ? attr_name : "";
+  out_proto->set_name(name);
+
+  OrtOpAttrType attr_type = ORT_OP_ATTR_UNDEFINED;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.OpAttr_GetType(attr, &attr_type));
+
+  using AP = ONNX_NAMESPACE::AttributeProto;
+
+  switch (attr_type) {
+    case ORT_OP_ATTR_INT: {
+      out_proto->set_type(AP::INT);
+      int64_t val = 0;
+      size_t out_size = 0;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.ReadOpAttr(attr, attr_type, &val, sizeof(val), &out_size));
+      out_proto->set_i(val);
+      break;
+    }
+    case ORT_OP_ATTR_INTS: {
+      out_proto->set_type(AP::INTS);
+      size_t needed = 0;
+      OrtStatus* probe = ort_api.ReadOpAttr(attr, attr_type, nullptr, 0, &needed);
+      if (probe != nullptr) {
+        ort_api.ReleaseStatus(probe);
+      }
+      if (needed > 0) {
+        std::vector<int64_t> vals(needed / sizeof(int64_t));
+        ORT_CXX_RETURN_ON_API_FAIL(ort_api.ReadOpAttr(attr, attr_type, vals.data(), needed, &needed));
+        for (auto v : vals) out_proto->add_ints(v);
+      }
+      break;
+    }
+    case ORT_OP_ATTR_FLOAT: {
+      out_proto->set_type(AP::FLOAT);
+      float val = 0.0f;
+      size_t out_size = 0;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.ReadOpAttr(attr, attr_type, &val, sizeof(val), &out_size));
+      out_proto->set_f(val);
+      break;
+    }
+    case ORT_OP_ATTR_FLOATS: {
+      out_proto->set_type(AP::FLOATS);
+      size_t needed = 0;
+      OrtStatus* probe = ort_api.ReadOpAttr(attr, attr_type, nullptr, 0, &needed);
+      if (probe != nullptr) {
+        ort_api.ReleaseStatus(probe);
+      }
+      if (needed > 0) {
+        std::vector<float> vals(needed / sizeof(float));
+        ORT_CXX_RETURN_ON_API_FAIL(ort_api.ReadOpAttr(attr, attr_type, vals.data(), needed, &needed));
+        for (auto v : vals) out_proto->add_floats(v);
+      }
+      break;
+    }
+    case ORT_OP_ATTR_STRING: {
+      out_proto->set_type(AP::STRING);
+      size_t needed = 0;
+      OrtStatus* probe = ort_api.ReadOpAttr(attr, attr_type, nullptr, 0, &needed);
+      if (probe != nullptr) {
+        ort_api.ReleaseStatus(probe);
+      }
+      std::string str(needed, '\0');
+      if (needed > 0) {
+        ORT_CXX_RETURN_ON_API_FAIL(ort_api.ReadOpAttr(attr, attr_type, str.data(), needed, &needed));
+      }
+      out_proto->set_s(str);
+      break;
+    }
+    case ORT_OP_ATTR_STRINGS: {
+      out_proto->set_type(AP::STRINGS);
+      size_t needed = 0;
+      OrtStatus* probe = ort_api.ReadOpAttr(attr, attr_type, nullptr, 0, &needed);
+      if (probe != nullptr) {
+        ort_api.ReleaseStatus(probe);
+      }
+      if (needed > 0) {
+        std::vector<char> buf(needed);
+        ORT_CXX_RETURN_ON_API_FAIL(ort_api.ReadOpAttr(attr, attr_type, buf.data(), needed, &needed));
+        const char* p = buf.data();
+        const char* end = buf.data() + needed;
+        while (p < end) {
+          size_t len = std::strlen(p);
+          out_proto->add_strings(std::string(p, len));
+          p += len + 1;
+          if (p > end) break;
+        }
+      }
+      break;
+    }
+    case ORT_OP_ATTR_TENSOR: {
+      out_proto->set_type(AP::TENSOR);
+      OrtValue* tensor_value_raw = nullptr;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.OpAttr_GetTensorAttributeAsOrtValue(attr, &tensor_value_raw));
+      if (tensor_value_raw == nullptr) {
+        return MAKE_EP_FAIL(("TENSOR attribute '" + name + "' produced no OrtValue.").c_str());
+      }
+      std::unique_ptr<OrtValue, FuncDeleter<OrtValue>> tensor_guard(
+          tensor_value_raw, FuncDeleter<OrtValue>{ort_api.ReleaseValue});
+
+      auto* tp = out_proto->mutable_t();
+      tp->set_name(name);
+
+      OrtTensorTypeAndShapeInfo* tt_raw = nullptr;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorTypeAndShape(tensor_value_raw, &tt_raw));
+      std::unique_ptr<OrtTensorTypeAndShapeInfo, FuncDeleter<OrtTensorTypeAndShapeInfo>> tt_guard(
+          tt_raw, FuncDeleter<OrtTensorTypeAndShapeInfo>{ort_api.ReleaseTensorTypeAndShapeInfo});
+
+      ONNXTensorElementDataType et = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorElementType(tt_raw, &et));
+      tp->set_data_type(static_cast<int>(et));
+
+      size_t ndim = 0;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetDimensionsCount(tt_raw, &ndim));
+      std::vector<int64_t> dims(ndim, 0);
+      if (ndim > 0) {
+        ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetDimensions(tt_raw, dims.data(), ndim));
+      }
+      for (auto d : dims) tp->add_dims(d);
+
+      size_t element_size = ElementSizeBytes(et);
+      if (element_size == 0 && et != ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
+        return MAKE_EP_FAIL(("TENSOR attribute '" + name +
+                             "' has unsupported element type " + std::to_string(static_cast<int>(et)) + ".")
+                                .c_str());
+      }
+      size_t count = 0;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorShapeElementCount(tt_raw, &count));
+      size_t bytes = count * element_size;
+      if (bytes > 0) {
+        void* data = nullptr;
+        ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorMutableData(tensor_value_raw, &data));
+        tp->set_raw_data(data, bytes);
+      }
+      break;
+    }
+    case ORT_OP_ATTR_GRAPH: {
+      return MAKE_EP_FAIL(("Subgraph (GRAPH) attribute '" + name +
+                           "' is not supported for ONNX subgraph dump (round-trip would be incomplete).")
+                              .c_str());
+    }
+    case ORT_OP_ATTR_UNDEFINED:
+    default: {
+      return MAKE_EP_FAIL(("Unknown attribute type " + std::to_string(static_cast<int>(attr_type)) +
+                           " on '" + name + "'.")
+                              .c_str());
+    }
+  }
+  return Ort::Status{nullptr};
+}
+
+Ort::Status ConvertNodeToProto(const OrtApi& ort_api,
+                               const OrtNode* node,
+                               ONNX_NAMESPACE::NodeProto* out_proto) {
+  const char* name = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetName(node, &name));
+  out_proto->set_name(name ? name : "");
+
+  const char* op_type = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetOperatorType(node, &op_type));
+  out_proto->set_op_type(op_type ? op_type : "");
+
+  const char* domain = nullptr;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetDomain(node, &domain));
+  if (domain && domain[0] != '\0') {
+    out_proto->set_domain(domain);
+  }
+
+  size_t num_inputs = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetNumInputs(node, &num_inputs));
+  std::vector<const OrtValueInfo*> inputs(num_inputs, nullptr);
+  if (num_inputs > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetInputs(node, inputs.data(), num_inputs));
+  }
+  for (const OrtValueInfo* vi : inputs) {
+    if (vi == nullptr) {
+      out_proto->add_input("");
+    } else {
+      const char* in_name = nullptr;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetValueInfoName(vi, &in_name));
+      out_proto->add_input(in_name ? in_name : "");
+    }
+  }
+
+  size_t num_outputs = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetNumOutputs(node, &num_outputs));
+  std::vector<const OrtValueInfo*> outputs(num_outputs, nullptr);
+  if (num_outputs > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetOutputs(node, outputs.data(), num_outputs));
+  }
+  for (const OrtValueInfo* vi : outputs) {
+    if (vi == nullptr) {
+      out_proto->add_output("");
+    } else {
+      const char* out_name = nullptr;
+      ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetValueInfoName(vi, &out_name));
+      out_proto->add_output(out_name ? out_name : "");
+    }
+  }
+
+  size_t num_attrs = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetNumAttributes(node, &num_attrs));
+  if (num_attrs > 0) {
+    std::vector<const OrtOpAttr*> attrs(num_attrs, nullptr);
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Node_GetAttributes(node, attrs.data(), num_attrs));
+    for (const OrtOpAttr* attr : attrs) {
+      auto* ap = out_proto->add_attribute();
+      RETURN_IF_ERROR(ConvertAttributeToProto(ort_api, attr, ap));
+    }
+  }
+
+  return Ort::Status{nullptr};
+}
+
+}  // namespace
+
+Ort::Status DumpPartitionAsOnnxModel(const OrtApi& ort_api,
+                                     const OrtGraph& subgraph,
+                                     const std::string& graph_name,
+                                     const std::filesystem::path& output_path,
+                                     const Ort::Logger& logger) {
+  // ORT has already synthesized a per-partition OrtGraph for CompileImpl with the boundary
+  // inputs/outputs computed. We can walk it directly using the standard Graph_* APIs.
+  const OrtGraph* sg = &subgraph;
+
+  ONNX_NAMESPACE::ModelProto model_proto;
+
+  int64_t ir_version = 0;
+  if (ort_api.Graph_GetOnnxIRVersion(sg, &ir_version) == nullptr && ir_version >= 4) {
+    model_proto.set_ir_version(ir_version);
+  } else {
+    // Force IR version >= 4 so that initializers do not have to also appear in graph.input.
+    // The dumped graph is intended for round-trip with QNN EP, so a modern IR is desired.
+    model_proto.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  }
+
+  model_proto.set_producer_name("onnxruntime-qnn-ep");
+  model_proto.set_producer_version("dump_onnx_subgraph");
+  model_proto.set_doc_string("ONNX subgraph dumped from QNN EP partition '" + graph_name + "'");
+
+  size_t num_opsets = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetNumOperatorSets(sg, &num_opsets));
+  if (num_opsets > 0) {
+    std::vector<const char*> domains(num_opsets, nullptr);
+    std::vector<int64_t> versions(num_opsets, 0);
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetOperatorSets(sg, domains.data(), versions.data(), num_opsets));
+    for (size_t i = 0; i < num_opsets; ++i) {
+      auto* opset = model_proto.add_opset_import();
+      opset->set_domain(domains[i] ? domains[i] : "");
+      opset->set_version(versions[i]);
+    }
+  }
+
+  auto* graph_proto = model_proto.mutable_graph();
+  graph_proto->set_name(graph_name);
+
+  // Open the per-partition external-data sidecar. Filename is `<onnx_filename>.data` so the two
+  // files always live next to each other and ONNX loaders resolve the relative `location` ref
+  // against the .onnx file's directory automatically. We pre-create the directory above; the
+  // ofstream open here will fail loudly if the path is bad.
+  std::filesystem::path sidecar_path = output_path;
+  sidecar_path += ".data";
+  ExternalDataSink sink;
+  sink.relative_filename = sidecar_path.filename().string();
+  sink.ofs.open(sidecar_path, std::ios::binary | std::ios::trunc);
+  if (!sink.ofs) {
+    return MAKE_EP_FAIL(("Failed to open external-data sidecar '" + sidecar_path.string() +
+                         "' for writing.")
+                            .c_str());
+  }
+
+  // Initializers (must come before inputs walk because some inputs are also initializers
+  // in IR<4 - we still emit them as initializers only).
+  size_t num_initializers = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetNumInitializers(sg, &num_initializers));
+  std::vector<const OrtValueInfo*> initializers(num_initializers, nullptr);
+  if (num_initializers > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetInitializers(sg, initializers.data(), num_initializers));
+  }
+  for (const OrtValueInfo* vi : initializers) {
+    auto* tp = graph_proto->add_initializer();
+    RETURN_IF_ERROR(ConvertInitializerToTensorProto(ort_api, vi, tp, sink));
+  }
+
+  // Inputs (skip constant initializers; non-constant initializers may also appear in inputs
+  // and are kept as both an input and an initializer for IR>=4 compatibility).
+  size_t num_inputs = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetNumInputs(sg, &num_inputs));
+  std::vector<const OrtValueInfo*> inputs(num_inputs, nullptr);
+  if (num_inputs > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetInputs(sg, inputs.data(), num_inputs));
+  }
+  for (const OrtValueInfo* vi : inputs) {
+    bool is_const_init = false;
+    if (ort_api.ValueInfo_IsConstantInitializer(vi, &is_const_init) == nullptr && is_const_init) {
+      continue;
+    }
+    auto* vip = graph_proto->add_input();
+    RETURN_IF_ERROR(ConvertValueInfoToProto(ort_api, vi, vip));
+  }
+
+  // Outputs.
+  size_t num_outputs = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetNumOutputs(sg, &num_outputs));
+  std::vector<const OrtValueInfo*> outputs(num_outputs, nullptr);
+  if (num_outputs > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetOutputs(sg, outputs.data(), num_outputs));
+  }
+  for (const OrtValueInfo* vi : outputs) {
+    auto* vip = graph_proto->add_output();
+    RETURN_IF_ERROR(ConvertValueInfoToProto(ort_api, vi, vip));
+  }
+
+  // Nodes.
+  size_t num_nodes = 0;
+  ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetNumNodes(sg, &num_nodes));
+  std::vector<const OrtNode*> nodes(num_nodes, nullptr);
+  if (num_nodes > 0) {
+    ORT_CXX_RETURN_ON_API_FAIL(ort_api.Graph_GetNodes(sg, nodes.data(), num_nodes));
+  }
+  for (const OrtNode* node : nodes) {
+    auto* np = graph_proto->add_node();
+    RETURN_IF_ERROR(ConvertNodeToProto(ort_api, node, np));
+  }
+
+  // Serialize.
+  std::error_code ec;
+  std::filesystem::path parent = output_path.parent_path();
+  if (!parent.empty() && !std::filesystem::exists(parent, ec)) {
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+      return MAKE_EP_FAIL(("Failed to create output directory '" + parent.string() +
+                           "': " + ec.message())
+                              .c_str());
+    }
+  }
+
+  // Close the sidecar before serializing the model proto. If no bytes were written (partition
+  // had no non-empty initializers), drop the empty file to avoid leaving 0-byte artifacts.
+  sink.ofs.flush();
+  const bool sidecar_has_data = sink.offset > 0 && sink.ofs.good();
+  sink.ofs.close();
+  if (!sidecar_has_data) {
+    std::error_code rm_ec;
+    std::filesystem::remove(sidecar_path, rm_ec);
+  }
+
+  std::ofstream ofs(output_path, std::ios::binary | std::ios::trunc);
+  if (!ofs) {
+    return MAKE_EP_FAIL(("Failed to open '" + output_path.string() + "' for writing.").c_str());
+  }
+  if (!model_proto.SerializeToOstream(&ofs)) {
+    return MAKE_EP_FAIL(("Failed to serialize ModelProto to '" + output_path.string() + "'.").c_str());
+  }
+  ofs.flush();
+  if (!ofs.good()) {
+    return MAKE_EP_FAIL(("Output stream not in good state after writing '" + output_path.string() + "'.").c_str());
+  }
+
+  if (!IsNullLogger(logger)) {
+    std::string msg = "Wrote ONNX subgraph dump: " + output_path.string();
+    if (sidecar_has_data) {
+      msg += " (+ " + sidecar_path.filename().string() + ", " +
+             std::to_string(sink.offset) + " bytes external)";
+    }
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO, msg.c_str());
+  }
+  return Ort::Status{nullptr};
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.cc
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include "onnx/onnx_pb.h"
+#include "core/providers/qnn/common/onnx_protobuf.h"
 
 namespace onnxruntime {
 namespace qnn {

--- a/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.cc
@@ -95,6 +95,29 @@ Ort::Status ConvertValueInfoToProto(const OrtApi& ort_api,
   return Ort::Status{nullptr};
 }
 
+// RAII helper: ensures that if DumpPartitionAsOnnxModel returns a non-OK status for ANY
+// reason after the output paths are known, both the `.onnx` and the `.onnx.data` are
+// removed from disk before we propagate the error. Disarmed via commit() once both files
+// have been fully written and flushed successfully. Without this guard, a mid-walk failure
+// (or a serialize failure after the sidecar was already populated) could leave behind a
+// partial/orphan pair on disk that round-trip tooling would then misread.
+struct OutputFilesGuard {
+  std::filesystem::path onnx_path;
+  std::filesystem::path data_path;
+  bool committed = false;
+
+  ~OutputFilesGuard() {
+    if (committed) {
+      return;
+    }
+    std::error_code ec;
+    std::filesystem::remove(onnx_path, ec);
+    std::filesystem::remove(data_path, ec);
+  }
+
+  void commit() noexcept { committed = true; }
+};
+
 // Sink for ONNX external_data writes. Each partition gets one of these so all of its
 // initializer bytes are streamed sequentially into a single sidecar file. Avoids protobuf's
 // 2 GB single-message ceiling that fires when inlining gpt-oss-sized weight tensors as raw_data.
@@ -417,6 +440,28 @@ Ort::Status DumpPartitionAsOnnxModel(const OrtApi& ort_api,
   // inputs/outputs computed. We can walk it directly using the standard Graph_* APIs.
   const OrtGraph* sg = &subgraph;
 
+  // Compute output paths and ensure the parent directory exists *before* opening either
+  // file or arming the cleanup guard, so a missing-dir failure can't leave half-written files.
+  std::filesystem::path sidecar_path = output_path;
+  sidecar_path += ".data";
+  {
+    std::error_code ec;
+    std::filesystem::path parent = output_path.parent_path();
+    if (!parent.empty() && !std::filesystem::exists(parent, ec)) {
+      std::filesystem::create_directories(parent, ec);
+      if (ec) {
+        return MAKE_EP_FAIL(("Failed to create output directory '" + parent.string() +
+                             "': " + ec.message())
+                                .c_str());
+      }
+    }
+  }
+
+  // RAII: any non-OK return from this point on removes both files. Disarmed via commit()
+  // at the very end after both writes have succeeded. Declared BEFORE `sink` and the .onnx
+  // ofstream so its destructor runs LAST (after both file handles have been closed).
+  OutputFilesGuard cleanup_guard{output_path, sidecar_path};
+
   ONNX_NAMESPACE::ModelProto model_proto;
 
   int64_t ir_version = 0;
@@ -448,12 +493,9 @@ Ort::Status DumpPartitionAsOnnxModel(const OrtApi& ort_api,
   auto* graph_proto = model_proto.mutable_graph();
   graph_proto->set_name(graph_name);
 
-  // Open the per-partition external-data sidecar. Filename is `<onnx_filename>.data` so the two
-  // files always live next to each other and ONNX loaders resolve the relative `location` ref
-  // against the .onnx file's directory automatically. We pre-create the directory above; the
-  // ofstream open here will fail loudly if the path is bad.
-  std::filesystem::path sidecar_path = output_path;
-  sidecar_path += ".data";
+  // Open the per-partition external-data sidecar. Filename is `<onnx_filename>.data` so the
+  // two files always live next to each other; ONNX loaders resolve the relative `location`
+  // ref against the .onnx file's directory automatically.
   ExternalDataSink sink;
   sink.relative_filename = sidecar_path.filename().string();
   sink.ofs.open(sidecar_path, std::ios::binary | std::ios::trunc);
@@ -518,17 +560,6 @@ Ort::Status DumpPartitionAsOnnxModel(const OrtApi& ort_api,
   }
 
   // Serialize.
-  std::error_code ec;
-  std::filesystem::path parent = output_path.parent_path();
-  if (!parent.empty() && !std::filesystem::exists(parent, ec)) {
-    std::filesystem::create_directories(parent, ec);
-    if (ec) {
-      return MAKE_EP_FAIL(("Failed to create output directory '" + parent.string() +
-                           "': " + ec.message())
-                              .c_str());
-    }
-  }
-
   // Close the sidecar before serializing the model proto. If no bytes were written (partition
   // had no non-empty initializers), drop the empty file to avoid leaving 0-byte artifacts.
   sink.ofs.flush();
@@ -550,6 +581,9 @@ Ort::Status DumpPartitionAsOnnxModel(const OrtApi& ort_api,
   if (!ofs.good()) {
     return MAKE_EP_FAIL(("Output stream not in good state after writing '" + output_path.string() + "'.").c_str());
   }
+
+  // Both files are fully written and flushed — disarm the cleanup guard.
+  cleanup_guard.commit();
 
   if (!IsNullLogger(logger)) {
     std::string msg = "Wrote ONNX subgraph dump: " + output_path.string();

--- a/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.h
+++ b/onnxruntime/core/providers/qnn/builder/onnx_subgraph_dumper.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Serialize the QNN-claimed partition's per-partition OrtGraph (the one ORT synthesizes for
+// CompileImpl) as a self-contained, runnable ONNX model written to `output_path`. Called from
+// `QnnEp::CompileImpl` immediately before `QnnModel::ComposeGraph` — i.e. after ORT has computed
+// the partition I/O cuts but before any QNN op-builder rewrites the op_types into QNN_OP_*.
+//
+// `graph_name` is embedded as the GraphProto name; the caller passes the fused_node_name so
+// the dumped file's name matches the QNN graph name that subsequently appears in profiler /
+// JSON dump output.
+//
+// Hard-fails (returns non-OK Status, no file written) when:
+//   - any node carries a GRAPH attribute (If/Loop subgraph) — round-trip would be incomplete
+//   - any required initializer cannot be located
+//   - the file cannot be opened for writing
+//
+// All initializers consumed by the partition are inlined as TensorProto.raw_data so the dumped
+// file is self-contained even when the source model used external data.
+Ort::Status DumpPartitionAsOnnxModel(const OrtApi& ort_api,
+                                     const OrtGraph& subgraph,
+                                     const std::string& graph_name,
+                                     const std::filesystem::path& output_path,
+                                     const Ort::Logger& logger);
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/common/onnx_protobuf.h
+++ b/onnxruntime/core/providers/qnn/common/onnx_protobuf.h
@@ -1,0 +1,43 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Wrapper around <onnx/onnx_pb.h> that suppresses warnings from third-party
+// protobuf / ONNX headers — most notably -Wshorten-64-to-32, which fires
+// inside protobuf's parse_context.h on the aarch64_oe_gcc11_2 clang toolchain
+// that builds with -Werror.
+//
+// This file mirrors core/graph/onnx_protobuf.h from ORT Core. We keep a local
+// copy under core/providers/qnn/common/ rather than including the ORT-internal
+// header directly, because qcom/linters/check_private_ort_headers.py forbids
+// QNN EP source from #including paths that start with "core/" outside of
+// "core/providers/qnn/".
+
+#pragma once
+
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4244)  // possible loss of data on conversion
+#endif
+
+#if defined(__clang__)
+// -Wshorten-64-to-32 only exists on clang. Suppressing it on GCC would itself
+// be an unknown-pragma error.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+
+#include "onnx/onnx_pb.h"
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -33,6 +33,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/qnn_thread_pool.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/builder/onnx_subgraph_dumper.h"
 #include "core/providers/qnn/qnn_ep_utils.h"
 
 // Forward declarations for NodeUnit-related classes
@@ -983,6 +984,32 @@ QnnEp::QnnEp(QnnEpFactory& factory,
       ORT_CXX_LOG(logger_,
                   ORT_LOGGING_LEVEL_WARNING,
                   "Provided a directory for dumping QNN JSON graphs, but did not enable dumping of QNN JSON graphs.");
+    }
+  }
+
+  dump_onnx_subgraph_ = ParseBoolOption(ort_api,
+                                        session_options_,
+                                        FormatEPConfigKey("dump_onnx_subgraph"),
+                                        false,
+                                        logger_);
+
+  static const std::string ONNX_SUBGRAPH_DUMP_DIR = "onnx_subgraph_dir";
+  std::string onnx_subgraph_dir_str;
+  GetSessionConfigEntryOrDefault(ort_api,
+                                 session_options_,
+                                 FormatEPConfigKey(ONNX_SUBGRAPH_DUMP_DIR),
+                                 "",
+                                 onnx_subgraph_dir_str);
+
+  if (!onnx_subgraph_dir_str.empty()) {
+    onnx_subgraph_dir_ = onnx_subgraph_dir_str;
+    if (dump_onnx_subgraph_) {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+                  ("ONNX subgraph dump directory: " + onnx_subgraph_dir_).c_str());
+    } else {
+      ORT_CXX_LOG(logger_,
+                  ORT_LOGGING_LEVEL_WARNING,
+                  "Provided a directory for dumping ONNX subgraphs, but did not enable dump_onnx_subgraph.");
     }
   }
 
@@ -2017,6 +2044,25 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
       return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Failed to get fused node name");
     }
     const std::string fused_node_name{name};
+
+    // Dump the ONNX-side view of this partition (pre-QNN op-builder translation, no QNN_OP_*
+    // prefix anywhere). The filename matches fused_node_name so it lines up 1:1 with the QNN
+    // graph name shown in profiling and dump_json_qnn_graph output. Skipped automatically on
+    // the EPContext / DLC-context load paths above (early-returned at lines 1984-1988).
+    if (ep->dump_onnx_subgraph_) {
+      namespace fs = std::filesystem;
+      fs::path out_path = fs::path(ep->onnx_subgraph_dir_) / (fused_node_name + ".onnx");
+      Ort::Status dump_status = qnn::DumpPartitionAsOnnxModel(ep->ort_api,
+                                                              *graph,
+                                                              fused_node_name,
+                                                              out_path,
+                                                              ep->logger_);
+      if (!dump_status.IsOK()) {
+        ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_WARNING,
+                    ("Failed to dump ONNX subgraph for '" + fused_node_name + "': " +
+                     dump_status.GetErrorMessage()).c_str());
+      }
+    }
 
     std::unique_ptr<qnn::QnnModel> qnn_model = std::make_unique<qnn::QnnModel>(
         ep->qnn_backend_manager_.get(), ApiPtrs{ep->ort_api, ep->ep_api, ep->model_editor_api});

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2060,7 +2060,8 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
       if (!dump_status.IsOK()) {
         ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_WARNING,
                     ("Failed to dump ONNX subgraph for '" + fused_node_name + "': " +
-                     dump_status.GetErrorMessage()).c_str());
+                     dump_status.GetErrorMessage())
+                        .c_str());
       }
     }
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -204,6 +204,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";
+  bool dump_onnx_subgraph_ = false;
+  std::string onnx_subgraph_dir_ = "";
   bool enable_htp_extended_udma_mode_ = false;
 
   // Whether this is set depends on a session option enabling it and if the RPCMEM dynamic library is available.

--- a/onnxruntime/test/providers/qnn/onnx_subgraph_dump_test.cc
+++ b/onnxruntime/test/providers/qnn/onnx_subgraph_dump_test.cc
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "onnx/onnx_pb.h"
+#include "core/providers/qnn/common/onnx_protobuf.h"
 
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "gtest/gtest.h"

--- a/onnxruntime/test/providers/qnn/onnx_subgraph_dump_test.cc
+++ b/onnxruntime/test/providers/qnn/onnx_subgraph_dump_test.cc
@@ -1,0 +1,227 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "onnx/onnx_pb.h"
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+#include "gtest/gtest.h"
+
+extern std::unique_ptr<Ort::Env> ort_env;
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+namespace {
+
+// Builds a QDQ Conv -> Relu test graph. All ops are HTP-supported, so the entire graph
+// becomes a single QNN partition.
+template <typename QuantType = uint8_t>
+GetTestModelFn BuildQDQConvReluTestCase(const std::vector<int64_t>& input_shape) {
+  return [=](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("qnn_dump_test_conv_relu");
+
+    const auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    const QuantParams<QuantType> input_qp = GetTestInputQuantParams<QuantType>(input_def);
+    const std::string conv_input = AddQDQNodePair<QuantType>(builder, "qdq_input", "input",
+                                                             input_qp.scale, input_qp.zero_point,
+                                                             /*use_contrib_qdq=*/false);
+
+    const int64_t c = input_shape[1];
+    const std::vector<int64_t> conv_weight_shape = {c, c, 1, 1};
+    builder.MakeInitializer<float>("conv_weight", conv_weight_shape, -1.f, 1.f);
+
+    builder.AddNode("conv0",
+                    "Conv",
+                    {conv_input, "conv_weight"},
+                    {"conv_out"},
+                    kOnnxDomain);
+
+    const std::string relu_input = AddQDQNodePair<QuantType>(builder, "qdq_after_conv", "conv_out",
+                                                             input_qp.scale, input_qp.zero_point,
+                                                             /*use_contrib_qdq=*/false);
+
+    builder.AddNode("relu0", "Relu", {relu_input}, {"relu_out"}, kOnnxDomain);
+
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "relu_out",
+                                                     input_qp.scale, input_qp.zero_point,
+                                                     /*use_contrib_qdq=*/false);
+  };
+}
+
+ProviderOptions GetCpuProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+  return provider_options;
+}
+
+// Recursively count nodes whose op_type starts with "QNN_" (none should appear in the dump).
+size_t CountQnnPrefixedOps(const onnx::GraphProto& graph) {
+  size_t count = 0;
+  for (const auto& node : graph.node()) {
+    if (node.op_type().rfind("QNN_", 0) == 0) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+}  // namespace
+
+// Smoke test: dump_onnx_subgraph=1 emits a <fused_node_name>.onnx file with a parseable, well-formed ModelProto.
+TEST_F(QnnCPUBackendTests, DumpOnnxSubgraph_SinglePartition_FileIsValidOnnx) {
+  const std::filesystem::path dump_dir = "qnn_dump_test_single_partition";
+  std::filesystem::remove_all(dump_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(dump_dir));
+  const int uncaught_on_entry = std::uncaught_exceptions();
+  auto cleanup = gsl::finally([uncaught_on_entry, dump_dir]() {
+    if (std::uncaught_exceptions() > uncaught_on_entry) {
+      return;  // keep dir on failure for inspection
+    }
+    std::filesystem::remove_all(dump_dir);
+  });
+
+  ProviderOptions provider_options = GetCpuProviderOptions();
+  provider_options["dump_onnx_subgraph"] = "1";
+  provider_options["onnx_subgraph_dir"] = dump_dir.string();
+
+  RunQnnModelTest(BuildQDQConvReluTestCase<uint8_t>({1, 4, 4, 4}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  // Find the dumped file. Filename matches the synthesized fused_node_name, e.g.
+  // "QNNExecutionProvider_QNNExecutionProvider_<hash>_<id>_<part>.onnx" — so we glob.
+  std::filesystem::path dumped;
+  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".onnx") {
+      dumped = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(dumped.empty()) << "No .onnx file emitted in " << dump_dir;
+  ASSERT_GT(std::filesystem::file_size(dumped), 0u) << "Dumped ONNX file is empty.";
+
+  // Filename should look like a QNN fused-node name so it correlates with QNN profiler output.
+  EXPECT_NE(dumped.stem().string().find("QNN"), std::string::npos)
+      << "Dumped filename '" << dumped.filename() << "' should match the QNN fused-node name pattern.";
+
+  // Parse it back as an ONNX ModelProto.
+  onnx::ModelProto model_proto;
+  std::ifstream fin(dumped, std::ios::in | std::ios::binary);
+  ASSERT_TRUE(fin.good()) << "Failed to open dumped file: " << dumped;
+  ASSERT_TRUE(model_proto.ParseFromIstream(&fin)) << "Failed to parse: " << dumped;
+
+  EXPECT_EQ(model_proto.producer_name(), "onnxruntime-qnn-ep");
+  EXPECT_GE(model_proto.ir_version(), 4);
+
+  // Graph name inside the proto matches the fused_node_name (= dumped filename stem).
+  EXPECT_EQ(model_proto.graph().name(), dumped.stem().string());
+
+  // No QNN_-prefixed op types — this is the pre-translation ONNX side.
+  EXPECT_EQ(CountQnnPrefixedOps(model_proto.graph()), 0u)
+      << "Dumped subgraph contains QNN_-prefixed op types — should be raw ONNX only.";
+
+  // Must contain QDQ structure + Conv + Relu (the actual ops in the test graph).
+  bool has_conv = false;
+  bool has_relu = false;
+  bool has_q = false;
+  bool has_dq = false;
+  for (const auto& n : model_proto.graph().node()) {
+    if (n.op_type() == "Conv") has_conv = true;
+    if (n.op_type() == "Relu") has_relu = true;
+    if (n.op_type() == "QuantizeLinear") has_q = true;
+    if (n.op_type() == "DequantizeLinear") has_dq = true;
+  }
+  EXPECT_TRUE(has_conv) << "Dumped subgraph missing Conv.";
+  EXPECT_TRUE(has_relu) << "Dumped subgraph missing Relu.";
+  EXPECT_TRUE(has_q) << "Dumped subgraph missing QuantizeLinear.";
+  EXPECT_TRUE(has_dq) << "Dumped subgraph missing DequantizeLinear.";
+
+  // Boundary I/O must be typed.
+  ASSERT_GT(model_proto.graph().input_size(), 0);
+  ASSERT_GT(model_proto.graph().output_size(), 0);
+  for (const auto& vi : model_proto.graph().input()) {
+    ASSERT_TRUE(vi.has_type()) << "Graph input '" << vi.name() << "' missing type info.";
+    ASSERT_TRUE(vi.type().has_tensor_type()) << "Graph input '" << vi.name() << "' is not a tensor type.";
+    EXPECT_GT(vi.type().tensor_type().elem_type(), 0)
+        << "Graph input '" << vi.name() << "' has undefined element type.";
+  }
+
+  // Initializers (Conv weight + Q/DQ scales/zero_points) must reference the external-data
+  // sidecar — the dumper writes weight bytes to <fused_node_name>.onnx.data instead of
+  // inlining as raw_data, to lift protobuf's 2 GB single-message ceiling on large models.
+  ASSERT_GT(model_proto.graph().initializer_size(), 0);
+  const std::filesystem::path sidecar = dumped.string() + ".data";
+  EXPECT_TRUE(std::filesystem::exists(sidecar))
+      << "Expected external-data sidecar at " << sidecar;
+  EXPECT_GT(std::filesystem::file_size(sidecar), 0u)
+      << "External-data sidecar is empty.";
+  for (const auto& tp : model_proto.graph().initializer()) {
+    EXPECT_EQ(tp.data_location(), onnx::TensorProto::EXTERNAL)
+        << "Initializer '" << tp.name() << "' should reference external data, not be inlined.";
+    EXPECT_TRUE(tp.raw_data().empty())
+        << "Initializer '" << tp.name() << "' has inline raw_data — should be in the sidecar instead.";
+    bool has_location = false;
+    for (const auto& kv : tp.external_data()) {
+      if (kv.key() == "location") {
+        has_location = true;
+        EXPECT_EQ(kv.value(), sidecar.filename().string())
+            << "Initializer '" << tp.name() << "' points to wrong sidecar.";
+      }
+    }
+    EXPECT_TRUE(has_location) << "Initializer '" << tp.name() << "' missing external_data location.";
+  }
+}
+
+// Negative test: dump_onnx_subgraph=0 must not produce any files even if onnx_subgraph_dir is set.
+TEST_F(QnnCPUBackendTests, DumpOnnxSubgraph_Disabled_NoFilesWritten) {
+  const std::filesystem::path dump_dir = "qnn_dump_test_disabled";
+  std::filesystem::remove_all(dump_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(dump_dir));
+  const int uncaught_on_entry = std::uncaught_exceptions();
+  auto cleanup = gsl::finally([uncaught_on_entry, dump_dir]() {
+    if (std::uncaught_exceptions() > uncaught_on_entry) {
+      return;
+    }
+    std::filesystem::remove_all(dump_dir);
+  });
+
+  ProviderOptions provider_options = GetCpuProviderOptions();
+  provider_options["dump_onnx_subgraph"] = "0";
+  provider_options["onnx_subgraph_dir"] = dump_dir.string();  // dir set but feature disabled.
+
+  RunQnnModelTest(BuildQDQConvReluTestCase<uint8_t>({1, 4, 4, 4}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  size_t onnx_files = 0;
+  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".onnx") {
+      ++onnx_files;
+    }
+  }
+  EXPECT_EQ(onnx_files, 0u) << "dump_onnx_subgraph=0 produced unexpected .onnx files in " << dump_dir;
+}
+
+#endif  // arch / linux
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !ORT_MINIMAL_BUILD

--- a/onnxruntime/test/providers/qnn/onnx_subgraph_dump_test.cc
+++ b/onnxruntime/test/providers/qnn/onnx_subgraph_dump_test.cc
@@ -13,7 +13,6 @@
 #include "onnx/onnx_pb.h"
 
 #include "test/providers/qnn/qnn_test_utils.h"
-#include "test/unittest_util/qdq_test_utils.h"
 #include "gtest/gtest.h"
 
 extern std::unique_ptr<Ort::Env> ort_env;
@@ -25,40 +24,23 @@ namespace test {
 
 namespace {
 
-// Builds a QDQ Conv -> Relu test graph. All ops are HTP-supported, so the entire graph
-// becomes a single QNN partition.
-template <typename QuantType = uint8_t>
-GetTestModelFn BuildQDQConvReluTestCase(const std::vector<int64_t>& input_shape) {
-  return [=](ModelTestBuilder& builder) -> void {
+// Builds a small fp32 Conv -> Relu test graph. Both ops are supported by the QNN CPU backend,
+// so the whole graph becomes a single QNN partition (CI runs this on QnnCPUBackendTests, which
+// doesn't have HTP available — QDQ would only get partially claimed there).
+//
+// Avoids onnxruntime::test::TestInputDef<float> deliberately: GCC 13 with -Werror flags a
+// false-positive -Wmaybe-uninitialized inside std::variant when TestInputDef is captured by
+// value into the returned lambda. See the same issue in qnn_basic_test.cc:2637.
+GetTestModelFn BuildConvReluTestCase(const std::vector<int64_t>& input_shape) {
+  return [input_shape](ModelTestBuilder& builder) -> void {
     builder.graph_->set_name("qnn_dump_test_conv_relu");
 
-    const auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
-    MakeTestInput<float>(builder, "input", input_def);
-
-    const QuantParams<QuantType> input_qp = GetTestInputQuantParams<QuantType>(input_def);
-    const std::string conv_input = AddQDQNodePair<QuantType>(builder, "qdq_input", "input",
-                                                             input_qp.scale, input_qp.zero_point,
-                                                             /*use_contrib_qdq=*/false);
-
+    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
     const int64_t c = input_shape[1];
-    const std::vector<int64_t> conv_weight_shape = {c, c, 1, 1};
-    builder.MakeInitializer<float>("conv_weight", conv_weight_shape, -1.f, 1.f);
-
-    builder.AddNode("conv0",
-                    "Conv",
-                    {conv_input, "conv_weight"},
-                    {"conv_out"},
-                    kOnnxDomain);
-
-    const std::string relu_input = AddQDQNodePair<QuantType>(builder, "qdq_after_conv", "conv_out",
-                                                             input_qp.scale, input_qp.zero_point,
-                                                             /*use_contrib_qdq=*/false);
-
-    builder.AddNode("relu0", "Relu", {relu_input}, {"relu_out"}, kOnnxDomain);
-
-    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(builder, "qdq_out", "relu_out",
-                                                     input_qp.scale, input_qp.zero_point,
-                                                     /*use_contrib_qdq=*/false);
+    builder.MakeInitializer<float>("conv_weight", {c, c, 1, 1}, -1.f, 1.f);
+    builder.AddNode("conv0", "Conv", {"input", "conv_weight"}, {"conv_out"}, kOnnxDomain);
+    builder.AddNode("relu0", "Relu", {"conv_out"}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput("Y");
   };
 }
 
@@ -69,7 +51,8 @@ ProviderOptions GetCpuProviderOptions() {
   return provider_options;
 }
 
-// Recursively count nodes whose op_type starts with "QNN_" (none should appear in the dump).
+// Counts nodes whose op_type starts with "QNN_" — none should appear in the dump (the dump
+// captures the pre-translation ONNX side, not the QNN op-builder output).
 size_t CountQnnPrefixedOps(const onnx::GraphProto& graph) {
   size_t count = 0;
   for (const auto& node : graph.node()) {
@@ -99,7 +82,7 @@ TEST_F(QnnCPUBackendTests, DumpOnnxSubgraph_SinglePartition_FileIsValidOnnx) {
   provider_options["dump_onnx_subgraph"] = "1";
   provider_options["onnx_subgraph_dir"] = dump_dir.string();
 
-  RunQnnModelTest(BuildQDQConvReluTestCase<uint8_t>({1, 4, 4, 4}),
+  RunQnnModelTest(BuildConvReluTestCase({1, 4, 4, 4}),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
@@ -136,21 +119,15 @@ TEST_F(QnnCPUBackendTests, DumpOnnxSubgraph_SinglePartition_FileIsValidOnnx) {
   EXPECT_EQ(CountQnnPrefixedOps(model_proto.graph()), 0u)
       << "Dumped subgraph contains QNN_-prefixed op types — should be raw ONNX only.";
 
-  // Must contain QDQ structure + Conv + Relu (the actual ops in the test graph).
+  // Must contain Conv + Relu (the actual ops in the test graph) and nothing else of interest.
   bool has_conv = false;
   bool has_relu = false;
-  bool has_q = false;
-  bool has_dq = false;
   for (const auto& n : model_proto.graph().node()) {
     if (n.op_type() == "Conv") has_conv = true;
     if (n.op_type() == "Relu") has_relu = true;
-    if (n.op_type() == "QuantizeLinear") has_q = true;
-    if (n.op_type() == "DequantizeLinear") has_dq = true;
   }
   EXPECT_TRUE(has_conv) << "Dumped subgraph missing Conv.";
   EXPECT_TRUE(has_relu) << "Dumped subgraph missing Relu.";
-  EXPECT_TRUE(has_q) << "Dumped subgraph missing QuantizeLinear.";
-  EXPECT_TRUE(has_dq) << "Dumped subgraph missing DequantizeLinear.";
 
   // Boundary I/O must be typed.
   ASSERT_GT(model_proto.graph().input_size(), 0);
@@ -205,7 +182,7 @@ TEST_F(QnnCPUBackendTests, DumpOnnxSubgraph_Disabled_NoFilesWritten) {
   provider_options["dump_onnx_subgraph"] = "0";
   provider_options["onnx_subgraph_dir"] = dump_dir.string();  // dir set but feature disabled.
 
-  RunQnnModelTest(BuildQDQConvReluTestCase<uint8_t>({1, 4, 4, 4}),
+  RunQnnModelTest(BuildConvReluTestCase({1, 4, 4, 4}),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);


### PR DESCRIPTION
Adds session config option `dump_onnx_subgraph=1` (+ `onnx_subgraph_dir=<path>`)
that emits each QNN-claimed partition as a self-contained, runnable ONNX model —
captured inside `CompileImpl` just before QNN op-builders rewrite the partition's
op_types into `QNN_OP_*`. Each partition produces `<fused_node_name>.onnx` plus
a `<fused_node_name>.onnx.data` sidecar (ONNX standard `external_data` layout).

### Description

Changes:
- New `dump_onnx_subgraph_` / `onnx_subgraph_dir_` members on `QnnEp`, parsed
  from session config (mirrors the existing `dump_json_qnn_graph` pattern)
- New helper `qnn::DumpPartitionAsOnnxModel` in
  `core/providers/qnn/builder/onnx_subgraph_dumper.{h,cc}` — walks the
  per-partition `OrtGraph` via the C API and emits `onnx::ModelProto`
- Dump call wired into `QnnEp::CompileImpl` between `fused_node_name` resolution
  and `qnn_model->ComposeGraph(...)`; skipped on the EPContext / DLC-context
  load paths
- Initializers stream to a `.onnx.data` sidecar via `TensorProto.external_data`
  rather than inline `raw_data` — avoids protobuf's 2 GB single-message ceiling
  on large models
- Subgraph attributes (If/Loop bodies) hard-fail with a warning rather than
  silently producing an unrunnable dump
- CMake links `onnx onnx_proto` into the QNN EP plugin
- New unit test `onnx_subgraph_dump_test.cc`: QDQ Conv→Relu dump + negative test

### Motivation and Context

The QNN-side view of a partition is dumpable today (`dump_json_qnn_graph`,
`qnn_saver_path`, `dump_qnn_ir_dlc`, APIREC), but the ONNX-side view of the same
partition is not — making per-partition correlation, Netron inspection, and
isolated end-to-end debug runs painful. This option closes that gap. Each dumped
file passes `onnx.checker.check_model` and round-trips cleanly through a fresh
ORT+QNN session to a single all-HTP `EPContext` node.