### PR TITLE
pytorch_half_pixel Route rank-4 linear Resize to ResizeBilinear

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -93,13 +93,19 @@ const OnnxAttrInfo<int64_t> ResizeOpBuilder::onnx_antialias_attr = {"antialias",
 const OnnxAttrInfo<int64_t> ResizeOpBuilder::onnx_exclude_outside_attr = {"exclude_outside", 0};
 const OnnxAttrInfo<float> ResizeOpBuilder::onnx_cubic_coeff_a_attr = {"cubic_coeff_a", -0.75f};
 
-// PYTORCH_HALF_PIXEL diverges from HALF_PIXEL only when an output spatial dim == 1
-// (then it pins the coord to 0). Elsewhere the two are identical.
-static bool IsEquivalentPyTorchHalfPixel(const OrtNodeUnit& node_unit) {
+// Returns true when ONNX 'pytorch_half_pixel' is bit-identical to 'half_pixel'
+// for this rank-4 Resize. Per ONNX spec, pytorch_half_pixel only diverges from
+// half_pixel on output axes whose length == 1 (it pins the source coord to 0
+// instead of evaluating (x + 0.5) / scale - 0.5). When both spatial output dims
+// are > 1, the two modes are mathematically equivalent and the node can be
+// lowered to QNN ResizeBilinear with half_pixel_centers=true.
+//
+// Caller contract: input_rank == 4 must already be verified by the gate, which
+// (per ONNX Resize: output_rank == input_rank) implies output rank == 4.
+// IsOpSupported has already validated that output shape is present.
+static bool IsPyTorchHalfPixelEquivalentToHalfPixel(const OrtNodeUnit& node_unit) {
   const auto& output_shape_opt = node_unit.Outputs()[0].shape;
-  if (!output_shape_opt.has_value() || output_shape_opt->size() != 4) {
-    return false;
-  }
+  assert(output_shape_opt.has_value() && output_shape_opt->size() == 4);
   const auto& output_shape = *output_shape_opt;
   const bool is_nhwc = node_unit.Domain() == kMSInternalNHWCDomain;
   const size_t h_axis = is_nhwc ? 1 : 2;
@@ -172,15 +178,18 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   // (Resize = QNN Resize op, RBL = QNN ResizeBilinear op, X = Unsupported).
   //
   //                                                   input rank:
-  // coordinate_transformation_mode: |   < 3      3        4        5        > 5
-  // ---------------------------------------------------------------------------------
-  //                      half_pixel |    X     Resize    RBL     Resize       X
-  //              pytorch_half_pixel |    X     Resize RBL/Resize Resize       X
-  //                   align_corners |    X     Resize    RBL     Resize       X
-  //                      asymmetric |    X     Resize    RBL     Resize       X
+  // coordinate_transformation_mode:    |   < 3      3        4        5        > 5
+  // ------------------------------------------------------------------------------------
+  //                         half_pixel |    X     Resize    RBL     Resize       X
+  //  pytorch_half_pixel (H>1 ∧ W>1)    |    X     Resize    RBL     Resize       X
+  //  pytorch_half_pixel (H==1 ∨ W==1)  |    X     Resize    Resize  Resize       X
+  //                      align_corners |    X     Resize    RBL     Resize       X
+  //                         asymmetric |    X     Resize    RBL     Resize       X
   //
-  // pytorch_half_pixel picks RBL when IsEquivalentPyTorchHalfPixel holds,
-  // otherwise falls back to Resize.
+  // The H>1 ∧ W>1 row routes pytorch_half_pixel to RBL because it is then
+  // bit-identical to half_pixel (see IsPyTorchHalfPixelEquivalentToHalfPixel).
+  // The fallback row preserves the length-1 "pin to 0" semantics by using QNN
+  // Resize, which natively supports the pytorch_half_pixel transformation_mode.
 
   // Resize w/ "nearest" mode.
   // Translation matrix of ONNX Resize w/ "nearest" mode on HTP backend.
@@ -372,7 +381,15 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_half_pixel_param));
   } else if (is_npu_backend && input_rank == 4 && interp_mode == "linear" &&
              (transformation_mode != "pytorch_half_pixel" ||
-              IsEquivalentPyTorchHalfPixel(node_unit))) {
+              IsPyTorchHalfPixelEquivalentToHalfPixel(node_unit))) {
+    // Lower rank-4 linear Resize to QNN's ResizeBilinear (2-parameter form) on the
+    // HTP backend. ResizeBilinear is also faster than the generic Resize op on HTP.
+    // For pytorch_half_pixel, this redirect is correctness-required: HTP's validator
+    // rejects the generic Resize op for pytorch_half_pixel + linear + multi-pixel
+    // output spatial dims (QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE 0xc26).
+    // The IsPyTorchHalfPixelEquivalentToHalfPixel guard ensures we only redirect when
+    // the modes are bit-identical; the H==1 ∨ W==1 case stays on the generic Resize
+    // path to preserve pytorch_half_pixel's length-1 "pin to 0" semantics.
     qnn_op_type = "ResizeBilinear";
 
     // 'align_corners'

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -93,6 +93,20 @@ const OnnxAttrInfo<int64_t> ResizeOpBuilder::onnx_antialias_attr = {"antialias",
 const OnnxAttrInfo<int64_t> ResizeOpBuilder::onnx_exclude_outside_attr = {"exclude_outside", 0};
 const OnnxAttrInfo<float> ResizeOpBuilder::onnx_cubic_coeff_a_attr = {"cubic_coeff_a", -0.75f};
 
+// PYTORCH_HALF_PIXEL diverges from HALF_PIXEL only when an output spatial dim == 1
+// (then it pins the coord to 0). Elsewhere the two are identical.
+static bool IsEquivalentPyTorchHalfPixel(const OrtNodeUnit& node_unit) {
+  const auto& output_shape_opt = node_unit.Outputs()[0].shape;
+  if (!output_shape_opt.has_value() || output_shape_opt->size() != 4) {
+    return false;
+  }
+  const auto& output_shape = *output_shape_opt;
+  const bool is_nhwc = node_unit.Domain() == kMSInternalNHWCDomain;
+  const size_t h_axis = is_nhwc ? 1 : 2;
+  const size_t w_axis = is_nhwc ? 2 : 3;
+  return output_shape[h_axis] > 1 && output_shape[w_axis] > 1;
+}
+
 // Returns the QNN parameter integer value that corresponds to the given ONNX attribute mode string value.
 static Ort::Status GetQnnModeValFromOnnxString(const std::unordered_map<std::string, uint32_t>& supported_qnn_modes,
                                                const std::string& onnx_attr_value,
@@ -161,9 +175,12 @@ Ort::Status ResizeOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   // coordinate_transformation_mode: |   < 3      3        4        5        > 5
   // ---------------------------------------------------------------------------------
   //                      half_pixel |    X     Resize    RBL     Resize       X
-  //              pytorch_half_pixel |    X     Resize    Resize  Resize       X
+  //              pytorch_half_pixel |    X     Resize RBL/Resize Resize       X
   //                   align_corners |    X     Resize    RBL     Resize       X
   //                      asymmetric |    X     Resize    RBL     Resize       X
+  //
+  // pytorch_half_pixel picks RBL when IsEquivalentPyTorchHalfPixel holds,
+  // otherwise falls back to Resize.
 
   // Resize w/ "nearest" mode.
   // Translation matrix of ONNX Resize w/ "nearest" mode on HTP backend.
@@ -354,11 +371,8 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     param_tensor_names.push_back(qnn_half_pixel_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(qnn_half_pixel_param));
   } else if (is_npu_backend && input_rank == 4 && interp_mode == "linear" &&
-             transformation_mode != "pytorch_half_pixel") {
-    // Translate Resize with
-    // {input_rank: 4, mode: "linear", coordinate_transformation_mode: XXX} to
-    // QNN's ResizeBilinear operator on the HTP backend. QNN ResizeBilinear seems to be faster than QNN Resize on
-    // Windows/HTP QNN SDK 2.19.2.
+             (transformation_mode != "pytorch_half_pixel" ||
+              IsEquivalentPyTorchHalfPixel(node_unit))) {
     qnn_op_type = "ResizeBilinear";
 
     // 'align_corners'
@@ -375,7 +389,8 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     // 'half_pixel_centers'
     Qnn_Scalar_t qnn_half_pixel = QNN_SCALAR_INIT;
     qnn_half_pixel.dataType = QNN_DATATYPE_BOOL_8;
-    qnn_half_pixel.bool8Value = static_cast<uint8_t>(transformation_mode == "half_pixel");
+    qnn_half_pixel.bool8Value = static_cast<uint8_t>(transformation_mode == "half_pixel" ||
+                                                     transformation_mode == "pytorch_half_pixel");
 
     QnnParamWrapper qnn_half_pixel_param(node_unit.Index(), node_unit.Name(),
                                          QNN_OP_RESIZE_BILINEAR_PARAM_HALF_PIXEL_CENTERS, qnn_half_pixel);

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -588,6 +588,10 @@ TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear
                                         {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
       provider_options, /*opset_version=*/19, ExpectedEPNodeAssignment::All);
 
+  // TestQDQModelAccuracy may GTEST_SKIP on HTP arch <= 68 (e.g., QCS6490),
+  // in which case no QNN graph is emitted and the assertions below would fail.
+  if (IsSkipped()) return;
+
   AssertOpInQnnGraph(graph_dir, "ResizeBilinear", 1);
   AssertOpInQnnGraph(graph_dir, "Resize", 0);
 }

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -4,12 +4,11 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <filesystem>
-#include <fstream>
-#include <functional>
 #include <optional>
 #include <string>
 #include <unordered_map>
 
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
@@ -570,26 +569,7 @@ TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear
   const fs::path graph_dir = fs::temp_directory_path() / "resize_pytorch_half_pixel_qnn_graph";
   fs::remove_all(graph_dir);
   fs::create_directories(graph_dir);
-
-  auto graph_checker_fn = [&graph_dir](const Ort::Session&) {
-    bool saw_resize_bilinear = false;
-    for (const auto& entry : fs::recursive_directory_iterator(graph_dir)) {
-      if (entry.path().extension() != ".json") continue;
-      std::ifstream in(entry.path());
-      std::string line;
-      while (std::getline(in, line)) {
-        if (line.find("\"ResizeBilinear\"") != std::string::npos) {
-          saw_resize_bilinear = true;
-          break;
-        }
-      }
-      if (saw_resize_bilinear) break;
-    }
-    EXPECT_TRUE(saw_resize_bilinear)
-        << "pytorch_half_pixel rank-4 linear Resize must lower to ResizeBilinear. "
-        << "JSON dumps under " << graph_dir;
-  };
-  std::function<void(const Ort::Session&)> graph_checker = graph_checker_fn;
+  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -606,11 +586,10 @@ TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear
                             {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
       GetQDQResizeModelBuilder<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
                                         {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
-      provider_options, /*opset_version=*/19, ExpectedEPNodeAssignment::All,
-      QDQTolerance(), OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR, "", {}, std::nullopt,
-      &graph_checker);
+      provider_options, /*opset_version=*/19, ExpectedEPNodeAssignment::All);
 
-  fs::remove_all(graph_dir);
+  AssertOpInQnnGraph(graph_dir, "ResizeBilinear", 1);
+  AssertOpInQnnGraph(graph_dir, "Resize", 0);
 }
 
 // Test 2x QDQ Resize mode: "linear", coordinate_transformation_mode: "half_pixel"

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -3,6 +3,9 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
+#include <fstream>
+#include <functional>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -550,13 +553,64 @@ TEST_F(QnnHTPBackendTests, Resize_DownSample_Linear_HalfPixel) {
 }
 
 // Test 2x QDQ Resize mode: "linear", coordinate_transformation_mode: "pytorch_half_pixel"
