### PR TITLE
[QNN EP] Minor CI Fixes

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -51,26 +51,26 @@ jobs:
       target_py_vsn: "3.10"
 
   build-linux-aarch64-oe-gcc11_2:
-      if: ${{ inputs.do_all }}
-      uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
-      secrets: inherit
-      with:
-        nightly_build: ${{ inputs.nightly_build }}
-        target_os: linux
-        target_arch: aarch64_oe_gcc11_2
-        target_py_vsn: None
-        upload_test_archive: true
-        upload_wheel: false
-        run_tests: false
+    if: ${{ inputs.do_all }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      target_os: linux
+      target_arch: aarch64_oe_gcc11_2
+      target_py_vsn: None
+      upload_test_archive: true
+      upload_wheel: false
+      run_tests: false
 
   test-linux-aarch64-oe-gcc11_2:
-   if: ${{ inputs.do_all }}
-   needs: [build-linux-aarch64-oe-gcc11_2]
-   uses: ./.github/workflows/qualcomm-internal-qdc-test.yml
-   secrets: inherit
-   with:
-     target_os: linux
-     target_arch: aarch64_oe_gcc11_2
+    if: ${{ inputs.do_all }}
+    needs: [build-linux-aarch64-oe-gcc11_2]
+    uses: ./.github/workflows/qualcomm-internal-qdc-test.yml
+    secrets: inherit
+    with:
+      target_os: linux
+      target_arch: aarch64_oe_gcc11_2
 
   build-and-test-linux-arm64:
     if: ${{ inputs.do_all }}

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -102,17 +102,17 @@ jobs:
       upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
 
   build-linux-aarch64-oe-gcc11_2:
-      if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
-      uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
-      secrets: inherit
-      with:
-        nightly_build: ${{ inputs.nightly_build }}
-        target_os: linux
-        target_arch: aarch64_oe_gcc11_2
-        target_py_vsn: None
-        run_tests: false
-        upload_test_archive: true
-        upload_wheel: false
+    if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      target_os: linux
+      target_arch: aarch64_oe_gcc11_2
+      target_py_vsn: None
+      run_tests: false
+      upload_test_archive: true
+      upload_wheel: false
 
   build-linux-x86_64:
     if: ${{ inputs.build_linux_x86_64 }}

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -217,7 +217,7 @@ jobs:
           EOF
           VERSION=$(ls "${{ github.workspace }}/build/dist/"*win_arm64*.whl 2>/dev/null | head -1 | xargs -I{} basename {} | sed 's/.*-\([0-9.]*rc[0-9]*\).*/\1/' | sed 's/-//g')
           ./qcom/scripts/signing/upload_unsigned_to_artifactory.sh \
-            "${{ github.workspace }}/build/dist/output/unsigned/wheels.zip" \
+            "${{ github.workspace }}/build/dist/output/unsigned_libs/wheel.zip" \
             "wheels.zip" "$VERSION" "$NETRC_FILE"
           rm -f "$NETRC_FILE"
 
@@ -288,7 +288,7 @@ jobs:
           $version = $pkg.BaseName -replace '^Qualcomm\.ML\.OnnxRuntime\.QNN\.' -replace '\.nupkg$' -replace '-', ''
 
           .\qcom\scripts\signing\upload_unsigned_to_artifactory.ps1 `
-            -ZipFile "${{ github.workspace }}\build\dist\output\unsigned\nuget.zip" `
+            -ZipFile "${{ github.workspace }}\build\dist\output\unsigned_libs\nuget.zip" `
             -Filename "nuget.zip" `
             -Version $version `
             -NetrcFile $netrcFile
@@ -387,7 +387,7 @@ jobs:
           EOF
           VERSION=$(basename "$(ls "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.zip 2>/dev/null | grep -v pdb | head -1)" | sed 's/.*-\([0-9.]*rc[0-9]*\).*/\1/' | sed 's/-//g')
           ./qcom/scripts/signing/upload_unsigned_to_artifactory.sh \
-            "${{ github.workspace }}/build/dist/output/unsigned/zip.zip" \
+            "${{ github.workspace }}/build/dist/output/unsigned_libs/zip.zip" \
             "zip.zip" "$VERSION" "$NETRC_FILE"
           rm -f "$NETRC_FILE"
 

--- a/qcom/scripts/signing/prepare_nuget_for_signing.ps1
+++ b/qcom/scripts/signing/prepare_nuget_for_signing.ps1
@@ -20,7 +20,7 @@ if (-not (Test-Path $OutputDirectory -PathType Container)) {
 }
 
 # Create unsigned/nuget subdirectories
-$unsignedDir = Join-Path $OutputDirectory "unsigned"
+$unsignedDir = Join-Path $OutputDirectory "unsigned_libs"
 $nugetDir = Join-Path $unsignedDir "nuget"
 
 if (-not (Test-Path $nugetDir -PathType Container)) {

--- a/qcom/scripts/signing/prepare_wheels_for_signing.sh
+++ b/qcom/scripts/signing/prepare_wheels_for_signing.sh
@@ -22,9 +22,9 @@ if [ ! -d "$OUTPUT_DIRECTORY" ]; then
     mkdir -p "$OUTPUT_DIRECTORY"
 fi
 
-# Create unsigned/wheels subdirectories
-UNSIGNED_DIR="$OUTPUT_DIRECTORY/unsigned"
-WHEELS_DIR="$UNSIGNED_DIR/wheels"
+# Create unsigned/wheel subdirectories
+UNSIGNED_DIR="$OUTPUT_DIRECTORY/unsigned_libs"
+WHEELS_DIR="$UNSIGNED_DIR/wheel"
 
 if [ ! -d "$WHEELS_DIR" ]; then
     mkdir -p "$WHEELS_DIR"
@@ -221,26 +221,26 @@ echo "=== End of Summary ==="
 # Compress unsigned wheels for signing
 echo ""
 echo "Compressing unsigned wheel libs"
-cd "$UNSIGNED_DIR/wheels"
+cd "$UNSIGNED_DIR/wheel"
 python3 << 'PYTHON_EOF'
 import os
 import shutil
 import sys
 try:
-    shutil.make_archive('../wheels', 'zip', '.', '.')
+    shutil.make_archive('../wheel', 'zip', '.', '.')
 except Exception as error:
     print(f"ERROR: Failed to create wheels.zip: {error}", file=sys.stderr)
     sys.exit(1)
 PYTHON_EOF
 
 if [ $? -eq 0 ]; then
-    if [ -f "../wheels.zip" ]; then
-        echo "Successfully created wheels.zip"
+    if [ -f "../wheel.zip" ]; then
+        echo "Successfully created wheel.zip"
     else
-        echo "ERROR: wheels.zip was not created" >&2
+        echo "ERROR: wheel.zip was not created" >&2
         exit 1
     fi
 else
-    echo "ERROR: Failed to create wheels.zip" >&2
+    echo "ERROR: Failed to create wheel.zip" >&2
     exit 1
 fi

--- a/qcom/scripts/signing/prepare_zip_for_signing.sh
+++ b/qcom/scripts/signing/prepare_zip_for_signing.sh
@@ -23,7 +23,7 @@ if [ ! -d "$OUTPUT_DIRECTORY" ]; then
 fi
 
 # Create unsigned/zip subdirectories
-UNSIGNED_DIR="$OUTPUT_DIRECTORY/unsigned"
+UNSIGNED_DIR="$OUTPUT_DIRECTORY/unsigned_libs"
 ZIP_DIR="$UNSIGNED_DIR/zip"
 
 if [ ! -d "$ZIP_DIR" ]; then

--- a/qcom/scripts/signing/upload_unsigned_to_artifactory.ps1
+++ b/qcom/scripts/signing/upload_unsigned_to_artifactory.ps1
@@ -31,7 +31,7 @@ $repoRoot = git rev-parse --show-toplevel
 Write-Host "Uploading $Filename"
 
 $caCertPath = Join-Path $repoRoot "qcom/scripts/upleveling/certs/artifactory-ca.pem"
-$uploadUrl = "https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/$Version/unsigned/$Filename"
+$uploadUrl = "https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/$Version/unsigned_libs/$Filename"
 
 curl.exe -T "$ZipFile" --fail `
     --cacert "$caCertPath" `

--- a/qcom/scripts/signing/upload_unsigned_to_artifactory.sh
+++ b/qcom/scripts/signing/upload_unsigned_to_artifactory.sh
@@ -35,6 +35,6 @@ echo "Uploading $FILENAME"
 curl --fail -s -T "$ZIP_FILE" \
     --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
     --netrc-file "$NETRC_FILE" \
-    https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${VERSION}"/unsigned/"$FILENAME" > /dev/null
+    https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${VERSION}"/unsigned_libs/"$FILENAME" > /dev/null
 
 echo "Successfully uploaded $FILENAME"

--- a/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
+++ b/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
@@ -43,12 +43,12 @@ find "$INPUT_DIR" \( -name "*.zip" -o -name "*.tgz" \) -type f -print0 | while I
         TARGET_SUFFIX=""
     fi
 
-    echo "Uploading $file_basename (version: $version)..."
+    echo "Uploading $file_basename (version: $version)"
 
-    curl -T "$file" \
+    curl --fail -s -T "$file" \
         --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
         --netrc-file "$NETRC_FILE" \
-        https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename"
+        https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename" > /dev/null
 
     echo "Successfully uploaded $file_basename"
 done


### PR DESCRIPTION
This PR fixes the following as part of the CI workflows

- Upload all the libs extracted from each RC candidate under the `unsigned_libs` folder. Before it was uploaded under the `unsigned` folder.
- Renamed the folder of the wheel artifacts from `wheels.zip` to `wheel.zip`
- When the zip is uploaded to the artifactory, the SHA and other metadata information is displayed. This change forwards the output to > dev/null to prevent it from being visible to external actors.
- Fix indentation errors