### PR TITLE
[QNN EP] Support NonZero with dynamic output shape

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -63,18 +63,16 @@ Ort::Status BaseOpBuilder::ProcessDataTypes(QnnModelWrapper& qnn_model_wrapper,
     if (IsOptionalOrtNodeUnitIODef(input)) {
       continue;
     }
-    TensorInfo tensor_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, tensor_info));
-    Qnn_DataType_t qnn_data_type = tensor_info.qnn_data_type;
+    Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
+    RETURN_IF_ERROR(utils::GetQnnDataType(input.quant_param.has_value(), input.type, qnn_data_type));
     input_qnn_dtypes.push_back(qnn_data_type);
   }
   for (auto output : outputs) {
     if (IsOptionalOrtNodeUnitIODef(output)) {
       continue;
     }
-    TensorInfo tensor_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output, tensor_info));
-    Qnn_DataType_t qnn_data_type = tensor_info.qnn_data_type;
+    Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
+    RETURN_IF_ERROR(utils::GetQnnDataType(output.quant_param.has_value(), output.type, qnn_data_type));
     output_qnn_dtypes.push_back(qnn_data_type);
   }
   if (IsCpuBackend(qnn_model_wrapper.GetQnnBackendType())) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
@@ -45,15 +45,13 @@ Ort::Status NonZeroOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_NOT(qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::HTP,
                 "NonZero is only supported on HTP backend.");
 
-  // NonZero output must have a static shape (no dynamic dims).
-  // The ONNX model should set the output shape to [rank, num_elements] where num_elements
-  // is the total number of elements in the input.
-  const auto& output = node_unit.Outputs()[0];
-  std::vector<uint32_t> output_shape;
-  RETURN_IF_NOT(QnnModelWrapper::GetOnnxShape(output.shape, output_shape),
-                "NonZero output shape must be static. Set shape to [rank, num_elements].");
+  // NonZero input must have a static shape so we can compute total_elements = max output size.
+  // The output shape may be dynamic ([rank, -1]); QNN HTP always outputs [rank, total_elements]
+  // with actual non-zero indices in the leading columns and -1 fill in the remainder.
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
 
