### PR TITLE
[QNN EP] Introduce ScopedOrtSession RAII pattern to all QNN test files

### DIFF
--- a/onnxruntime/test/providers/qnn/genie_integration_test.cc
+++ b/onnxruntime/test/providers/qnn/genie_integration_test.cc
@@ -159,10 +159,8 @@ TEST_F(GenieSessionTest, MockGenie_CallTrackingFunctions_Resolvable) {
   reset();
 
   EXPECT_EQ(get_count("DlcConfig_create"), 0);
-  {
-    ScopedOrtSession scoped = MakeGenieSession(*env_);
-    EXPECT_EQ(get_count("DlcConfig_create"), 1);
-  }
+  ScopedOrtSession scoped = MakeGenieSession(*env_);
+  EXPECT_EQ(get_count("DlcConfig_create"), 1);
   reset();
   EXPECT_EQ(get_count("DlcConfig_create"), 0);
 }
@@ -227,10 +225,11 @@ TEST_F(GenieSessionTest, Compute_InvokesExpectedApiSequence) {
 }
 
 // ---------------------------------------------------------------------------
-// Test: two sequential sessions backed by independent EP registrations both
-// succeed end-to-end. Each ScopedOrtSession owns its own
-// RegisteredEpDeviceUniquePtr, so the first session's destructor unregisters
-// the EP library before the second session re-registers it.
+// Test: two concurrent sessions backed by the same EP registration both
+// succeed end-to-end. The second session reuses scoped1's already-registered
+// OrtEpDevice directly (via AppendExecutionProvider_V2) rather than calling
+// RegisterQnnEpLibrary again, which would fail because the ORT environment
+// rejects duplicate registrations for the same name.
 // ---------------------------------------------------------------------------
 TEST_F(GenieSessionTest, TwoSequentialSessions_BothSucceed) {
   void* h = LoadMockLib();
@@ -239,17 +238,35 @@ TEST_F(GenieSessionTest, TwoSequentialSessions_BothSucceed) {
   ASSERT_NE(reset, nullptr);
   ASSERT_NE(get_count, nullptr);
 
-  // First session — registers the EP library, creates the backend, then unregisters on scope exit.
-  {
-    ScopedOrtSession scoped1 = MakeGenieSession(*env_);
-    reset();
-  }  // scoped1 destroyed: session first, then EP unregistered.
+  // First session — registers the EP library and creates the backend.
+  ScopedOrtSession scoped1 = MakeGenieSession(*env_);
+  reset();
 
-  // Second session — registers freshly; verifies a clean re-registration cycle.
+  // Second session — reuse scoped1's registration; do NOT call RegisterQnnEpLibrary.
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  CreateDlcContextGraph()(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{
+        helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+  const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
+
+  Ort::SessionOptions so2;
+  ProviderOptions provider_options;
+  provider_options["backend_path"] = kMockGeniePath;
+  so2.AppendExecutionProvider_V2(*GetOrtEnv(), {Ort::ConstEpDevice(scoped1.ep_device())}, provider_options);
   {
-    ScopedOrtSession scoped2 = MakeGenieSession(*env_);
+    Ort::Session session2(*env_, model_data_span.data(), model_data_span.size(), so2);
+    // session2's CreateStateImpl ran exactly once.
     EXPECT_EQ(get_count("DlcConfig_create"), 1);
-  }  // scoped2 destroyed: session first, then EP unregistered.
+  }  // session2 destroyed before scoped1
+  // scoped1 destroyed here: session1 first, then EP unregistered
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/genie_integration_test.cc
+++ b/onnxruntime/test/providers/qnn/genie_integration_test.cc
@@ -225,7 +225,7 @@ TEST_F(GenieSessionTest, Compute_InvokesExpectedApiSequence) {
 }
 
 // ---------------------------------------------------------------------------
-// Test: two concurrent sessions backed by the same EP registration both
+// Test: two sequential sessions backed by the same EP registration both
 // succeed end-to-end. The second session reuses scoped1's already-registered
 // OrtEpDevice directly (via AppendExecutionProvider_V2) rather than calling
 // RegisterQnnEpLibrary again, which would fail because the ORT environment

--- a/onnxruntime/test/providers/qnn/genie_integration_test.cc
+++ b/onnxruntime/test/providers/qnn/genie_integration_test.cc
@@ -72,12 +72,11 @@ static GetTestModelFn CreateDlcContextGraph() {
 
 // ---------------------------------------------------------------------------
 // Shared helper: builds the serialised model bytes and creates a session
-// backed by MockGenie. Returns the session; registered_ep_device lifetime
-// must outlive the session.
+// backed by MockGenie. Returns a ScopedOrtSession that owns both the
+// registered EP device and the Ort::Session, ensuring the session is
+// destroyed before the EP device is unregistered.
 // ---------------------------------------------------------------------------
-static Ort::Session MakeGenieSession(
-    Ort::Env& env,
-    RegisteredEpDeviceUniquePtr& registered_ep_device) {
+static ScopedOrtSession MakeGenieSession(Ort::Env& env) {
   const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
   ModelTestBuilder helper;
   CreateDlcContextGraph()(helper);
@@ -97,18 +96,19 @@ static Ort::Session MakeGenieSession(
   Ort::SessionOptions so;
   ProviderOptions provider_options;
   provider_options["backend_path"] = kMockGeniePath;
+  RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", provider_options);
 
-  return Ort::Session(env, model_data_span.data(), model_data_span.size(), so);
+  return ScopedOrtSession(std::move(registered_ep_device),
+                          Ort::Session(env, model_data_span.data(), model_data_span.size(), so));
 }
 
 // ---------------------------------------------------------------------------
 // Test: session creation with MockGenie succeeds (no exception thrown).
 // ---------------------------------------------------------------------------
 TEST_F(GenieSessionTest, CreateSession_Succeeds) {
-  RegisteredEpDeviceUniquePtr registered_ep_device;
   EXPECT_NO_THROW({
-    Ort::Session session = MakeGenieSession(*env_, registered_ep_device);
+    ScopedOrtSession scoped = MakeGenieSession(*env_);
   });
 }
 
@@ -118,35 +118,32 @@ TEST_F(GenieSessionTest, CreateSession_Succeeds) {
 // at index 1, so the final output shape is {1, 1, 1}.
 // ---------------------------------------------------------------------------
 TEST_F(GenieSessionTest, Run_ProducesExpectedOutputShape) {
-  RegisteredEpDeviceUniquePtr registered_ep_device;
-  {
-    Ort::Session session = MakeGenieSession(*env_, registered_ep_device);
+  ScopedOrtSession scoped = MakeGenieSession(*env_);
 
-    // Input: int32 tensor of shape {1, 1} — matches the graph definition.
-    std::vector<int32_t> input_data = {0};
-    const std::vector<int64_t> input_shape = {1, 1};
-    Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-    Ort::Value input_tensor = Ort::Value::CreateTensor<int32_t>(
-        mem_info, input_data.data(), input_data.size(),
-        input_shape.data(), input_shape.size());
+  // Input: int32 tensor of shape {1, 1} — matches the graph definition.
+  std::vector<int32_t> input_data = {0};
+  const std::vector<int64_t> input_shape = {1, 1};
+  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  Ort::Value input_tensor = Ort::Value::CreateTensor<int32_t>(
+      mem_info, input_data.data(), input_data.size(),
+      input_shape.data(), input_shape.size());
 
-    const char* input_names[] = {"genie_input"};
-    const char* output_names[] = {"genie_output"};
-    std::vector<Ort::Value> outputs;
+  const char* input_names[] = {"genie_input"};
+  const char* output_names[] = {"genie_output"};
+  std::vector<Ort::Value> outputs;
 
-    EXPECT_NO_THROW({
-      outputs = session.Run(Ort::RunOptions{nullptr},
-                            input_names, &input_tensor, 1,
-                            output_names, 1);
-    });
+  EXPECT_NO_THROW({
+    outputs = scoped.session().Run(Ort::RunOptions{nullptr},
+                                   input_names, &input_tensor, 1,
+                                   output_names, 1);
+  });
 
-    ASSERT_EQ(outputs.size(), 1u);
-    auto shape = outputs[0].GetTensorTypeAndShapeInfo().GetShape();
-    ASSERT_EQ(shape.size(), 3u);
-    EXPECT_EQ(shape[0], 1);
-    EXPECT_EQ(shape[1], 1);
-    EXPECT_EQ(shape[2], 1);
-  }  // session destroyed before registered_ep_device
+  ASSERT_EQ(outputs.size(), 1u);
+  auto shape = outputs[0].GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(shape.size(), 3u);
+  EXPECT_EQ(shape[0], 1);
+  EXPECT_EQ(shape[1], 1);
+  EXPECT_EQ(shape[2], 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -162,11 +159,10 @@ TEST_F(GenieSessionTest, MockGenie_CallTrackingFunctions_Resolvable) {
   reset();
 
   EXPECT_EQ(get_count("DlcConfig_create"), 0);
-  RegisteredEpDeviceUniquePtr registered_ep_device;
   {
-    Ort::Session session = MakeGenieSession(*env_, registered_ep_device);
+    ScopedOrtSession scoped = MakeGenieSession(*env_);
     EXPECT_EQ(get_count("DlcConfig_create"), 1);
-  }  // session destroyed before registered_ep_device
+  }
   reset();
   EXPECT_EQ(get_count("DlcConfig_create"), 0);
 }
@@ -184,17 +180,14 @@ TEST_F(GenieSessionTest, CreateState_InvokesExpectedApiSequence) {
   ASSERT_NE(get_count, nullptr);
   reset();
 
-  RegisteredEpDeviceUniquePtr registered_ep_device;
-  {
-    Ort::Session session = MakeGenieSession(*env_, registered_ep_device);
+  ScopedOrtSession scoped = MakeGenieSession(*env_);
 
-    EXPECT_EQ(get_count("DlcConfig_create"), 1) << "GenieDlcConfig_create";
-    EXPECT_EQ(get_count("Dlc_create"), 1) << "GenieDlc_create";
-    EXPECT_EQ(get_count("NodeConfig_createFromDlc"), 1) << "GenieNodeConfig_createFromDlc";
-    EXPECT_EQ(get_count("Log_create"), 1) << "GenieLog_create";
-    EXPECT_EQ(get_count("NodeConfig_bindLogger"), 1) << "GenieNodeConfig_bindLogger";
-    EXPECT_EQ(get_count("Node_create"), 1) << "GenieNode_create";
-  }  // session destroyed before registered_ep_device
+  EXPECT_EQ(get_count("DlcConfig_create"), 1) << "GenieDlcConfig_create";
+  EXPECT_EQ(get_count("Dlc_create"), 1) << "GenieDlc_create";
+  EXPECT_EQ(get_count("NodeConfig_createFromDlc"), 1) << "GenieNodeConfig_createFromDlc";
+  EXPECT_EQ(get_count("Log_create"), 1) << "GenieLog_create";
+  EXPECT_EQ(get_count("NodeConfig_bindLogger"), 1) << "GenieNodeConfig_bindLogger";
+  EXPECT_EQ(get_count("Node_create"), 1) << "GenieNode_create";
 }
 
 // ---------------------------------------------------------------------------
@@ -211,37 +204,33 @@ TEST_F(GenieSessionTest, Compute_InvokesExpectedApiSequence) {
   ASSERT_NE(get_count, nullptr);
   reset();
 
-  RegisteredEpDeviceUniquePtr registered_ep_device;
-  {
-    Ort::Session session = MakeGenieSession(*env_, registered_ep_device);
+  ScopedOrtSession scoped = MakeGenieSession(*env_);
 
-    std::vector<int32_t> input_data = {0};
-    const std::vector<int64_t> input_shape = {1, 1};
-    Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-    Ort::Value input_tensor = Ort::Value::CreateTensor<int32_t>(
-        mem_info, input_data.data(), input_data.size(),
-        input_shape.data(), input_shape.size());
+  std::vector<int32_t> input_data = {0};
+  const std::vector<int64_t> input_shape = {1, 1};
+  Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  Ort::Value input_tensor = Ort::Value::CreateTensor<int32_t>(
+      mem_info, input_data.data(), input_data.size(),
+      input_shape.data(), input_shape.size());
 
-    const char* input_names[] = {"genie_input"};
-    const char* output_names[] = {"genie_output"};
-    session.Run(Ort::RunOptions{nullptr},
-                input_names, &input_tensor, 1,
-                output_names, 1);
+  const char* input_names[] = {"genie_input"};
+  const char* output_names[] = {"genie_output"};
+  scoped.session().Run(Ort::RunOptions{nullptr},
+                       input_names, &input_tensor, 1,
+                       output_names, 1);
 
-    EXPECT_EQ(get_count("Node_setData"), 1) << "GenieNode_setData";
-    EXPECT_EQ(get_count("Node_execute"), 1) << "GenieNode_execute";
-    EXPECT_EQ(get_count("Node_getData"), 1) << "GenieNode_getData";
-    // KV-cache rewind is not triggered on a fresh session (rewind_ starts at 1):
-    EXPECT_EQ(get_count("Node_reset"), 0) << "GenieNode_reset should not be called on first Run";
-  }  // session destroyed before registered_ep_device
+  EXPECT_EQ(get_count("Node_setData"), 1) << "GenieNode_setData";
+  EXPECT_EQ(get_count("Node_execute"), 1) << "GenieNode_execute";
+  EXPECT_EQ(get_count("Node_getData"), 1) << "GenieNode_getData";
+  // KV-cache rewind is not triggered on a fresh session (rewind_ starts at 1):
+  EXPECT_EQ(get_count("Node_reset"), 0) << "GenieNode_reset should not be called on first Run";
 }
 
 // ---------------------------------------------------------------------------
-// Test: two sequential sessions backed by the same EP registration both
-// succeed end-to-end.  The second session reuses ep1's already-registered
-// OrtEpDevice directly (via AppendExecutionProvider_V2) rather than calling
-// RegisterQnnEpLibrary again, which would fail because the ORT environment
-// rejects duplicate registrations for the same name.
+// Test: two sequential sessions backed by independent EP registrations both
+// succeed end-to-end. Each ScopedOrtSession owns its own
+// RegisteredEpDeviceUniquePtr, so the first session's destructor unregisters
+// the EP library before the second session re-registers it.
 // ---------------------------------------------------------------------------
 TEST_F(GenieSessionTest, TwoSequentialSessions_BothSucceed) {
   void* h = LoadMockLib();
@@ -250,39 +239,17 @@ TEST_F(GenieSessionTest, TwoSequentialSessions_BothSucceed) {
   ASSERT_NE(reset, nullptr);
   ASSERT_NE(get_count, nullptr);
 
-  // First session — registers the EP library and creates the backend.
-  RegisteredEpDeviceUniquePtr ep1;
+  // First session — registers the EP library, creates the backend, then unregisters on scope exit.
   {
-    Ort::Session session1 = MakeGenieSession(*env_, ep1);
+    ScopedOrtSession scoped1 = MakeGenieSession(*env_);
     reset();
+  }  // scoped1 destroyed: session first, then EP unregistered.
 
-    // Second session — reuse ep1's registration; do NOT call RegisterQnnEpLibrary.
-    const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
-    ModelTestBuilder helper;
-    CreateDlcContextGraph()(helper);
-    for (const auto& [domain, version] : domain_to_version) {
-      const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{
-          helper.model_.add_opset_import()};
-      opset_id_proto->set_domain(domain);
-      opset_id_proto->set_version(version);
-    }
-    helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
-    std::string model_data;
-    helper.model_.SerializeToString(&model_data);
-    const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
-
-    Ort::SessionOptions so2;
-    ProviderOptions provider_options;
-    provider_options["backend_path"] = kMockGeniePath;
-    so2.AppendExecutionProvider_V2(*GetOrtEnv(), {Ort::ConstEpDevice(ep1.get())}, provider_options);
-    {
-      Ort::Session session2(*env_, model_data_span.data(), model_data_span.size(), so2);
-
-      // session2's CreateStateImpl ran exactly once.
-      EXPECT_EQ(get_count("DlcConfig_create"), 1);
-    }  // session2 destroyed before ep1
-  }  // session1 destroyed before ep1
-  // ep1 destroyed here
+  // Second session — registers freshly; verifies a clean re-registration cycle.
+  {
+    ScopedOrtSession scoped2 = MakeGenieSession(*env_);
+    EXPECT_EQ(get_count("DlcConfig_create"), 1);
+  }  // scoped2 destroyed: session first, then EP unregistered.
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -238,24 +238,22 @@ TEST_F(QnnHTPBackendTests, TestAddEpUsingPublicApi) {
 
   const ORTCHAR_T* ort_model_path = ORT_MODEL_FOLDER "constant_floats.onnx";
 
-  {
-    Ort::SessionOptions so;
-    // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
-    so.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
+  Ort::SessionOptions so;
+  // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
+  so.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
 
-    // TODO: Remove #ifdef when Windows Arm64 machines support the CPU backend.
+  // TODO: Remove #ifdef when Windows Arm64 machines support the CPU backend.
 #if defined(__linux__)
-    so.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");  // Disable fallback to the CPU EP.
+  so.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");  // Disable fallback to the CPU EP.
 #endif
 
-    RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
-    Ort::Session session(*ort_env, ort_model_path, so);
-    ASSERT_TRUE(SessionHasEp(session, kQnnExecutionProvider))
-        << "QNN EP was not found in registered providers for session "
-        << "when added to session with name '" << kQnnExecutionProvider << "'";
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ort_model_path, so));
+  ASSERT_TRUE(SessionHasEp(scoped.session(), kQnnExecutionProvider))
+      << "QNN EP was not found in registered providers for session "
+      << "when added to session with name '" << kQnnExecutionProvider << "'";
 }
 
 // Conv node `Conv` is not supported: GetFileLength for conv_qdq_external_ini.bin failed:open file conv_qdq_external_ini.bin fail,
@@ -283,9 +281,7 @@ TEST_F(QnnHTPBackendTests, TestConvWithExternalData) {
 
   const ORTCHAR_T* ort_model_path = ORT_MODEL_FOLDER "conv_qdq_external_ini.onnx";
 
-  {
-    Ort::Session session(*ort_env, ort_model_path, so);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ort_model_path, so));
 }
 
 TEST_F(QnnHTPBackendTests, RunConvInt4Model) {
@@ -311,33 +307,31 @@ TEST_F(QnnHTPBackendTests, RunConvInt4Model) {
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   const ORTCHAR_T* ort_model_path = ORT_MODEL_FOLDER "conv.int4_weights.qdq.onnx";
-  {
-    Ort::Session session(*ort_env, ort_model_path, so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ort_model_path, so));
 
-    std::array<int64_t, 4> inputs_shape{1, 3, 8, 8};
-    std::vector<float> input0_data(1 * 3 * 8 * 8, 0.2f);
+  std::array<int64_t, 4> inputs_shape{1, 3, 8, 8};
+  std::vector<float> input0_data(1 * 3 * 8 * 8, 0.2f);
 
-    auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
-    std::vector<Ort::Value> ort_inputs;
-    std::vector<const char*> ort_input_names;
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::vector<Ort::Value> ort_inputs;
+  std::vector<const char*> ort_input_names;
 
-    // Add input0
-    ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
-        memory_info, input0_data.data(), input0_data.size(), inputs_shape.data(), inputs_shape.size()));
-    ort_input_names.push_back("input_0");
+  // Add input0
+  ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
+      memory_info, input0_data.data(), input0_data.size(), inputs_shape.data(), inputs_shape.size()));
+  ort_input_names.push_back("input_0");
 
-    // Run session and get outputs
-    std::array<const char*, 1> output_names{"output_0"};
-    std::vector<Ort::Value> ort_outputs = session.Run(Ort::RunOptions{nullptr}, ort_input_names.data(), ort_inputs.data(),
-                                                      ort_inputs.size(), output_names.data(), output_names.size());
+  // Run session and get outputs
+  std::array<const char*, 1> output_names{"output_0"};
+  std::vector<Ort::Value> ort_outputs = scoped.session().Run(Ort::RunOptions{nullptr}, ort_input_names.data(), ort_inputs.data(),
+                                                             ort_inputs.size(), output_names.data(), output_names.size());
 
-    // Check output shape.
-    Ort::Value& ort_output = ort_outputs[0];
-    auto typeshape = ort_output.GetTensorTypeAndShapeInfo();
-    std::vector<int64_t> output_shape = typeshape.GetShape();
+  // Check output shape.
+  Ort::Value& ort_output = ort_outputs[0];
+  auto typeshape = ort_output.GetTensorTypeAndShapeInfo();
+  std::vector<int64_t> output_shape = typeshape.GetShape();
 
-    EXPECT_THAT(output_shape, ::testing::ElementsAre(1, 5, 6, 6));
-  }
+  EXPECT_THAT(output_shape, ::testing::ElementsAre(1, 5, 6, 6));
 }
 #endif  // #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
@@ -389,15 +383,14 @@ static void AddSerializerConfigs(TestBackend serializer_backend, ProviderOptions
 #endif
 }
 
-static Ort::Session InitNHWCResizeModel(const ORTCHAR_T* ort_model_path,
-                                        TestBackend backend,
-                                        RegisteredEpDeviceUniquePtr& registered_ep_device,
-                                        std::optional<TestBackend> serializer_backend = std::nullopt,
-                                        std::string htp_graph_finalization_opt_mode = "",
-                                        std::string qnn_context_priority = "",
-                                        std::string soc_model = "",
-                                        std::string htp_arch = "",
-                                        std::string device_id = "") {
+static std::unique_ptr<ScopedOrtSession> InitNHWCResizeModel(const ORTCHAR_T* ort_model_path,
+                                                             TestBackend backend,
+                                                             std::optional<TestBackend> serializer_backend = std::nullopt,
+                                                             std::string htp_graph_finalization_opt_mode = "",
+                                                             std::string qnn_context_priority = "",
+                                                             std::string soc_model = "",
+                                                             std::string htp_arch = "",
+                                                             std::string device_id = "") {
   Ort::SessionOptions so;
 
   // Ensure all type/shape inference warnings result in errors!
@@ -446,10 +439,10 @@ static Ort::Session InitNHWCResizeModel(const ORTCHAR_T* ort_model_path,
     options["device_id"] = std::move(device_id);
   }
 
+  RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
-  Ort::Session session(*ort_env, ort_model_path, so);
-
-  return session;
+  return std::make_unique<ScopedOrtSession>(std::move(registered_ep_device),
+                                            Ort::Session(*ort_env, ort_model_path, so));
 }
 
 // Helper function that runs an ONNX model with a NHWC Resize operator to test that
@@ -467,56 +460,51 @@ static void RunNHWCResizeModel(const ORTCHAR_T* ort_model_path,
                                std::string soc_model = "",
                                std::string htp_arch = "",
                                std::string device_id = "") {
-  // Only constructed if use_abi=true.
-  RegisteredEpDeviceUniquePtr registered_ep_device;
-  {
-    Ort::Session session = InitNHWCResizeModel(ort_model_path,
-                                               backend,
-                                               registered_ep_device,
-                                               serializer_backend,
-                                               htp_graph_finalization_opt_mode,
-                                               qnn_context_priority,
-                                               soc_model,
-                                               htp_arch,
-                                               device_id);
+  auto scoped = InitNHWCResizeModel(ort_model_path,
+                                    backend,
+                                    serializer_backend,
+                                    htp_graph_finalization_opt_mode,
+                                    qnn_context_priority,
+                                    soc_model,
+                                    htp_arch,
+                                    device_id);
 
-    // Input can be all zeros since we're testing for correct shape inference.
-    std::array<float, 1 * 3 * 4 * 5> input0_data = {};
-    std::array<float, 1 * 3 * 4 * 5> input1_data = {};
-    std::array<float, 1 * 3 * 4 * 5> input2_data = {};
+  // Input can be all zeros since we're testing for correct shape inference.
+  std::array<float, 1 * 3 * 4 * 5> input0_data = {};
+  std::array<float, 1 * 3 * 4 * 5> input1_data = {};
+  std::array<float, 1 * 3 * 4 * 5> input2_data = {};
 
-    auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
-    std::vector<Ort::Value> ort_inputs;
-    std::vector<const char*> ort_input_names;
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  std::vector<Ort::Value> ort_inputs;
+  std::vector<const char*> ort_input_names;
 
-    // Add input0
-    std::array<int64_t, 4> inputs_shape{1, 3, 4, 5};
-    ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
-        memory_info, input0_data.data(), input0_data.size(), inputs_shape.data(), inputs_shape.size()));
-    ort_input_names.push_back("input0");
+  // Add input0
+  std::array<int64_t, 4> inputs_shape{1, 3, 4, 5};
+  ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
+      memory_info, input0_data.data(), input0_data.size(), inputs_shape.data(), inputs_shape.size()));
+  ort_input_names.push_back("input0");
 
-    // Add input1
-    ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
-        memory_info, input1_data.data(), input1_data.size(), inputs_shape.data(), inputs_shape.size()));
-    ort_input_names.push_back("input1");
+  // Add input1
+  ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
+      memory_info, input1_data.data(), input1_data.size(), inputs_shape.data(), inputs_shape.size()));
+  ort_input_names.push_back("input1");
 
