### PR TITLE
Split test archive: per-arch binaries + shared global testdata

### DIFF
--- a/.github/workflows/qualcomm-internal-archive-testdata.yml
+++ b/.github/workflows/qualcomm-internal-archive-testdata.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Build testdata archive
         run: python3 qcom/build_and_test.py archive_testdata
 
+      # Artifactory steps are no-ops on fork PRs (secrets unavailable). The build still validates the script.
       - name: Setup JFrog CLI
+        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -40,12 +42,14 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Upload testdata zip
+        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: testdata-zip
           src_pattern: "onnxruntime-testdata.zip"
 
       - name: Upload testdata tar.bz2
+        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: testdata-tarbz2

--- a/.github/workflows/qualcomm-internal-archive-testdata.yml
+++ b/.github/workflows/qualcomm-internal-archive-testdata.yml
@@ -1,0 +1,52 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+# Reusable workflow: build and upload the global testdata archives.
+#
+# Produces two Artifactory artifacts consumed by every test job:
+#   testdata-zip     — onnxruntime-testdata.zip     (Windows + Android test jobs)
+#   testdata-tarbz2  — onnxruntime-testdata.tar.bz2 (Linux test jobs)
+
+name: Build and upload testdata archives
+
+on:
+  workflow_call: {}
+
+env:
+  BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
+
+jobs:
+  archive-testdata:
+    name: archive-testdata
+    runs-on: ["self-hosted", "linux", "X64", "Build"]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build testdata archive
+        run: python3 qcom/build_and_test.py archive_testdata
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v5
+        with:
+          disable-auto-build-publish: true
+          disable-job-summary: true
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Upload testdata zip
+        uses: ./.github/actions/upload-ci-artifact
+        with:
+          name: testdata-zip
+          src_pattern: "onnxruntime-testdata.zip"
+
+      - name: Upload testdata tar.bz2
+        uses: ./.github/actions/upload-ci-artifact
+        with:
+          name: testdata-tarbz2
+          src_pattern: "onnxruntime-testdata.tar.bz2"

--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -85,6 +85,12 @@ on:
         description: "If true, upload the PDB archive as a CI artifact."
         default: false
         type: boolean
+      testdata_archive_artifact_name:
+        description: |
+          Artifact name to download as the testdata archive in the test step.
+          Empty disables the download.
+        type: string
+        default: ""
       build_aar:
         description: |
           If true, also build the Android AAR during the Android build.
@@ -271,6 +277,12 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-tests"
+
+      - name: Download testdata from Artifactory
+        if: ${{ inputs.testdata_archive_artifact_name != '' }}
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: ${{ inputs.testdata_archive_artifact_name }}
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
         run: >

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -194,3 +194,4 @@ jobs:
     with:
       target_os: android
       target_arch: aarch64
+      testdata_archive_artifact_name: testdata-zip

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -37,14 +37,20 @@ env:
 
 jobs:
 
+  archive-testdata:
+    uses: ./.github/workflows/qualcomm-internal-archive-testdata.yml
+    secrets: inherit
+
   build-and-test-linux-x86_64:
     if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: x86_64
+      testdata_archive_artifact_name: testdata-tarbz2
       # Specifying a python version here doesn't actually do anything at this point since we don't know what the Linux
       # wheel distribution story is yet. For now, this is just so that all of the job and artifact names reflect the
       # version of cpython that's installed on our Linux build machines.
@@ -52,12 +58,14 @@ jobs:
 
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: aarch64_oe_gcc11_2
+      testdata_archive_artifact_name: testdata-tarbz2
       target_py_vsn: None
       upload_test_archive: true
       upload_wheel: false
@@ -72,15 +80,18 @@ jobs:
     with:
       target_os: linux
       target_arch: aarch64_oe_gcc11_2
+      testdata_archive_artifact_name: testdata-tarbz2
 
   build-and-test-linux-arm64:
     if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: aarch64_manylinux_2_34
+      testdata_archive_artifact_name: testdata-tarbz2
       target_py_vsn: ${{ inputs.target_py_vsn }}
       upload_test_archive: true
       upload_wheel: true
@@ -91,10 +102,12 @@ jobs:
 
   build-and-test-windows-arm64:
     if: ${{ inputs.do_all || inputs.do_windows_arm64 }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       target_arch: arm64
+      testdata_archive_artifact_name: testdata-zip
       build_runner_arch: ${{ inputs.windows_arm64_runner_arch }}
       test_runner_arch: arm64
       upload_wheel: ${{ inputs.windows_arm64_runner_arch == 'ARM64' && inputs.target_py_vsn }}
@@ -105,11 +118,13 @@ jobs:
 
   build-and-test-windows-arm64ec:
     if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       target_arch: arm64ec
+      testdata_archive_artifact_name: testdata-zip
       upload_wheel: true
       test_wheel: true
       target_py_vsn: ${{ inputs.target_py_vsn }}
@@ -118,11 +133,13 @@ jobs:
 
   build-and-test-windows-x86_64:
     if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       target_arch: x86_64
+      testdata_archive_artifact_name: testdata-zip
       target_py_vsn: ${{ inputs.target_py_vsn }}
 
   lint:
@@ -139,6 +156,7 @@ jobs:
 
   build-android-aarch64:
     if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -55,8 +55,13 @@ on:
     inputs: *common_inputs
 
 jobs:
+  archive-testdata:
+    uses: ./.github/workflows/qualcomm-internal-archive-testdata.yml
+    secrets: inherit
+
   build-android-aarch64:
     if: ${{ inputs.build_android_aarch64 || inputs.build_android_aarch64_aar }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
@@ -65,6 +70,7 @@ jobs:
       build_runner_os: linux
       target_os: android
       target_arch: aarch64
+      testdata_archive_artifact_name: testdata-tarbz2
       target_py_vsn: None
       run_tests: false
       upload_test_archive: true
@@ -83,6 +89,7 @@ jobs:
 
   build-linux-aarch64-manylinux_2_34:
     if: ${{ toJSON(fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)) != '[]' }}
+    needs: [archive-testdata]
     strategy:
       matrix:
         target_py_vsn: ${{ fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns) }}
@@ -93,6 +100,7 @@ jobs:
       version_suffix: ${{ inputs.version_suffix }}
       target_os: linux
       target_arch: aarch64_manylinux_2_34
+      testdata_archive_artifact_name: testdata-tarbz2
       target_py_vsn: ${{ matrix.target_py_vsn }}
       run_tests: false
       # Upload the test archive with the first Python version we encounter
@@ -103,12 +111,14 @@ jobs:
 
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: aarch64_oe_gcc11_2
+      testdata_archive_artifact_name: testdata-tarbz2
       target_py_vsn: None
       run_tests: false
       upload_test_archive: true
@@ -116,6 +126,7 @@ jobs:
 
   build-linux-x86_64:
     if: ${{ inputs.build_linux_x86_64 }}
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
@@ -123,6 +134,7 @@ jobs:
       version_suffix: ${{ inputs.version_suffix }}
       target_os: linux
       target_arch: x86_64
+      testdata_archive_artifact_name: testdata-tarbz2
       # Specifying a python version here doesn't actually do anything at this point since we don't know what the Linux
       # wheel distribution story is yet. For now, this is just so that all of the job and artifact names reflect the
       # version of cpython that's installed on our Linux build machines.
@@ -133,6 +145,7 @@ jobs:
 
   build-windows:
     if: ${{ toJSON(fromJSON(inputs.windows_target_archs)) != '[]' && toJSON(fromJSON(inputs.windows_target_py_vsns)) != '[]' }}
+    needs: [archive-testdata]
     strategy:
       matrix:
         target_arch: ${{ fromJSON(inputs.windows_target_archs) }}
@@ -144,6 +157,7 @@ jobs:
       version_suffix: ${{ inputs.version_suffix }}
       target_os: windows
       target_arch: ${{ matrix.target_arch }}
+      testdata_archive_artifact_name: testdata-zip
       target_py_vsn: ${{ matrix.target_py_vsn }}
       build_runner_arch: "${{ matrix.target_arch == 'arm64' && 'ARM64' || 'X64' }}"
       test_runner_arch: ARM64
@@ -158,12 +172,14 @@ jobs:
       upload_pdb_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.windows_target_py_vsns)[0] }}
 
   build-windows-arm64x:
+    needs: [archive-testdata]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
       nightly_build: ${{ inputs.nightly_build }}
       version_suffix: ${{ inputs.version_suffix }}
       target_arch: arm64x
+      testdata_archive_artifact_name: testdata-zip
       target_py_vsn: ${{ fromJSON(inputs.windows_target_py_vsns)[0] }}
       build_runner_arch: ARM64
       run_tests: false

--- a/.github/workflows/qualcomm-internal-qdc-test.yml
+++ b/.github/workflows/qualcomm-internal-qdc-test.yml
@@ -16,6 +16,12 @@ on:
       target_arch:
         default: aarch64
         type: string
+      testdata_archive_artifact_name:
+        description: |
+          Artifact name to download as the testdata archive before running QDC tests.
+          Empty disables the download.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       target_os:
@@ -62,6 +68,12 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-pyNone-tests"
+
+      - name: Download testdata from Artifactory
+        if: ${{ inputs.testdata_archive_artifact_name != '' }}
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: ${{ inputs.testdata_archive_artifact_name }}
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} pynone
         env:

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -244,6 +244,20 @@ jobs:
         with:
           name: windows-x86_64-py3.11-tests
 
+      # --------------------------
+      # Download testdata archives
+      # --------------------------
+
+      - name: Download testdata zip from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: testdata-zip
+
+      - name: Download testdata tar.bz2 from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: testdata-tarbz2
+
       # -----------------------------
       # Download other distributables
       # -----------------------------
@@ -336,14 +350,14 @@ jobs:
         run: |
           count=$(find "${{ github.workspace }}/build" -name "*.tar.bz2" | wc -l)
           echo "Found $count .tar.bz2 archive(s)"
-          [ "$count" -eq 3 ] || { echo "ERROR: Expected 3 .tar.bz2 archives, found $count"; exit 1; }
+          [ "$count" -eq 4 ] || { echo "ERROR: Expected 4 .tar.bz2 archives, found $count"; exit 1; }
 
       - name: Verify Zip artifacts
         run: |
-          # 4 test archives + 1 Windows ARM64 zip + 1 Windows ARM64 (ARM64x) zip + 4 PDB archives = 10 zips
+          # 4 test archives + 1 testdata-zip + 1 Windows ARM64 zip + 1 Windows ARM64 (ARM64x) zip + 4 PDB archives = 11 zips
           count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
           echo "Found $count Zip archive(s)"
