### PR TITLE
[QNN EP] Fix ReshapeGemmFusion rank-5 input regression

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -80,6 +80,12 @@ bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape
   RETURN_DEFAULT_IF_API_FAIL(ort_api.GetDimensionsCount(input_tensor_info, &input_dims_count), ort_api, false);
   RETURN_DEFAULT_IF_API_FAIL(ort_api.GetDimensionsCount(output_tensor_info, &output_dims_count), ort_api, false);
 
+  // QNN HTP FullyConnected only supports input rank <= 4. The fusion passes the input_reshape's
+  // original input directly to FC (bypassing the reshape), so reject rank > 4.
+  if (input_dims_count > 4) {
+    return false;
+  }
+
   // Output must be 2D [batch, n]
   if (output_dims_count != 2) {
     return false;

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
@@ -190,7 +190,7 @@ ProviderOptions GetProviderOptions() {
 }
 
 // Build a test case with rank-5 input: Reshape -> Gemm -> Reshape
-// Mirrors the ImageMattingV2 proj/MatMul pattern: [3,3,14,14,384] -> [1764,384] -> Gemm -> output
+// Mirrors the proj/MatMul pattern: [3,3,14,14,384] -> [1764,384] -> Gemm -> output
 // ReshapeGemmFusion must NOT fire because QNN HTP FC rejects rank-5 input.
 GetTestModelFn BuildReshapeGemmReshapeRank5InputTestCase() {
   return [](ModelTestBuilder& builder) -> void {
@@ -532,7 +532,7 @@ TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_DynamicWeight) {
 
 // Test: Fusion should NOT happen when the input Reshape's input has rank 5.
 // QNN HTP FullyConnected only supports input rank <= 4.
-// Mirrors the ImageMattingV2 proj/MatMul regression introduced by PR #232.
+// Mirrors the proj/MatMul regression introduced by PR #232.
 // All ops (Reshape, Gemm, Reshape) must still run on QNN EP via standalone builders.
 TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_Rank5Input) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
@@ -552,8 +552,9 @@ TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_Rank5Input) {
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
                   /*fp32_abs_err=*/1e-2f);
 
-  // Verify the fusion did NOT fire: no FullyConnected node in the QNN graph
-  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 0);
+  // Verify the fusion did NOT fire: one FullyConnected node and two Reshape nodes in the QNN graph
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 2);
 }
 
 // ============================================================================

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
@@ -189,6 +189,36 @@ ProviderOptions GetProviderOptions() {
   return provider_options;
 }
 
+// Build a test case with rank-5 input: Reshape -> Gemm -> Reshape
+// Mirrors the ImageMattingV2 proj/MatMul pattern: [3,3,14,14,384] -> [1764,384] -> Gemm -> output
+// ReshapeGemmFusion must NOT fire because QNN HTP FC rejects rank-5 input.
+GetTestModelFn BuildReshapeGemmReshapeRank5InputTestCase() {
+  return [](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_gemm_reshape_rank5_graph");
+
+    // Rank-5 input mimicking ViT-Matte attention output: [3, 3, 14, 14, 384]
+    auto input_def = TestInputDef<float>({3, 3, 14, 14, 384}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Reshape: [3,3,14,14,384] -> [1764,384] (flatten first 4 dims)
+    builder.Make1DInitializer<int64_t>("reshape1_shape", {1764, 384});
+    builder.AddNode("reshape1", "Reshape", {"input", "reshape1_shape"}, {"reshape1_out"}, kOnnxDomain);
+
+    // Gemm weight: [384, 384], bias: [384]
+    builder.MakeInitializer<float>("weight", {384, 384}, -0.5f, 0.5f);
+    builder.MakeInitializer<float>("bias", {384}, -0.1f, 0.1f);
+
+    // Gemm: [1764, 384] x [384, 384] -> [1764, 384]
+    builder.AddNode("gemm", "Gemm", {"reshape1_out", "weight", "bias"}, {"gemm_out"}, kOnnxDomain);
+
+    // Reshape output back to [3,3,14,14,384]
+    builder.Make1DInitializer<int64_t>("reshape2_shape", {3, 3, 14, 14, 384});
+    builder.AddNode("reshape2", "Reshape", {"gemm_out", "reshape2_shape"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
 }  // namespace
 
 // Test 2-node fusion: Reshape -> Gemm (3D input)
@@ -498,6 +528,32 @@ TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_DynamicWeight) {
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
                   /*fp32_abs_err=*/1e-2f);
+}
+
+// Test: Fusion should NOT happen when the input Reshape's input has rank 5.
+// QNN HTP FullyConnected only supports input rank <= 4.
+// Mirrors the ImageMattingV2 proj/MatMul regression introduced by PR #232.
+// All ops (Reshape, Gemm, Reshape) must still run on QNN EP via standalone builders.
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_Rank5Input) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "ReshapeGemmFusion_Negative_Rank5Input";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  // All nodes must run on QNN EP (Gemm handled standalone, not as fused FC)
+  RunQnnModelTest(BuildReshapeGemmReshapeRank5InputTestCase(),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+
+  // Verify the fusion did NOT fire: no FullyConnected node in the QNN graph
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", 0);
 }
 
 // ============================================================================


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Add a rank guard in CheckShape so the fusion is skipped when the pre-reshape tensor has rank > 4. The standalone GemmOpBuilder then handles the Gemm with the already-flattened rank-2 input as before.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- QNN HTP FullyConnected rejects input tensors with rank > 4. PR #232 added ReshapeGemmFusionGroup which bypasses the input Reshape and passes the original (pre-reshape) tensor directly to QNN FC. This makes MatMul receives a rank-5 input and causes it fall back to CPU with error 3110 "incorrect Rank 5".