-    // Add input2
-    ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
-        memory_info, input2_data.data(), input2_data.size(), inputs_shape.data(), inputs_shape.size()));
-    ort_input_names.push_back("input2");
+  // Add input2
+  ort_inputs.emplace_back(Ort::Value::CreateTensor<float>(
+      memory_info, input2_data.data(), input2_data.size(), inputs_shape.data(), inputs_shape.size()));
+  ort_input_names.push_back("input2");
 
-    // Run session and get outputs
-    std::array<const char*, 2> output_names{"output0", "output1"};
-    std::vector<Ort::Value> ort_outputs = session.Run(Ort::RunOptions{nullptr}, ort_input_names.data(), ort_inputs.data(),
-                                                      ort_inputs.size(), output_names.data(), output_names.size());
+  // Run session and get outputs
+  std::array<const char*, 2> output_names{"output0", "output1"};
+  std::vector<Ort::Value> ort_outputs = scoped->session().Run(Ort::RunOptions{nullptr}, ort_input_names.data(), ort_inputs.data(),
+                                                              ort_inputs.size(), output_names.data(), output_names.size());
 
-    // Check output shape.
-    Ort::Value& ort_output = ort_outputs[1];
-    auto typeshape = ort_output.GetTensorTypeAndShapeInfo();
-    std::vector<int64_t> output_shape = typeshape.GetShape();
+  // Check output shape.
+  Ort::Value& ort_output = ort_outputs[1];
+  auto typeshape = ort_output.GetTensorTypeAndShapeInfo();
+  std::vector<int64_t> output_shape = typeshape.GetShape();
 
