### PR TITLE
[QNN EP] Final 2.1.1 Release Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is maintained by Qualcomm. For the general ONNX Runtime project,
 
 ONNX Runtime supports hardware acceleration through **Execution Providers (EPs)**. The QNN EP is a *plugin* EP — a separately distributed shared library that plugs into a standard ONNX Runtime installation at runtime, without requiring a custom ORT build.
 
-> **QNN EP 2.1.0 is the Plugin QNN EP.** Starting with version 2.0.0, the QNN EP ships as a standalone plugin package (`onnxruntime-qnn>=2.0.0`) that works with any standard ORT installation — no custom build required. [Learn more about Plugin EPs →](https://onnxruntime.ai/docs/execution-providers/plugin-ep-libraries/)
+> **QNN EP 2.1.1 is the Plugin QNN EP.** Starting with version 2.0.0, the QNN EP ships as a standalone plugin package (`onnxruntime-qnn>=2.0.0`) that works with any standard ORT installation — no custom build required. [Learn more about Plugin EPs →](https://onnxruntime.ai/docs/execution-providers/plugin-ep-libraries/)
 
 <br/>
 <p align="center"><img width="80%" src="docs/images/PluginEP-final.png" /></p>
@@ -77,15 +77,23 @@ ort.unregister_execution_provider_library(lib_registration_name)
 ## Install
 
 ```bash
-pip install onnxruntime
-pip install onnxruntime-qnn
+pip install onnxruntime==1.24.4
+pip install onnxruntime-qnn==2.1.1
 ```
 
 **Requirements:**
 - Windows ARM64 (for on-device inference with Qualcomm NPU)
 - Windows X64 (for model quantization and AOT compilation)
+- Python 3.11 – 3.14
+- Numpy 1.25.2 or >= 1.26.4
 
 For NuGet: [`Qualcomm.ML.OnnxRuntime.QNN`](https://www.nuget.org/packages/Qualcomm.ML.OnnxRuntime.QNN) (Windows ARM64 only)
+
+### Linux Wheels and .tgz Files
+
+- **2.1.1+**: Linux ARM64 Wheels and .tgz files available
+- **2.1.0**: Linux ARM64 preview wheels available
+- **2.0.0**: No Linux ARM64 Wheels or .tgz files
 
 ---
 

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -38,7 +38,7 @@ download the Qualcomm AI Runtime SDK (QAIRT SDK) from [https://qpm.qualcomm.com/
 ONNX Runtime QNN EP has been built and tested with the following SDK version combinations on Windows:
 | QNN EP Version | QAIRT SDK Version | ONNX Runtime Version |
 |----------------|-------------------|----------------------|
-| v2.1.0         | v2.45.40           | v1.24.4             |
+| v2.1.1         | v2.45.41          | v1.24.4              |
 
 > **Note**: ONNX Runtime QNN EP is built and tested by using the arm64 ONNX Runtime SDK (ex: onnxruntime-win-arm64-1.24.0.zip).
 
@@ -52,9 +52,12 @@ For build instructions, please see the [BUILD page](./build.md).
   - Requirements:
     - Windows ARM64 (for inferencing on local device with Qualcomm NPU)
     - Windows X64 (for quantizing models. see [Generating a quantized model](./QNN-ExecutionProvider.md#generating-a-quantized-model-x64-only))
+    - Linux ARM64 (for inferencing on local Qualcomm-powered Linux devices)
     - Python 3.11.x
     - Numpy 1.25.2 or >= 1.26.4
   - Install: `pip install onnxruntime-qnn`
+- Linux ARM64 archive (`.tgz`)
+  - **Note**: Ships the QNN EP shared library and headers for use outside of Python on Linux ARM64.
 
 ## Qualcomm AI Hub
 Qualcomm AI Hub can be used to optimize and run models on Qualcomm hosted devices.

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -40,7 +40,7 @@ ONNX Runtime QNN EP has been built and tested with the following SDK version com
 |----------------|-------------------|----------------------|
 | v2.1.1         | v2.45.41          | v1.24.4              |
 
-> **Note**: ONNX Runtime QNN EP is built and tested by using the arm64 ONNX Runtime SDK (ex: onnxruntime-win-arm64-1.24.0.zip).
+> **Note**: ONNX Runtime QNN EP is built and tested by using the arm64 ONNX Runtime SDK (ex: onnxruntime-win-arm64-1.24.4.zip).
 
 ## Build (Windows)
 For build instructions, please see the [BUILD page](./build.md).

--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -9,6 +9,11 @@ This repository is maintained by Qualcomm. For the general ONNX Runtime project,
 Changes
 -------
 
+2.1.1
+^^^^^^
+
+Release Notes : https://github.com/onnxruntime/onnxruntime-qnn/releases/tag/v2.1.1
+
 2.1.0
 ^^^^^^
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,51 @@
+# ONNX Runtime QNN Execution Provider v2.1.1
+This is a patch release of the QNN Execution Provider, containing bug fixes and packaging updates.
+
+**ONNX Runtime Compatibility:** >= 1.24.1 (compiled with v1.24.4)<br>
+**QAIRT SDK Compatibility:** 2.45.41
+
+```
+pip install onnxruntime==1.24.4
+pip install onnxruntime-qnn==2.1.1
+```
+
+## Bug Fixes
+
+- QNN EP: Fixed a per-tensor, per-inference memory leak in `OrtTensorTypeAndShapeInfo` during `ExecuteGraph` on the ABI path. ([#326](https://github.com/onnxruntime/onnxruntime-qnn/pull/326))
+- QNN EP: Fixed `TryGetMaxSpillFillSize` reading all EP contexts instead of only main contexts, which caused `QNN_CONTEXT_ERROR_INVALID_CONFIG` on multi-split weight-shared models. ([#328](https://github.com/onnxruntime/onnxruntime-qnn/pull/328))
+
+## Improvements
+
+- QNN EP: Switched `onnxruntime_providers_qnn.dll` to static MSVC runtime linkage, eliminating the runtime dependency on `MSVCP140.dll` and `VCRUNTIME140.dll`. ([#241](https://github.com/onnxruntime/onnxruntime-qnn/pull/241))
+
+## Packaging
+
+- Linux ARM64 Python wheels — promoted from preview (v2.1.0) to officially supported. As with Windows, wheels are published for Python 3.11 through Python 3.14.
+- Linux ARM64 `.tgz` archive — new distribution shipping the QNN EP shared library and headers for use outside of Python.
+
+### Platform Support
+
+| Package | Windows ARM64 | Windows x64 | Linux ARM64 |
+|---|---|---|---|
+| Python Wheel | Inference | AOT compilation + Inference | Inference |
+| NuGet | Inference | — | — |
+| ZIP | Inference | — | — |
+| tgz | — | — | Inference |
+
+**Full Changelog:** [rel-2.1.0...rel-2.1.1](https://github.com/onnxruntime/onnxruntime-qnn/compare/rel-2.1.0...rel-2.1.1)
+
+## Contributors
+
+This release includes contributions from:
+
+[Arnav Deshpande](https://github.com/qti-arnadesh), [Ashwath Shankarnarayan](https://github.com/qti-ashwshan), [Badri Narayanan](https://github.com/qti-mbadnara), [Calvin Nguyen](https://github.com/quic-calvnguy), [Cheng-Hsin Weng](https://github.com/qti-chenweng), [Chun-Chih Teng](https://github.com/qti-chuteng), [Hua-Yu Chou](https://github.com/huaychou), [Hung-Jui Wang](https://github.com/qti-hungjuiw), [Jeff Kilpatrick](https:/github.com/qti-jkilpatrick), [Kuan-Yu Lin](https://github.com/kuanyul-qti), [Kyle Romero](https://github.com/qti-kromero), [Matthew Sinclair](https://github.com/qti-mattsinc), [Mike Hsu](https://github.com/quic-muchhsu), [Min Fong Hong](https://github.com/minfhong-qti), [Samrat Dutta](https://github.com/samrdutt-design), [Shubham Patel](https://github.com/qti-shubham), [Tirupathi Reddy T](https://github.com/tirupath-qti), [Yathindra Kota](https://github.com/quic-ykota), [Yuduo Wu](https://github.com/qti-yuduo), [Yu-Hung Chuang](https://github.com/yuhuchua-qti)
+
+---
+
+---
+
+
+
 # ONNX Runtime QNN Execution Provider v2.1.0
 
 **ONNX Runtime Compatibility:** >= 1.24.1 (compiled with v1.24.4)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,7 @@ pip install onnxruntime-qnn==2.1.1
 ## Improvements
 
 - QNN EP: Switched `onnxruntime_providers_qnn.dll` to static MSVC runtime linkage, eliminating the runtime dependency on `MSVCP140.dll` and `VCRUNTIME140.dll`. ([#241](https://github.com/onnxruntime/onnxruntime-qnn/pull/241))
+- QNN EP: Reduced peak memory in model compatibility validation from ~200 MB to ~50 MB by removing the context blob version from compatibility checks, avoiding the fake context binary creation and preparation library load. ([#366](https://github.com/onnxruntime/onnxruntime-qnn/pull/366))
 
 ## Packaging
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -341,6 +341,7 @@ Ort::Status QnnBackendManager::LoadBackend() {
                                                                                          &backend_interface_provider)));
   qnn_interface_ = backend_interface_provider->QNN_INTERFACE_VER_NAME;
   backend_id_ = backend_interface_provider->backendId;
+  backend_api_version_ = backend_interface_provider->apiVersion.backendApiVersion;
   SetQnnBackendType(backend_id_);
 
   Qnn_Version_t backend_interface_version = GetQnnInterfaceApiVersion(backend_interface_provider);
@@ -392,6 +393,7 @@ Ort::Status QnnBackendManager::LoadQnnSerializerBackend() {
 
   // Set the "intended" backend type so that QNN builders still make the expected QNN API calls.
   backend_id_ = backend_interface_provider->backendId;
+  backend_api_version_ = backend_interface_provider->apiVersion.backendApiVersion;
   SetQnnBackendType(backend_id_);
 
   // Load the serializer backend and set it as the activate backend.
@@ -1754,6 +1756,12 @@ Ort::Status QnnBackendManager::SetupBackend(
   }
   if (status.IsOK()) {
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "CreateDevice succeed.");
+
+    if (Ort::Status _status = GetPlatformInfo(); !_status.IsOK()) {
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_WARNING,
+                      ("Unable to get platform info: " + _status.GetErrorMessage()).c_str());
+    }
   }
 
   if (status.IsOK()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -244,13 +244,11 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   void SetQnnBackendType(uint32_t backend_id);
   QnnBackendType GetQnnBackendType() { return qnn_backend_type_; }
 
+  Qnn_Version_t GetBackendApiVersion() { return backend_api_version_; }
+
   const std::string& GetSdkVersion() { return sdk_build_version_; }
 
-  Ort::Status GetHtpArch(QnnHtpDevice_Arch_t& htp_arch) {
-    RETURN_IF_ERROR(GetPlatformInfo());
-    htp_arch = htp_arch_internal_;
-    return Ort::Status();
-  }
+  QnnHtpDevice_Arch_t GetHtpArch() { return htp_arch_internal_; }
 
   // Get backend library directory by adopting identical logic as in LoadLib.
   std::string GetBackendLibDir() {
@@ -563,6 +561,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   bool vtcm_backup_buffer_sharing_enabled_ = false;
 
   uint32_t backend_id_ = QNN_BACKEND_ID_CPU;
+  Qnn_Version_t backend_api_version_ = QNN_VERSION_INIT;
   bool file_mapped_weights_enabled_ = false;
 
 #ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE

--- a/onnxruntime/core/providers/qnn/builder/qnn_cache_compatibility_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_cache_compatibility_manager.cc
@@ -1,17 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-
 #include <string>
-#include <type_traits>
 
-#include "QnnCommon.h"
-#include "System/QnnSystemContext.h"
+#include "HTP/QnnHtpDevice.h"
 
 #include "core/providers/qnn/builder/qnn_cache_compatibility_manager.h"
 #include "core/providers/qnn/builder/qnn_def.h"
@@ -22,193 +14,12 @@
 namespace onnxruntime {
 namespace qnn {
 
-namespace {
-
-int RedirectStdout() {
-  // Save the current stdout file descriptor.
-#ifdef _WIN32
-  int saved_stdout_fd = _dup(_fileno(stdout));
-#else
-  int saved_stdout_fd = dup(fileno(stdout));
-#endif
-  if (saved_stdout_fd == -1) {
-    return saved_stdout_fd;
-  }
-
-  // Redirect stdout to NUL.
-#ifdef _WIN32
-  const char* filename = "NUL";
-#else
-  const char* filename = "/dev/null";
-#endif
-#ifdef _WIN32
-  FILE* redirected = nullptr;
-  if (freopen_s(&redirected, filename, "w", stdout) != 0 || redirected == nullptr) {
-    _close(saved_stdout_fd);
-#else
-  if (freopen(filename, "w", stdout) == nullptr) {
-    close(saved_stdout_fd);
-#endif
-    return saved_stdout_fd;
-  }
-
-  return saved_stdout_fd;
-}
-
-void RestoreStdout(int saved_stdout_fd) {
-  if (saved_stdout_fd == -1) {
-    return;
-  }
-
-  fflush(stdout);
-#ifdef _WIN32
-  _dup2(saved_stdout_fd, _fileno(stdout));
-  _close(saved_stdout_fd);
-#else
-  dup2(saved_stdout_fd, fileno(stdout));
-  close(saved_stdout_fd);
-#endif
-}
-
-}  // namespace
-
-Ort::Status QnnCacheCompatibilityManager::CreateFakeContextBinary(std::unique_ptr<unsigned char[]>& context_buffer,
-                                                                  uint64_t& context_buffer_size) {
-  const auto& qnn_interface = qnn_backend_manager_->GetQnnInterface();
-  const auto& backend_handle = qnn_backend_manager_->GetQnnBackendHandle();
-  const auto& device_handle = qnn_backend_manager_->GetQnnDeviceHandle();
-
-  Qnn_ErrorHandle_t result = 0;
-
-  // Create context.
-  Qnn_ContextHandle_t context_raw = nullptr;
-  result = qnn_interface.contextCreate(backend_handle, device_handle, nullptr, &context_raw);
-  RETURN_IF(result != QNN_CONTEXT_NO_ERROR,
-            ("Failed to create context. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  std::unique_ptr<std::remove_pointer_t<Qnn_ContextHandle_t>, std::function<void(Qnn_ContextHandle_t)>>
-      context(context_raw, [&qnn_interface](Qnn_ContextHandle_t context) { qnn_interface.contextFree(context, nullptr); });
-
-  // Create graph.
-  Qnn_GraphHandle_t graph = nullptr;
-  result = qnn_interface.graphCreate(context.get(), "fake_context_bin", nullptr, &graph);
-  RETURN_IF(result != QNN_GRAPH_NO_ERROR,
-            ("Failed to create graph. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  // Create input tensor.
-  QnnTensorWrapper input_tensor_wrapper("input",
-                                        QNN_TENSOR_TYPE_APP_WRITE,
-                                        QNN_DATATYPE_FLOAT_16,
-                                        QnnQuantParamsWrapper(),
-                                        {1, 32, 32, 3});
-  Qnn_Tensor_t& input_tensor = input_tensor_wrapper.GetQnnTensor();
-  result = qnn_interface.tensorCreateGraphTensor(graph, &input_tensor);
-  RETURN_IF(result != QNN_TENSOR_NO_ERROR,
-            ("Failed to create tensor. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  // Create output tensor.
-  QnnTensorWrapper output_tensor_wrapper("output",
-                                         QNN_TENSOR_TYPE_APP_READ,
-                                         QNN_DATATYPE_FLOAT_16,
-                                         QnnQuantParamsWrapper(),
-                                         {1, 32, 32, 3});
-  Qnn_Tensor_t& output_tensor = output_tensor_wrapper.GetQnnTensor();
-  result = qnn_interface.tensorCreateGraphTensor(graph, &output_tensor);
-  RETURN_IF(result != QNN_TENSOR_NO_ERROR,
-            ("Failed to create tensor. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  // Create node.
-  QnnOpConfigWrapper op_config_wrapper("node",
-                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                       QNN_OP_RELU,
-                                       {input_tensor},
-                                       {output_tensor},
-                                       {});
-  const Qnn_OpConfig_t& op_config = op_config_wrapper.GetQnnOpConfig();
-  result = qnn_interface.backendValidateOpConfig(backend_handle, op_config);
-  RETURN_IF(result != QNN_SUCCESS,
-            ("Failed to validate node. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-  result = qnn_interface.graphAddNode(graph, op_config);
-  RETURN_IF(result != QNN_GRAPH_NO_ERROR,
-            ("Failed to add node. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  // Finalize graph.
-  int saved_stdout_fd = RedirectStdout();  // Redirect stdout to avoid confusing user.
-  result = qnn_interface.graphFinalize(graph, nullptr, nullptr);
-  RestoreStdout(saved_stdout_fd);
-  RETURN_IF(result != QNN_GRAPH_NO_ERROR,
-            ("Failed to finalize graph. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  // Get binary size.
-  uint64_t required_buffer_size = 0;
-  result = qnn_interface.contextGetBinarySize(context.get(), &required_buffer_size);
-  RETURN_IF(result != QNN_CONTEXT_NO_ERROR,
-            ("Failed to get context binary size. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-
-  // Allocate buffer.
-  context_buffer = std::make_unique<unsigned char[]>(required_buffer_size);
-  RETURN_IF(context_buffer == nullptr, "Failed to allocate buffer for context binary.");
-
-  // Get binary.
-  result = qnn_interface.contextGetBinary(context.get(),
-                                          reinterpret_cast<void*>(context_buffer.get()),
-                                          required_buffer_size,
-                                          &context_buffer_size);
-  RETURN_IF(result != QNN_CONTEXT_NO_ERROR,
-            ("Failed to get context binary. Error: " + utils::GetQnnErrorMessage(qnn_interface, result)).c_str());
-  RETURN_IF(required_buffer_size < context_buffer_size, "Written buffer size exceeded allocated buffer size.");
-
-  return Ort::Status();
-}
-
-Ort::Status QnnCacheCompatibilityManager::GetCompatibilityInfo(unsigned char* context_buffer,
-                                                               uint64_t context_buffer_size,
-                                                               QnnCompatibilityInfo& info) {
-  const auto& qnn_sys_interface = qnn_backend_manager_->GetQnnSystemInterface();
-  RETURN_IF(qnn_sys_interface.systemContextCreate == nullptr ||
-                qnn_sys_interface.systemContextGetBinaryInfo == nullptr ||
-                qnn_sys_interface.systemContextFree == nullptr,
-            "Failed to get valid QnnSystem function pointers.");
-
-  QnnSystemContext_Handle_t sys_ctx_raw_handle = nullptr;
-  RETURN_IF(qnn_sys_interface.systemContextCreate(&sys_ctx_raw_handle) != QNN_SUCCESS,
-            "Failed to create system handle.");
-
-  std::unique_ptr<std::remove_pointer_t<QnnSystemContext_Handle_t>, std::function<void(QnnSystemContext_Handle_t)>>
-      sys_ctx_handle(
-          sys_ctx_raw_handle,
-          [&qnn_sys_interface](QnnSystemContext_Handle_t sys_ctx_handle) {
-            qnn_sys_interface.systemContextFree(sys_ctx_handle);
-          });
-
-  const QnnSystemContext_BinaryInfo_t* binary_info = nullptr;
-  Qnn_ContextBinarySize_t binary_info_size = 0;
-  RETURN_IF(qnn_sys_interface.systemContextGetBinaryInfo(sys_ctx_handle.get(),
-                                                         static_cast<void*>(context_buffer),
-                                                         context_buffer_size,
-                                                         &binary_info,
-                                                         &binary_info_size) != QNN_SUCCESS,
-            "Failed to get context binary info.");
-  RETURN_IF(binary_info == nullptr, "Failed to get context binary info.");
-
+Ort::Status QnnCacheCompatibilityManager::GetCompatibilityInfo(QnnCompatibilityInfo& info) {
   info.backend_id = qnn_backend_manager_->GetBackendId();
-  if (binary_info->version == QNN_SYSTEM_CONTEXT_BINARY_INFO_VERSION_3) {
-    info.backend_api_version = binary_info->contextBinaryInfoV3.backendApiVersion;
-    info.context_blob_version = binary_info->contextBinaryInfoV3.contextBlobVersion;
-  } else if (binary_info->version == QNN_SYSTEM_CONTEXT_BINARY_INFO_VERSION_2) {
-    info.backend_api_version = binary_info->contextBinaryInfoV2.backendApiVersion;
-    info.context_blob_version = binary_info->contextBinaryInfoV2.contextBlobVersion;
-  } else if (binary_info->version == QNN_SYSTEM_CONTEXT_BINARY_INFO_VERSION_1) {
-    info.backend_api_version = binary_info->contextBinaryInfoV1.backendApiVersion;
-    info.context_blob_version = binary_info->contextBinaryInfoV1.contextBlobVersion;
-  } else {
-    return MAKE_FAIL("Unknown context binary info version.");
-  }
+  info.backend_api_version = qnn_backend_manager_->GetBackendApiVersion();
 
-  // Although HTP arch can be extracted from V3 context binary info, unify to query through backend manager again.
-  QnnHtpDevice_Arch_t htp_arch;
-  RETURN_IF_ERROR(qnn_backend_manager_->GetHtpArch(htp_arch));
-  info.htp_arch = static_cast<uint32_t>(htp_arch);
+  info.htp_arch = static_cast<uint32_t>(qnn_backend_manager_->GetHtpArch());
+  RETURN_IF(info.htp_arch == static_cast<uint32_t>(QNN_HTP_DEVICE_ARCH_NONE), "Unable to acquire HTP arch.");
 
   RETURN_IF_ERROR(htp_usr_drv::IsHtpUsrDrvEnabled(qnn_backend_manager_->GetBackendLibDir(),
                                                   info.htp_arch,
@@ -238,16 +49,9 @@ Ort::Status QnnCacheCompatibilityManager::ValidateCompatibilityInfo(const QnnCom
                                                                     OrtCompiledModelCompatibility& compatibility) {
   compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
 
-  // A fake context binary is created here to acquire context blob version which is not querable through current APIs
-  // but can only be extracted from context binary info.
-  // Remove this context binary if context blob version could be directly queried through new APIs.
-  std::unique_ptr<unsigned char[]> context_buffer;
-  uint64_t context_buffer_size;
-  RETURN_IF_ERROR(CreateFakeContextBinary(context_buffer, context_buffer_size));
-
   // Get runtime info to be compared with the given one.
   QnnCompatibilityInfo runtime_info;
-  RETURN_IF_ERROR(GetCompatibilityInfo(context_buffer.get(), context_buffer_size, runtime_info));
+  RETURN_IF_ERROR(GetCompatibilityInfo(runtime_info));
 
   auto is_htp_arch_compatible = [cb_htp_arch = info.htp_arch, rt_htp_arch = runtime_info.htp_arch] {
     if (cb_htp_arch < rt_htp_arch) {
@@ -262,12 +66,15 @@ Ort::Status QnnCacheCompatibilityManager::ValidateCompatibilityInfo(const QnnCom
   // The comparison order is as below:
   //   1. backend ID
   //   2. backend API version (if no HNRD involved) / SDK version (if HNRD involved)
-  //   3. context blob bersion
+  //   3. (Deprecated) context blob version
   //   4. HTP arch
   //
-  // Note that since the fake context binary approach is adopted, there is no need to compare context blob version with
-  // SDK and HNRD separately in HNRD paths. The fake context binary has context blob version tagged with the smaller
-  // one between SDK and HNRD, and thus comparing to it directly reflect comparing to both SDK and HNRD.
+  // Notes:
+  //   - Context blob version is deprecated from compatibility info due to the peak memory concern in the previous
+  //     approach which acquires the runtime context blob version through creating a fake context binary. Nevertheless,
+  //     the removal in fact does not impact the compatibility validation since the combination of a new context binary
+  //     generated by an old SDK is impossible. Thus, comparing backend API version / SDK version is enough to cover
+  //     context blob version.
 
   if (info.backend_id != runtime_info.backend_id) {
     compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
@@ -277,21 +84,13 @@ Ort::Status QnnCacheCompatibilityManager::ValidateCompatibilityInfo(const QnnCom
   // Deliberately leave all branches without reduction for readibility and maintainability.
   if (!info.is_htp_usr_drv && !runtime_info.is_htp_usr_drv) {
     if (info.backend_api_version <= runtime_info.backend_api_version) {
-      if (info.context_blob_version <= runtime_info.context_blob_version) {
-        compatibility = is_htp_arch_compatible();
-      } else {
-        compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
-      }
+      compatibility = is_htp_arch_compatible();
     } else {
       compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
     }
   } else if (!info.is_htp_usr_drv && runtime_info.is_htp_usr_drv) {
     if (info.sdk_version <= runtime_info.sdk_version) {
-      if (info.context_blob_version <= runtime_info.context_blob_version) {
-        compatibility = is_htp_arch_compatible();
-      } else {
-        compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
-      }
+      compatibility = is_htp_arch_compatible();
     } else {
       compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
     }
@@ -300,11 +99,7 @@ Ort::Status QnnCacheCompatibilityManager::ValidateCompatibilityInfo(const QnnCom
     compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
   } else {  // (info.is_htp_usr_drv && runtime_info.is_htp_usr_drv)
     if (info.sdk_version <= runtime_info.sdk_version) {
-      if (info.context_blob_version <= runtime_info.context_blob_version) {
-        compatibility = is_htp_arch_compatible();
-      } else {
-        compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
-      }
+      compatibility = is_htp_arch_compatible();
     } else {
       compatibility = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
     }

--- a/onnxruntime/core/providers/qnn/builder/qnn_cache_compatibility_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_cache_compatibility_manager.h
@@ -45,7 +45,7 @@ struct QnnCompatibilityInfo {
   uint32_t backend_id = 0;
   QnnVersion sdk_version = QNN_VERSION_INIT;
   QnnVersion backend_api_version = QNN_VERSION_INIT;
-  QnnVersion context_blob_version = QNN_VERSION_INIT;
+  QnnVersion context_blob_version = QNN_VERSION_INIT;  // Deprecated.
   uint32_t htp_arch = 0;
   bool is_htp_usr_drv = false;
 };
@@ -55,14 +55,9 @@ class QnnCacheCompatibilityManager {
   QnnCacheCompatibilityManager(QnnBackendManager* qnn_backend_manager)
       : qnn_backend_manager_(qnn_backend_manager) {}
 
-  Ort::Status GetCompatibilityInfo(unsigned char* context_buffer,
-                                   uint64_t context_buffer_size,
-                                   QnnCompatibilityInfo& info);
+  Ort::Status GetCompatibilityInfo(QnnCompatibilityInfo& info);
 
   Ort::Status ValidateCompatibilityInfo(const QnnCompatibilityInfo& info, OrtCompiledModelCompatibility& compatibility);
-
- private:
-  Ort::Status CreateFakeContextBinary(std::unique_ptr<unsigned char[]>& context_buffer, uint64_t& context_buffer_size);
 
  private:
   QnnBackendManager* qnn_backend_manager_;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1870,9 +1870,7 @@ OrtStatus* QnnEp::CreateEPContextNodes(const OrtGraph* graph,
                                              name_));
 
   // Get compatibility info for later query in GetCompiledModelCompatibilityInfo.
-  Ort::Status status = qnn_cache_compatibility_manager_->GetCompatibilityInfo(context_buffer.get(),
-                                                                              buffer_size,
-                                                                              compatibility_info_);
+  Ort::Status status = qnn_cache_compatibility_manager_->GetCompatibilityInfo(compatibility_info_);
   if (!status.IsOK()) {
     ORT_CXX_LOG(logger_,
                 ORT_LOGGING_LEVEL_VERBOSE,
@@ -2331,7 +2329,6 @@ const char* ORT_API_CALL QnnEp::GetCompiledModelCompatibilityInfoImpl(_In_ OrtEp
   qnn::QnnCompatibilityInfo default_info;
   if (ep->compatibility_info_.sdk_version == default_info.sdk_version ||
       ep->compatibility_info_.backend_api_version == default_info.backend_api_version ||
-      ep->compatibility_info_.context_blob_version == default_info.context_blob_version ||
       ep->compatibility_info_.htp_arch == default_info.htp_arch) {
     return "";
   }

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3401,9 +3401,7 @@ struct CompatibilityTestInfo {
             std::to_string(backend_api_version_major) + "." +
             std::to_string(backend_api_version_minor) + "." +
             std::to_string(backend_api_version_patch) + ":" +
-            std::to_string(context_blob_version_major) + "." +
-            std::to_string(context_blob_version_minor) + "." +
-            std::to_string(context_blob_version_patch) + ":" +
+            "0.0.0:" +  // Context blob version is deprecated.
             std::to_string(htp_arch) + ":" +
             (is_htp_usr_drv ? "1" : "0"));
   }
@@ -3517,6 +3515,16 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_DiffBackend) {
   TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_UNSUPPORTED);
 }
 
+TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_CbTradRtTrad_CbOldApiVersion) {
+  CompatibilityTestInfo test_info;
+  test_info.backend_api_version_major = 0;
+  test_info.backend_api_version_minor = 0;
+  test_info.backend_api_version_patch = 0;
+  test_info.htp_arch = static_cast<uint32_t>(QnnHTPBackendTests::GetPlatformAttributes().htp_arch);
+
+  TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL);
+}
+
 TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_CbTradRtTrad_CbNewApiVersion) {
   CompatibilityTestInfo test_info;
   test_info.backend_api_version_major = 9999;
@@ -3526,13 +3534,18 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_CbTradRtTrad_CbNewApiV
   TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_UNSUPPORTED);
 }
 
-TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_CbTradRtTrad_CbNewBlobVersion) {
-  CompatibilityTestInfo test_info;
-  test_info.context_blob_version_major = 9999;
-  test_info.context_blob_version_minor = 9999;
-  test_info.context_blob_version_patch = 9999;
+// TODO: Re-enable once CI supports HNRD. One can still run the test on local WoS machine.
+TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_ApiValidate_CbTradRtHnrd_CbOldSdkVersion) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
 
-  TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_UNSUPPORTED);
+  QnnHtpDevice_Arch_t htp_arch = QnnHTPBackendTests::GetPlatformAttributes().htp_arch;
+  auto hnrd_test_handle = std::make_unique<HnrdTestHandle>(static_cast<uint32_t>(htp_arch));
+
+  CompatibilityTestInfo test_info;
+  test_info.sdk_build_id = "v0.0.0.0";
+  test_info.htp_arch = static_cast<uint32_t>(htp_arch);
+
+  TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL);
 }
 
 // TODO: Re-enable once CI supports HNRD. One can still run the test on local WoS machine.
@@ -3549,18 +3562,18 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_ApiValidate_CbTradRtHnrd_
 }
 
 // TODO: Re-enable once CI supports HNRD. One can still run the test on local WoS machine.
-TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_ApiValidate_CbTradRtHnrd_CbNewBlobVersion) {
+TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_ApiValidate_CbHnrdRtHnrd_CbOldSdkVersion) {
   QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
 
   QnnHtpDevice_Arch_t htp_arch = QnnHTPBackendTests::GetPlatformAttributes().htp_arch;
   auto hnrd_test_handle = std::make_unique<HnrdTestHandle>(static_cast<uint32_t>(htp_arch));
 
   CompatibilityTestInfo test_info;
-  test_info.context_blob_version_major = 9999;
-  test_info.context_blob_version_minor = 9999;
-  test_info.context_blob_version_patch = 9999;
+  test_info.sdk_build_id = "v0.0.0.0";
+  test_info.htp_arch = static_cast<uint32_t>(htp_arch);
+  test_info.is_htp_usr_drv = true;
 
-  TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_UNSUPPORTED);
+  TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL);
 }
 
 // TODO: Re-enable once CI supports HNRD. One can still run the test on local WoS machine.
@@ -3572,22 +3585,6 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_ApiValidate_CbHnrdRtHnrd_
 
   CompatibilityTestInfo test_info;
   test_info.sdk_build_id = "v9999.9999.9999.9999";
-  test_info.is_htp_usr_drv = true;
-
-  TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_UNSUPPORTED);
-}
-
-// TODO: Re-enable once CI supports HNRD. One can still run the test on local WoS machine.
-TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_ApiValidate_CbHnrdRtHnrd_CbNewBlobVersion) {
-  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
-
-  QnnHtpDevice_Arch_t htp_arch = QnnHTPBackendTests::GetPlatformAttributes().htp_arch;
-  auto hnrd_test_handle = std::make_unique<HnrdTestHandle>(static_cast<uint32_t>(htp_arch));
-
-  CompatibilityTestInfo test_info;
-  test_info.context_blob_version_major = 9999;
-  test_info.context_blob_version_minor = 9999;
-  test_info.context_blob_version_patch = 9999;
   test_info.is_htp_usr_drv = true;
 
   TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_UNSUPPORTED);

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -177,7 +177,7 @@ python_314_windows_arm64:
   version: 3.14.3
   md5: 1183951d055ef6c0ae1fb686b3342a6f
 qairt:
-  version: 2.45.40.260406
+  version: 2.45.41.260507
   url: https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/{version}/v{version}.zip
   content_root: qairt/{version}
   bindir: bin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coloredlogs
 flatbuffers
 numpy >= 1.21.6
-onnxruntime >= 1.24.2
+onnxruntime == 1.24.4
 packaging
 protobuf
 sympy


### PR DESCRIPTION
Final changes for `2.1.1` Release. Cherry-picked the following changes from `mainline` to the release branch: `rel-2.1.1`. QAIRT was upleveled from `2.45.40` to `2.45.41`

- #366 
- #369 
- #373 
- #382 


