### PR TITLE
[QNN EP] Enable INT8 and INT16 Tests on Linux ARM64

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/gelu_fusion_test.cc
@@ -650,7 +650,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_2D) {
 
 // Test GELU Pattern 1 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern1_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
@@ -674,7 +673,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern1_QDQ_U8) {
 TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern2_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
   auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
 
@@ -694,7 +692,6 @@ TEST_F(QnnHTPBackendTests, GeluFusionPattern2_QDQ_U8) {
 
 // Test GELU Pattern 3 with QDQ
 TEST_F(QnnHTPBackendTests, GeluFusionPattern3_QDQ_U8) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   const std::filesystem::path json_qnn_graph_dir = "GeluFusionPattern3_QDQ_U8";
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));

--- a/onnxruntime/test/providers/qnn/qnn_node_group/spacetodepth_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/spacetodepth_fusion_test.cc
@@ -356,7 +356,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Wrapped4Node_Head_Float_CRD) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Wrapped4Node_Head_QDQ_CRD) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunWrappedPatternSpaceToDepthFusionTest("SpaceToDepthFusionWrapped4NodeHeadQDQCRD_HTP",
                                           BuildHeadWrappedSpaceToDepthTestCase<>(/*use_qdq=*/true,
                                                                                  /*use_contrib_qdq=*/false),
@@ -373,7 +372,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Wrapped4Node_Tail_Float_CRD) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Wrapped4Node_Tail_QDQ_CRD) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunWrappedPatternSpaceToDepthFusionTest("SpaceToDepthFusionWrapped4NodeTailQDQCRD_HTP",
                                           BuildTailWrappedSpaceToDepthTestCase<>(/*use_qdq=*/true,
                                                                                  /*use_contrib_qdq=*/false),
@@ -421,7 +419,6 @@ TEST_F(QnnHTPBackendTests, DISABLED_SpaceToDepthFusion_Float_DCR) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_DCR) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest("SpaceToDepthFusionFloatDCRQDQ",
                             /*input_shape=*/{1, 2, 4, 4},
                             /*block_height=*/2,
@@ -446,7 +443,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Float_CRD) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_CRD) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest("SpaceToDepthFusionQDQ_CRD",
                             /*input_shape=*/{1, 2, 4, 4},
                             /*block_height=*/2,
@@ -485,7 +481,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_CRD) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest("SpaceToDepthFusionUnequalBlockQDQ",
                             /*input_shape=*/{1, 2, 4, 6},
                             /*block_height=*/2,
@@ -498,7 +493,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_CRD) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest("SpaceToDepthFusionUnequalBlockQDQ_CRD",
                             /*input_shape=*/{1, 2, 4, 6},
                             /*block_height=*/2,
@@ -511,7 +505,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_CRD) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_U16_DCR) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest<uint16_t>("SpaceToDepthFusionQDQ_U16_DCR",
                                       /*input_shape=*/{1, 2, 4, 4},
                                       /*block_height=*/2,
@@ -523,7 +516,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_U16_DCR) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_U16_CRD) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest<uint16_t>("SpaceToDepthFusionQDQ_U16_CRD",
                                       /*input_shape=*/{1, 2, 4, 4},
                                       /*block_height=*/2,
@@ -535,7 +527,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_U16_CRD) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_U16) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest<uint16_t>("SpaceToDepthFusionUnequalBlockQDQ_U16",
                                       /*input_shape=*/{1, 2, 4, 6},
                                       /*block_height=*/2,
@@ -547,7 +538,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_U16) {
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_U16_CRD) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest<uint16_t>("SpaceToDepthFusionUnequalBlockQDQ_U16_CRD",
                                       /*input_shape=*/{1, 2, 4, 6},
                                       /*block_height=*/2,

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -842,9 +842,7 @@ void VerifyQDQOutput(const std::vector<Ort::Value>& cpu_qdq_outputs,
 
 // Helper macro to check if QuantType is a supported QDQ type
 #define QNN_IS_SUPPORTED_QDQ_TYPE(QuantType)                                    \
-  (std::is_same_v<QuantType, uint8_t> || std::is_same_v<QuantType, int8_t> ||   \
-   std::is_same_v<QuantType, uint16_t> || std::is_same_v<QuantType, int16_t> || \
-   std::is_same_v<QuantType, uint32_t> || std::is_same_v<QuantType, int32_t> || \
+  (std::is_same_v<QuantType, uint32_t> || std::is_same_v<QuantType, int32_t> || \
    std::is_same_v<QuantType, Int4x2> || std::is_same_v<QuantType, UInt4x2>)
 
 // Macro for test skip logic based on provider options and architecture


### PR DESCRIPTION
This PR enables INT8 and INT16 Tests on Linux ARM64 which were disabled by #303 