-          [ "$count" -eq 10 ] || { echo "ERROR: Expected 10 Zip archives, found $count"; exit 1; }
+          [ "$count" -eq 11 ] || { echo "ERROR: Expected 11 Zip archives, found $count"; exit 1; }
 
       - name: Verify TGZ artifact
         run: |

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -348,16 +348,67 @@ jobs:
 
       - name: Verify tarball artifacts
         run: |
-          count=$(find "${{ github.workspace }}/build" -name "*.tar.bz2" | wc -l)
-          echo "Found $count .tar.bz2 archive(s)"
-          [ "$count" -eq 4 ] || { echo "ERROR: Expected 4 .tar.bz2 archives, found $count"; exit 1; }
+          # Expected .tar.bz2 artifacts. Append its glob here for a new one.
+          expected=(
+            "onnxruntime-tests-linux-aarch64_manylinux_2_34.tar.bz2"
+            "onnxruntime-tests-linux-aarch64_oe_gcc11_2.tar.bz2"
+            "onnxruntime-tests-linux-x86_64.tar.bz2"
+            "onnxruntime-testdata.tar.bz2"
+          )
+          missing=()
+          for pattern in "${expected[@]}"; do
+            if ! find "${{ github.workspace }}/build" -type f -name "$pattern" | grep -q .; then
+              missing+=("$pattern")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "ERROR: missing .tar.bz2 artifacts:"
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+          actual_count=$(find "${{ github.workspace }}/build" -type f -name "*.tar.bz2" | wc -l)
+          if [ "$actual_count" -ne "${#expected[@]}" ]; then
+            echo "ERROR: expected ${#expected[@]} .tar.bz2 archive(s), found $actual_count. Inventory:"
+            find "${{ github.workspace }}/build" -type f -name "*.tar.bz2"
+            exit 1
+          fi
+          echo "Found ${#expected[@]} expected .tar.bz2 archive(s)."
 
       - name: Verify Zip artifacts
         run: |
-          # 4 test archives + 1 testdata-zip + 1 Windows ARM64 zip + 1 Windows ARM64 (ARM64x) zip + 4 PDB archives = 11 zips
-          count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
-          echo "Found $count Zip archive(s)"
-          [ "$count" -eq 11 ] || { echo "ERROR: Expected 11 Zip archives, found $count"; exit 1; }
+          # Expected .zip artifacts. Append its glob here for a new one.
+          # Versioned distributable + PDB zips use 'onnxruntime-qnn-<version>-win-<arch>{-pdb}.zip'.
+          expected=(
+            "onnxruntime-tests-android-aarch64.zip"
+            "onnxruntime-tests-windows-arm64.zip"
+            "onnxruntime-tests-windows-arm64ec.zip"
+            "onnxruntime-tests-windows-x86_64.zip"
+            "onnxruntime-testdata.zip"
+            "onnxruntime-qnn-*-win-arm64.zip"
+            "onnxruntime-qnn-*-win-arm64x.zip"
+            "onnxruntime-qnn-*-win-arm64-pdb.zip"
+            "onnxruntime-qnn-*-win-arm64ec-pdb.zip"
+            "onnxruntime-qnn-*-win-x86_64-pdb.zip"
+            "onnxruntime-qnn-*-win-arm64x-pdb.zip"
+          )
+          missing=()
+          for pattern in "${expected[@]}"; do
+            if ! find "${{ github.workspace }}/build" -type f -name "$pattern" | grep -q .; then
+              missing+=("$pattern")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "ERROR: missing .zip artifacts:"
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+          actual_count=$(find "${{ github.workspace }}/build" -type f -name "*.zip" | wc -l)
+          if [ "$actual_count" -ne "${#expected[@]}" ]; then
+            echo "ERROR: expected ${#expected[@]} Zip archive(s), found $actual_count. Inventory:"
+            find "${{ github.workspace }}/build" -type f -name "*.zip"
+            exit 1
+          fi
+          echo "Found ${#expected[@]} expected Zip archive(s)."
 
       - name: Verify TGZ artifact
         run: |

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -388,7 +388,7 @@ jobs:
             "onnxruntime-qnn-*-win-arm64x.zip"
             "onnxruntime-qnn-*-win-arm64-pdb.zip"
             "onnxruntime-qnn-*-win-arm64ec-pdb.zip"
-            "onnxruntime-qnn-*-win-x86_64-pdb.zip"
+            "onnxruntime-qnn-*-win-x64-pdb.zip"
             "onnxruntime-qnn-*-win-arm64x-pdb.zip"
           )
           missing=()

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -368,10 +368,34 @@ jobs:
 
       - name: Verify Zip artifacts
         run: |
-          # 1 Windows ARM64 Zip + 4 PDB archives + 1 Windows ARM64 (ARM64x) Zip = 6 zips
-          count=$(find "${{ github.workspace }}/build" -name "*.zip" | wc -l)
-          echo "Found $count Zip archive(s)"
-          [ "$count" -eq 6 ] || { echo "ERROR: Expected 6 Zip archive, found $count"; exit 1; }
+          # Expected .zip artifacts. Append its glob here for a new one.
+          # Versioned distributable + PDB zips use 'onnxruntime-qnn-<version>-win-<arch>{-pdb}.zip'.
+          expected=(
+            "onnxruntime-qnn-*-win-arm64.zip"
+            "onnxruntime-qnn-*-win-arm64x.zip"
+            "onnxruntime-qnn-*-win-arm64-pdb.zip"
+            "onnxruntime-qnn-*-win-arm64ec-pdb.zip"
+            "onnxruntime-qnn-*-win-x86_64-pdb.zip"
+            "onnxruntime-qnn-*-win-arm64x-pdb.zip"
+          )
+          missing=()
+          for pattern in "${expected[@]}"; do
+            if ! find "${{ github.workspace }}/build" -type f -name "$pattern" | grep -q .; then
+              missing+=("$pattern")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "ERROR: missing .zip artifacts:"
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+          actual_count=$(find "${{ github.workspace }}/build" -type f -name "*.zip" | wc -l)
+          if [ "$actual_count" -ne "${#expected[@]}" ]; then
+            echo "ERROR: expected ${#expected[@]} Zip archive(s), found $actual_count. Inventory:"
+            find "${{ github.workspace }}/build" -type f -name "*.zip"
+            exit 1
+          fi
+          echo "Found ${#expected[@]} expected Zip archive(s)."
 
       - name: Verify TGZ artifact
         run: |

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -375,7 +375,7 @@ jobs:
             "onnxruntime-qnn-*-win-arm64x.zip"
             "onnxruntime-qnn-*-win-arm64-pdb.zip"
             "onnxruntime-qnn-*-win-arm64ec-pdb.zip"
-            "onnxruntime-qnn-*-win-x86_64-pdb.zip"
+            "onnxruntime-qnn-*-win-x64-pdb.zip"
             "onnxruntime-qnn-*-win-arm64x-pdb.zip"
           )
           missing=()

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -30,6 +30,7 @@ from ep_build.task import (
     ExtractArchiveTask,
     ListTasksTask,
     NoOpTask,
+    RunExecutablesTask,
 )
 from ep_build.tasks.build import (
     AdbTestsTask,
@@ -425,6 +426,20 @@ class TaskLibrary:
                 )
             )
 
