### PR TITLE
Add Genie model test infrastructure for Windows ARM CI

### DIFF
--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -43,6 +43,7 @@ from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, DockerBuildTask
 from ep_build.tasks.python import (
     CreateOrtVenvTask,
     CreateQdcVenvTask,
+    OrtWheelGenieModelTestTask,
     OrtWheelGpuModelTestTask,
     OrtWheelSmokeTestTask,
     RunLinterTask,
@@ -1001,6 +1002,22 @@ class TaskLibrary:
             return plan.add_step(
                 OrtWheelGpuModelTestTask(
                     "Running GPU model tests on ARM64",
+                    self.__venv_path,
+                    "arm64",
+                    self.__config,
+                    self.__target_py_version,
+                )
+            )
+
+    if is_host_windows():
+
+        @task
+        @depends(["build_ort_windows_arm64"])
+        def test_ort_windows_arm64_pygenie(self, plan: Plan) -> str:
+            assert self.__target_py_version is not None
+            return plan.add_step(
+                OrtWheelGenieModelTestTask(
+                    "Running Genie model tests on ARM64",
                     self.__venv_path,
                     "arm64",
                     self.__config,

--- a/qcom/ep_build/tasks/python.py
+++ b/qcom/ep_build/tasks/python.py
@@ -21,6 +21,7 @@ from ..task import (
 )
 from ..tools import (
     PythonExecutableArchT,
+    get_genai_models_root,
     get_model_zoo_root,
     get_onnx_models_root,
     get_python_executable,
@@ -397,6 +398,32 @@ class OrtWheelGpuModelTestTask(OrtWheelModelTestTask):
                 **os.environ,
                 "ORT_MODEL_ZOO_TEST_ROOTS": str(get_model_zoo_root(venv) / "winml-cert-gpu"),
                 "ORT_MODEL_ZOO_BACKEND": "gpu",
+            },
+        )
+
+
+class OrtWheelGenieModelTestTask(OrtWheelModelTestTask):
+    def __init__(
+        self,
+        group_name: str | None,
+        venv: Path | None,
+        target_arch: TargetArchT,
+        config: BuildConfigT,
+        py_version: TargetPyVersionT,
+    ) -> None:
+        super().__init__(
+            group_name,
+            venv,
+            target_arch,
+            config,
+            py_version,
+            [
+                str(REPO_ROOT / "qcom" / "model_test" / "genie_model_test.py"),
+            ],
+            get_test_env=lambda: {
+                **os.environ,
+                "ORT_MODEL_ZOO_TEST_ROOTS": str(get_genai_models_root(venv)),
+                "ORT_MODEL_ZOO_BACKEND": "genie",
             },
         )
 

--- a/qcom/ep_build/tools.py
+++ b/qcom/ep_build/tools.py
@@ -26,6 +26,10 @@ def get_onnx_models_root(package_manager_venv: Path | None) -> Path:
     return get_package_content_dir(package_manager_venv, "onnx_models")
 
 
+def get_genai_models_root(package_manager_venv: Path | None) -> Path:
+    return get_package_content_dir(package_manager_venv, "genai_models")
+
+
 def get_qualcomm_device_cloud_sdk_root(package_manager_venv: Path | None) -> Path:
     return get_package_content_dir(package_manager_venv, "qualcomm_device_cloud_sdk")
 

--- a/qcom/model_test/genie_model_test.py
+++ b/qcom/model_test/genie_model_test.py
@@ -1,0 +1,32 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import os
+from pathlib import Path
+from typing import cast, get_args
+
+import pytest
+from model_test import BackendT, ModelTestCase, ModelTestDef, ModelTestSuite
+
+GENIE_MODEL_ROOTS = [Path(p) for p in os.getenv("ORT_MODEL_ZOO_TEST_ROOTS", "").split(os.pathsep) if len(p) > 0]
+GENIE_BACKEND = cast(BackendT, os.getenv("ORT_MODEL_ZOO_BACKEND", "genie"))
+assert GENIE_BACKEND in get_args(BackendT)
+
+for genie_model_root in GENIE_MODEL_ROOTS:
+    TEST_DEFS = list(
+        ModelTestSuite(
+            genie_model_root,
+            backend_type=GENIE_BACKEND,
+            rtol=None,
+            atol=None,
+            cosine_similarity=None,
+            enable_context=False,
+            enable_cpu_fallback=False,
+        ).tests
+    )
+
+    TEST_IDS = [str(st) for st in TEST_DEFS]
+
+    @pytest.mark.parametrize("test_def", TEST_DEFS, ids=TEST_IDS)
+    def test_genie_models(test_def: ModelTestDef) -> None:
+        ModelTestCase(test_def).run_and_check_nonempty()

--- a/qcom/model_test/model_test.py
+++ b/qcom/model_test/model_test.py
@@ -22,7 +22,7 @@ DEFAULT_RTOL = 1e-3
 DEFAULT_ATOL = 1e-5
 DEFAULT_COSINE_SIMILARITY: float | None = None
 
-BackendT = Literal["cpu", "gpu", "htp"]
+BackendT = Literal["cpu", "gpu", "htp", "genie"]
 
 _ep_plugin_loaded = False
 
@@ -52,19 +52,23 @@ class ModelTestCase:
 
         session_options = onnxruntime.SessionOptions()
 
-        qnn_device, backend_path = get_qnn_ep_device(model_def.backend_type)
-        session_options.add_provider_for_devices([qnn_device], {"backend_path": str(backend_path)})
+        if model_def.backend_type == "genie":
+            genie_ep_devices = get_qnn_genie_ep_devices()
+            session_options.add_provider_for_devices(genie_ep_devices, {"genie_log_level": "error"})
+        else:
+            qnn_device, backend_path = get_qnn_ep_device(model_def.backend_type)
+            session_options.add_provider_for_devices([qnn_device], {"backend_path": str(backend_path)})
 
-        if not model_def.enable_cpu_fallback and model_def.backend_type != "cpu":
-            session_options.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+            if not model_def.enable_cpu_fallback and model_def.backend_type != "cpu":
+                session_options.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
 
-        if model_def.enable_context:
-            context_model_path = model_def.model_root / f"{model_def.model_root.name}_ctx.onnx"
-            if context_model_path.exists():
-                logging.debug(f"Clobbering stale context in {context_model_path}")
-                context_model_path.unlink()
-            session_options.add_session_config_entry("ep.context_enable", "1")
-            session_options.add_session_config_entry("ep.context_file_path", str(context_model_path))
+            if model_def.enable_context:
+                context_model_path = model_def.model_root / f"{model_def.model_root.name}_ctx.onnx"
+                if context_model_path.exists():
+                    logging.debug(f"Clobbering stale context in {context_model_path}")
+                    context_model_path.unlink()
+                session_options.add_session_config_entry("ep.context_enable", "1")
+                session_options.add_session_config_entry("ep.context_file_path", str(context_model_path))
 
         logging.info(f"Preparing {self.__model_root.name}")
         self.__session = onnxruntime.InferenceSession(
@@ -144,6 +148,18 @@ class ModelTestCase:
                 else:
                     np.testing.assert_allclose(actual[name], expected[ds_idx][name], atol=atol, rtol=rtol)
                     logging.info(f"{name} is close enough (rtol: {rtol}; atol: {atol})")
+
+    def run_and_check_nonempty(self) -> None:
+        inputs = self.load_inputs()
+        if len(inputs) == 0:
+            logging.info(f"{self.__model_root.name} has no reference data.")
+            return
+        logging.info(f"Running {self.__model_root.name} with {len(inputs)} reference datasets.")
+        for input_set in inputs:
+            outputs = self.__session.run(None, input_set)
+            assert len(outputs) > 0, f"{self.__model_root.name} produced no outputs."
+            for i, output in enumerate(outputs):
+                assert output.size > 0, f"{self.__model_root.name} output {i} is empty."
 
 
 class ModelTestSuite:
@@ -284,6 +300,18 @@ def get_qnn_ep_device(backend_type: BackendT) -> tuple[onnxruntime.OrtEpDevice, 
     ep_device = eps_and_devices[backend_type]
 
     return ep_device, get_qnn_backend_path(backend_type)
+
+
+def get_qnn_genie_ep_devices() -> list[onnxruntime.OrtEpDevice]:
+    global _ep_plugin_loaded  # noqa: PLW0603
+    if not _ep_plugin_loaded:
+        onnxruntime.register_execution_provider_library("QNNExecutionProvider", onnxruntime_qnn.get_library_path())
+        _ep_plugin_loaded = True
+
+    ep_names = onnxruntime_qnn.get_ep_names()
+    assert len(ep_names) == 1, f"Got {len(ep_names)} EP names, expected 1"
+
+    return [ed for ed in onnxruntime.get_ep_devices() if ed.ep_name == ep_names[0]]
 
 
 def initialize_logging(log_name: str) -> None:

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -110,6 +110,11 @@ maven_linux_x86_64:
   sha256: 067672629075b740e3d0a928e21021dd615a53287af36d4ccca44e87e081d102
   content_root: apache-maven-{version}
   bindir: bin
+genai_models:
+  version: TBD
+  url: http://ort-ep-win-01.na.qualcomm.com:8000/genai-models/genai-models-{version}.zip
+  sha256: TBD
+  content_root: genai-models
 model_zoo:
   version: 2026-04-03
   url: http://ort-ep-win-01.na.qualcomm.com:8000/model-zoo/model-zoo-{version}.zip


### PR DESCRIPTION
### Description

Adds the scaffolding needed to run a Genie LLM model through the existing Windows ARM Python model test pipeline. No new CI jobs are triggered yet — the `genai_models` package entry in `packages.yml` contains placeholder values that will be filled in once the model is hosted, and the CI workflow wiring will land in a follow-up PR alongside those values.

Changes:
- `qcom/model_test/model_test.py` — adds `"genie"` to `BackendT`; new session setup branch that uses `genie_log_level` (instead of `backend_path`) when constructing an ORT session for Genie models; adds `get_qnn_genie_ep_devices()` helper; adds `ModelTestCase.run_and_check_nonempty()` for tests that assert non-empty output without comparing to golden values
- `qcom/model_test/genie_model_test.py` (new) — thin pytest driver for Genie model tests; reads `ORT_MODEL_ZOO_TEST_ROOTS` and `ORT_MODEL_ZOO_BACKEND=genie`; calls `run_and_check_nonempty()` (golden value comparison is a follow-up)
- `qcom/ep_build/tools.py` — adds `get_genai_models_root` package helper
- `qcom/ep_build/tasks/python.py` — adds `OrtWheelGenieModelTestTask` extending `OrtWheelModelTestTask`
- `qcom/build_and_test.py` — adds `test_ort_windows_arm64_pygenie` task
- `qcom/packages.yml` — adds `genai_models` entry with placeholder `version`/`url`/`sha256`

### Motivation and Context

The Genie backend enables autoregressive LLM inference through ORT via EPContext nodes that wrap Genie DLCs. This pathway currently has no automated CI coverage on Windows ARM — the existing model zoo tests cover HTP and GPU backends but not Genie.

This PR adds the test infrastructure so that once a model package is available, enabling CI coverage requires only filling in `packages.yml` and adding the task to the workflow's wheel test step. The initial test intentionally skips output value comparison (asserting only that inference produces non-empty tensors) to avoid a dependency on golden values that have not yet been established.