-    EXPECT_THAT(output_shape, ::testing::ElementsAre(1, 6, 7, 10));
-  }
+  EXPECT_THAT(output_shape, ::testing::ElementsAre(1, 6, 7, 10));
 }
 
 // Test shape inference of NHWC Resize operator (opset 11) that uses
@@ -696,21 +684,20 @@ TEST_F(QnnCPUBackendTests, MultithreadSessionRun) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts));
 
-    std::vector<std::thread> threads;
-    constexpr int num_threads = 5;
-    constexpr int loop_count = 10;
+  std::vector<std::thread> threads;
+  constexpr int num_threads = 5;
+  constexpr int loop_count = 10;
 
-    for (int i = 0; i < num_threads; i++) {
-      threads.push_back(std::thread(RunSessionAndVerify, std::ref(session), Ort::RunOptions{nullptr},
-                                    std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
-    }
+  for (int i = 0; i < num_threads; i++) {
+    threads.push_back(std::thread(RunSessionAndVerify, std::ref(scoped.session()), Ort::RunOptions{nullptr},
+                                  std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
+  }
 
-    for (auto& th : threads) {
-      th.join();
-    }
+  for (auto& th : threads) {
+    th.join();
   }
 }
 
@@ -780,21 +767,20 @@ TEST_F(QnnHTPBackendTests, MultithreadSessionRun) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts));
 
-    std::vector<std::thread> threads;
-    constexpr int num_threads = 5;
-    constexpr int loop_count = 10;
+  std::vector<std::thread> threads;
+  constexpr int num_threads = 5;
+  constexpr int loop_count = 10;
 
-    for (int i = 0; i < num_threads; i++) {
-      threads.push_back(std::thread(RunSessionAndVerify, std::ref(session), Ort::RunOptions{nullptr},
-                                    std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
-    }
+  for (int i = 0; i < num_threads; i++) {
+    threads.push_back(std::thread(RunSessionAndVerify, std::ref(scoped.session()), Ort::RunOptions{nullptr},
+                                  std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
+  }
 
-    for (auto& th : threads) {
-      th.join();
-    }
+  for (auto& th : threads) {
+    th.join();
   }
 }
 
@@ -836,27 +822,26 @@ TEST_F(QnnHTPBackendTests, MultithreadHtpPowerCfgSessionRunOption) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts));
 
-    std::vector<std::thread> threads;
-    constexpr int num_threads = 5;
-    constexpr int loop_count = 10;
+  std::vector<std::thread> threads;
+  constexpr int num_threads = 5;
+  constexpr int loop_count = 10;
 
-    size_t post_i = perf_modes.size() - 1;
-    ASSERT_TRUE(post_i > num_threads);
-    for (int i = 0; i < num_threads; i++, post_i--) {
-      Ort::RunOptions run_opts;
-      run_opts.SetRunTag("logger0");
-      run_opts.AddConfigEntry("qnn.htp_perf_mode", perf_modes[i].c_str());
-      run_opts.AddConfigEntry("qnn.htp_perf_mode_post_run", perf_modes[post_i].c_str());
-      threads.push_back(std::thread(RunSessionAndVerify, std::ref(session), std::move(run_opts),
-                                    std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
-    }
+  size_t post_i = perf_modes.size() - 1;
+  ASSERT_TRUE(post_i > num_threads);
+  for (int i = 0; i < num_threads; i++, post_i--) {
+    Ort::RunOptions run_opts;
+    run_opts.SetRunTag("logger0");
+    run_opts.AddConfigEntry("qnn.htp_perf_mode", perf_modes[i].c_str());
+    run_opts.AddConfigEntry("qnn.htp_perf_mode_post_run", perf_modes[post_i].c_str());
+    threads.push_back(std::thread(RunSessionAndVerify, std::ref(scoped.session()), std::move(run_opts),
+                                  std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
+  }
 
-    for (auto& th : threads) {
-      th.join();
-    }
+  for (auto& th : threads) {
+    th.join();
   }
 }
 
@@ -895,20 +880,19 @@ TEST_F(QnnHTPBackendTests, MultithreadDefaultHtpPowerCfgFromEpOption) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts));
 
-    std::vector<std::thread> threads;
-    constexpr int num_threads = 5;
-    constexpr int loop_count = 10;
-    for (int i = 0; i < num_threads; i++) {
-      threads.push_back(std::thread(RunSessionAndVerify, std::ref(session), Ort::RunOptions{nullptr},
-                                    std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
-    }
+  std::vector<std::thread> threads;
+  constexpr int num_threads = 5;
+  constexpr int loop_count = 10;
+  for (int i = 0; i < num_threads; i++) {
+    threads.push_back(std::thread(RunSessionAndVerify, std::ref(scoped.session()), Ort::RunOptions{nullptr},
+                                  std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
+  }
 
-    for (auto& th : threads) {
-      th.join();
-    }
+  for (auto& th : threads) {
+    th.join();
   }
 }
 
@@ -952,27 +936,26 @@ TEST_F(QnnHTPBackendTests, MultithreadHtpPowerCfgDefaultAndRunOption) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), session_opts));
 
-    std::vector<std::thread> threads;
-    constexpr int num_threads = 5;
-    constexpr int loop_count = 10;
+  std::vector<std::thread> threads;
+  constexpr int num_threads = 5;
+  constexpr int loop_count = 10;
 
-    size_t post_i = perf_modes.size() - 1;
-    ASSERT_TRUE(post_i > num_threads);
-    for (int i = 0; i < num_threads; i++, post_i--) {
-      Ort::RunOptions run_opts;
-      run_opts.SetRunTag("logger0");
-      run_opts.AddConfigEntry("qnn.htp_perf_mode", perf_modes[i].c_str());
-      run_opts.AddConfigEntry("qnn.htp_perf_mode_post_run", perf_modes[post_i].c_str());
-      threads.push_back(std::thread(RunSessionAndVerify, std::ref(session), std::move(run_opts),
-                                    std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
-    }
+  size_t post_i = perf_modes.size() - 1;
+  ASSERT_TRUE(post_i > num_threads);
+  for (int i = 0; i < num_threads; i++, post_i--) {
+    Ort::RunOptions run_opts;
+    run_opts.SetRunTag("logger0");
+    run_opts.AddConfigEntry("qnn.htp_perf_mode", perf_modes[i].c_str());
+    run_opts.AddConfigEntry("qnn.htp_perf_mode_post_run", perf_modes[post_i].c_str());
+    threads.push_back(std::thread(RunSessionAndVerify, std::ref(scoped.session()), std::move(run_opts),
+                                  std::ref(model->builder.feeds_), output_shapes, output_values, loop_count));
+  }
 
-    for (auto& th : threads) {
-      th.join();
-    }
+  for (auto& th : threads) {
+    th.join();
   }
 }
 
@@ -992,7 +975,6 @@ TEST_F(QnnHTPBackendTests, QnnIr_OutputFiles) {
   }
   ASSERT_NE(ir_backend_support, BackendSupport::SUPPORT_ERROR) << "Failed to check if QNN IR backend is available.";
 
-  RegisteredEpDeviceUniquePtr registered_ep_device;
   const std::filesystem::path qnn_dlc_dir = kDlcOutputDir;
 
   // Remove pre-existing QNN Ir output files. Note that fs::remove_all() can handle non-existing paths.
@@ -1000,9 +982,8 @@ TEST_F(QnnHTPBackendTests, QnnIr_OutputFiles) {
   ASSERT_FALSE(std::filesystem::exists(qnn_dlc_dir));
 
   InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Htp,      // backend
-                      registered_ep_device,  // registered_ep_device
-                      TestBackend::Ir);      // serializer backend
+                      TestBackend::Htp,  // backend
+                      TestBackend::Ir);  // serializer backend
 
   // File names are taken from graph node names. Just make sure that we got one .dlc
   // in the expected directory.
@@ -1409,18 +1390,16 @@ TEST_F(QnnHTPBackendTests, DumpJsonQNNGraph) {
   Ort::SessionOptions so;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, ort_model_path, so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ort_model_path, so));
 
-    // Check that QNN JSON file(s) exist.
-    bool has_a_json_file = false;
-    for (auto const& dir_entry : std::filesystem::directory_iterator{dump_dir}) {
-      EXPECT_TRUE(dir_entry.is_regular_file());
-      EXPECT_EQ(dir_entry.path().extension().string(), ".json");
-      has_a_json_file = true;
-    }
-    EXPECT_TRUE(has_a_json_file);
+  // Check that QNN JSON file(s) exist.
+  bool has_a_json_file = false;
+  for (auto const& dir_entry : std::filesystem::directory_iterator{dump_dir}) {
+    EXPECT_TRUE(dir_entry.is_regular_file());
+    EXPECT_EQ(dir_entry.path().extension().string(), ".json");
+    has_a_json_file = true;
   }
+  EXPECT_TRUE(has_a_json_file);
 
   // Cleaup generated files.
   // Comment the following line to inspect generated JSON files.
@@ -1595,47 +1574,45 @@ TEST_F(QnnHTPBackendTests, OffloadGraphIoQuantizationTensorNameOverrides) {
   so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
 
-    // Find the JSON graph file
-    std::filesystem::path json_file_path;
-    for (const auto& dir_entry : std::filesystem::directory_iterator{dump_dir}) {
-      if (dir_entry.is_regular_file() && dir_entry.path().extension().string() == ".json" &&
-          dir_entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-        json_file_path = dir_entry.path();
-        break;
-      }
+  // Find the JSON graph file
+  std::filesystem::path json_file_path;
+  for (const auto& dir_entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (dir_entry.is_regular_file() && dir_entry.path().extension().string() == ".json" &&
+        dir_entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_file_path = dir_entry.path();
+      break;
     }
-    ASSERT_FALSE(json_file_path.empty()) << "No JSON graph file found in " << dump_dir;
-
-    // Parse JSON and extract tensor names
-    std::set<std::string> tensor_names;
-    {
-      std::ifstream json_file(json_file_path);
-      ASSERT_TRUE(json_file.is_open()) << "Failed to open JSON file: " << json_file_path;
-
-      nlohmann::json root_json;
-      json_file >> root_json;
-
-      ASSERT_TRUE(root_json.contains("graph")) << "JSON missing 'graph' field";
-      const auto& graph_json = root_json["graph"];
-      ASSERT_TRUE(graph_json.contains("tensors")) << "JSON graph missing 'tensors' field";
-
-      for (const auto& [name, tensor] : graph_json["tensors"].items()) {
-        tensor_names.insert(name);
-      }
-    }
-
-    // Verify original ONNX names appear in DLC (not internal quantized names)
-    const std::string expected_input_name = "input";
-    const std::string expected_output_name = "qdq_output_dq_out";
-
-    EXPECT_TRUE(tensor_names.count(expected_input_name))
-        << "Expected input '" << expected_input_name << "' not found.";
-    EXPECT_TRUE(tensor_names.count(expected_output_name))
-        << "Expected output '" << expected_output_name << "' not found.";
   }
+  ASSERT_FALSE(json_file_path.empty()) << "No JSON graph file found in " << dump_dir;
+
+  // Parse JSON and extract tensor names
+  std::set<std::string> tensor_names;
+  {
+    std::ifstream json_file(json_file_path);
+    ASSERT_TRUE(json_file.is_open()) << "Failed to open JSON file: " << json_file_path;
+
+    nlohmann::json root_json;
+    json_file >> root_json;
+
+    ASSERT_TRUE(root_json.contains("graph")) << "JSON missing 'graph' field";
+    const auto& graph_json = root_json["graph"];
+    ASSERT_TRUE(graph_json.contains("tensors")) << "JSON graph missing 'tensors' field";
+
+    for (const auto& [name, tensor] : graph_json["tensors"].items()) {
+      tensor_names.insert(name);
+    }
+  }
+
+  // Verify original ONNX names appear in DLC (not internal quantized names)
+  const std::string expected_input_name = "input";
+  const std::string expected_output_name = "qdq_output_dq_out";
+
+  EXPECT_TRUE(tensor_names.count(expected_input_name))
+      << "Expected input '" << expected_input_name << "' not found.";
+  EXPECT_TRUE(tensor_names.count(expected_output_name))
+      << "Expected output '" << expected_output_name << "' not found.";
 }
 
 // TODO: Test will be re-enabled for Linux once QNN API issue is resolved
@@ -2031,28 +2008,25 @@ TEST_F(QnnHTPBackendTests, OffloadGraphIoQuantizationContextBinaryRoundTrip) {
     RegisteredEpDeviceUniquePtr registered_ep_device;
     RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
     ASSERT_TRUE(std::filesystem::exists(ctx_model_file)) << "Context binary not generated";
   }
 
-  {
-    Ort::SessionOptions so2;
-    so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_model_file.c_str());
+  Ort::SessionOptions so2;
+  so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_model_file.c_str());
 
-    RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so2, kQnnExecutionProvider, provider_options);
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so2, kQnnExecutionProvider, provider_options);
 