+    @public_task("Build the global testdata archive (zip + tar.bz2)")
+    def archive_testdata(self, plan: Plan) -> str:
+        return plan.add_step(
+            RunExecutablesTask(
+                "Building the testdata archive",
+                [
+                    [
+                        str(self.__python_executable),
+                        str(REPO_ROOT / "qcom" / "scripts" / "all" / "archive_testdata.py"),
+                    ]
+                ],
+            )
+        )
+
     @public_task("Build ONNX Runtime for this host's native architecture")
     @depends(
         [
@@ -713,40 +728,112 @@ class TaskLibrary:
         @task
         def extract_ort_linux_aarch64_manylinux_2_34(self, plan: Plan) -> str:
             return plan.add_step(
-                ExtractArchiveTask(
-                    "Extracting ONNX Runtime for Linux",
-                    REPO_ROOT / "build" / "onnxruntime-tests-linux-aarch64_manylinux_2_34.tar.bz2",
-                    REPO_ROOT,
+                CompositeTask(
+                    None,
+                    [
+                        ExtractArchiveTask(
+                            "Extracting per-arch ONNX Runtime archive",
+                            REPO_ROOT / "build" / "onnxruntime-tests-linux-aarch64_manylinux_2_34.tar.bz2",
+                            REPO_ROOT,
+                        ),
+                        RunExecutablesTask(
+                            "Extracting global testdata archive",
+                            [
+                                [
+                                    str(self.__python_executable),
+                                    str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
+                                    "--target-platform",
+                                    "linux-aarch64_manylinux_2_34",
+                                    "--archive",
+                                    str(REPO_ROOT / "build" / "onnxruntime-testdata.tar.bz2"),
+                                ]
+                            ],
+                        ),
+                    ],
                 )
             )
 
     @task
     def extract_ort_linux_x86_64(self, plan: Plan) -> str:
         return plan.add_step(
-            ExtractArchiveTask(
-                "Extracting ONNX Runtime for Linux",
-                REPO_ROOT / "build" / "onnxruntime-tests-linux-x86_64.tar.bz2",
-                REPO_ROOT,
+            CompositeTask(
+                None,
+                [
+                    ExtractArchiveTask(
+                        "Extracting per-arch ONNX Runtime archive",
+                        REPO_ROOT / "build" / "onnxruntime-tests-linux-x86_64.tar.bz2",
+                        REPO_ROOT,
+                    ),
+                    RunExecutablesTask(
+                        "Extracting global testdata archive",
+                        [
+                            [
+                                str(self.__python_executable),
+                                str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
+                                "--target-platform",
+                                "linux-x86_64",
+                                "--archive",
+                                str(REPO_ROOT / "build" / "onnxruntime-testdata.tar.bz2"),
+                            ]
+                        ],
+                    ),
+                ],
             )
         )
 
     @task
     def extract_ort_windows_arm64(self, plan: Plan) -> str:
         return plan.add_step(
-            ExtractArchiveTask(
-                "Extracting ONNX Runtime for Windows on ARM64",
-                REPO_ROOT / "build" / "onnxruntime-tests-windows-arm64.zip",
-                REPO_ROOT,
+            CompositeTask(
+                None,
+                [
+                    ExtractArchiveTask(
+                        "Extracting per-arch ONNX Runtime archive",
+                        REPO_ROOT / "build" / "onnxruntime-tests-windows-arm64.zip",
+                        REPO_ROOT,
+                    ),
+                    RunExecutablesTask(
+                        "Extracting global testdata archive",
+                        [
+                            [
+                                str(self.__python_executable),
+                                str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
+                                "--target-platform",
+                                "windows-arm64",
+                                "--archive",
+                                str(REPO_ROOT / "build" / "onnxruntime-testdata.zip"),
+                            ]
+                        ],
+                    ),
+                ],
             )
         )
 
     @task
     def extract_ort_windows_x86_64(self, plan: Plan) -> str:
         return plan.add_step(
-            ExtractArchiveTask(
-                "Extracting ONNX Runtime for Windows on x86_64",
-                REPO_ROOT / "build" / "onnxruntime-tests-windows-x86_64.zip",
-                REPO_ROOT,
+            CompositeTask(
+                None,
+                [
+                    ExtractArchiveTask(
+                        "Extracting per-arch ONNX Runtime archive",
+                        REPO_ROOT / "build" / "onnxruntime-tests-windows-x86_64.zip",
+                        REPO_ROOT,
+                    ),
+                    RunExecutablesTask(
+                        "Extracting global testdata archive",
+                        [
+                            [
+                                str(self.__python_executable),
+                                str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
+                                "--target-platform",
+                                "windows-x86_64",
+                                "--archive",
+                                str(REPO_ROOT / "build" / "onnxruntime-testdata.zip"),
+                            ]
+                        ],
+                    ),
+                ],
             )
         )
 
@@ -883,7 +970,7 @@ class TaskLibrary:
     if is_host_linux() or is_host_mac():
 
         @task
-        @depends(["archive_ort_android_aarch64"])
+        @depends(["archive_ort_android_aarch64", "archive_testdata"])
         def test_ort_local_android_aarch64(self, plan: Plan) -> str:
             return plan.add_step(
                 AdbTestsTask(
@@ -894,7 +981,7 @@ class TaskLibrary:
     if is_host_linux() or is_host_mac():
 
         @task
-        @depends(["archive_ort_linux_aarch64_manylinux_2_34"])
+        @depends(["archive_ort_linux_aarch64_manylinux_2_34", "archive_testdata"])
         def test_ort_local_linux_aarch64_manylinux_2_34(self, plan: Plan) -> str:
             return plan.add_step(
                 AdbTestsTask(
@@ -908,7 +995,7 @@ class TaskLibrary:
     if (is_host_linux() and is_host_x86_64()) or is_host_mac():
 
         @task
-        @depends(["archive_ort_linux_aarch64_oe_gcc11_2"])
+        @depends(["archive_ort_linux_aarch64_oe_gcc11_2", "archive_testdata"])
         def test_ort_local_linux_aarch64_oe_gcc11_2(self, plan: Plan) -> str:
             return plan.add_step(
                 AdbTestsTask(

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -282,11 +282,27 @@ class AdbTestsTask(RunInTempDirectoryTask):
                     },
                 ),
                 ExtractArchiveTask(
-                    "Extracting ONNX Runtime test package",
+                    "Extracting per-arch test archive",
                     REPO_ROOT
                     / "build"
                     / f"onnxruntime-tests-{self.__platform}-{self.__target_arch}.{test_archive_ext}",
                     tmpdir,
+                ),
+                BashScriptsWithVenvTask(
+                    "Extracting testdata archive",
+                    None,
+                    [
+                        [
+                            "python3",
+                            str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
+                            "--target-platform",
+                            f"{self.__platform}-{self.__target_arch}",
+                            "--archive",
+                            str(REPO_ROOT / "build" / f"onnxruntime-testdata.{test_archive_ext}"),
+                            "--repo-root",
+                            str(tmpdir),
+                        ]
+                    ],
                 ),
                 PyTestTask(
                     "Testing ONNX Runtime with a local device",
@@ -321,6 +337,9 @@ class QdcTestsTask(RunExecutablesWithVenvTask):
 
         if extra_args is not None:
             cmd.extend(extra_args)
+
+        testdata_archive = REPO_ROOT / "build" / "onnxruntime-testdata.zip"
+        cmd.append(f"--testdata-archive={testdata_archive}")
 
         if is_host_github_runner():
             actor = os.environ["GITHUB_ACTOR"]

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -338,7 +338,12 @@ class QdcTestsTask(RunExecutablesWithVenvTask):
         if extra_args is not None:
             cmd.extend(extra_args)
 
-        testdata_archive = REPO_ROOT / "build" / "onnxruntime-testdata.zip"
+        # qualcomm_linux jobs download the .tar.bz2 testdata artifact; everything else uses .zip.
+        # qdc_runner._resolve_testdata_archive() probes the alternate extension as a safety net,
+        # but pointing at the right file from the start makes intent clear when reading this task
+        # in isolation.
+        testdata_ext = "tar.bz2" if set(platforms) == {"qualcomm_linux"} else "zip"
+        testdata_archive = REPO_ROOT / "build" / f"onnxruntime-testdata.{testdata_ext}"
         cmd.append(f"--testdata-archive={testdata_archive}")
 
         if is_host_github_runner():

--- a/qcom/scripts/all/archive_testdata.py
+++ b/qcom/scripts/all/archive_testdata.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+"""Produce a single global testdata archive consumed by every test job.
+
+Output: build/onnxruntime-testdata.zip and build/onnxruntime-testdata.tar.bz2
+
+The archive contains four arch-neutral top-level directories:
+    testdata/            (from upstream ORT source — fetched via cmake/deps.txt)
+    pytorch-converted/   (from cmake/external/onnx submodule)
+    pytorch-operator/    (from cmake/external/onnx submodule)
+    node/                (from cmake/external/onnx submodule)
+
+extract_testdata.py knows how to re-map these handles into the on-disk locations
+expected by run_tests.{ps1,sh} and the test binaries.
+"""
+
+import argparse
+import hashlib
+import logging
+import re
+import shutil
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import urlretrieve
+
+QCOM_ROOT = Path(__file__).parent.parent.parent
+REPO_ROOT = QCOM_ROOT.parent
+
+__all__ = [
+    "OrtCoreDep",
+    "download_and_verify",
+    "parse_deps_txt",
+    "stage_sources",
+    "write_archives",
+]
+
+
+@dataclass(frozen=True)
+class OrtCoreDep:
+    url: str
+    sha1: str
+
+
+_ORT_CORE_LINE_RE = re.compile(r"^ort_core;([^;]+);([0-9a-fA-F]+)\s*$")
+
+
+def parse_deps_txt(deps_file: Path) -> OrtCoreDep:
+    """Parse cmake/deps.txt and return the ort_core URL + SHA1."""
+    for line in deps_file.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _ORT_CORE_LINE_RE.match(stripped)
+        if m:
+            return OrtCoreDep(url=m.group(1), sha1=m.group(2))
+    raise ValueError(f"ort_core entry not found in {deps_file}")
+
+
+def _sha1_of(path: Path) -> str:
+    h = hashlib.sha1()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download_and_verify(url: str, sha1: str, cache_path: Path) -> Path:
+    """Download `url` to `cache_path`. Skip fetch when cache exists with matching SHA1.
+    Removes and re-downloads when a stale cache (mismatched SHA1) is found, so persistent
+    CI workspaces recover automatically after a QAIRT uplevel changes cmake/deps.txt."""
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    if cache_path.exists():
+        actual = _sha1_of(cache_path)
+        if actual == sha1.lower():
+            logging.info("ort_core zip cache hit: %s", cache_path)
+            return cache_path
+        # Stale cache — delete and re-download rather than raising, so CI runners with
+        # persistent build/ directories recover automatically after an ORT version bump.
+        logging.warning(
+            "SHA1 mismatch on cached %s (expected %s, got %s) — removing and re-downloading",
+            cache_path,
+            sha1,
+            actual,
+        )
+        cache_path.unlink()
+    logging.info("Downloading %s -> %s", url, cache_path)
+    urlretrieve(url, cache_path)
+    actual = _sha1_of(cache_path)
+    if actual != sha1.lower():
+        raise ValueError(f"SHA1 mismatch on freshly downloaded {cache_path}: expected {sha1}, got {actual}")
+    return cache_path
+
+
+# Maps each handle name to its source path. Handle names must match MAPPING in extract_testdata.py.
+_HANDLES = {
+    "testdata": "ort_core_src/onnxruntime/test/testdata",
+    "pytorch-converted": "onnx_src/backend/test/data/pytorch-converted",
+    "pytorch-operator": "onnx_src/backend/test/data/pytorch-operator",
+    "node": "onnx_src/backend/test/data/node",
+}
+
+
+def stage_sources(stage_root: Path, ort_core_src: Path, onnx_src: Path) -> None:
+    """Copy the 4 source trees into stage_root under their handle names.
+    Existing stage_root contents are removed first."""
+    if stage_root.exists():
+        shutil.rmtree(stage_root)
+    stage_root.mkdir(parents=True)
+    for handle, rel in _HANDLES.items():
+        if rel.startswith("ort_core_src/"):
+            src = ort_core_src / rel[len("ort_core_src/") :]
+        elif rel.startswith("onnx_src/"):
+            src = onnx_src / rel[len("onnx_src/") :]
+        else:
+            raise AssertionError(f"unknown handle root in {rel}")
+        if not src.is_dir():
+            raise FileNotFoundError(f"Source for handle {handle!r} missing: {src}")
+        shutil.copytree(src, stage_root / handle)
+
+
+def write_archives(stage_root: Path, output_dir: Path) -> list[Path]:
+    """Write both onnxruntime-testdata.zip and onnxruntime-testdata.tar.bz2 from stage_root."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = output_dir / "onnxruntime-testdata.zip"
+    tar_path = output_dir / "onnxruntime-testdata.tar.bz2"
+    zip_path.unlink(missing_ok=True)
+    tar_path.unlink(missing_ok=True)
+
+    files = sorted(p for p in stage_root.glob("**/*") if p.is_file())
+
+    with zipfile.ZipFile(zip_path, "x", compression=zipfile.ZIP_DEFLATED) as zf:
+        for f in files:
+            zf.write(f, f.relative_to(stage_root).as_posix())
+
+    with tarfile.open(tar_path, "w:bz2") as tf:
+        for f in files:
+            tf.add(f, str(f.relative_to(stage_root).as_posix()))
+
+    return [zip_path, tar_path]
+
+
+def main() -> int:
+    log_format = "[%(asctime)s] [archive_testdata.py] [%(levelname)s] %(message)s"
+    logging.basicConfig(level=logging.INFO, format=log_format, force=True)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=REPO_ROOT / "build" / "testdata-stage",
+        help="Working directory for the ort_core download + extract.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT / "build",
+        help="Directory to write onnxruntime-testdata.{zip,tar.bz2} into.",
+    )
+    args = parser.parse_args()
+
+    dep = parse_deps_txt(REPO_ROOT / "cmake" / "deps.txt")
+
+    cache_zip = args.build_dir / "ort_core.zip"
+    download_and_verify(dep.url, dep.sha1, cache_zip)
+
+    extract_root = args.build_dir / "ort_core-src"
+    if extract_root.exists():
+        shutil.rmtree(extract_root)
+    extract_root.mkdir(parents=True)
+    with zipfile.ZipFile(cache_zip) as zf:
+        zf.extractall(extract_root)
+    # The zip extracts to onnxruntime-<version>/, hop down one level.
+    children = [p for p in extract_root.iterdir() if p.is_dir()]
+    if len(children) != 1:
+        raise RuntimeError(f"Unexpected layout in ort_core extraction: {children}")
+    ort_core_src = children[0]
+
+    onnx_src = REPO_ROOT / "cmake" / "external" / "onnx" / "onnx"
+
+    stage_root = args.build_dir / "stage"
+    stage_sources(stage_root=stage_root, ort_core_src=ort_core_src, onnx_src=onnx_src)
+    written = write_archives(stage_root=stage_root, output_dir=args.output_dir)
+    for p in written:
+        logging.info("Wrote %s (%.1f MiB)", p, p.stat().st_size / (1 << 20))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -2,146 +2,179 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: MIT
 
+"""Produce the per-arch test archive: binaries + scripts only (testdata moved to a separate archive)."""
+
 import argparse
 import logging
 import platform
 import re
 import tarfile
 import zipfile
-from collections.abc import Callable
 from pathlib import Path
 
 QCOM_ROOT = Path(__file__).parent.parent.parent
 REPO_ROOT = QCOM_ROOT.parent
 
-_ALWAYS_REJECT_PATTERNS = [r".*/__pycache__/.*", r".*/.pytest_cache/.*"]
+# Top-level files inside Release/ accepted purely by extension or exact name.
+_TOP_LEVEL_EXT_RE = re.compile(r"\.(dll|exe|cat|so|so\.[0-9.]+)$")
+_TOP_LEVEL_EXACT_NAMES = {
+    "CTestTestfile.cmake",
+    "run_tests.ps1",
+    "run_tests.sh",
+    "ctest",
+    "ctest.exe",
+    "python_test_files.txt",
+}
+_TOP_LEVEL_PYTHON_TEST_RE = re.compile(r"^onnxruntime_test_python.*\.py$")
+_QCOM_SCRIPTS_RE = re.compile(r"^qcom/scripts/")
+_QUANTIZATION_RE = re.compile(r"^quantization/")
+_PROVIDERS_QNN_RE = re.compile(r".*onnxruntime_providers_qnn.*")
 
-_ALWAYS_REJECT_RE = re.compile("|".join(_ALWAYS_REJECT_PATTERNS))
-
-_ORT_REJECT_PATTERNS = [
-    *_ALWAYS_REJECT_PATTERNS,
-    r".*\.(a|cc?|exp|h|i|lib|o|obj)$",
-    r".*/\.ninja_deps$",
-    r".*/\.ninja_log$",
-    r".*/CMakeCache.txt$",
-    r".*/build.ninja$",
-    r".*/compile_commands.json$",
-    r".*/_deps/(?!onnx-src/onnx/backend/test/data/pytorch-(converted|operator)/).*",
-    r".*/CMakeFiles/.*",
-    r".*/Google\.Protobuf\.Tools.*/.*",
-    r".*/Microsoft\.AI\.DirectML.*/.*",
-    r".*/Microsoft\.Windows\.CppWinRT.*/.*",
-    r".*/Testing/.*",
-    r".*/pkgconfig/.*",
-]
-
-_ORT_REJECT_RE = re.compile("|".join(_ORT_REJECT_PATTERNS))
-
-_QAIRT_ACCEPT_PATTERNS = [".*/aarch64-android/.*", r".*/hexagon-v.+/.*"]
-
-_QAIRT_ACCEPT_RE = re.compile("|".join(_QAIRT_ACCEPT_PATTERNS))
+# Drop __pycache__ and .pytest_cache unconditionally.
+_ALWAYS_REJECT_RE = re.compile(r".*/(__pycache__|\.pytest_cache)/")
 
 
-def _add_directory(add_file: Callable[[Path, Path], None], root: Path) -> None:
-    for filename in root.glob("**/*"):
-        if _should_archive(filename, reject=_ORT_REJECT_RE):
-            arcname = filename.relative_to(REPO_ROOT)
-            add_file(filename, arcname)
+class PerArchAcceptRules:
+    """Accept-list filter for per-arch test archive contents.
 
+    Two surfaces:
+      - top-level (Release/<file>): extension / exact name / exec-bit
+      - subpath (under Release/<subdir>/...): full pattern matching
+    """
 
-def _add_node_models(add_file: Callable[[Path, Path], None]) -> None:
-    node_tests_root = REPO_ROOT / "cmake" / "external" / "onnx" / "onnx" / "backend" / "test" / "data" / "node"
-    logging.debug(f"Adding node model tests from ONNX submodule in {node_tests_root}")
-    _add_directory(add_file, node_tests_root)
-
-
-def _add_qcom_scripts(add_file: Callable[[Path, Path], None]) -> None:
-    qcom_scripts_root = REPO_ROOT / "qcom" / "scripts"
-    logging.debug(f"Adding {qcom_scripts_root}")
-    _add_directory(add_file, qcom_scripts_root)
-
-
-def _should_archive(path: Path, accept: re.Pattern | None = None, reject: re.Pattern | None = None) -> bool:
-    if (platform.system() == "Windows" and path.is_symlink()) or not path.is_file():
+    def accept_top_level(self, name: str) -> bool:
+        if _TOP_LEVEL_EXT_RE.search(name):
+            return True
+        if name in _TOP_LEVEL_EXACT_NAMES:
+            return True
+        if _TOP_LEVEL_PYTHON_TEST_RE.match(name):
+            return True
         return False
-    posix_path = str(path.as_posix())
-    if accept is not None and accept.match(posix_path) is None:
+
+    def accept_top_level_with_path(self, path: Path) -> bool:
+        """For Linux/Android: extension-less executables (+x) are test runners."""
+        if self.accept_top_level(path.name):
+            return True
+        if not path.is_file():
+            return False
+        if "." in path.name:
+            return False
+        try:
+            return bool(path.stat().st_mode & 0o111)
+        except OSError:
+            return False
+
+    def accept_repo_relative(self, rel: Path) -> bool:
+        """For files under build/<plat>/Release/<subdir>/... or qcom/scripts/...
+        The caller strips build/<plat>/Release/ prefix for subdir paths."""
+        s = rel.as_posix()
+        if _QCOM_SCRIPTS_RE.match(s):
+            return True
+        if _QUANTIZATION_RE.match(s):
+            return True
+        if _PROVIDERS_QNN_RE.match(s):
+            return True
         return False
-    if reject is not None and reject.match(posix_path):
-        return False
-    return True
 
 
-def archive_android(target_platform: str, config: str, qairt_sdk_root: Path) -> None:
-    build_root = REPO_ROOT / "build"
-    archive_path = build_root / f"onnxruntime-tests-{target_platform}.zip"
-    build_dir = build_root / target_platform
-
-    archive_path.unlink(missing_ok=True)
-
-    logging.info(f"Creating test archive in {archive_path}.")
-    with zipfile.ZipFile(archive_path, "x", compression=zipfile.ZIP_DEFLATED) as archive:
-        logging.debug(f"Adding items from ONNX Runtime build in {build_dir}.")
-        for filename in build_dir.glob(f"{config}/**/*"):
-            if _should_archive(filename, reject=_ORT_REJECT_RE):
-                arcname = filename.relative_to(REPO_ROOT)
-                archive.write(filename, arcname)
-
-        logging.debug(f"Adding QNN libraries from {qairt_sdk_root}.")
-        for filename in (qairt_sdk_root / "lib").glob("**/*"):
-            if _should_archive(filename, accept=_QAIRT_ACCEPT_RE):
-                arcname = filename.relative_to(qairt_sdk_root)
-                archive.write(filename, arcname)
-
-        _add_node_models(archive.write)
-        _add_qcom_scripts(archive.write)
+def _iter_release_files(release_dir: Path):
+    for p in release_dir.glob("**/*"):
+        if not p.is_file() or (platform.system() == "Windows" and p.is_symlink()):
+            continue
+        if _ALWAYS_REJECT_RE.search(p.as_posix()):
+            continue
+        yield p
 
 
-def archive_linux(target_platform: str, config: str) -> None:
-    build_root = REPO_ROOT / "build"
-    archive_path = build_root / f"onnxruntime-tests-{target_platform}.tar.bz2"
-    build_dir = build_root / target_platform
-
-    archive_path.unlink(missing_ok=True)
-
-    logging.info(f"Creating test archive in {archive_path}.")
-    with tarfile.open(archive_path, "w:bz2") as archive:
-        logging.debug(f"Adding ONNX build from {build_dir / config}")
-        for filename in (build_dir / config).glob("**/*"):
-            if _should_archive(filename, reject=_ORT_REJECT_RE):
-                arcname = filename.relative_to(REPO_ROOT)
-                archive.add(filename, arcname)
-        _add_node_models(archive.add)
-        _add_qcom_scripts(archive.add)
+def _iter_qcom_scripts(repo_root: Path):
+    for p in (repo_root / "qcom" / "scripts").glob("**/*"):
+        if not p.is_file():
+            continue
+        if _ALWAYS_REJECT_RE.search(p.as_posix()):
+            continue
+        yield p
 
 
-def archive_windows(target_platform: str, config: str) -> None:
-    build_root = REPO_ROOT / "build"
-    archive_path = build_root / f"onnxruntime-tests-{target_platform}.zip"
-    build_dir = build_root / target_platform
-
-    archive_path.unlink(missing_ok=True)
-
-    logging.info(f"Creating test archive in {archive_path}.")
-    with zipfile.ZipFile(archive_path, "x", compression=zipfile.ZIP_DEFLATED) as archive:
-        if (build_dir / config / config).exists():
-            # This is a multi-config build with a redundant configuration name
-            ep_build_dir = build_dir / config / config
-            logging.debug("Adding individual files.")
-            arc_build_dir = (build_dir / config).relative_to(REPO_ROOT)
-            archive.write(build_dir / config / "CTestTestfile.cmake", arc_build_dir / "CTestTestfile.cmake")
-            archive.write(build_dir / config / "ctest.exe", arc_build_dir / "ctest.exe")
-            archive.write(build_dir / config / "run_tests.ps1", arc_build_dir / "run_tests.ps1")
+def _select_release_entries(release_dir: Path, rules: PerArchAcceptRules, repo_root: Path = REPO_ROOT):
+    """Yield (filesystem_path, arcname_relative_to_REPO_ROOT) for accepted Release/ files."""
+    for p in _iter_release_files(release_dir):
+        rel_to_release = p.relative_to(release_dir)
+        if rel_to_release.parent == Path("."):
+            # Top-level under Release/
+            if rules.accept_top_level_with_path(p):
+                yield p, p.relative_to(repo_root)
         else:
-            ep_build_dir = build_dir / config
+            if rules.accept_repo_relative(rel_to_release):
+                yield p, p.relative_to(repo_root)
 
-        logging.debug(f"Adding ONNX build from {ep_build_dir}")
-        for filename in ep_build_dir.glob("**/*"):
-            if _should_archive(filename, reject=_ORT_REJECT_RE):
-                arcname = str(filename.relative_to(REPO_ROOT))
-                archive.write(filename, arcname)
-        _add_node_models(archive.write)
-        _add_qcom_scripts(archive.write)
+
+def archive_linux(target_platform: str, config: str = "Release", repo_root: Path = REPO_ROOT) -> None:
+    build_root = repo_root / "build"
+    archive_path = build_root / f"onnxruntime-tests-{target_platform}.tar.bz2"
+    release_dir = build_root / target_platform / config
+    rules = PerArchAcceptRules()
+
+    archive_path.unlink(missing_ok=True)
+    logging.info(f"Creating per-arch archive at {archive_path}")
+    with tarfile.open(archive_path, "w:bz2") as tf:
+        for fs, arc in _select_release_entries(release_dir, rules, repo_root):
+            tf.add(fs, str(arc))
+        for p in _iter_qcom_scripts(repo_root):
+            tf.add(p, str(p.relative_to(repo_root)))
+
+
+def archive_windows(target_platform: str, config: str = "Release", repo_root: Path = REPO_ROOT) -> None:
+    build_root = repo_root / "build"
+    archive_path = build_root / f"onnxruntime-tests-{target_platform}.zip"
+    release_dir = build_root / target_platform / config
+    rules = PerArchAcceptRules()
+
+    # Multi-config generators (VS) nest config again: build/<plat>/Release/Release/
+    if (release_dir / config).is_dir():
+        nested = release_dir / config
+        outer_keep = ["CTestTestfile.cmake", "ctest.exe", "run_tests.ps1"]
+        archive_path.unlink(missing_ok=True)
+        logging.info(f"Creating per-arch archive at {archive_path}")
+        with zipfile.ZipFile(archive_path, "x", compression=zipfile.ZIP_DEFLATED) as zf:
+            for name in outer_keep:
+                src = release_dir / name
+                if src.exists():
+                    zf.write(src, str(src.relative_to(repo_root)))
+            for fs, arc in _select_release_entries(nested, rules, repo_root):
+                # Drop the inner Release/ doubling so layout matches single-config.
+                outer_arc = Path("build") / target_platform / config / Path(*arc.parts[3:])
+                zf.write(fs, str(outer_arc))
+            for p in _iter_qcom_scripts(repo_root):
+                zf.write(p, str(p.relative_to(repo_root)))
+        return
+
+    archive_path.unlink(missing_ok=True)
+    logging.info(f"Creating per-arch archive at {archive_path}")
+    with zipfile.ZipFile(archive_path, "x", compression=zipfile.ZIP_DEFLATED) as zf:
+        for fs, arc in _select_release_entries(release_dir, rules, repo_root):
+            zf.write(fs, str(arc))
+        for p in _iter_qcom_scripts(repo_root):
+            zf.write(p, str(p.relative_to(repo_root)))
+
+
+def archive_android(target_platform: str, config: str, qairt_sdk_root: Path, repo_root: Path = REPO_ROOT) -> None:
+    """Like archive_linux but also includes QNN aarch64-android + hexagon libs from QAIRT SDK."""
+    build_root = repo_root / "build"
+    archive_path = build_root / f"onnxruntime-tests-{target_platform}.zip"
+    release_dir = build_root / target_platform / config
+    rules = PerArchAcceptRules()
+
+    archive_path.unlink(missing_ok=True)
+    logging.info(f"Creating per-arch archive at {archive_path}")
+    with zipfile.ZipFile(archive_path, "x", compression=zipfile.ZIP_DEFLATED) as zf:
+        for fs, arc in _select_release_entries(release_dir, rules, repo_root):
+            zf.write(fs, str(arc))
+        for p in _iter_qcom_scripts(repo_root):
+            zf.write(p, str(p.relative_to(repo_root)))
+        qairt_accept_re = re.compile(r".*/(aarch64-android|hexagon-v.+)/.*")
+        for p in (qairt_sdk_root / "lib").glob("**/*"):
+            if p.is_file() and qairt_accept_re.match(p.as_posix()):
+                zf.write(p, str(p.relative_to(qairt_sdk_root)))
 
 
 if __name__ == "__main__":
@@ -149,17 +182,10 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG, format=log_format, force=True)
 
     parser = argparse.ArgumentParser()
-
-    parser.add_argument(
-        "--config",
-        help="The build configuration to archive",
-        default="Release",
-        choices=["Debug", "Release", "RelWithDebInfo"],
-    )
-
+    parser.add_argument("--config", default="Release", choices=["Debug", "Release", "RelWithDebInfo"])
     parser.add_argument(
         "--target-platform",
-        help="The platform for which to package tests.",
+        required=True,
         choices=[
             "android-aarch64",
             "linux-x86_64",
@@ -170,16 +196,8 @@ if __name__ == "__main__":
             "windows-arm64x",
             "windows-x86_64",
         ],
-        required=True,
     )
-
-    parser.add_argument(
-        "--qairt-sdk-root",
-        help="Path to the QAIRT SDK.",
-        required=True,
-        type=Path,
-    )
-
+    parser.add_argument("--qairt-sdk-root", type=Path, required=True)
     args = parser.parse_args()
 
     if args.target_platform.startswith("android-"):

--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -29,6 +29,10 @@ _TOP_LEVEL_PYTHON_TEST_RE = re.compile(r"^onnxruntime_test_python.*\.py$")
 _QCOM_SCRIPTS_RE = re.compile(r"^qcom/scripts/")
 _QUANTIZATION_RE = re.compile(r"^quantization/")
 _PROVIDERS_QNN_RE = re.compile(r".*onnxruntime_providers_qnn[^/]*\.(so|so\.[0-9.]+|dll)$")
+# AAR-build APKs consumed by qcom/scripts/linux/appium/tests/test_aar.py. These live under
+# java/androidtest/android/app/build/outputs/apk/{debug,androidTest/debug}/ and are only
+# produced when the Android build runs with -BuildAar/build_aar=true.
+_AAR_APK_RE = re.compile(r"^java/androidtest/.*\.apk$")
 
 # Drop __pycache__ and .pytest_cache unconditionally.
 _ALWAYS_REJECT_RE = re.compile(r".*/(__pycache__|\.pytest_cache)/")
@@ -73,6 +77,8 @@ class PerArchAcceptRules:
         if _QUANTIZATION_RE.match(s):
             return True
         if _PROVIDERS_QNN_RE.match(s):
+            return True
+        if _AAR_APK_RE.match(s):
             return True
         return False
 

--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -28,7 +28,7 @@ _TOP_LEVEL_EXACT_NAMES = {
 _TOP_LEVEL_PYTHON_TEST_RE = re.compile(r"^onnxruntime_test_python.*\.py$")
 _QCOM_SCRIPTS_RE = re.compile(r"^qcom/scripts/")
 _QUANTIZATION_RE = re.compile(r"^quantization/")
-_PROVIDERS_QNN_RE = re.compile(r".*onnxruntime_providers_qnn.*")
+_PROVIDERS_QNN_RE = re.compile(r".*onnxruntime_providers_qnn[^/]*\.(so|so\.[0-9.]+|dll)$")
 
 # Drop __pycache__ and .pytest_cache unconditionally.
 _ALWAYS_REJECT_RE = re.compile(r".*/(__pycache__|\.pytest_cache)/")

--- a/qcom/scripts/all/extract_testdata.py
+++ b/qcom/scripts/all/extract_testdata.py
@@ -36,10 +36,14 @@ MAPPING: dict[str, str] = {
 def _detect_config_dir(repo_root: Path, plat: str) -> str:
     """Return 'Release/Release' for multi-config Windows builds, 'Release' otherwise.
 
+    Documented fallback. Prefer passing config explicitly via the --config flag —
+    this probe relies on the per-arch test archive having already been extracted
+    so build/<plat>/Release/Release/ exists, which couples this script to caller
+    ordering. Future callers that parallelise the two extractions or reuse build/
+    across single-config and multi-config flavours should not depend on this.
+
     Visual Studio generators create build/<plat>/Release/Release/ for cross-compiled
-    Windows targets (e.g. ARM64 built from an X64 host).  Detect by probing whether
-    that second-level directory already exists — which it will after the per-arch
-    test archive has been extracted (the caller must ensure that ordering).
+    Windows targets (e.g. ARM64 built from an X64 host).
     """
     if (repo_root / "build" / plat / "Release" / "Release").is_dir():
         return "Release/Release"
@@ -62,13 +66,18 @@ def _extract_to_staging(archive: Path, staging: Path) -> None:
         raise ValueError(f"Unsupported archive format: {archive}")
 
 
-def extract(archive: Path, target_platform: str, repo_root: Path = REPO_ROOT) -> None:
+def extract(archive: Path, target_platform: str, repo_root: Path = REPO_ROOT, config: str | None = None) -> None:
     """Extract testdata archive and re-map its 4 handles to expected on-disk paths.
 
-    The per-arch test archive must already be extracted into repo_root before calling
-    this function so that _detect_config_dir() can probe for the multi-config layout.
+    `config` selects the build config dir under build/<plat>/. Pass it explicitly
+    ("Release" or "Release/Release") to make the layout self-describing. When omitted,
+    falls back to probing build/<plat>/Release/Release/ — which only exists if the
+    per-arch test archive was already extracted into repo_root.
     """
-    config_dir = _detect_config_dir(repo_root, target_platform)
+    if config is None:
+        config_dir = _detect_config_dir(repo_root, target_platform)
+    else:
+        config_dir = config
     with tempfile.TemporaryDirectory(prefix="extract-testdata-") as tmp:
         staging = Path(tmp)
         _extract_to_staging(archive, staging)
@@ -102,8 +111,22 @@ def main() -> int:
         default=REPO_ROOT,
         help="Repository root; defaults to REPO_ROOT inferred from script location.",
     )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            'Build config dir under build/<plat>/. Pass "Release" for single-config '
+            'or "Release/Release" for multi-config Visual Studio builds. '
+            "When omitted, probes the filesystem (requires the per-arch archive to be extracted first)."
+        ),
+    )
     args = parser.parse_args()
-    extract(archive=args.archive, target_platform=args.target_platform, repo_root=args.repo_root)
+    extract(
+        archive=args.archive,
+        target_platform=args.target_platform,
+        repo_root=args.repo_root,
+        config=args.config,
+    )
     return 0
 
 

--- a/qcom/scripts/all/extract_testdata.py
+++ b/qcom/scripts/all/extract_testdata.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+"""Extract a global testdata archive into per-platform on-disk locations.
+
+The archive has 4 top-level handles; each is re-mapped to where run_tests.{ps1,sh}
+and the test binaries expect to find it.
+"""
+
+import argparse
+import logging
+import shutil
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+QCOM_ROOT = Path(__file__).parent.parent.parent
+REPO_ROOT = QCOM_ROOT.parent
+
+# Each value is a format-string with placeholders {plat} and {config}.
+# {plat}   = "<os>-<arch>",  e.g. "linux-x86_64" or "windows-arm64"
+# {config} = build config dir, normally "Release" but "Release/Release" for
+#            Windows cross-compiled with a multi-config generator (VS).
+# Handle names must match _HANDLES in archive_testdata.py — keep in sync.
+MAPPING: dict[str, str] = {
+    "testdata": "build/{plat}/{config}/testdata",
+    "pytorch-converted": "build/{plat}/{config}/_deps/onnx-src/onnx/backend/test/data/pytorch-converted",
+    "pytorch-operator": "build/{plat}/{config}/_deps/onnx-src/onnx/backend/test/data/pytorch-operator",
+    # The `node` handle is REPO_ROOT-relative — {plat}/{config} placeholders are unused.
+    "node": "cmake/external/onnx/onnx/backend/test/data/node",
+}
+
+
+def _detect_config_dir(repo_root: Path, plat: str) -> str:
+    """Return 'Release/Release' for multi-config Windows builds, 'Release' otherwise.
+
+    Visual Studio generators create build/<plat>/Release/Release/ for cross-compiled
+    Windows targets (e.g. ARM64 built from an X64 host).  Detect by probing whether
+    that second-level directory already exists — which it will after the per-arch
+    test archive has been extracted (the caller must ensure that ordering).
+    """
+    if (repo_root / "build" / plat / "Release" / "Release").is_dir():
+        return "Release/Release"
+    return "Release"
+
+
+def _extract_to_staging(archive: Path, staging: Path) -> None:
+    """Extract archive into staging dir. Supports .zip and .tar.bz2."""
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(staging)
+    elif archive.name.endswith(".tar.bz2") or archive.suffix in (".tbz2", ".bz2"):
+        with tarfile.open(archive, "r:bz2") as tf:
+            try:
+                tf.extractall(staging, filter="data")
+            except TypeError:
+                # filter= parameter added in Python 3.12; fall back for older runtimes.
+                tf.extractall(staging)
+    else:
+        raise ValueError(f"Unsupported archive format: {archive}")
+
+
+def extract(archive: Path, target_platform: str, repo_root: Path = REPO_ROOT) -> None:
+    """Extract testdata archive and re-map its 4 handles to expected on-disk paths.
+
+    The per-arch test archive must already be extracted into repo_root before calling
+    this function so that _detect_config_dir() can probe for the multi-config layout.
+    """
+    config_dir = _detect_config_dir(repo_root, target_platform)
+    with tempfile.TemporaryDirectory(prefix="extract-testdata-") as tmp:
+        staging = Path(tmp)
+        _extract_to_staging(archive, staging)
+
+        present_handles = {p.name for p in staging.iterdir() if p.is_dir()}
+        unknown = present_handles - set(MAPPING.keys())
+        if unknown:
+            raise ValueError(f"Archive contains unexpected top-level entries: {sorted(unknown)}")
+
+        for handle, rel_template in MAPPING.items():
+            src = staging / handle
+            if not src.exists():
+                logging.warning("Handle %r missing from archive — skipping.", handle)
+                continue
+            dest = repo_root / rel_template.format(plat=target_platform, config=config_dir)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.move(str(src), str(dest))
+
+
+def main() -> int:
+    log_format = "[%(asctime)s] [extract_testdata.py] [%(levelname)s] %(message)s"
+    logging.basicConfig(level=logging.INFO, format=log_format, force=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target-platform", required=True, help='e.g., "linux-x86_64", "windows-arm64"')
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root; defaults to REPO_ROOT inferred from script location.",
+    )
+    args = parser.parse_args()
+    extract(archive=args.archive, target_platform=args.target_platform, repo_root=args.repo_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qcom/scripts/all/qdc_runner.py
+++ b/qcom/scripts/all/qdc_runner.py
@@ -10,6 +10,7 @@ import os
 import random
 import shutil
 import signal
+import tarfile
 import tempfile
 import time
 import uuid
@@ -23,6 +24,7 @@ from typing import ClassVar, NamedTuple
 
 import backoff
 import requests
+from extract_testdata import MAPPING as _TESTDATA_MAPPING
 from package_manager import PackageManager
 from prettytable import PrettyTable
 from qualcomm_device_cloud_sdk import Client
@@ -891,6 +893,13 @@ class RunnerCli:
             help="Append the contents of this package to the Windows test archive in the given subdirectory.",
             required=False,
         )
+        parser.add_argument(
+            "--testdata-archive",
+            type=Path,
+            help="Path to onnxruntime-testdata.{zip,tar.bz2}; if set, its 4 handles are merged into each per-platform archive.",
+            required=False,
+            default=None,
+        )
         args = parser.parse_args()
 
         provided_name = args.name[:100].replace("/", "_")
@@ -910,8 +919,37 @@ class RunnerCli:
         self.append_android_package: str = args.append_android_package
         self.append_qli_package: str = args.append_qli_package
         self.append_windows_package: str = args.append_windows_package
+        self.testdata_archive: Path | None = args.testdata_archive
 
         logging.info(f"Initialized runner. Test name prefix={self.test_name}")
+
+    def _resolve_testdata_archive(self) -> "Path | None":
+        """Resolve the testdata archive path, probing both .zip and .tar.bz2 formats.
+
+        Returns the path if found in either format, or None with a warning if missing.
+        Handles the case where a Linux runner downloads .tar.bz2 but the QdcTestsTask
+        hardcodes the .zip path.
+        """
+        if self.testdata_archive is None:
+            return None
+        if self.testdata_archive.exists():
+            return self.testdata_archive
+        # Probe the alternate format (.zip <-> .tar.bz2).
+        name = self.testdata_archive.name
+        if name.endswith(".tar.bz2"):
+            alt = self.testdata_archive.parent / (name[: -len(".tar.bz2")] + ".zip")
+        elif name.endswith(".zip"):
+            alt = self.testdata_archive.parent / (name[: -len(".zip")] + ".tar.bz2")
+        else:
+            alt = None
+        if alt is not None and alt.exists():
+            logging.info("Testdata archive %s not found; using %s instead", self.testdata_archive, alt)
+            return alt
+        logging.warning(
+            "Testdata archive not found at %s (or alternate format) — testdata will NOT be merged into the QDC payload",
+            self.testdata_archive,
+        )
+        return None
 
     def run(self) -> bool:
         test_runs = TestRuns()
@@ -922,18 +960,36 @@ class RunnerCli:
 
         # If you change this temp dir's prefix, please also update the QDC CI job, which attempts to clean
         # up after us if we're killed and don't do it outselves.
+        testdata_archive = self._resolve_testdata_archive()
         with tempfile.TemporaryDirectory(prefix="QdcRunner-") as tmpdir:
             if android_archive.exists():
                 android_archive = self.__append_package(
-                    android_archive, Path(tmpdir), self.append_android_package, Platform.ANDROID
+                    android_archive,
+                    Path(tmpdir),
+                    self.append_android_package,
+                    Platform.ANDROID,
+                    testdata_archive=testdata_archive,
+                    target_platform_for_testdata="android-aarch64",
                 )
             if qli_archive.exists():
                 qli_archive = self.__append_package(
-                    qli_archive, Path(tmpdir), self.append_qli_package, Platform.QUALCOMM_LINUX
+                    qli_archive,
+                    Path(tmpdir),
+                    self.append_qli_package,
+                    Platform.QUALCOMM_LINUX,
+                    testdata_archive=testdata_archive,
+                    target_platform_for_testdata="linux-aarch64_oe_gcc11_2",
                 )
             if windows_archive.exists():
                 windows_archive = self.__append_package(
-                    windows_archive, Path(tmpdir), self.append_windows_package, None
+                    windows_archive,
+                    Path(tmpdir),
+                    self.append_windows_package,
+                    None,
+                    testdata_archive=testdata_archive,
+                    # QDC currently supports Windows ARM64 only; update if QDC gains
+                    # multi-platform support for testdata path re-mapping.
+                    target_platform_for_testdata="windows-arm64",
                 )
 
             with TemporarySignalHandler(lambda sig, frame: test_runs.abort()):
@@ -1013,16 +1069,57 @@ class RunnerCli:
             archive.write(file_to_archive, arcname)
 
     @classmethod
+    def __merge_testdata(
+        cls,
+        archive_path: Path,
+        testdata_archive: Path,
+        target_platform: str,
+    ) -> None:
+        """Re-pack the 4 handles from the testdata archive into the per-platform QDC payload."""
+        suffix = ".tar.bz2" if testdata_archive.name.endswith(".tar.bz2") else testdata_archive.suffix
+        with tempfile.TemporaryDirectory(prefix="QdcMergeTestdata-") as tmp:
+            staging = Path(tmp)
+            if suffix == ".zip":
+                with zipfile.ZipFile(testdata_archive) as zf:
+                    zf.extractall(staging)
+            else:
+                with tarfile.open(testdata_archive, "r:bz2") as tf:
+                    try:
+                        tf.extractall(staging, filter="data")
+                    except TypeError:
+                        # filter= parameter added in Python 3.12; fall back for older runtimes.
+                        tf.extractall(staging)
+
+            with zipfile.ZipFile(archive_path, mode="a") as out_zip:
+                for handle, rel_template in _TESTDATA_MAPPING.items():
+                    src = staging / handle
+                    if not src.exists():
+                        continue
+                    # QDC payloads always use a flat Release/ layout regardless of build config.
+                    target_prefix = rel_template.format(plat=target_platform, config="Release")
+                    for p in src.glob("**/*"):
+                        if p.is_file():
+                            arcname = f"{target_prefix}/{p.relative_to(src).as_posix()}"
+                            out_zip.write(p, arcname)
+
+    @classmethod
     def __append_package(
         cls,
         orig_archive_path: Path,
         new_archive_dir: Path,
         package_and_subdir: str | None,
         append_appium: Platform | None,
+        testdata_archive: Path | None = None,
+        target_platform_for_testdata: str | None = None,
     ) -> Path:
         """Add the contents of a package and/or directory into the QDC payload archive."""
         new_archive_path = new_archive_dir / orig_archive_path.name
         shutil.copyfile(orig_archive_path, new_archive_path)
+
+        if testdata_archive is not None:
+            if target_platform_for_testdata is None:
+                raise ValueError("testdata_archive requires target_platform_for_testdata")
+            cls.__merge_testdata(new_archive_path, testdata_archive, target_platform_for_testdata)
 
         if package_and_subdir is not None:
             package, subdir = package_and_subdir.split(":")

--- a/qcom/scripts/all/tests/conftest.py
+++ b/qcom/scripts/all/tests/conftest.py
@@ -1,0 +1,9 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+"""pytest configuration: make qcom/scripts/all importable from this sub-directory."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/qcom/scripts/all/tests/test_archive_testdata.py
+++ b/qcom/scripts/all/tests/test_archive_testdata.py
@@ -1,0 +1,156 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from archive_testdata import OrtCoreDep, download_and_verify, parse_deps_txt, stage_sources, write_archives
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_parse_deps_txt_returns_url_and_sha1(tmp_path):
+    deps_file = tmp_path / "deps.txt"
+    deps_file.write_text(
+        "# Comment\n"
+        "abseil_cpp;https://example.com/abseil.zip;deadbeef\n"
+        "ort_core;https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.24.4.zip;c05dbfeb4841d9d1d0760ddb26d30d6d24352a67\n"
+        "onnx;https://example.com/onnx.zip;cafebabe\n"
+    )
+    result = parse_deps_txt(deps_file)
+    assert isinstance(result, OrtCoreDep)
+    assert result.url == "https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.24.4.zip"
+    assert result.sha1 == "c05dbfeb4841d9d1d0760ddb26d30d6d24352a67"
+
+
+def test_parse_deps_txt_raises_when_ort_core_missing(tmp_path):
+    deps_file = tmp_path / "deps.txt"
+    deps_file.write_text("abseil_cpp;https://example.com/abseil.zip;deadbeef\n")
+    with pytest.raises(ValueError, match="ort_core"):
+        parse_deps_txt(deps_file)
+
+
+def _make_fake_zip(path: Path) -> str:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("hello.txt", "world")
+    return hashlib.sha1(path.read_bytes()).hexdigest()
+
+
+def test_download_and_verify_uses_cache_when_sha_matches(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    fake_zip = cache_dir / "ort_core.zip"
+    sha1 = _make_fake_zip(fake_zip)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("urlretrieve should not be called when cache is valid")
+
+    monkeypatch.setattr("archive_testdata.urlretrieve", fail_if_called)
+
+    result = download_and_verify(
+        url="https://example.invalid/should-not-fetch.zip",
+        sha1=sha1,
+        cache_path=fake_zip,
+    )
+    assert result == fake_zip
+
+
+def test_download_and_verify_removes_stale_cache_and_redownloads(tmp_path, monkeypatch):
+    """Stale cached zip (wrong SHA) is deleted and re-fetched automatically."""
+    stale_zip = tmp_path / "ort_core.zip"
+    # Write a zip with different content from what we'll claim the "fresh" download has.
+    with zipfile.ZipFile(stale_zip, "w") as zf:
+        zf.writestr("stale.txt", "old content")
+
+    # A second zip that urlretrieve will "download" — has a known SHA1.
+    fresh_zip = tmp_path / "fresh.zip"
+    fresh_sha1 = _make_fake_zip(fresh_zip)  # {"hello.txt": "world"}
+
+    calls: list[str] = []
+
+    def fake_urlretrieve(url: str, path: str) -> None:
+        calls.append(path)
+        shutil.copy(str(fresh_zip), path)
+
+    monkeypatch.setattr("archive_testdata.urlretrieve", fake_urlretrieve)
+
+    result = download_and_verify(
+        url="https://example.invalid/",
+        sha1=fresh_sha1,
+        cache_path=stale_zip,
+    )
+    assert len(calls) == 1, "urlretrieve must be called exactly once for the stale-cache case"
+    assert result == stale_zip
+    assert stale_zip.exists()
+
+
+def test_download_and_verify_raises_on_fresh_download_sha_mismatch(tmp_path, monkeypatch):
+    """When the freshly downloaded file doesn't match the expected SHA, raise ValueError."""
+    cache = tmp_path / "ort_core.zip"
+    downloaded = tmp_path / "downloaded.zip"
+    _make_fake_zip(downloaded)  # has a real SHA1 ≠ "0"*40
+
+    def fake_urlretrieve(url: str, path: str) -> None:
+        shutil.copy(str(downloaded), path)
+
+    monkeypatch.setattr("archive_testdata.urlretrieve", fake_urlretrieve)
+
+    with pytest.raises(ValueError, match="SHA1 mismatch"):
+        download_and_verify(
+            url="https://example.invalid/",
+            sha1="0" * 40,
+            cache_path=cache,
+        )
+
+
+def _make_tree(root: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+
+def test_stage_sources_lays_out_four_handles(tmp_path):
+    ort_core_src = tmp_path / "ort_core"
+    onnx_src = tmp_path / "onnx"
+    _make_tree(ort_core_src / "onnxruntime/test/testdata", {"a.onnx": "TD-A"})
+    _make_tree(onnx_src / "backend/test/data/pytorch-converted", {"x.pb": "PC-X"})
+    _make_tree(onnx_src / "backend/test/data/pytorch-operator", {"y.pb": "PO-Y"})
+    _make_tree(onnx_src / "backend/test/data/node", {"z.pb": "ND-Z"})
+
+    stage = tmp_path / "stage"
+    stage_sources(
+        stage_root=stage,
+        ort_core_src=ort_core_src,
+        onnx_src=onnx_src,
+    )
+    assert (stage / "testdata" / "a.onnx").read_text() == "TD-A"
+    assert (stage / "pytorch-converted" / "x.pb").read_text() == "PC-X"
+    assert (stage / "pytorch-operator" / "y.pb").read_text() == "PO-Y"
+    assert (stage / "node" / "z.pb").read_text() == "ND-Z"
+
+
+def test_write_archives_emits_zip_and_tar_bz2(tmp_path):
+    stage = tmp_path / "stage"
+    _make_tree(stage / "testdata", {"a.onnx": "A"})
+    _make_tree(stage / "pytorch-converted", {"b.pb": "B"})
+    _make_tree(stage / "pytorch-operator", {"c.pb": "C"})
+    _make_tree(stage / "node", {"d.pb": "D"})
+
+    out = tmp_path / "out"
+    out.mkdir()
+    written = write_archives(stage_root=stage, output_dir=out)
+
+    assert sorted(p.name for p in written) == ["onnxruntime-testdata.tar.bz2", "onnxruntime-testdata.zip"]
+
+    with zipfile.ZipFile(out / "onnxruntime-testdata.zip") as z:
+        names = sorted(z.namelist())
+    assert names == ["node/d.pb", "pytorch-converted/b.pb", "pytorch-operator/c.pb", "testdata/a.onnx"]
+
+    with tarfile.open(out / "onnxruntime-testdata.tar.bz2", "r:bz2") as t:
+        names = sorted(m.name for m in t.getmembers() if m.isfile())
+    assert names == ["node/d.pb", "pytorch-converted/b.pb", "pytorch-operator/c.pb", "testdata/a.onnx"]

--- a/qcom/scripts/all/tests/test_archive_tests.py
+++ b/qcom/scripts/all/tests/test_archive_tests.py
@@ -1,0 +1,171 @@
+# qcom/scripts/all/test_archive_tests.py
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import tarfile
+from pathlib import Path
+
+import pytest
+from archive_tests import (
+    PerArchAcceptRules,
+    archive_linux,
+)
+
+
+def _touch(p: Path, content: str = "") -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+@pytest.fixture
+def per_arch_rules() -> PerArchAcceptRules:
+    return PerArchAcceptRules()
+
+
+# --- accept-list rule unit tests ---
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "onnxruntime.dll",
+        "onnxruntime_providers_qnn.dll",
+        "libonnxruntime.so",
+        "libonnxruntime.so.1.24.4",
+        "libQnnHtp.so",
+        "QnnHtpV73Skel.cat",
+        "MockGenie.dll",
+    ],
+)
+def test_accepts_top_level_binaries_by_extension(per_arch_rules, name):
+    assert per_arch_rules.accept_top_level(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "onnxruntime_provider_test",
+        "onnxruntime_perf_test",
+        "onnxruntime_plugin_ep_onnx_test",
+    ],
+)
+def test_accepts_linux_top_level_executables_no_extension(per_arch_rules, tmp_path, name):
+    p = tmp_path / name
+    _touch(p)
+    p.chmod(p.stat().st_mode | 0o100)  # +x
+    assert per_arch_rules.accept_top_level_with_path(p)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "CTestTestfile.cmake",
+        "run_tests.ps1",
+        "run_tests.sh",
+        "ctest",
+        "ctest.exe",
+        "python_test_files.txt",
+        "onnxruntime_test_python.py",
+        "onnxruntime_test_python_compile_api.py",
+    ],
+)
+def test_accepts_top_level_test_drivers(per_arch_rules, name):
+    assert per_arch_rules.accept_top_level(name)
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "quantization/run_tests.py",
+        "quantization/__init__.py",
+    ],
+)
+def test_accepts_quantization_tree(per_arch_rules, rel):
+    assert per_arch_rules.accept_repo_relative(Path(rel))
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "_deps/onnx-src/onnx/backend/test/data/pytorch-converted/test_x/model.onnx",
+        "testdata/float32/model.onnx",
+        "_deps/abseil_cpp-src/foo/bar.cc",
+        "bin/something",
+        "lib/libfoo.a",
+        "dist/onnxruntime_qnn-1.24.4.whl",
+        "docs/index.html",
+        "LICENSE",
+        "Privacy.md",
+        "Qualcomm_LICENSE.pdf",
+        "ThirdPartyNotices.txt",
+        "compile_commands.json",
+        "build.ninja",
+        "CMakeFiles/foo.txt",
+        "CMakeCache.txt",
+    ],
+)
+def test_rejects_dropped_paths(per_arch_rules, rel):
+    assert not per_arch_rules.accept_repo_relative(Path(rel))
+
+
+# --- providers_qnn anywhere-rule ---
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "subdir/libonnxruntime_providers_qnn.so",
+        "deeper/path/onnxruntime_providers_qnn.dll",
+    ],
+)
+def test_accepts_providers_qnn_in_any_subdir(per_arch_rules, rel):
+    assert per_arch_rules.accept_repo_relative(Path(rel))
+
+
+# --- end-to-end archive smoke ---
+
+
+def test_archive_linux_excludes_testdata(tmp_path):
+    """Build a fake Release tree, run archive_linux, confirm testdata is NOT in the archive."""
+    repo_root = tmp_path / "repo"
+    build_root = repo_root / "build"
+    plat = "linux-x86_64"
+    rel = build_root / plat / "Release"
+    _touch(rel / "libonnxruntime.so", "B")
+    _touch(rel / "libQnnHtp.so", "B")
+    _touch(rel / "onnxruntime_provider_test", "B")
+    (rel / "onnxruntime_provider_test").chmod(0o755)
+    _touch(rel / "CTestTestfile.cmake", "ctest")
+    _touch(rel / "run_tests.sh", "#!/bin/sh")
+    (rel / "run_tests.sh").chmod(0o755)
+    _touch(rel / "python_test_files.txt", "")
+    _touch(rel / "onnxruntime_test_python.py", "")
+    _touch(rel / "quantization/__init__.py", "")
+    _touch(rel / "testdata/float32/model.onnx", "DROP-ME")
+    _touch(rel / "_deps/onnx-src/onnx/backend/test/data/pytorch-converted/foo/model.onnx", "DROP-ME")
+    _touch(rel / "_deps/onnx-src/onnx/backend/test/data/node/foo/model.onnx", "DROP-ME")
+    _touch(rel / "lib/libfoo.a", "DROP-ME")
+    _touch(rel / "subdir/libonnxruntime_providers_qnn.so", "B")
+    _touch(repo_root / "qcom/scripts/all/foo.py", "B")
+
+    archive_linux(target_platform=plat, config="Release", repo_root=repo_root)
+
+    archive = build_root / f"onnxruntime-tests-{plat}.tar.bz2"
+    assert archive.exists()
+
+    with tarfile.open(archive, "r:bz2") as tf:
+        names = sorted(m.name for m in tf.getmembers() if m.isfile())
+
+    # Sanity: binaries + scripts present
+    assert any(n.endswith("Release/libonnxruntime.so") for n in names)
+    assert any(n.endswith("Release/CTestTestfile.cmake") for n in names)
+    assert any(n.endswith("Release/run_tests.sh") for n in names)
+    assert any(n.endswith("Release/onnxruntime_provider_test") for n in names)
+    assert any(n.endswith("subdir/libonnxruntime_providers_qnn.so") for n in names)
+    assert any(n.endswith("qcom/scripts/all/foo.py") for n in names)
+
+    # CRUCIAL: testdata is NOT inside the archive
+    assert not any("testdata/" in n for n in names), [n for n in names if "testdata" in n]
+    assert not any("pytorch-converted" in n for n in names)
+    assert not any("backend/test/data/node" in n for n in names)
+    assert not any(n.endswith("libfoo.a") for n in names)

--- a/qcom/scripts/all/tests/test_archive_tests.py
+++ b/qcom/scripts/all/tests/test_archive_tests.py
@@ -137,6 +137,19 @@ def test_rejects_providers_qnn_non_shared_library(per_arch_rules, rel):
     assert not per_arch_rules.accept_repo_relative(Path(rel))
 
 
+# AAR-build test APKs must be included so test_aar.py runs the instrumentation suite
+# instead of silently skipping with "AAR APKs not in test archive".
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "java/androidtest/android/app/build/outputs/apk/debug/app-debug.apk",
+        "java/androidtest/android/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
+    ],
+)
+def test_accepts_aar_test_apks(per_arch_rules, rel):
+    assert per_arch_rules.accept_repo_relative(Path(rel))
+
+
 # --- end-to-end archive smoke ---
 
 

