### PR TITLE
feat: add IsInf op builder to QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -32,6 +32,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateIdentityOpBuilder("Identity", *this);
   CreateInstanceNormalizationOpBuilder("InstanceNormalization", *this);
   CreateInverseOpBuilder("Inverse", *this);
+  CreateIsInfOpBuilder("IsInf", *this);
   CreateIsNaNOpBuilder("IsNaN", *this);
   CreateLayerNormalizationOpBuilder("LayerNormalization", *this);
   CreateLRNOpBuilder("LRN", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -76,6 +76,7 @@ void CreateHardSigmoidOpBuilder(const std::string& op_type, OpBuilderRegistratio
 void CreateIdentityOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateInstanceNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateInverseOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateIsInfOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateIsNaNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLayerNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateLRNOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/isinf_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/isinf_op_builder.cc
@@ -1,0 +1,133 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class IsInfOpBuilder : public BaseOpBuilder {
+ public:
+  IsInfOpBuilder() : BaseOpBuilder("IsInfOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(IsInfOpBuilder);
+
+  // Override IsOpSupported to decline IsInf on the NPU/HTP backend (see implementation).
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Ort::Status IsInfOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          const Ort::Logger& logger) const {
+  // IsInf is declined on the NPU/HTP backend. The QnnHtp op-config validator accepts the node
+  // (so it would be claimed during partitioning), but graphFinalize then fails with error 1002
+  // (QNN_COMMON_ERROR_MEM_ALLOC): the only registered HTP IsInf kernel is fp16 crouton-tiled
+  // (IsInf.*@CB.Ce.t*2) with no TCM/flat fallback, so finalize cannot allocate it and the whole
+  // QNN subgraph fails to compile at session creation. Declining here lets ORT fall IsInf back to
+  // the CPU EP instead of failing to load any model that contains it.
+  RETURN_IF(IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()),
+            "QNN EP does not support IsInf on the HTP backend "
+            "(graphFinalize fails with error 1002 / QNN_COMMON_ERROR_MEM_ALLOC).");
+  return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
+}
+
+Ort::Status IsInfOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          const Ort::Logger& logger,
+                                          std::vector<std::string>& input_names,
+                                          bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+
+  if (do_op_validation) {
+    TensorInfo input_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
+    Qnn_DataType_t target_tensor_type = input_info.qnn_data_type;
+
+    RETURN_IF((QNN_DATATYPE_FLOAT_32 != target_tensor_type && QNN_DATATYPE_FLOAT_16 != target_tensor_type),
+              "QNN IsInf Op supports only float32 and float16 input tensors.");
+  }
+  const auto input_count = GetInputCountQnnRequired(node_unit);
+  for (size_t input_i = 0; input_i < input_count; ++input_i) {
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[input_i], logger, input_names));
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status IsInfOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                        const OrtNodeUnit& node_unit,
+                                                        std::vector<std::string>&& input_names,
+                                                        const Ort::Logger& logger,
+                                                        bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+
+  // ONNX IsInf detect_positive / detect_negative default to 1 (detect both).
+  OrtNodeAttrHelper node_helper(node_unit);
+  const bool detect_positive = node_helper.Get("detect_positive", static_cast<int64_t>(1)) != 0;
+  const bool detect_negative = node_helper.Get("detect_negative", static_cast<int64_t>(1)) != 0;
+
+  std::vector<std::string> param_tensor_names;
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper,
+                                     node_unit.Index(),
+                                     node_unit.Name(),
+                                     detect_positive,
+                                     QNN_OP_IS_INF_PARAM_DETECT_POSITIVE,
+                                     param_tensor_names));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper,
+                                     node_unit.Index(),
+                                     node_unit.Name(),
+                                     detect_negative,
+                                     QNN_OP_IS_INF_PARAM_DETECT_NEGATIVE,
+                                     param_tensor_names));
+
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+  if (do_op_validation) {
+    RETURN_IF(QNN_DATATYPE_BOOL_8 != output_info.qnn_data_type, "QNN IsInf Op supports only bool8 output tensor.");
+  }
+  const std::string& org_output_name = node_unit.Outputs()[0].name;
+  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
+  std::vector<uint32_t> output_shape = output_info.shape;
+  const std::string isinf_node_name = utils::UniqueNameGenerator().New(node_unit, "_IsInf");
+
+  QnnTensorWrapper isinf_output(org_output_name,
+                                is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
+                                output_info.qnn_data_type,
+                                output_info.quant_param.Copy(),
+                                std::move(output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(isinf_output)), "Failed to add tensor.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(isinf_node_name,
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_IS_INF,
+                                                {input_names[0]},
+                                                {org_output_name},
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
+                "Failed to create QNN IsInf node.");
+
+  return Ort::Status();
+}
+
+void CreateIsInfOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<IsInfOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/isinf_test.cc
+++ b/onnxruntime/test/providers/qnn/isinf_test.cc
@@ -1,0 +1,121 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+template <typename DataType>
+static void RunIsInfTest(const std::vector<TestInputDef<DataType>>& input_defs,
+                         const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                         ExpectedEPNodeAssignment expected_ep_assignment,
+                         float fp32_abs_err = 1e-5,
+                         const std::string& backend_name = "cpu",
+                         int opset = 20,
+                         bool enable_htp_fp16_precision = false) {
+  ProviderOptions provider_options;
+
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+  if (enable_htp_fp16_precision) {
+    provider_options["enable_htp_fp16_precision"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+    provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  }
+
+  RunQnnModelTest(BuildOpTestCase<DataType>("isinf_node", "IsInf", input_defs, {}, attrs, kOnnxDomain),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  fp32_abs_err);
+}
+
+TEST_F(QnnCPUBackendTests, IsInfScalarPosInf) {
+  const std::vector<int64_t> input_shape{};
+  const std::vector<float> input_data{std::numeric_limits<float>::infinity()};
+
+  RunIsInfTest<float>({TestInputDef<float>(input_shape, false, input_data)},
+                      {},
+                      ExpectedEPNodeAssignment::All,
+                      0.0f);
+}
+
+TEST_F(QnnCPUBackendTests, IsInfMix2D) {
+  const std::vector<int64_t> input_shape{2, 4};
+  const std::vector<float> input_data{
+      std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), 1.0f, 2.0f,
+      3.0f, 4.0f, std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()};
+
+  RunIsInfTest<float>({TestInputDef<float>(input_shape, false, input_data)},
+                      {},
+                      ExpectedEPNodeAssignment::All,
+                      0.0f);
+}
+
+TEST_F(QnnCPUBackendTests, IsInfDetectPositiveOnly) {
+  const std::vector<int64_t> input_shape{2, 2};
+  const std::vector<float> input_data{
+      std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), 0.0f, 1.0f};
+
+  std::vector<ONNX_NAMESPACE::AttributeProto> attrs;
+  attrs.push_back(test::MakeAttribute("detect_positive", static_cast<int64_t>(1)));
+  attrs.push_back(test::MakeAttribute("detect_negative", static_cast<int64_t>(0)));
+
+  RunIsInfTest<float>({TestInputDef<float>(input_shape, false, input_data)},
+                      attrs,
+                      ExpectedEPNodeAssignment::All,
+                      0.0f);
+}
+
+TEST_F(QnnCPUBackendTests, IsInfDetectNegativeOnly) {
+  const std::vector<int64_t> input_shape{2, 2};
+  const std::vector<float> input_data{
+      std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), 0.0f, 1.0f};
+
+  std::vector<ONNX_NAMESPACE::AttributeProto> attrs;
+  attrs.push_back(test::MakeAttribute("detect_positive", static_cast<int64_t>(0)));
+  attrs.push_back(test::MakeAttribute("detect_negative", static_cast<int64_t>(1)));
+
+  RunIsInfTest<float>({TestInputDef<float>(input_shape, false, input_data)},
+                      attrs,
+                      ExpectedEPNodeAssignment::All,
+                      0.0f);
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// IsInf is intentionally declined on the HTP backend: the only registered HTP IsInf kernel
+// is fp16 crouton-tiled with no TCM/flat fallback, so QnnHtp graphFinalize fails with error
+// 1002 (QNN_COMMON_ERROR_MEM_ALLOC) even though op-config validation accepts the node. The
+// IsInfOpBuilder::IsOpSupported override rejects the NPU backend so ORT falls IsInf back to the
+// CPU EP. This test asserts that fallback: no node is assigned to QNN.
+TEST_F(QnnHTPBackendTests, IsInfMix2D) {
+  const std::vector<int64_t> input_shape{2, 4};
+  const std::vector<float> input_data{
+      std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), 1.0f, 2.0f,
+      3.0f, 4.0f, std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity()};
+
+  RunIsInfTest<float>({TestInputDef<float>(input_shape, false, input_data)},
+                      {},
+                      ExpectedEPNodeAssignment::None,
+                      0.0f,
+                      "htp",
+                      20,
+                      true);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
Maps ONNX IsInf -> QNN_OP_IS_INF, wiring the detect_positive and detect_negative ONNX attributes (default 1) to the corresponding QNN_DATATYPE_BOOL_8 scalar params. Without this, models containing IsInf (typically emitted by torch.nan_to_num decompositions) fall back to CPU and shatter the single-graph requirement of qnn_context_binary compilation.

Validates input is FP32/FP16 and output is BOOL_8 per the QNN op contract.
