### PR TITLE
Fix Docker volume mounts failing on symlinked host paths

### DIFF
--- a/qcom/ep_build/tasks/docker.py
+++ b/qcom/ep_build/tasks/docker.py
@@ -62,7 +62,7 @@ class DockerRunTask(RunExecutablesTask):
             if working_dir is not None:
                 cmd.extend(["--workdir", str(working_dir)])
             if volumes is not None:
-                cmd.extend(_argify("--volume", ":", {k.absolute(): v for k, v in volumes.items()}))
+                cmd.extend(_argify("--volume", ":", {k.resolve(): v for k, v in volumes.items()}))
             if env is not None:
                 cmd.extend(_argify("--env", "=", env))
             if remove:


### PR DESCRIPTION
### Description
* Uses resolve() instead of absolute() to get the path of volume



### Motivation and Context
* absolute() is incompatible if people happen to use a symlink for this cache, whereas resolve() follows the symlink