--- a/qcom/scripts/all/tests/test_archive_tests.py
+++ b/qcom/scripts/all/tests/test_archive_tests.py
@@ -122,6 +122,21 @@ def test_accepts_providers_qnn_in_any_subdir(per_arch_rules, rel):
     assert per_arch_rules.accept_repo_relative(Path(rel))
 
 
+# Non-shared-library variants must NOT be re-bundled — PDBs ship via upload_pdb_archive,
+# .lib/.exp/.a are link-only artifacts that bloat the per-arch archive.
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "subdir/onnxruntime_providers_qnn.lib",
+        "subdir/onnxruntime_providers_qnn.exp",
+        "subdir/onnxruntime_providers_qnn.pdb",
+        "_deps/abseil_cpp-build/libonnxruntime_providers_qnn.a",
+    ],
+)
+def test_rejects_providers_qnn_non_shared_library(per_arch_rules, rel):
+    assert not per_arch_rules.accept_repo_relative(Path(rel))
+
+
 # --- end-to-end archive smoke ---
 
 

--- a/qcom/scripts/all/tests/test_extract_testdata.py
+++ b/qcom/scripts/all/tests/test_extract_testdata.py
@@ -1,0 +1,115 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from extract_testdata import MAPPING, extract
+
+
+def _make_archive(path: Path, files: dict[str, str]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for arcname, content in files.items():
+            zf.writestr(arcname, content)
+
+
+def test_mapping_contains_all_four_handles():
+    assert set(MAPPING.keys()) == {"testdata", "pytorch-converted", "pytorch-operator", "node"}
+
+
+def test_extract_places_files_at_expected_paths(tmp_path):
+    archive = tmp_path / "td.zip"
+    _make_archive(
+        archive,
+        {
+            "testdata/a.onnx": "A",
+            "pytorch-converted/b.pb": "B",
+            "pytorch-operator/c.pb": "C",
+            "node/d.pb": "D",
+        },
+    )
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    extract(archive=archive, target_platform="linux-x86_64", repo_root=repo_root)
+    assert (repo_root / "build/linux-x86_64/Release/testdata/a.onnx").read_text() == "A"
+    assert (
+        repo_root / "build/linux-x86_64/Release/_deps/onnx-src/onnx/backend/test/data/pytorch-converted/b.pb"
+    ).read_text() == "B"
+    assert (
+        repo_root / "build/linux-x86_64/Release/_deps/onnx-src/onnx/backend/test/data/pytorch-operator/c.pb"
+    ).read_text() == "C"
+    assert (repo_root / "cmake/external/onnx/onnx/backend/test/data/node/d.pb").read_text() == "D"
+
+
+def test_extract_rejects_unknown_handle(tmp_path):
+    archive = tmp_path / "td.zip"
+    _make_archive(archive, {"unexpected/a.onnx": "A"})
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    with pytest.raises(ValueError, match="unexpected"):
+        extract(archive=archive, target_platform="linux-x86_64", repo_root=repo_root)
+
+
+def test_extract_supports_tar_bz2(tmp_path):
+    archive = tmp_path / "td.tar.bz2"
+    src = tmp_path / "src"
+    (src / "testdata").mkdir(parents=True)
+    (src / "testdata" / "a.onnx").write_text("A")
+    (src / "pytorch-converted").mkdir()
+    (src / "pytorch-converted" / "b.pb").write_text("B")
+    (src / "pytorch-operator").mkdir()
+    (src / "pytorch-operator" / "c.pb").write_text("C")
+    (src / "node").mkdir()
+    (src / "node" / "d.pb").write_text("D")
+    with tarfile.open(archive, "w:bz2") as tf:
+        for p in src.glob("**/*"):
+            if p.is_file():
+                tf.add(p, str(p.relative_to(src)))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    extract(archive=archive, target_platform="linux-aarch64_oe_gcc11_2", repo_root=repo_root)
+    assert (repo_root / "build/linux-aarch64_oe_gcc11_2/Release/testdata/a.onnx").read_text() == "A"
+
+
+def test_extract_cli_repo_root(tmp_path):
+    """Verify --repo-root directs output to a custom location."""
+    archive = tmp_path / "td.zip"
+    _make_archive(archive, {"testdata/a.onnx": "A"})
+    custom_root = tmp_path / "custom_root"
+    custom_root.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parent.parent / "extract_testdata.py"),
+            "--target-platform",
+            "linux-x86_64",
+            "--archive",
+            str(archive),
+            "--repo-root",
+            str(custom_root),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (custom_root / "build/linux-x86_64/Release/testdata/a.onnx").exists()
+
+
+def test_extract_uses_release_release_for_multiconfig_windows(tmp_path):
+    """When Release/Release/ already exists (multi-config VS build), testdata goes there."""
+    archive = tmp_path / "td.zip"
+    _make_archive(archive, {"testdata/a.onnx": "A", "node/d.pb": "D"})
+    repo_root = tmp_path / "repo"
+    # Simulate a previously-extracted per-arch archive that has Release/Release/ binaries.
+    (repo_root / "build/windows-arm64/Release/Release").mkdir(parents=True)
+    extract(archive=archive, target_platform="windows-arm64", repo_root=repo_root)
+    # testdata must land inside Release/Release/, not Release/
+    assert (repo_root / "build/windows-arm64/Release/Release/testdata/a.onnx").read_text() == "A"
+    assert not (repo_root / "build/windows-arm64/Release/testdata").exists()
+    # node is repo-root-relative; unaffected by multi-config detection
+    assert (repo_root / "cmake/external/onnx/onnx/backend/test/data/node/d.pb").read_text() == "D"