-    std::ifstream ifs(ctx_model_file, std::ios::binary);
-    std::string ctx_data((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
-    Ort::Session session2(*ort_env, ctx_data.data(), ctx_data.size(), so2);
-  }
+  std::ifstream ifs(ctx_model_file, std::ios::binary);
+  std::string ctx_data((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_data.data(), ctx_data.size(), so2));
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Test that QNN Ir generates the expected files for a model meant to run on any QNN backend.
 TEST_F(QnnIRBackendTests, QnnIr_OutputFiles) {
-  RegisteredEpDeviceUniquePtr registered_ep_device;
   const std::filesystem::path qnn_dlc_dir = kDlcOutputDir;
 
   // Remove pre-existing QNN Ir output files. Note that fs::remove_all() can handle non-existing paths.
@@ -2060,9 +2034,8 @@ TEST_F(QnnIRBackendTests, QnnIr_OutputFiles) {
   ASSERT_FALSE(std::filesystem::exists(qnn_dlc_dir));
 
   InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Ir,       // backend
-                      registered_ep_device,  // registered_ep_device
-                      TestBackend::Ir);      // serializer backend
+                      TestBackend::Ir,   // backend
+                      TestBackend::Ir);  // serializer backend
 
   // File names are taken from graph node names. Just make sure that we got one .dlc
   // in the expected directory.
@@ -2079,7 +2052,6 @@ TEST_F(QnnIRBackendTests, QnnIr_OutputFiles) {
 
 // Test that QNN Saver generates the expected files for a model meant to run on any QNN backend.
 TEST(QnnSaverBackendTests, DISABLED_QnnSaver_OutputFiles) {
-  RegisteredEpDeviceUniquePtr registered_ep_device;
   const std::filesystem::path qnn_saver_output_dir = "saver_output";
 
   // Remove pre-existing QNN Saver output files. Note that fs::remove_all() can handle non-existing paths.
@@ -2087,9 +2059,8 @@ TEST(QnnSaverBackendTests, DISABLED_QnnSaver_OutputFiles) {
   ASSERT_FALSE(std::filesystem::exists(qnn_saver_output_dir));
 
   InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Saver,    // backend
-                      registered_ep_device,  // registered_ep_device
-                      TestBackend::Saver);   // serializer_backend
+                      TestBackend::Saver,   // backend
+                      TestBackend::Saver);  // serializer_backend
 
   // Check that QNN Saver output files exist.
   EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "saver_output.c"));
@@ -2146,39 +2117,38 @@ TEST_F(QnnCPUBackendTests, PartitionAddedInputRegisteredAsGraphInput) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
 
-    std::filesystem::path json_path;
-    for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
-      if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-          entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-        json_path = entry.path();
-        break;
-      }
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
     }
-    ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
-
-    std::vector<std::pair<std::string, int>> inputs_with_id;
-    {
-      std::ifstream json_file(json_path);
-      ASSERT_TRUE(json_file.is_open());
-      nlohmann::json root;
-      json_file >> root;
-      for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
-        if (tensor.value("type", -1) == 0) {  // QNN_TENSOR_TYPE_APP_WRITE
-          inputs_with_id.emplace_back(name, tensor.value("id", -1));
-        }
-      }
-    }
-    std::sort(inputs_with_id.begin(), inputs_with_id.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-
-    // ONNX-declared input first, partition-added input second.
-    ASSERT_EQ(inputs_with_id.size(), 2u);
-    EXPECT_EQ(inputs_with_id[0].first, "input");
-    EXPECT_EQ(inputs_with_id[1].first, "rnl_output");
   }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  std::vector<std::pair<std::string, int>> inputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+    nlohmann::json root;
+    json_file >> root;
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      if (tensor.value("type", -1) == 0) {  // QNN_TENSOR_TYPE_APP_WRITE
+        inputs_with_id.emplace_back(name, tensor.value("id", -1));
+      }
+    }
+  }
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  // ONNX-declared input first, partition-added input second.
+  ASSERT_EQ(inputs_with_id.size(), 2u);
+  EXPECT_EQ(inputs_with_id[0].first, "input");
+  EXPECT_EQ(inputs_with_id[1].first, "rnl_output");
 }
 
 // Returns a function that builds a QDQ model with RandomNormalLike (CPU-only) + Add
@@ -2241,40 +2211,39 @@ TEST_F(QnnCPUBackendTests, PartitionAddedInputRegisteredAsGraphInputOffloadGraph
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
 
-    std::filesystem::path json_path;
-    for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
-      if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-          entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-        json_path = entry.path();
-        break;
-      }
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
     }
-    ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
-
-    std::vector<std::pair<std::string, int>> inputs_with_id;
-    {
-      std::ifstream json_file(json_path);
-      ASSERT_TRUE(json_file.is_open());
-      nlohmann::json root;
-      json_file >> root;
-      for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
-        if (tensor.value("type", -1) == 0) {  // QNN_TENSOR_TYPE_APP_WRITE
-          inputs_with_id.emplace_back(name, tensor.value("id", -1));
-        }
-      }
-    }
-    std::sort(inputs_with_id.begin(), inputs_with_id.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-
-    // ONNX-declared input first (registered under its external name "input" via tensor_name_overrides),
-    // partition-added input second.
-    ASSERT_EQ(inputs_with_id.size(), 2u);
-    EXPECT_EQ(inputs_with_id[0].first, "input");
-    EXPECT_EQ(inputs_with_id[1].first, "rnl_output");
   }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  std::vector<std::pair<std::string, int>> inputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+    nlohmann::json root;
+    json_file >> root;
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      if (tensor.value("type", -1) == 0) {  // QNN_TENSOR_TYPE_APP_WRITE
+        inputs_with_id.emplace_back(name, tensor.value("id", -1));
+      }
+    }
+  }
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  // ONNX-declared input first (registered under its external name "input" via tensor_name_overrides),
+  // partition-added input second.
+  ASSERT_EQ(inputs_with_id.size(), 2u);
+  EXPECT_EQ(inputs_with_id[0].first, "input");
+  EXPECT_EQ(inputs_with_id[1].first, "rnl_output");
 }
 
 // Returns a model where a single graph input fans out to two separate Q->DQ chains,
@@ -2335,7 +2304,8 @@ TEST_F(QnnCPUBackendTests, OffloadGraphIoQuantizationMultipleQDQPairsOnGraphInpu
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
-  Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
+  auto& session = scoped.session();
 
   // Run inference: verify output ≈ 2 * input (two identical DQ branches added together).
   std::vector<float> input_data = {0.1f, 0.2f, 0.3f};
@@ -2407,67 +2377,66 @@ TEST_F(QnnCPUBackendTests, GraphInputOutputOrderMatchesOnnx) {
   so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
 
-    // Find the JSON graph file
-    std::filesystem::path json_path;
-    for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
-      if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-          entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-        json_path = entry.path();
-        break;
-      }
+  // Find the JSON graph file
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
     }
-    ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
-
-    // Parse JSON and extract tensor names with IDs
-    std::vector<std::pair<std::string, int>> inputs_with_id, outputs_with_id;
-    {
-      std::ifstream json_file(json_path);
-      ASSERT_TRUE(json_file.is_open());
-
-      nlohmann::json root;
-      json_file >> root;
-
-      for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
-        int type = tensor.value("type", -1);
-        int id = tensor.value("id", -1);
-        if (type == 0) {
-          inputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_WRITE
-        } else if (type == 1) {
-          outputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_READ
-        }
-      }
-    }
-
-    // Sort by tensor ID to recover registration order
-    std::sort(inputs_with_id.begin(), inputs_with_id.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-    std::sort(outputs_with_id.begin(), outputs_with_id.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-
-    std::vector<std::string> input_names, output_names;
-    for (const auto& [name, id] : inputs_with_id) {
-      input_names.push_back(name);
-    }
-    for (const auto& [name, id] : outputs_with_id) {
-      output_names.push_back(name);
-    }
-
-    // Verify correct count
-    ASSERT_EQ(input_names.size(), 3u) << "Expected 3 inputs";
-    ASSERT_EQ(output_names.size(), 3u) << "Expected 3 outputs";
-
-    // Verify ordering matches ONNX declaration: {i2, i1, i3} and {o2, o1, o3}
-    EXPECT_EQ(input_names[0], "i2");
-    EXPECT_EQ(input_names[1], "i1");
-    EXPECT_EQ(input_names[2], "i3");
-
-    EXPECT_EQ(output_names[0], "o2");
-    EXPECT_EQ(output_names[1], "o1");
-    EXPECT_EQ(output_names[2], "o3");
   }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  // Parse JSON and extract tensor names with IDs
+  std::vector<std::pair<std::string, int>> inputs_with_id, outputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+
+    nlohmann::json root;
+    json_file >> root;
+
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      int type = tensor.value("type", -1);
+      int id = tensor.value("id", -1);
+      if (type == 0) {
+        inputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_WRITE
+      } else if (type == 1) {
+        outputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_READ
+      }
+    }
+  }
+
+  // Sort by tensor ID to recover registration order
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+  std::sort(outputs_with_id.begin(), outputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  std::vector<std::string> input_names, output_names;
+  for (const auto& [name, id] : inputs_with_id) {
+    input_names.push_back(name);
+  }
+  for (const auto& [name, id] : outputs_with_id) {
+    output_names.push_back(name);
+  }
+
+  // Verify correct count
+  ASSERT_EQ(input_names.size(), 3u) << "Expected 3 inputs";
+  ASSERT_EQ(output_names.size(), 3u) << "Expected 3 outputs";
+
+  // Verify ordering matches ONNX declaration: {i2, i1, i3} and {o2, o1, o3}
+  EXPECT_EQ(input_names[0], "i2");
+  EXPECT_EQ(input_names[1], "i1");
+  EXPECT_EQ(input_names[2], "i3");
+
+  EXPECT_EQ(output_names[0], "o2");
+  EXPECT_EQ(output_names[1], "o1");
+  EXPECT_EQ(output_names[2], "o3");
 }
 
 // Returns a function that builds a QDQ model with 3 Sigmoid ops to test I/O ordering with offload_graph_io_quantization.
