### PR TITLE
[QNN EP] Fix Windows arm64x archive suffix

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1110,7 +1110,9 @@ def main():
                 args.version_suffix,
                 use_ninja=(args.cmake_generator == "Ninja"),
                 target_arch=(
-                    "arm64ec"
+                    "arm64x"
+                    if getattr(args, "arm64ec", False) and getattr(args, "buildasx", False)
+                    else "arm64ec"
                     if getattr(args, "arm64ec", False)
                     else "arm64"
                     if getattr(args, "arm64", False)


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
- Fix it as arm64x


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The arm64x archive suffix is arm64ec now