-// Maps to QNN's Resize operator.
+// Maps to QNN's ResizeBilinear operator (output spatial dims > 1, equivalent to half_pixel).
 TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel) {
   std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
   RunQDQResizeOpTest<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
                               {1, 3, 8, 8}, "linear", "pytorch_half_pixel", "",
                               ExpectedEPNodeAssignment::All,
                               19);
+}
+
+// Asserts rank-4 linear + pytorch_half_pixel Resize lowers to QNN's ResizeBilinear
+// op when both output spatial dims > 1 (the other path tripped HTP op validation
+// with "Wrong number of Parameters 6 / ResizeBilinear failed 3110").
+TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear) {
+  namespace fs = std::filesystem;
+  const fs::path graph_dir = fs::temp_directory_path() / "resize_pytorch_half_pixel_qnn_graph";
+  fs::remove_all(graph_dir);
+  fs::create_directories(graph_dir);
+
+  auto graph_checker_fn = [&graph_dir](const Ort::Session&) {
+    bool saw_resize_bilinear = false;
+    for (const auto& entry : fs::recursive_directory_iterator(graph_dir)) {
+      if (entry.path().extension() != ".json") continue;
+      std::ifstream in(entry.path());
+      std::string line;
+      while (std::getline(in, line)) {
+        if (line.find("\"ResizeBilinear\"") != std::string::npos) {
+          saw_resize_bilinear = true;
+          break;
+        }
+      }
+      if (saw_resize_bilinear) break;
+    }
+    EXPECT_TRUE(saw_resize_bilinear)
+        << "pytorch_half_pixel rank-4 linear Resize must lower to ResizeBilinear. "
+        << "JSON dumps under " << graph_dir;
+  };
+  std::function<void(const Ort::Session&)> graph_checker = graph_checker_fn;
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = graph_dir.string();
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+  provider_options["num_graph_prepare_threads"] = "1";
+#endif
+
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  TestQDQModelAccuracy<uint8_t>(
+      GetResizeModelBuilder(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                            {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
+      GetQDQResizeModelBuilder<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                        {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
+      provider_options, /*opset_version=*/19, ExpectedEPNodeAssignment::All,
+      QDQTolerance(), OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR, "", {}, std::nullopt,
+      &graph_checker);
+
+  fs::remove_all(graph_dir);
 }
 
 // Test 2x QDQ Resize mode: "linear", coordinate_transformation_mode: "half_pixel"

--- a/onnxruntime/test/providers/qnn/resize_test.cc
+++ b/onnxruntime/test/providers/qnn/resize_test.cc
@@ -561,12 +561,22 @@ TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel) {
                               19);
 }
 
-// Asserts rank-4 linear + pytorch_half_pixel Resize lowers to QNN's ResizeBilinear
-// op when both output spatial dims > 1 (the other path tripped HTP op validation
-// with "Wrong number of Parameters 6 / ResizeBilinear failed 3110").
-TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear) {
+// Runs a QDQ Resize (linear, opset 19) on HTP and asserts the lowered QNN graph
+// contains exactly `expected_count` instances of `expected_qnn_op` and zero of
+// `forbidden_qnn_op`. Used to lock both exits of the
+// IsPyTorchHalfPixelEquivalentToHalfPixel predicate.
+//
+// Note on the IsSkipped() guard: TestQDQModelAccuracy invokes GTEST_SKIP on HTP
+// arch <= 68 (e.g., QCS6490) where the bilinear path is not exercised; in that
+// case no QNN graph JSON is written and AssertOpInQnnGraph would fail spuriously.
+static void RunQDQResizeAndAssertQnnOp(const std::vector<int64_t>& input_shape,
+                                       const std::vector<int64_t>& output_shape,
+                                       const std::string& transformation_mode,
+                                       const std::string& expected_qnn_op,
+                                       const std::string& forbidden_qnn_op,
+                                       const std::string& dump_dir_name) {
   namespace fs = std::filesystem;
-  const fs::path graph_dir = fs::temp_directory_path() / "resize_pytorch_half_pixel_qnn_graph";
+  const fs::path graph_dir = fs::temp_directory_path() / dump_dir_name;
   fs::remove_all(graph_dir);
   fs::create_directories(graph_dir);
   auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
@@ -580,20 +590,66 @@ TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear
   provider_options["num_graph_prepare_threads"] = "1";
 #endif
 
-  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  int64_t num_elements = 1;
+  for (int64_t d : input_shape) num_elements *= d;
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, static_cast<size_t>(num_elements));
   TestQDQModelAccuracy<uint8_t>(
-      GetResizeModelBuilder(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
-                            {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
-      GetQDQResizeModelBuilder<uint8_t>(TestInputDef<float>({1, 3, 4, 4}, false, input_data),
-                                        {1, 3, 8, 8}, "linear", "pytorch_half_pixel", ""),
+      GetResizeModelBuilder(TestInputDef<float>(input_shape, false, input_data),
+                            output_shape, "linear", transformation_mode, ""),
+      GetQDQResizeModelBuilder<uint8_t>(TestInputDef<float>(input_shape, false, input_data),
+                                        output_shape, "linear", transformation_mode, ""),
       provider_options, /*opset_version=*/19, ExpectedEPNodeAssignment::All);
 
-  // TestQDQModelAccuracy may GTEST_SKIP on HTP arch <= 68 (e.g., QCS6490),
-  // in which case no QNN graph is emitted and the assertions below would fail.
-  if (IsSkipped()) return;
+  if (::testing::Test::IsSkipped()) return;
 
-  AssertOpInQnnGraph(graph_dir, "ResizeBilinear", 1);
-  AssertOpInQnnGraph(graph_dir, "Resize", 0);
+  AssertOpInQnnGraph(graph_dir, expected_qnn_op, 1);
+  AssertOpInQnnGraph(graph_dir, forbidden_qnn_op, 0);
+}
+
+// Asserts rank-4 linear + pytorch_half_pixel Resize lowers to QNN's ResizeBilinear
+// when both output spatial dims > 1. The other path tripped HTP op validation
+// with "Wrong number of Parameters 6 / 0xc26 / failure code 3110".
+TEST_F(QnnHTPBackendTests, ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear) {
+  RunQDQResizeAndAssertQnnOp(/*input_shape=*/{1, 3, 4, 4}, /*output_shape=*/{1, 3, 8, 8},
+                             "pytorch_half_pixel", /*expected=*/"ResizeBilinear",
+                             /*forbidden=*/"Resize", "resize_phpx_multi_pixel_qnn_graph");
+}
+
+// Locks formula equivalence between ONNX pytorch_half_pixel and QNN
+// ResizeBilinear half_pixel_centers=true at non-integer scale (input 5x5 ->
+// output 7x7, scale = 1.4). Integer scales (e.g. 2x) coincidentally mask
+// half-pixel formula divergence; non-integer scales surface them.
+TEST_F(QnnHTPBackendTests, ResizeU8_NonIntScaleLinearPytorchHalfPixel_EmitsResizeBilinear) {
+  RunQDQResizeAndAssertQnnOp(/*input_shape=*/{1, 3, 5, 5}, /*output_shape=*/{1, 3, 7, 7},
+                             "pytorch_half_pixel", /*expected=*/"ResizeBilinear",
+                             /*forbidden=*/"Resize", "resize_phpx_non_int_scale_qnn_graph");
+}
+
+// Guards the else-branch of IsPyTorchHalfPixelEquivalentToHalfPixel: when an
+// output spatial dim == 1, pytorch_half_pixel pins the source coord to 0 and is
+// no longer equivalent to half_pixel, so rank-4 linear Resize must fall back to
+// QNN's generic Resize op (which natively supports pytorch_half_pixel).
+TEST_F(QnnHTPBackendTests, ResizeU8_DownsampleToHeight1_LinearPytorchHalfPixel) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 24);
+  RunQDQResizeOpTest<uint8_t>(TestInputDef<float>({1, 3, 4, 2}, false, input_data),
+                              {1, 3, 1, 2}, "linear", "pytorch_half_pixel", "",
+                              ExpectedEPNodeAssignment::All, 19);
+}
+
+// Pairs with ResizeU8_2xLinearPytorchHalfPixel_EmitsResizeBilinear to lock both
+// exits of IsPyTorchHalfPixelEquivalentToHalfPixel: H==1 must use generic Resize.
+TEST_F(QnnHTPBackendTests, ResizeU8_DownsampleToHeight1_LinearPytorchHalfPixel_EmitsResize) {
+  RunQDQResizeAndAssertQnnOp(/*input_shape=*/{1, 3, 4, 2}, /*output_shape=*/{1, 3, 1, 2},
+                             "pytorch_half_pixel", /*expected=*/"Resize",
+                             /*forbidden=*/"ResizeBilinear", "resize_phpx_h1_qnn_graph");
+}
+
+// Symmetric W==1 fallback: catches future bugs where someone swaps h_axis/w_axis
+// or accidentally checks only one spatial dim in the predicate.
+TEST_F(QnnHTPBackendTests, ResizeU8_DownsampleToWidth1_LinearPytorchHalfPixel_EmitsResize) {
+  RunQDQResizeAndAssertQnnOp(/*input_shape=*/{1, 3, 2, 4}, /*output_shape=*/{1, 3, 2, 1},
+                             "pytorch_half_pixel", /*expected=*/"Resize",
+                             /*forbidden=*/"ResizeBilinear", "resize_phpx_w1_qnn_graph");
 }
 
 // Test 2x QDQ Resize mode: "linear", coordinate_transformation_mode: "half_pixel"


### PR DESCRIPTION
^ fixes QNN error:

```
Error occurred due to op : node_upsample_bilinear2d_1_token_1050_2;
reason : Wrong number of Parameters 6.
Op specific validation failed.
Failed to validate op node_upsample_bilinear2d_1_token_1050_2 with error 0xc26 : QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE
```