@@ -2528,76 +2497,75 @@ TEST_F(QnnCPUBackendTests, GraphInputOutputOrderMatchesOnnxOffloadGraphIoQuantiz
   so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model->model_data.data(), model->model_data.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model->model_data.data(), model->model_data.size(), so));
 
-    // Find the JSON graph file
-    std::filesystem::path json_path;
-    for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
-      if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-          entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-        json_path = entry.path();
-        break;
-      }
+  // Find the JSON graph file
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{tmp_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
     }
-    ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
-
-    // Parse JSON and extract tensor names with IDs
-    std::vector<std::pair<std::string, int>> inputs_with_id, outputs_with_id;
-    {
-      std::ifstream json_file(json_path);
-      ASSERT_TRUE(json_file.is_open());
-
-      nlohmann::json root;
-      json_file >> root;
-
-      for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
-        int type = tensor.value("type", -1);
-        int id = tensor.value("id", -1);
-        if (type == 0) {
-          inputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_WRITE
-        } else if (type == 1) {
-          outputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_READ
-        }
-      }
-    }
-
-    // Sort by tensor ID to recover registration order
-    std::sort(inputs_with_id.begin(), inputs_with_id.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-    std::sort(outputs_with_id.begin(), outputs_with_id.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-
-    std::vector<std::string> input_names, output_names;
-    for (const auto& [name, id] : inputs_with_id) {
-      input_names.push_back(name);
-    }
-    for (const auto& [name, id] : outputs_with_id) {
-      output_names.push_back(name);
-    }
-
-    // Verify correct count
-    ASSERT_EQ(input_names.size(), 3u) << "Expected 3 inputs";
-    ASSERT_EQ(output_names.size(), 3u) << "Expected 3 outputs";
-
-    // Verify all expected names are present
-    std::set<std::string> expected_input_set = {"i1", "i2", "i3"};
-    std::set<std::string> actual_input_set(input_names.begin(), input_names.end());
-    EXPECT_EQ(actual_input_set, expected_input_set);
-
-    std::set<std::string> expected_output_set = {"qdq1_out_dq_out", "qdq2_out_dq_out", "qdq3_out_dq_out"};
-    std::set<std::string> actual_output_set(output_names.begin(), output_names.end());
-    EXPECT_EQ(actual_output_set, expected_output_set);
-
-    // Verify ordering matches ONNX declaration: {i2, i1, i3} and {o2, o1, o3}
-    EXPECT_EQ(input_names[0], "i2");
-    EXPECT_EQ(input_names[1], "i1");
-    EXPECT_EQ(input_names[2], "i3");
-
-    EXPECT_EQ(output_names[0], "qdq2_out_dq_out");
-    EXPECT_EQ(output_names[1], "qdq1_out_dq_out");
-    EXPECT_EQ(output_names[2], "qdq3_out_dq_out");
   }
+  ASSERT_FALSE(json_path.empty()) << "No JSON file found in " << tmp_dir;
+
+  // Parse JSON and extract tensor names with IDs
+  std::vector<std::pair<std::string, int>> inputs_with_id, outputs_with_id;
+  {
+    std::ifstream json_file(json_path);
+    ASSERT_TRUE(json_file.is_open());
+
+    nlohmann::json root;
+    json_file >> root;
+
+    for (const auto& [name, tensor] : root["graph"]["tensors"].items()) {
+      int type = tensor.value("type", -1);
+      int id = tensor.value("id", -1);
+      if (type == 0) {
+        inputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_WRITE
+      } else if (type == 1) {
+        outputs_with_id.emplace_back(name, id);  // QNN_TENSOR_TYPE_APP_READ
+      }
+    }
+  }
+
+  // Sort by tensor ID to recover registration order
+  std::sort(inputs_with_id.begin(), inputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+  std::sort(outputs_with_id.begin(), outputs_with_id.end(),
+            [](const auto& a, const auto& b) { return a.second < b.second; });
+
+  std::vector<std::string> input_names, output_names;
+  for (const auto& [name, id] : inputs_with_id) {
+    input_names.push_back(name);
+  }
+  for (const auto& [name, id] : outputs_with_id) {
+    output_names.push_back(name);
+  }
+
+  // Verify correct count
+  ASSERT_EQ(input_names.size(), 3u) << "Expected 3 inputs";
+  ASSERT_EQ(output_names.size(), 3u) << "Expected 3 outputs";
+
+  // Verify all expected names are present
+  std::set<std::string> expected_input_set = {"i1", "i2", "i3"};
+  std::set<std::string> actual_input_set(input_names.begin(), input_names.end());
+  EXPECT_EQ(actual_input_set, expected_input_set);
+
+  std::set<std::string> expected_output_set = {"qdq1_out_dq_out", "qdq2_out_dq_out", "qdq3_out_dq_out"};
+  std::set<std::string> actual_output_set(output_names.begin(), output_names.end());
+  EXPECT_EQ(actual_output_set, expected_output_set);
+
+  // Verify ordering matches ONNX declaration: {i2, i1, i3} and {o2, o1, o3}
+  EXPECT_EQ(input_names[0], "i2");
+  EXPECT_EQ(input_names[1], "i1");
+  EXPECT_EQ(input_names[2], "i3");
+
+  EXPECT_EQ(output_names[0], "qdq2_out_dq_out");
+  EXPECT_EQ(output_names[1], "qdq1_out_dq_out");
+  EXPECT_EQ(output_names[2], "qdq3_out_dq_out");
 }
 
 // Verify GetUniqueName counter resets between compilations in the same process.

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -981,9 +981,9 @@ TEST_F(QnnHTPBackendTests, QnnIr_OutputFiles) {
   std::filesystem::remove_all(qnn_dlc_dir);
   ASSERT_FALSE(std::filesystem::exists(qnn_dlc_dir));
 
-  InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Htp,  // backend
-                      TestBackend::Ir);  // serializer backend
+  auto scoped = InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
+                                    TestBackend::Htp,  // backend
+                                    TestBackend::Ir);  // serializer backend
 
   // File names are taken from graph node names. Just make sure that we got one .dlc
   // in the expected directory.
@@ -2033,9 +2033,9 @@ TEST_F(QnnIRBackendTests, QnnIr_OutputFiles) {
   std::filesystem::remove_all(qnn_dlc_dir);
   ASSERT_FALSE(std::filesystem::exists(qnn_dlc_dir));
 
-  InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Ir,   // backend
-                      TestBackend::Ir);  // serializer backend
+  auto scoped = InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
+                                    TestBackend::Ir,   // backend
+                                    TestBackend::Ir);  // serializer backend
 
   // File names are taken from graph node names. Just make sure that we got one .dlc
   // in the expected directory.
@@ -2058,9 +2058,9 @@ TEST(QnnSaverBackendTests, DISABLED_QnnSaver_OutputFiles) {
   std::filesystem::remove_all(qnn_saver_output_dir);
   ASSERT_FALSE(std::filesystem::exists(qnn_saver_output_dir));
 
-  InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Saver,   // backend
-                      TestBackend::Saver);  // serializer_backend
+  auto scoped = InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
+                                    TestBackend::Saver,   // backend
+                                    TestBackend::Saver);  // serializer_backend
 
   // Check that QNN Saver output files exist.
   EXPECT_TRUE(std::filesystem::exists(qnn_saver_output_dir / "saver_output.c"));

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -205,9 +205,9 @@ void QnnContextBinaryMultiPartitionTestBody(bool single_ep_node = true) {
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-    Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
 
     // Make sure the Qnn context cache binary file is generated
     EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
@@ -236,18 +236,16 @@ void QnnContextBinaryMultiPartitionTestBody(bool single_ep_node = true) {
     ASSERT_EQ(non_ep_context_node_count, expected_node_count);
   }
 
-  {
-    Ort::SessionOptions so2;
-    // context file path is required if it's non-embed mode and the model is loaded from memory
-    so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
+  Ort::SessionOptions so2;
+  // context file path is required if it's non-embed mode and the model is loaded from memory
+  so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
 
-    RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so2, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so2, kQnnExecutionProvider, provider_options);
 
-    std::string ctx_model_data;
-    ctx_model_proto.SerializeToString(&ctx_model_data);
-    Ort::Session session2(*ort_env, ctx_model_data.data(), ctx_model_data.size(), so2);
-  }
+  std::string ctx_model_data;
+  ctx_model_proto.SerializeToString(&ctx_model_data);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_data.data(), ctx_model_data.size(), so2));
 
   // clean up
   CleanUpCtxFile(context_model_file);
@@ -366,7 +364,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_DisableEpCompile_ThenCompileExplicitly) {
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   so.AddConfigEntry(kOrtSessionOptionsDisableModelCompile, "1");  // Disable model compilation!
 
@@ -378,7 +376,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_DisableEpCompile_ThenCompileExplicitly) {
     OrtErrorCode error_code = excpt.GetOrtErrorCode();
     std::string_view error_msg = excpt.what();
     ASSERT_EQ(error_code, ORT_MODEL_REQUIRES_COMPILATION);
-    ASSERT_THAT(error_msg, testing::HasSubstr(onnxruntime::kQnnExecutionProvider));
+    ASSERT_THAT(error_msg, testing::HasSubstr(kQnnExecutionProvider));
   }
 
   // Session creation failed because the model was not pre-compiled.
@@ -432,7 +430,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputModelFromPath) {
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Create model compilation options from the session options.
   Ort::ModelCompilationOptions compile_options(*ort_env, so);
@@ -479,7 +477,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputModelAsBuffer_Embe
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Create model compilation options from the session options.
   Ort::ModelCompilationOptions compile_options(*ort_env, so);
@@ -526,7 +524,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_OutputModelBuffer) {
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Create model compilation options from the session options. Output model is stored in a buffer.
   Ort::ModelCompilationOptions compile_options(*ort_env, so);
@@ -578,7 +576,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_InputAndOutputModelsInB
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions session_options;
-  RegisterQnnEpLibrary(registered_ep_device, session_options, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, session_options, kQnnExecutionProvider, provider_options);
 
   Ort::AllocatorWithDefaultOptions allocator;
 
@@ -689,7 +687,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_FromSessionOptions_OutputModelBuffer_Outpu
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Create model compilation options from the session options. Output model is stored in a buffer.
   Ort::ModelCompilationOptions compile_options(*ort_env, so);
@@ -767,7 +765,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_SetFlags_ErrorIfOutputFileAlreadyExists) {
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions session_options;
-  RegisterQnnEpLibrary(registered_ep_device, session_options, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, session_options, kQnnExecutionProvider, provider_options);
 
   // Compile with QNN EP. Should succeed the first time.
   {
@@ -815,7 +813,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_ErrorIfCompilingACompiledModel) {
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions session_options;
-  RegisterQnnEpLibrary(registered_ep_device, session_options, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, session_options, kQnnExecutionProvider, provider_options);
 
   // Compile with QNN EP. Should succeed the first time.
   {
@@ -890,9 +888,9 @@ TEST_F(QnnHTPBackendTests, QnnContextBinary_OriginalCompileApproach_IgnoreCompil
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, output_model_file.c_str());
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file));  // check compiled model was generated.
   }
 
