### PR TITLE
[QNN-EP] mem leak issue found by ASan

### DIFF
--- a/onnxruntime/core/providers/qnn/genie/genie_node_compute_info.h
+++ b/onnxruntime/core/providers/qnn/genie/genie_node_compute_info.h
@@ -7,12 +7,13 @@
 
 #include "core/providers/qnn/genie/genie_node.h"
 #include "core/providers/qnn/ort_api.h"
+#include "core/providers/qnn/qnn_node_compute_info_base.h"
 
 namespace onnxruntime {
 
 class QnnEp;
 
-struct GenieNodeComputeInfo : OrtNodeComputeInfo {
+struct GenieNodeComputeInfo : QnnNodeComputeInfoBase {
   GenieNodeComputeInfo(QnnEp& ep, std::shared_ptr<GenieNodeBuilder> builder);
 
   static OrtStatus* ORT_API_CALL CreateStateImpl(OrtNodeComputeInfo* this_ptr,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2174,7 +2174,9 @@ void ORT_API_CALL QnnEp::ReleaseNodeComputeInfosImpl(OrtEp* this_ptr,
                                                      size_t num_node_compute_infos) noexcept {
   ORT_UNUSED_PARAMETER(this_ptr);
   for (size_t idx = 0; idx < num_node_compute_infos; ++idx) {
-    delete node_compute_infos[idx];
+    // All derived types share QnnNodeComputeInfoBase, which provides the virtual destructor
+    // required to safely delete through the OrtNodeComputeInfo C-API base.
+    delete static_cast<QnnNodeComputeInfoBase*>(node_compute_infos[idx]);
   }
 }
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -21,6 +21,7 @@
 #include "core/providers/qnn/builder/onnx_ctx_model_helper.h"
 #include "core/providers/qnn/qnn_telemetry.h"
 #include "core/providers/qnn/rpcmem_library.h"
+#include "core/providers/qnn/qnn_node_compute_info_base.h"
 #include "core/providers/qnn/genie/genie_api_loader.h"
 #include "core/providers/qnn/genie/genie_node.h"
 #include "core/providers/qnn/genie/genie_node_compute_info.h"
@@ -128,7 +129,7 @@ class QnnEp : public OrtEp, public ApiPtrs {
     return GetProviderOptionPrefix(name_) + key;
   }
 
-  struct QnnNodeComputeInfo : OrtNodeComputeInfo {
+  struct QnnNodeComputeInfo : QnnNodeComputeInfoBase {
     explicit QnnNodeComputeInfo(QnnEp& ep);
 
     static OrtStatus* ORT_API_CALL CreateStateImpl(OrtNodeComputeInfo* this_ptr,

--- a/onnxruntime/core/providers/qnn/qnn_node_compute_info_base.h
+++ b/onnxruntime/core/providers/qnn/qnn_node_compute_info_base.h
@@ -1,0 +1,19 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+
+// Internal C++ base class for all QNN EP node compute info objects.
+// Provides a virtual destructor so derived objects stored as
+// `OrtNodeComputeInfo*` can be safely deleted in `ReleaseNodeComputeInfosImpl`.
+// The C-API base `OrtNodeComputeInfo` is a POD struct with no virtual
+// destructor and cannot get one without breaking ABI.
+struct QnnNodeComputeInfoBase : OrtNodeComputeInfo {
+  virtual ~QnnNodeComputeInfoBase() = default;
+};
+
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3655,6 +3655,7 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_GetCompatibility) {
     CompatibilityTestInfo expected_info;
     expected_info.htp_arch = htp_arch;
     ASSERT_TRUE(val != nullptr && expected_info.ToString() == val);
+    free(val);
 
     Ort::GetApi().ReleaseModelMetadata(model_metadata);
   }

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -258,7 +258,7 @@ void RunAndVerifyOutputsWithEP(ModelPathOrBytes model_path_or_bytes,
   Ort::AllocatorWithDefaultOptions allocator;
   for (size_t i = 0; i < output_count; ++i) {
     auto output_name = cpu_session.GetOutputNameAllocated(i, allocator);
-    output_names.push_back(output_name.release());
+    output_names.push_back(output_name.get());
   }
 
   Ort::RunOptions cpu_run_options;


### PR DESCRIPTION
## Summary

Fix three issues found by AddressSanitizer on Linux x86_64:
1. **Heap UB** — `new-delete-type-mismatch` on every session destruction (`qnn_execution_provider.cc`)
2. **Memory leak** — output name `char*` leaked in test utility (`test_utils.cc`)
3. **Memory leak** — metadata lookup `char*` leaked in EP context test (`qnn_ep_context_test.cc`)

---

## Fix 1 — `new-delete-type-mismatch` (qnn_execution_provider.cc:2177)

### ASan finding
```
==XXXX==ERROR: AddressSanitizer: new-delete-type-mismatch
  allocated:   40 bytes;
  deallocated: 32 bytes.
    #1 onnxruntime::QnnEp::ReleaseNodeComputeInfosImpl
       qnn_execution_provider.cc:2177
```
Trigger: `./onnxruntime_provider_test --gtest_filter='QnnHTPBackendTests.ConvU16S4S32_PerChannel'`

### Root cause
`CompileImpl` may allocate either `QnnNodeComputeInfo` (40B, regular path) or `GenieNodeComputeInfo` (56B, DLC context model path), and stores both as `OrtNodeComputeInfo*`. The release callback deleted through the C-API base pointer (`OrtNodeComputeInfo*`, 32B), which is a POD with no virtual destructor — the wrong destructor runs and the wrong size is passed to `operator delete`. For `GenieNodeComputeInfo` this also leaks the embedded `std::shared_ptr<GenieNodeBuilder>`.

### Fix
`OrtNodeComputeInfo` is a public C-API struct and cannot get a virtual destructor (ABI break). Introduce an internal C++ base `QnnNodeComputeInfoBase` with a virtual destructor; both `QnnNodeComputeInfo` and `GenieNodeComputeInfo` inherit from it. Release casts via the base so virtual dispatch picks the correct derived destructor.

```cpp
// New: qnn_node_compute_info_base.h
struct QnnNodeComputeInfoBase : OrtNodeComputeInfo {
  virtual ~QnnNodeComputeInfoBase() = default;
};

// Release callback
delete static_cast<QnnNodeComputeInfoBase*>(node_compute_infos[idx]);
```

---

## Fix 2 — output name leak (test_utils.cc:260)

### ASan finding
```
Direct leak of N byte(s) in 1 object(s) allocated from:
    #0 operator new
    #5 onnxruntime::StrDup
    #8 OrtApis::SessionGetOutputName
    #9 Ort::ConstSessionImpl::GetOutputNameAllocated
    #10 onnxruntime::test::RunAndVerifyOutputsWithEP
        test_utils.cc:260
```
Trigger: any test that goes through `RunQnnModelTest`, e.g. `QnnHTPBackendTests.RMSNorm1D_LastAxis`.

### Root cause
`GetOutputNameAllocated` returns `AllocatedStringPtr` (a `unique_ptr` with the ORT allocator's deleter). Calling `.release()` transferred ownership to the caller, but the raw `char*` was never freed.

### Fix
`output_names` is `std::vector<std::string>`. Switch to `.get()` so `std::string` copies the content and the smart ptr frees the original on scope exit.

```cpp
// Before
output_names.push_back(output_name.release());  // leaks char*

// After
output_names.push_back(output_name.get());      // std::string copies; smart ptr frees
```

---

## Fix 3 — metadata val leak (qnn_ep_context_test.cc:3652)

### ASan finding
```
Direct leak of 28 byte(s) in 1 object(s) allocated from:
    #0 __interceptor_malloc
    #1 onnxruntime::test::MallocAllocator::Alloc
        qnn_ep_context_test.cc:3598
    #6 OrtApis::ModelMetadataLookupCustomMetadataMap
    #7 QnnHTPBackendTests_ModelCompatibility_GetCompatibility_Test::TestBody
        qnn_ep_context_test.cc:3652
```
Trigger: `./onnxruntime_provider_test --gtest_filter='QnnHTPBackendTests.ModelCompatibility_GetCompatibility'`

### Root cause
`ModelMetadataLookupCustomMetadataMap` allocates `char* val` via the caller-provided `MallocAllocator`. The test used `val` but never freed it (C-API ownership pattern: ORT allocates, caller frees).

### Fix
```cpp
ASSERT_TRUE(val != nullptr && expected_info.ToString() == val);
free(val);  // added
```

---

## Reproduce on Linux x86_64

```bash
export LD_LIBRARY_PATH=$PWD:<qairt>/lib/x86_64-linux-clang:$LD_LIBRARY_PATH
export ASAN_OPTIONS="halt_on_error=0:detect_leaks=1"
export LSAN_OPTIONS="exitcode=0"
./onnxruntime_provider_test --gtest_filter='*'
```

## Test plan

- [x] Linux x86_64 `--enable_address_sanitizer` build — all 969 tests pass (`--gtest_filter='*'`), zero ORT-side ASan findings
- [x] Remaining leaks are QAIRT SDK backend libraries only: `libQnnHtp.so` (5600B) and `libQnnCpu.so` (32B), suppressed via #419
- [x] CI green