### PR TITLE
Fix build fail caused by system language

### DIFF
--- a/qcom/scripts/windows/run_tests.ps1
+++ b/qcom/scripts/windows/run_tests.ps1
@@ -12,6 +12,8 @@ param(
 $RootDir = (Resolve-Path -Path "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)").Path
 $RepoRoot= (Resolve-Path -Path ("$RootDir\..\..\.."))
 
+. (Join-Path $RootDir "utils.ps1")
+
 if (-not $OnnxModelsRoot) {
     $OnnxModelsRoot = (Join-Path $RootDir (Join-Path "model_tests" "onnx_models"))
 }
@@ -51,7 +53,7 @@ $NewBuildDirectoryBackslashes = ($NewBuildDirectory -replace "/", "\\")
     Out-File -Encoding ascii $CTestTestFile
 
 # Figure out if HTP is available
-if ((Get-CimInstance Win32_operatingsystem).OSArchitecture -eq "ARM 64-bit Processor") {
+if ((Get-HostArch) -eq "arm64") {
     $QdqBackend = "htp"
 } else {
     $QdqBackend = "cpu"

--- a/qcom/scripts/windows/utils.ps1
+++ b/qcom/scripts/windows/utils.ps1
@@ -113,10 +113,13 @@ function Get-DefaultCMakeGenerator() {
 }
 
 function Get-HostArch() {
-    switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
-        ([System.Runtime.InteropServices.Architecture]::Arm64) { "arm64" }
-        ([System.Runtime.InteropServices.Architecture]::X64)   { "x86_64" }
-        default { throw "Unknown OS Architecture $_." }
+    # Read from machine-level registry entry set by the OS installer — locale-independent
+    # and unaffected by WOW64 or process architecture.
+    $arch = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", "Machine")
+    switch ($arch) {
+        "ARM64" { "arm64" }
+        "AMD64" { "x86_64" }
+        default { throw "Unknown OS Architecture $arch." }
     }
 }
 

--- a/qcom/scripts/windows/utils.ps1
+++ b/qcom/scripts/windows/utils.ps1
@@ -113,10 +113,10 @@ function Get-DefaultCMakeGenerator() {
 }
 
 function Get-HostArch() {
-    switch ((Get-CimInstance Win32_operatingsystem).OSArchitecture) {
-        "ARM 64-bit Processor" { "arm64" }
-        "64-bit" { "x86_64" }
-        default { throw "Unknown OS Architecture $OsArch." }
+    switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
+        ([System.Runtime.InteropServices.Architecture]::Arm64) { "arm64" }
+        ([System.Runtime.InteropServices.Architecture]::X64)   { "x86_64" }
+        default { throw "Unknown OS Architecture $_." }
     }
 }
 

--- a/qcom/scripts/windows/utils.ps1
+++ b/qcom/scripts/windows/utils.ps1
@@ -113,9 +113,12 @@ function Get-DefaultCMakeGenerator() {
 }
 
 function Get-HostArch() {
-    # Read from machine-level registry entry set by the OS installer — locale-independent
-    # and unaffected by WOW64 or process architecture.
-    $arch = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", "Machine")
+    # PROCESSOR_ARCHITEW6432 is set on WOW64 / x64-emulated processes and reports the
+    # real host arch. Fall back to machine-scope PROCESSOR_ARCHITECTURE (locale-independent).
+    $arch = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITEW6432", "Process")
+    if ([string]::IsNullOrEmpty($arch)) {
+        $arch = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", "Machine")
+    }
     switch ($arch) {
         "ARM64" { "arm64" }
         "AMD64" { "x86_64" }


### PR DESCRIPTION
### Description
`Win32_OperatingSystem.OSArchitecture` returns localized strings, causing Unknown OS Architecture on non-English systems. Switch to language-neutral `RuntimeInformation::OSArchitecture` enum



### Motivation and Context
When system language is set to Chinese `(Get-CimInstance Win32_operatingsystem).OSArchitecture` will return `ARM 64 位元處理器`, which cause build fail.