@@ -906,7 +904,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinary_OriginalCompileApproach_IgnoreCompil
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, new_output_model_file);
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
     // Currently it would failed at ConvertEpContextNodes in ep_plugin_provider_interfaces.cc.
     try {
@@ -1068,7 +1066,7 @@ void EpCtxCpuNodeWithExternalIniFileTestBody(bool expect_external_ini_file, bool
   so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   const std::string ep_context_model_file = "./qnn_ctx_part_external_ini_ctx.onnx";
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ep_context_model_file.c_str());
@@ -1171,7 +1169,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryGenerationFolderPathNotExpected) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ep_context_onnx_file.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   try {
     Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
@@ -1223,7 +1221,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryGenerationFolderPathNotExpected2) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ep_context_onnx_file.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   try {
     Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
@@ -1279,22 +1277,20 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryGenerationNoOverWrite) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ep_context_onnx_file.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session1(*ort_env, model_data_span.data(), model_data_span.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
 
-    auto modify_time_1 = std::filesystem::last_write_time(ep_context_binary_file);
+  auto modify_time_1 = std::filesystem::last_write_time(ep_context_binary_file);
 
-    try {
-      Ort::Session session2(*ort_env, model_data_span.data(), model_data_span.size(), so);
-      FAIL();  // Should not get here!
-    } catch (const Ort::Exception& excpt) {
-      ASSERT_EQ(excpt.GetOrtErrorCode(), ORT_FAIL);
-      ASSERT_THAT(excpt.what(), testing::HasSubstr("exists already."));
-      auto modify_time_2 = std::filesystem::last_write_time(ep_context_binary_file);
-      ASSERT_EQ(modify_time_1, modify_time_2);
-    }
+  try {
+    Ort::Session session2(*ort_env, model_data_span.data(), model_data_span.size(), so);
+    FAIL();  // Should not get here!
+  } catch (const Ort::Exception& excpt) {
+    ASSERT_EQ(excpt.GetOrtErrorCode(), ORT_FAIL);
+    ASSERT_THAT(excpt.what(), testing::HasSubstr("exists already."));
+    auto modify_time_2 = std::filesystem::last_write_time(ep_context_binary_file);
+    ASSERT_EQ(modify_time_1, modify_time_2);
   }
 
   ASSERT_EQ(std::remove(ep_context_onnx_file.c_str()), 0);
@@ -1411,14 +1407,12 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryGeneration2InputTypes) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
 
-    // Make sure the Qnn context cache binary file is generated
-    EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
-  }
+  // Make sure the Qnn context cache binary file is generated
+  EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
 
   // clean up
   CleanUpCtxFile(context_model_file);
@@ -1467,14 +1461,12 @@ TEST_F(QnnHTPBackendTests, QnnContextGeneration2InputsOrderIssue) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
 
-    // Make sure the Qnn context cache binary file is generated
-    EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
-  }
+  // Make sure the Qnn context cache binary file is generated
+  EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
 
   // Load generated context model using ONNX protobuf API.
   ONNX_NAMESPACE::ModelProto model_proto;
@@ -1537,14 +1529,12 @@ TEST_F(QnnHTPBackendTests, DISABLED_QnnContextGenerationNodeNamePrefix) {
   so.AddConfigEntry(kOrtSessionOptionEpContextNodeNamePrefix, node_name_prefix.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
 
-    // Make sure the Qnn context cache binary file is generated
-    EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
-  }
+  // Make sure the Qnn context cache binary file is generated
+  EXPECT_TRUE(std::filesystem::exists(context_model_file.c_str()));
 
   // Load generated context model using ONNX protobuf API.
   ONNX_NAMESPACE::ModelProto model_proto;
@@ -1692,15 +1682,13 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCacheNonEmbedModeTest) {
 
   Ort::SessionOptions so;  // No need to set the context file path in so since it's load from file
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
-  {
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 #ifdef _WIN32
-    std::wstring ctx_model_file(context_binary_file.begin(), context_binary_file.end());
+  std::wstring ctx_model_file(context_binary_file.begin(), context_binary_file.end());
 #else
-    std::string ctx_model_file(context_binary_file.begin(), context_binary_file.end());
+  std::string ctx_model_file(context_binary_file.begin(), context_binary_file.end());
 #endif
-    Ort::Session session(*ort_env.get(), ctx_model_file.c_str(), so);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env.get(), ctx_model_file.c_str(), so));
 
   // Clean up
   ASSERT_EQ(std::remove(context_binary_file.c_str()), 0);
@@ -1765,7 +1753,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCache_InvalidGraph) {
   so.SetLogId("logger0");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Verify session creation fails with INVALID_GRAPH when the external context binary is missing.
   try {
@@ -1826,7 +1814,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryRelativePathTest) {
   so.SetLogId("qnn_ctx_model_logger");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Verify session creation fails with INVALID_GRAPH.
   try {
@@ -1855,7 +1843,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryAbsolutePathTest) {
   so.SetLogId("qnn_ctx_model_logger");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Verify session creation fails with INVALID_GRAPH.
   try {
@@ -1880,7 +1868,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryFileNotExistTest) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, "./qnn_context_not_exist.onnx");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Verify session creation fails with INVALID_GRAPH.
   try {
@@ -1905,7 +1893,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryFileEmptyStringTest) {
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, "./test_ctx.onnx");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Verify session creation fails with INVALID_GRAPH.
   try {
@@ -2043,7 +2031,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCache_SingleNodeNameNotMatchGraphName
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Session creation should succeed even if EPContext node name does not match graph name in the bin file.
   EXPECT_NO_THROW((Ort::Session(*ort_env, model_data.data(), model_data.size(), so)));
@@ -2062,11 +2050,9 @@ TEST_F(QnnHTPBackendTests, QnnMultiContextEmbeded) {
 
   Ort::SessionOptions so;
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, ORT_TSTR("testdata/qnn_ctx/qnn_multi_ctx_embed.onnx"), so);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ORT_TSTR("testdata/qnn_ctx/qnn_multi_ctx_embed.onnx"), so));
 }
 
 // Model has 2 EPContext nodes, both with main_context=1 and external context binary
@@ -2078,11 +2064,9 @@ TEST_F(QnnHTPBackendTests, QnnMultiContextExternal) {
 
   Ort::SessionOptions so;
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, ORT_TSTR("testdata/qnn_ctx/qnn_multi_ctx_external.onnx"), so);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ORT_TSTR("testdata/qnn_ctx/qnn_multi_ctx_external.onnx"), so));
 }
 
 static void CreateQdqModel(const std::string& model_file_name) {
@@ -2128,25 +2112,23 @@ static void DumpModelWithSharedCtx(ProviderOptions provider_options,
 #endif  // !__aarch64__
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Create 2 sessions to generate context binary models, the 1st session will share the QnnBackendManager
   // to the 2nd session, so graphs from these 2 models are all included in the 2nd context binary
-  {
 #if defined(_WIN32)
-    const std::wstring onnx_model_path1_w(onnx_model_path1.begin(), onnx_model_path1.end());
-    const std::wstring onnx_model_path2_w(onnx_model_path2.begin(), onnx_model_path2.end());
-    Ort::Session session1(*ort_env, onnx_model_path1_w.c_str(), so);
+  const std::wstring onnx_model_path1_w(onnx_model_path1.begin(), onnx_model_path1.end());
+  const std::wstring onnx_model_path2_w(onnx_model_path2.begin(), onnx_model_path2.end());
+  ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, onnx_model_path1_w.c_str(), so));
 
-    so.AddConfigEntry(kOrtSessionOptionStopShareEpContexts, "1");
-    Ort::Session session2(*ort_env, onnx_model_path2_w.c_str(), so);
+  so.AddConfigEntry(kOrtSessionOptionStopShareEpContexts, "1");
+  Ort::Session session2(*ort_env, onnx_model_path2_w.c_str(), so);
 #else
-    Ort::Session session1(*ort_env, onnx_model_path1.c_str(), so);
+  ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, onnx_model_path1.c_str(), so));
 
-    so.AddConfigEntry(kOrtSessionOptionStopShareEpContexts, "1");
-    Ort::Session session2(*ort_env, onnx_model_path2.c_str(), so);
+  so.AddConfigEntry(kOrtSessionOptionStopShareEpContexts, "1");
+  Ort::Session session2(*ort_env, onnx_model_path2.c_str(), so);
 #endif
-  }
 }
 
 static void GetModelInputNames(const std::string& model_path,
@@ -2238,7 +2220,7 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
   so1.AddConfigEntry(kOrtSessionOptionShareEpContexts, "1");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so1, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so1, kQnnExecutionProvider, provider_options);
 
   Ort::SessionOptions so2;
   so2.SetLogId("so2");
@@ -2246,42 +2228,40 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
   so2.AppendExecutionProvider_V2(*ort_env, {Ort::ConstEpDevice(registered_ep_device.get())}, provider_options);
 
   EXPECT_TRUE(2 == ctx_model_paths.size());
-  {
 #ifdef _WIN32
-    std::wstring ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
-    std::wstring ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
+  std::wstring ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
+  std::wstring ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
 #else
-    std::string ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
-    std::string ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
+  std::string ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
+  std::string ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
 #endif
-    Ort::Session session1(*ort_env, ctx_model_file1.c_str(), so1);
-    Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
+  ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_file1.c_str(), so1));
+  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
 
-    std::vector<std::string> input_names;
-    std::vector<std::string> output_names;
-    GetModelInputNames(ctx_model_paths[1], input_names, output_names);
+  std::vector<std::string> input_names;
+  std::vector<std::string> output_names;
+  GetModelInputNames(ctx_model_paths[1], input_names, output_names);
 
-    // Run sessions
-    // prepare input
-    std::vector<int64_t> input_dim{2, 3};
-    std::vector<float> input_value(2 * 3, 0.0f);
-    Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
-    std::vector<Ort::Value> ort_inputs;
-    std::vector<const char*> input_names_c;
-    for (size_t i = 0; i < input_names.size(); ++i) {
-      auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
-                                                   input_dim.data(), input_dim.size());
-      ort_inputs.push_back(std::move(input_tensor));
-      input_names_c.push_back(input_names[i].c_str());
-    }
-    std::vector<const char*> output_names_c;
-    for (size_t i = 0; i < output_names.size(); ++i) {
-      output_names_c.push_back(output_names[i].c_str());
-    }
-
-    auto ort_outputs1 = session1.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                     output_names_c.data(), 1);
+  // Run sessions
+  // prepare input
+  std::vector<int64_t> input_dim{2, 3};
+  std::vector<float> input_value(2 * 3, 0.0f);
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<Ort::Value> ort_inputs;
+  std::vector<const char*> input_names_c;
+  for (size_t i = 0; i < input_names.size(); ++i) {
+    auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
+                                                 input_dim.data(), input_dim.size());
+    ort_inputs.push_back(std::move(input_tensor));
+    input_names_c.push_back(input_names[i].c_str());
   }
+  std::vector<const char*> output_names_c;
+  for (size_t i = 0; i < output_names.size(); ++i) {
+    output_names_c.push_back(output_names[i].c_str());
+  }
+
+  auto ort_outputs1 = scoped1.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                            output_names_c.data(), 1);
 #endif
 
   for (auto model_path : onnx_model_paths) {
@@ -2357,49 +2337,47 @@ TEST_F(QnnHTPBackendTests, DISABLED_VTCMBackupBufferSharing) {
   so1.SetLogId("so1");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so1, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so1, kQnnExecutionProvider, provider_options);
 
   Ort::SessionOptions so2;
   so2.SetLogId("so2");
   so2.AppendExecutionProvider_V2(*ort_env, {Ort::ConstEpDevice(registered_ep_device.get())}, provider_options);
 
   EXPECT_TRUE(2 == ctx_model_paths.size());
-  {
 #ifdef _WIN32
-    std::wstring ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
-    std::wstring ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
+  std::wstring ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
+  std::wstring ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
 #else
-    std::string ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
-    std::string ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
+  std::string ctx_model_file1(ctx_model_paths[0].begin(), ctx_model_paths[0].end());
+  std::string ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
 #endif
-    Ort::Session session1(*ort_env, ctx_model_file1.c_str(), so1);
-    Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
+  ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_file1.c_str(), so1));
+  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
 
