### PR TITLE
Coverage: disable PR comment and echo diff summary to CI log

### DIFF
--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -81,13 +81,16 @@ jobs:
         run: |
           txt="${COVERAGE_DIR}/diff-coverage.txt"
           if [ -f "${txt}" ]; then
+            cat "${txt}"
             echo '```' >> "${GITHUB_STEP_SUMMARY}"
             cat "${txt}" >> "${GITHUB_STEP_SUMMARY}"
             echo '```' >> "${GITHUB_STEP_SUMMARY}"
           fi
 
       - name: Post Diff Coverage to PR
-        if: steps.gate.outputs.run == 'true' && github.event_name != 'workflow_dispatch'
+        # TODO: re-enable once the coverage pipeline is stable.
+        # if: steps.gate.outputs.run == 'true' && github.event_name != 'workflow_dispatch'
+        if: false
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
### Description
- Disable "Post Diff Coverage to PR" step while the pipeline stabilizes. The original condition is preserved in a comment for easy re-enable.
- Also print diff-coverage.txt to stdout so the result is visible directly in the CI step log, in addition to the workflow summary.