-  const std::string& output_name = output.name;
+  const std::string& output_name = node_unit.Outputs()[0].name;
   if (qnn_model_wrapper.IsGraphOutput(output_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
                 "NonZero output is a graph output. QNN HTP pads unused elements with -1.");

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -841,9 +841,10 @@ Ort::Status QnnModelWrapper::GetTensorInfo(const OrtNodeUnitIODef& tensor, Tenso
   // Fill in shape. When the ONNX shape is dynamic, fall back to the registered QNN tensor shape
   // if a prior op already built this tensor (e.g., NonZero output padded to [rank, total_elements]).
   if (!GetOnnxShape(tensor.shape, tensor_info.shape)) {
-    RETURN_IF_NOT(IsQnnTensorWrapperExist(name),
+    auto it = model_tensors_map_.find(name);
+    RETURN_IF_NOT(it != model_tensors_map_.end(),
                   ("Cannot get shape for tensor: " + name).c_str());
-    tensor_info.shape = GetQnnTensorWrapper(name).GetTensorDims();
+    tensor_info.shape = it->second.GetTensorDims();
   }
 
   // Fill in initializer info.

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -838,8 +838,13 @@ Ort::Status QnnModelWrapper::GetTensorInfo(const OrtNodeUnitIODef& tensor, Tenso
                                         tensor.type,
                                         tensor_info.qnn_data_type));
 
-  // Fill in shape.
-  RETURN_IF_NOT(GetOnnxShape(tensor.shape, tensor_info.shape), "Cannot get shape");
+  // Fill in shape. When the ONNX shape is dynamic, fall back to the registered QNN tensor shape
+  // if a prior op already built this tensor (e.g., NonZero output padded to [rank, total_elements]).
+  if (!GetOnnxShape(tensor.shape, tensor_info.shape)) {
+    RETURN_IF_NOT(IsQnnTensorWrapperExist(name),
+                  ("Cannot get shape for tensor: " + name).c_str());
+    tensor_info.shape = GetQnnTensorWrapper(name).GetTensorDims();
+  }
 
   // Fill in initializer info.
   tensor_info.is_initializer = IsConstantInput(name);

--- a/onnxruntime/test/providers/qnn/nonzero_test.cc
+++ b/onnxruntime/test/providers/qnn/nonzero_test.cc
@@ -273,6 +273,51 @@ TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape) {
   RunNonZeroTest(build_model, 11, ExpectedEPNodeAssignment::All);
 }
 
+// NonZero with dynamic output → Reshape (static shape tensor) → graph output.
+// Input is all non-zero so there is no -1 padding: CPU and QNN produce identical results.
+TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape_WithReshape) {
+  // All 6 elements non-zero: NonZero returns [2, 6] on both CPU and QNN (no padding).
+  // Reshape [2, -1] -> [12] gives identical output on both.
+  auto build_model = [](ModelTestBuilder& builder) {
+    TestInputDef<float> input_def({2, 3}, false, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+    MakeTestInput<float>(builder, "X", input_def);
+    builder.AddNode("nonzero_node", "NonZero", {"X"}, {"nz_out"}, kOnnxDomain);
+    builder.Make1DInitializer<int64_t>("reshape_shape", {12});
+    builder.AddNode("reshape_node", "Reshape", {"nz_out", "reshape_shape"}, {"Y"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{12});
+  };
+
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  build_model(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  std::vector<Ort::Value> expected;
+  InferenceModelCPU(model_data, "NonZero_Reshape_CPU", helper.feeds_, expected);
+
+  std::vector<Ort::Value> actual;
+  InferenceModel(model_data, "NonZero_Reshape_QNN", HtpProviderOptions(),
+                 ExpectedEPNodeAssignment::All, helper.feeds_, actual);
+
+  auto exp_shape = expected[0].GetTensorTypeAndShapeInfo().GetShape();
+  auto act_shape = actual[0].GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(exp_shape, act_shape);
+
+  auto element_count = expected[0].GetTensorTypeAndShapeInfo().GetElementCount();
+  const int64_t* exp_data = expected[0].GetTensorData<int64_t>();
+  const int64_t* act_data = actual[0].GetTensorData<int64_t>();
+  for (size_t i = 0; i < element_count; ++i) {
+    EXPECT_EQ(exp_data[i], act_data[i]) << "Mismatch at index " << i;
+  }
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/nonzero_test.cc
+++ b/onnxruntime/test/providers/qnn/nonzero_test.cc
@@ -259,8 +259,9 @@ TEST_F(QnnHTPBackendTests, NonZero_Gather_1D_Int32) {
   }
 }
 
-// Negative test: NonZero with dynamic output shape should not be assigned to QNN EP.
-TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape_Negative) {
+// NonZero with dynamic output shape [rank, -1] is now supported.
+// QNN HTP outputs [rank, total_elements] with -1 fill; RunNonZeroTest compares only the valid region.
+TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape) {
   auto build_model = [](ModelTestBuilder& builder) {
     TestInputDef<float> input_def({2, 3}, false, {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f});
     MakeTestInput<float>(builder, "X", input_def);
@@ -269,7 +270,7 @@ TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape_Negative) {
     builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{2, -1});
   };
 
-  RunNonZeroTest(build_model, 11, ExpectedEPNodeAssignment::None);
+  RunNonZeroTest(build_model, 11, ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Remove the static output-shape requirement in IsOpSupported and instead verify the input has a static shape (required to compute total_elements). ProcessAttributesAndOutputs already derives the QNN output shape from the input dims, so no model-building logic changes are needed.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- QNN HTP NonZero always outputs [rank, total_elements] with actual non-zero indices in the leading columns and -1 fill in the remainder.