-    std::vector<std::string> input_names;
-    std::vector<std::string> output_names;
-    GetModelInputNames(ctx_model_paths[1], input_names, output_names);
+  std::vector<std::string> input_names;
+  std::vector<std::string> output_names;
+  GetModelInputNames(ctx_model_paths[1], input_names, output_names);
 
-    // Run sessions
-    // prepare input
-    std::vector<int64_t> input_dim{2, 3};
-    std::vector<float> input_value(2 * 3, 0.0f);
-    Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
-    std::vector<Ort::Value> ort_inputs;
-    std::vector<const char*> input_names_c;
-    for (size_t i = 0; i < input_names.size(); ++i) {
-      auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
-                                                   input_dim.data(), input_dim.size());
-      ort_inputs.push_back(std::move(input_tensor));
-      input_names_c.push_back(input_names[i].c_str());
-    }
-    std::vector<const char*> output_names_c;
-    for (size_t i = 0; i < output_names.size(); ++i) {
-      output_names_c.push_back(output_names[i].c_str());
-    }
-
-    auto ort_outputs1 = session1.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                     output_names_c.data(), 1);
+  // Run sessions
+  // prepare input
+  std::vector<int64_t> input_dim{2, 3};
+  std::vector<float> input_value(2 * 3, 0.0f);
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<Ort::Value> ort_inputs;
+  std::vector<const char*> input_names_c;
+  for (size_t i = 0; i < input_names.size(); ++i) {
+    auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
+                                                 input_dim.data(), input_dim.size());
+    ort_inputs.push_back(std::move(input_tensor));
+    input_names_c.push_back(input_names[i].c_str());
   }
+  std::vector<const char*> output_names_c;
+  for (size_t i = 0; i < output_names.size(); ++i) {
+    output_names_c.push_back(output_names[i].c_str());
+  }
+
+  auto ort_outputs1 = scoped1.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                            output_names_c.data(), 1);
 #endif
 
   for (auto model_path : onnx_model_paths) {
@@ -2490,41 +2468,39 @@ TEST_F(QnnHTPBackendTests, FileMapping_Off) {
 #endif
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so1, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so1, kQnnExecutionProvider, provider_options);
 
   provider_options["enable_vtcm_backup_buffer_sharing"] = "1";
   so2.AppendExecutionProvider_V2(*ort_env, {Ort::ConstEpDevice(registered_ep_device.get())}, provider_options);
-  {
-    Ort::Session session1(*ort_env, ctx_model_file1.c_str(), so1);
-    Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
+  ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_file1.c_str(), so1));
+  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
 
-    std::vector<std::string> input_names;
-    std::vector<std::string> output_names;
-    GetModelInputNames(ctx_model_paths[1], input_names, output_names);
+  std::vector<std::string> input_names;
+  std::vector<std::string> output_names;
+  GetModelInputNames(ctx_model_paths[1], input_names, output_names);
 
-    // Run sessions
-    // prepare input
-    std::vector<int64_t> input_dim{2, 3};
-    std::vector<float> input_value(2 * 3, 0.0f);
-    Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
-    std::vector<Ort::Value> ort_inputs;
-    std::vector<const char*> input_names_c;
-    for (size_t i = 0; i < input_names.size(); ++i) {
-      auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
-                                                   input_dim.data(), input_dim.size());
-      ort_inputs.push_back(std::move(input_tensor));
-      input_names_c.push_back(input_names[i].c_str());
-    }
-    std::vector<const char*> output_names_c;
-    for (size_t i = 0; i < output_names.size(); ++i) {
-      output_names_c.push_back(output_names[i].c_str());
-    }
-
-    auto ort_outputs1 = session1.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                     output_names_c.data(), 1);
-    auto ort_outputs2 = session2.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                     output_names_c.data(), 1);
+  // Run sessions
+  // prepare input
+  std::vector<int64_t> input_dim{2, 3};
+  std::vector<float> input_value(2 * 3, 0.0f);
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<Ort::Value> ort_inputs;
+  std::vector<const char*> input_names_c;
+  for (size_t i = 0; i < input_names.size(); ++i) {
+    auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
+                                                 input_dim.data(), input_dim.size());
+    ort_inputs.push_back(std::move(input_tensor));
+    input_names_c.push_back(input_names[i].c_str());
   }
+  std::vector<const char*> output_names_c;
+  for (size_t i = 0; i < output_names.size(); ++i) {
+    output_names_c.push_back(output_names[i].c_str());
+  }
+
+  auto ort_outputs1 = scoped1.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                            output_names_c.data(), 1);
+  auto ort_outputs2 = session2.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                   output_names_c.data(), 1);
 #endif  // defined(__aarch64__) || defined(_M_ARM64)
 
   for (auto model_path : onnx_model_paths) {
@@ -2641,7 +2617,7 @@ TEST_F(QnnHTPBackendTests, LoadFromArrayWithQnnEpContextGenPathValidation) {
   so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   ORT_TRY {
     Ort::Session session1(*ort_env, model_data_span.data(), model_data_span.size(), so);
@@ -2682,80 +2658,78 @@ TEST_F(QnnHTPBackendTests, QnnEpDynamicOptions) {
   so.SetLogSeverityLevel(ORT_LOGGING_LEVEL_VERBOSE);
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, ORT_TSTR("testdata/qnn_ctx/qnn_multi_ctx_embed.onnx"), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, ORT_TSTR("testdata/qnn_ctx/qnn_multi_ctx_embed.onnx"), so));
 
-    std::vector<std::string> input_names;
-    std::vector<std::string> output_names;
-    GetModelInputNames("testdata/qnn_ctx/qnn_multi_ctx_embed.onnx", input_names, output_names);
+  std::vector<std::string> input_names;
+  std::vector<std::string> output_names;
+  GetModelInputNames("testdata/qnn_ctx/qnn_multi_ctx_embed.onnx", input_names, output_names);
 
-    // Run sessions
-    // prepare input
-    std::vector<int64_t> input_dim{3, 4};
-    std::vector<float> input_value(3 * 4, 0.0f);
-    Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
-    std::vector<Ort::Value> ort_inputs;
-    std::vector<const char*> input_names_c;
-    for (size_t i = 0; i < input_names.size(); ++i) {
-      auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
-                                                   input_dim.data(), input_dim.size());
-      ort_inputs.push_back(std::move(input_tensor));
-      input_names_c.push_back(input_names[i].c_str());
-    }
-    std::vector<const char*> output_names_c;
-    for (size_t i = 0; i < output_names.size(); ++i) {
-      output_names_c.push_back(output_names[i].c_str());
-    }
-
-    auto ort_output = session.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                  output_names_c.data(), 1);
-
-    const char* const workload_type[] = {"ep.dynamic.workload_type"};
-    const char* const efficient_type[] = {"Efficient"};
-    const char* const default_type[] = {"Default"};
-
-    // Test Efficient & Default options
-    session.SetEpDynamicOptions(workload_type, efficient_type, 1);
-    ort_output = session.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                             output_names_c.data(), 1);
-
-    session.SetEpDynamicOptions(workload_type, default_type, 1);
-    ort_output = session.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                             output_names_c.data(), 1);
-
-    // Test invalid EP dynamic option and invalid workload type
-    const char* const dne[] = {"DNE"};
-    try {
-      session.SetEpDynamicOptions(workload_type, dne, 1);
-      FAIL() << "Expected exception to be thrown for workload type DNE but was set successfully";
-    } catch (const std::exception& e) {
-      EXPECT_STREQ("Invalid EP Workload Type.", e.what());
-    }
-
-    try {
-      session.SetEpDynamicOptions(dne, efficient_type, 1);
-      FAIL() << "Expected exception to be thrown for dynamic option DNE but was set successfully";
-    } catch (const std::exception& e) {
-      EXPECT_STREQ("Unsupported EP Dynamic Option", e.what());
-    }
-
-    const char* const htp_perf_mode_type[] = {"ep.dynamic.qnn_htp_performance_mode"};
-    const char* const eps_type[] = {"extreme_power_saver"};
-    const char* const shp_type[] = {"sustained_high_performance"};
-    session.SetEpDynamicOptions(htp_perf_mode_type, shp_type, 1);
-    ort_output = session.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                             output_names_c.data(), 1);
-
-    session.SetEpDynamicOptions(htp_perf_mode_type, eps_type, 1);
-    ort_output = session.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                             output_names_c.data(), 1);
-
-    session.SetEpDynamicOptions(htp_perf_mode_type, shp_type, 1);
-    ort_output = session.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                             output_names_c.data(), 1);
+  // Run sessions
+  // prepare input
+  std::vector<int64_t> input_dim{3, 4};
+  std::vector<float> input_value(3 * 4, 0.0f);
+  Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<Ort::Value> ort_inputs;
+  std::vector<const char*> input_names_c;
+  for (size_t i = 0; i < input_names.size(); ++i) {
+    auto input_tensor = Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
+                                                 input_dim.data(), input_dim.size());
+    ort_inputs.push_back(std::move(input_tensor));
+    input_names_c.push_back(input_names[i].c_str());
   }
+  std::vector<const char*> output_names_c;
+  for (size_t i = 0; i < output_names.size(); ++i) {
+    output_names_c.push_back(output_names[i].c_str());
+  }
+
+  auto ort_output = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                         output_names_c.data(), 1);
+
+  const char* const workload_type[] = {"ep.dynamic.workload_type"};
+  const char* const efficient_type[] = {"Efficient"};
+  const char* const default_type[] = {"Default"};
+
+  // Test Efficient & Default options
+  scoped.session().SetEpDynamicOptions(workload_type, efficient_type, 1);
+  ort_output = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                    output_names_c.data(), 1);
+
+  scoped.session().SetEpDynamicOptions(workload_type, default_type, 1);
+  ort_output = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                    output_names_c.data(), 1);
+
+  // Test invalid EP dynamic option and invalid workload type
+  const char* const dne[] = {"DNE"};
+  try {
+    scoped.session().SetEpDynamicOptions(workload_type, dne, 1);
+    FAIL() << "Expected exception to be thrown for workload type DNE but was set successfully";
+  } catch (const std::exception& e) {
+    EXPECT_STREQ("Invalid EP Workload Type.", e.what());
+  }
+
+  try {
+    scoped.session().SetEpDynamicOptions(dne, efficient_type, 1);
+    FAIL() << "Expected exception to be thrown for dynamic option DNE but was set successfully";
+  } catch (const std::exception& e) {
+    EXPECT_STREQ("Unsupported EP Dynamic Option", e.what());
+  }
+
+  const char* const htp_perf_mode_type[] = {"ep.dynamic.qnn_htp_performance_mode"};
+  const char* const eps_type[] = {"extreme_power_saver"};
+  const char* const shp_type[] = {"sustained_high_performance"};
+  scoped.session().SetEpDynamicOptions(htp_perf_mode_type, shp_type, 1);
+  ort_output = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                    output_names_c.data(), 1);
+
+  scoped.session().SetEpDynamicOptions(htp_perf_mode_type, eps_type, 1);
+  ort_output = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                    output_names_c.data(), 1);
+
+  scoped.session().SetEpDynamicOptions(htp_perf_mode_type, shp_type, 1);
+  ort_output = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                    output_names_c.data(), 1);
 }
 
 // Implementation of OrtOutStreamWriteFunc that writes the compiled model to a file.
@@ -2798,7 +2772,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_InputFile_WriteOutputModelBytes) {
 #endif
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   const ORTCHAR_T* output_model_file = ORT_TSTR("compileapi_inputfile_writeoutputmodelbytes_ctx.onnx");
   std::filesystem::remove(output_model_file);
@@ -2846,7 +2820,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_OutputStream_ReturnStatus) {
 #endif
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Create model compilation options from the session options.
   Ort::ModelCompilationOptions compile_options(*ort_env, so);
@@ -2881,9 +2855,9 @@ TEST_F(QnnHTPBackendTests, QnnContextBinary_SetNumGraphPrepareThreads_InRange) {
     so.AddConfigEntry(kOrtSessionOptionsFailOnSuboptimalCompiledModel, "1");
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file.c_str()));
   }
 