--- a/qcom/scripts/all/tests/test_extract_testdata.py
+++ b/qcom/scripts/all/tests/test_extract_testdata.py
@@ -8,6 +8,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from archive_testdata import _HANDLES
 from extract_testdata import MAPPING, extract
 
 
@@ -19,6 +20,15 @@ def _make_archive(path: Path, files: dict[str, str]) -> None:
 
 def test_mapping_contains_all_four_handles():
     assert set(MAPPING.keys()) == {"testdata", "pytorch-converted", "pytorch-operator", "node"}
+
+
+def test_handles_match_extract_mapping():
+    """Contract: archive_testdata._HANDLES and extract_testdata.MAPPING must declare the same handle set.
+
+    qdc_runner.py also imports MAPPING; a key drift between producer (archive_testdata) and
+    consumers (extract_testdata, qdc_runner) silently breaks testdata layout on at least one platform.
+    """
+    assert set(_HANDLES.keys()) == set(MAPPING.keys())
 
 
 def test_extract_places_files_at_expected_paths(tmp_path):


### PR DESCRIPTION
Today every per-arch CI job uploads ~250 MB, most of which is byte-identical testdata across all architectures. This PR splits the single archive into two:

- onnxruntime-tests-<os>-<arch>.{zip,tar.bz2}: binaries + scripts only
- onnxruntime-testdata.{zip,tar.bz2}: shared testdata, built once per workflow by a new reusable job (qualcomm-internal-archive-testdata.yml)