@@ -2912,13 +2886,11 @@ TEST_F(QnnHTPBackendTests, QnnContextBinary_SetNumGraphPrepareThreads_InRange) {
   ProviderOptions qnn_options = {{"backend_type", "htp"}};
   Ort::SessionOptions so;
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-  {
-    Ort::Session session_ctx(*ort_env, output_model_file.native().c_str(), so);
-    auto outputs = session_ctx.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                   output_names_c.data(), 1);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.native().c_str(), so));
+  auto outputs = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                      output_names_c.data(), 1);
 
   std::filesystem::remove(output_model_file);
 }
@@ -2944,9 +2916,9 @@ TEST_F(QnnHTPBackendTests, QnnContextBinary_SetNumGraphPrepareThreads_OutOfRange
     so.AddConfigEntry(kOrtSessionOptionsFailOnSuboptimalCompiledModel, "1");
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file.c_str()));
   }
 
@@ -2975,13 +2947,11 @@ TEST_F(QnnHTPBackendTests, QnnContextBinary_SetNumGraphPrepareThreads_OutOfRange
   ProviderOptions qnn_options = {{"backend_type", "htp"}};
   Ort::SessionOptions so;
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-  {
-    Ort::Session session_ctx(*ort_env, output_model_file.native().c_str(), so);
-    auto outputs = session_ctx.Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
-                                   output_names_c.data(), 1);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.native().c_str(), so));
+  auto outputs = scoped.session().Run(Ort::RunOptions{}, input_names_c.data(), ort_inputs.data(), ort_inputs.size(),
+                                      output_names_c.data(), 1);
   std::filesystem::remove(output_model_file);
 }
 #endif  // _WIN32 && (defined(__aarch64__) || defined(_M_ARM64))
@@ -3072,7 +3042,7 @@ TEST_F(QnnHTPBackendTests, CompileApi_InputFile_OutputFile_InitializerHandler) {
 #endif
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // Open a file to store external initializers. ORT will call our handler function for every initializer.
   ASSERT_FALSE(std::filesystem::exists(initializer_file));
@@ -3223,12 +3193,10 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_CtxFileWritten) {
   SetPrepareOnlyOptions(so, ctx_path);
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  {
-    Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
-    EXPECT_TRUE(std::filesystem::exists(ctx_path));
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
+  EXPECT_TRUE(std::filesystem::exists(ctx_path));
 
   CleanUpCtxFile(ctx_path);
 }
@@ -3264,7 +3232,7 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_DisabledWhenContextCacheNotSet) {
   SetPrepareOnlyOptions(so, ctx_path, /*explicit_context_enable=*/false);
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // since ep.context_enable was not set. Session falls back to normal (non-prepare_only) mode.
   ORT_TRY {
@@ -3308,9 +3276,10 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_RunReturnsError) {
   SetPrepareOnlyOptions(so, ctx_path);
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, provider_options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
+  auto& session = scoped.session();
   ASSERT_TRUE(std::filesystem::exists(ctx_path));
 
   // Get actual input/output names from the session — BuildGraphWithQAndNonQ uses
@@ -3404,19 +3373,17 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_SelfValidate_CbTradRtTrad) {
     so.AddConfigEntry(kOrtSessionOptionsFailOnSuboptimalCompiledModel, "1");
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file));
   }
 
-  {
-    Ort::SessionOptions so;
-    RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+  Ort::SessionOptions so;
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, output_model_file.wstring().c_str(), so);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.wstring().c_str(), so));
 
   std::filesystem::remove(output_model_file);
 }
@@ -3439,9 +3406,9 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbTradRtHnrd
     so.AddConfigEntry(kOrtSessionOptionsFailOnSuboptimalCompiledModel, "1");
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file));
   }
 
@@ -3452,9 +3419,9 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbTradRtHnrd
     {
       Ort::SessionOptions so;
       RegisteredEpDeviceUniquePtr registered_ep_device;
-      RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+      RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-      Ort::Session session(*ort_env, output_model_file.wstring().c_str(), so);
+      ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.wstring().c_str(), so));
     }
     // Compare to ModelCompatibility_SelfValidate_CbHnrdRtTrad, this testcase could get here if driver is as new as
     // compiled SDK.
@@ -3490,9 +3457,9 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbHnrdRtTrad
     so.AddConfigEntry(kOrtSessionOptionsFailOnSuboptimalCompiledModel, "1");
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file));
   }
 
@@ -3502,9 +3469,9 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbHnrdRtTrad
     {
       Ort::SessionOptions so;
       RegisteredEpDeviceUniquePtr registered_ep_device;
-      RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+      RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-      Ort::Session session(*ort_env, output_model_file.wstring().c_str(), so);
+      ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.wstring().c_str(), so));
     }
     FAIL() << "Expect compiled model not supported by execution provider.";  // Should not get here.
   }
@@ -3539,19 +3506,17 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbHnrdRtHnrd
     so.AddConfigEntry(kOrtSessionOptionsFailOnSuboptimalCompiledModel, "1");
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file));
   }
 
-  {
-    Ort::SessionOptions so;
-    RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+  Ort::SessionOptions so;
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, output_model_file.wstring().c_str(), so);
-  }
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.wstring().c_str(), so));
 
   std::filesystem::remove(output_model_file);
 }
@@ -3629,25 +3594,26 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_GetCompatibility) {
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, std::filesystem::path(output_model_file).string().c_str());
 
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, input_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
     ASSERT_TRUE(std::filesystem::exists(output_model_file));
   }
 
   {
     Ort::SessionOptions so;
     RegisteredEpDeviceUniquePtr registered_ep_device;
-    RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, qnn_options);
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, qnn_options);
 
-    Ort::Session session(*ort_env, output_model_file, so);
+    ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file, so));
+    auto& session = scoped.session();
 
     // Extract generated compatibility info from model metadata.
     OrtModelMetadata* model_metadata = nullptr;
     ASSERT_EQ(nullptr, Ort::GetApi().SessionGetModelMetadata(session, &model_metadata));
 
     MallocAllocator allocator;
-    std::string key = std::string(kOrtModelMetadata_EpCompatibilityInfoPrefix) + onnxruntime::kQnnExecutionProvider;
+    std::string key = std::string(kOrtModelMetadata_EpCompatibilityInfoPrefix) + kQnnExecutionProvider;
     char* val = nullptr;
     ASSERT_EQ(nullptr,
               Ort::GetApi().ModelMetadataLookupCustomMetadataMap(model_metadata, &allocator, key.c_str(), &val));
@@ -3670,7 +3636,7 @@ static void TestModelCompatibilityApiValidate(const CompatibilityTestInfo& test_
   Ort::SessionOptions so;
   RegisterQnnEpLibrary(registered_ep_device,
                        so,
-                       onnxruntime::kQnnExecutionProvider,
+                       kQnnExecutionProvider,
                        {{"backend_type", "htp"}, {"num_graph_prepare_threads", "1"}});
 
   OrtEpFactory* ep_factory = registered_ep_device->GetMutableFactory();
@@ -3695,7 +3661,7 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate) {
 TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_NoEp) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, {{"backend_type", "htp"}});
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, {{"backend_type", "htp"}});
 
   const OrtEpDevice* ep_device = registered_ep_device.get();
   OrtCompiledModelCompatibility out_status;

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -2236,7 +2236,7 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
   std::string ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
 #endif
   ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_file1.c_str(), so1));
-  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
+  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);  // session2 borrows the EP device from scoped1; must be declared after scoped1.
 
   std::vector<std::string> input_names;
   std::vector<std::string> output_names;
@@ -2352,7 +2352,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_VTCMBackupBufferSharing) {
   std::string ctx_model_file2(ctx_model_paths[1].begin(), ctx_model_paths[1].end());
 #endif
   ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_file1.c_str(), so1));
-  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
+  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);  // session2 borrows the EP device from scoped1; must be declared after scoped1.
 
   std::vector<std::string> input_names;
   std::vector<std::string> output_names;
@@ -2473,7 +2473,7 @@ TEST_F(QnnHTPBackendTests, FileMapping_Off) {
   provider_options["enable_vtcm_backup_buffer_sharing"] = "1";
   so2.AppendExecutionProvider_V2(*ort_env, {Ort::ConstEpDevice(registered_ep_device.get())}, provider_options);
   ScopedOrtSession scoped1(std::move(registered_ep_device), Ort::Session(*ort_env, ctx_model_file1.c_str(), so1));
-  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);
+  Ort::Session session2(*ort_env, ctx_model_file2.c_str(), so2);  // session2 borrows the EP device from scoped1; must be declared after scoped1.
 
   std::vector<std::string> input_names;
   std::vector<std::string> output_names;

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -437,14 +437,15 @@ void InferenceModel(const std::string& model_data,
 
   auto provider_type = "QNNExecutionProvider";
   session_options.AddConfigEntry(kOrtSessionOptionsRecordEpGraphAssignmentInfo, "1");
-  Ort::Session session(*GetOrtEnv(), model_data.data(), model_data.size(), session_options);
-  ASSERT_NO_FATAL_FAILURE(VerifyEPNodeAssignment(session, provider_type, expected_ep_assignment));
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*GetOrtEnv(), model_data.data(), model_data.size(), session_options));
+  ASSERT_NO_FATAL_FAILURE(VerifyEPNodeAssignment(scoped.session(), provider_type, expected_ep_assignment));
 
   if (graph_checker) {
-    (*graph_checker)(session);
+    (*graph_checker)(scoped.session());
   }
 
-  RunWithEP(session, ort_run_options, feeds, output_vals);
+  RunWithEP(scoped.session(), ort_run_options, feeds, output_vals);
 }
 
 std::string MakeTestQDQBiasInput(ModelTestBuilder& builder,

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -590,6 +590,35 @@ void RegisterQnnEpLibrary(RegisteredEpDeviceUniquePtr& registered_ep_device,
                           const std::unordered_map<std::string, std::string>& ep_options,
                           bool simulated = false);
 
+// RAII holder that ensures Ort::Session is destroyed before RegisteredEpDeviceUniquePtr.
+// Construct after registering the EP and creating the session:
+//
+//   RegisteredEpDeviceUniquePtr ep;
+//   RegisterQnnEpLibrary(ep, so, name, options);
+//   ScopedOrtSession scoped(std::move(ep), Ort::Session(env, model_path, so));
+//
+// ORDER MATTERS — non-static members are destroyed in reverse declaration order,
+// so ep_device_ is declared first (destroyed last) and session_ second (destroyed first).
+class ScopedOrtSession {
+ public:
+  ScopedOrtSession(RegisteredEpDeviceUniquePtr ep, Ort::Session session)
+      : ep_device_(std::move(ep)), session_(std::move(session)) {}
+
+  ScopedOrtSession(const ScopedOrtSession&) = delete;
+  ScopedOrtSession& operator=(const ScopedOrtSession&) = delete;
+  ScopedOrtSession(ScopedOrtSession&&) = delete;
+  ScopedOrtSession& operator=(ScopedOrtSession&&) = delete;
+
+  Ort::Session& session() { return session_; }
+  const Ort::Session& session() const { return session_; }
+  const OrtEpDevice* ep_device() const { return ep_device_.get(); }
+
+ private:
+  // ORDER MATTERS — destroyed in reverse decl order: session_ first, then ep_device_.
+  RegisteredEpDeviceUniquePtr ep_device_;
+  Ort::Session session_;
+};
+
 /**
  * Inferences a given serialized model. Returns output values via an out-param.
  *


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- ScopedOrtSession jointly owns RegisteredEpDeviceUniquePtr and Ort::Session. C++ reverse member-destruction order guarantees the session is always destroyed before the EP device handle is unregistered, making the constraint structural rather than editorial.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Replace fragile bracket-scoping and flat-scope workarounds in qnn_basic_test.cc, qnn_ep_context_test.cc, qnn_test_utils.cc, and genie_integration_test.cc with a ScopedOrtSession RAII holder.
