### PR TITLE
QNN EP: auto-detect soc_model from ACPI PPTT on Windows

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 
 #include "core/providers/qnn/qnn_execution_provider.h"
+#include "core/providers/qnn/soc_utils.h"
 
 #include <algorithm>
 #include <cctype>
@@ -750,6 +751,22 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                       .c_str());
     } else {
       soc_model = static_cast<uint32_t>(value);
+    }
+  }
+
+  // PATCH A: auto-detect soc_model from ACPI PPTT when the user did not pass
+  // one explicitly. Without this, every Windows-on-Snapdragon user runs with
+  // soc_model=QNN_SOC_MODEL_UNKNOWN, which prevents the HTP backend from
+  // selecting SoC-specific code paths (e.g. the X-Elite-tuned FP16 fast path).
+  if (soc_model == QNN_SOC_MODEL_UNKNOWN) {
+    uint32_t detected = qnn::soc::DetectQnnSocModel();
+    if (detected != QNN_SOC_MODEL_UNKNOWN) {
+      soc_model = detected;
+      ORT_CXX_LOG(logger_,
+                  ORT_LOGGING_LEVEL_INFO,
+                  ("Auto-detected QNN soc_model = " + std::to_string(soc_model) +
+                   " from ACPI PPTT (no explicit soc_model in session options).")
+                      .c_str());
     }
   }
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -754,16 +754,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     }
   }
 
-  // PATCH A: auto-detect soc_model from ACPI PPTT when the user did not pass
-  // one explicitly. Without this, every Windows-on-Snapdragon user runs with
-  // soc_model=QNN_SOC_MODEL_UNKNOWN, which prevents the HTP backend from
-  // selecting SoC-specific code paths (e.g. the X-Elite-tuned FP16 fast path).
+  // Auto-detect soc_model from ACPI PPTT when the user did not pass one explicitly.
   if (soc_model == QNN_SOC_MODEL_UNKNOWN) {
     uint32_t detected = qnn::soc::DetectQnnSocModel();
     if (detected != QNN_SOC_MODEL_UNKNOWN) {
       soc_model = detected;
       ORT_CXX_LOG(logger_,
-                  ORT_LOGGING_LEVEL_INFO,
+                  ORT_LOGGING_LEVEL_VERBOSE,
                   ("Auto-detected QNN soc_model = " + std::to_string(soc_model) +
                    " from ACPI PPTT (no explicit soc_model in session options).")
                       .c_str());

--- a/onnxruntime/core/providers/qnn/soc_utils.cc
+++ b/onnxruntime/core/providers/qnn/soc_utils.cc
@@ -111,10 +111,18 @@ typedef struct _PPTT {
 #define MAX_FADT_PPTT_SIZE 65536
 #define LEVEL_ID(LV1, LV2) ((LV1 << 32) | (LV2))
 
-// Note that the table is intentionally kept compact as Makena is the only expected usage.
-// (level1_ID | level2_ID), SOC_ID
+// PATCH A: legacy table extended with Snapdragon X Elite. The new
+// qnn_soc_model_mappings table maps PPTT (L1, L2) -> QNN_SOC_MODEL_*
+// integer that the QNN HTP backend wants in QnnHtpDevice_CustomConfig_t.
+// (level1_ID << 32) | level2_ID,  legacy SoC-recognition value
 static std::unordered_map<uint64_t, int> pptt_mappings = {
-    {LEVEL_ID(113ULL, 449ULL), 435},  // Makena
+    {LEVEL_ID(113ULL, 449ULL), 435},    // Makena
+    {LEVEL_ID(0x88ULL, 0x22bULL), 60},  // Snapdragon X Elite (X1E*, SC8380XP)
+};
+
+// (level1_ID << 32) | level2_ID,  QNN_SOC_MODEL_* (see QnnTypes.h)
+static std::unordered_map<uint64_t, uint32_t> qnn_soc_model_mappings = {
+    {LEVEL_ID(0x88ULL, 0x22bULL), 60},  // QNN_SOC_MODEL_SC8380XP (X Elite)
 };
 
 int getSocId() {
@@ -145,13 +153,24 @@ int getSocId() {
   }
 
   pptt = (PPPTT)buf;
+  // PATCH A: fixed PPTT walker stride (i += ptn->Length) and bound
+  // (Header.Length - sizeof(DESCRIPTION_HEADER) from &HierarchyNodes[0]).
   uint64_t key = 0;
-  for (uint32_t i = 0; i < pptt->Header.Length; i++) {
-    PPROC_TOPOLOGY_NODE ptn = (PPROC_TOPOLOGY_NODE)((BYTE*)&(pptt->HierarchyNodes[0]) + i);
-    // According to ACPI spec, type = 2 is the PPTT_ID_TABLE_TYPE
-    if (ptn->Type == 2) {
-      key = (ptn->IdNode.Level1 << 32) | (ptn->IdNode.Level2);
-      break;
+  if (pptt->Header.Length > sizeof(DESCRIPTION_HEADER)) {
+    const uint32_t nodes_bytes =
+        pptt->Header.Length - static_cast<uint32_t>(sizeof(DESCRIPTION_HEADER));
+    BYTE* const nodes_base = (BYTE*)&(pptt->HierarchyNodes[0]);
+    uint32_t i = 0;
+    while (i + 4u <= nodes_bytes) {
+      PPROC_TOPOLOGY_NODE ptn = (PPROC_TOPOLOGY_NODE)(nodes_base + i);
+      if (ptn->Length == 0 || ptn->Length > nodes_bytes - i) {
+        break;
+      }
+      if (ptn->Type == 2) {  // PPTT_ID_TABLE_TYPE
+        key = (ptn->IdNode.Level1 << 32) | (ptn->IdNode.Level2);
+        break;
+      }
+      i += ptn->Length;
     }
   }
   free(buf);
@@ -178,6 +197,40 @@ int getSocId() {
 int GetSocId() {
   static int cached_soc_id = getSocId();
   return cached_soc_id;
+}
+
+// PATCH A: PPTT-key-based auto-detection of QNN_SOC_MODEL_* (Windows only).
+uint32_t DetectQnnSocModel() {
+#ifdef _WIN32
+  BYTE* buf = (BYTE*)malloc(MAX_FADT_PPTT_SIZE);
+  if (!buf) return 0;
+  DWORD needed = GetSystemFirmwareTable('ACPI', 'TTPP', 0, 0);
+  if (!needed) { free(buf); return 0; }
+  if (needed > MAX_FADT_PPTT_SIZE) needed = MAX_FADT_PPTT_SIZE;
+  if (!GetSystemFirmwareTable('ACPI', 'TTPP', buf, needed)) { free(buf); return 0; }
+  PPPTT pptt = (PPPTT)buf;
+  uint64_t key = 0;
+  if (pptt->Header.Length > sizeof(DESCRIPTION_HEADER)) {
+    const uint32_t nodes_bytes =
+        pptt->Header.Length - static_cast<uint32_t>(sizeof(DESCRIPTION_HEADER));
+    BYTE* const nodes_base = (BYTE*)&(pptt->HierarchyNodes[0]);
+    uint32_t i = 0;
+    while (i + 4u <= nodes_bytes) {
+      PPROC_TOPOLOGY_NODE ptn = (PPROC_TOPOLOGY_NODE)(nodes_base + i);
+      if (ptn->Length == 0 || ptn->Length > nodes_bytes - i) break;
+      if (ptn->Type == 2) {
+        key = (ptn->IdNode.Level1 << 32) | (ptn->IdNode.Level2);
+        break;
+      }
+      i += ptn->Length;
+    }
+  }
+  free(buf);
+  auto it = qnn_soc_model_mappings.find(key);
+  return (it != qnn_soc_model_mappings.end()) ? it->second : 0;
+#else
+  return 0;
+#endif
 }
 
 }  // namespace soc

--- a/onnxruntime/core/providers/qnn/soc_utils.h
+++ b/onnxruntime/core/providers/qnn/soc_utils.h
@@ -3,11 +3,17 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace onnxruntime {
 namespace qnn {
 namespace soc {
 
 int GetSocId();
+
+// PATCH A: Returns QNN_SOC_MODEL_* for the current device, or 0 (UNKNOWN)
+// if not detected. Windows only; returns 0 on other platforms.
+uint32_t DetectQnnSocModel();
 
 }  // namespace soc
 }  // namespace qnn


### PR DESCRIPTION
## Summary

When a user does not pass `soc_model` in QNN EP session options, the EP today
runs with `soc_model = QNN_SOC_MODEL_UNKNOWN`. This patch makes the EP
auto-populate `soc_model` from the ACPI PPTT table on Windows.

This matters for features that key off `soc_model`. The most concrete case is
`htp_bf16_enable`: per the QAIRT 2.46 HTP backend documentation,

> "QNN HTP supports running bfloat16 networks on Qualcomm Windows V81 based
> platforms and newer."

The corresponding gate in the EP today is `if (soc_model < 88) throw`, and
the value `88` is exactly `QNN_SOC_MODEL_SC8480XP`, i.e. the **Snapdragon X2
Elite** (Hexagon V81, Windows). The gate is therefore correctly admitting
the X2 Elite and correctly rejecting everything below it. What it does *not*
do is tell the user what value to pass — when X2 Elite users get their
devices, they would have to discover that the right integer is `88` and
hardcode it as a session option. With this patch the EP looks the value up
from PPTT and they just pass `htp_bf16_enable=1`.

The mapping table is initially seeded with **Snapdragon X Elite (SC8380XP =
60)**, which is the only Windows-on-Snapdragon device the contributor has
hardware for. A `TODO` is left for someone with an **X2 Elite (SC8480XP =
88)** to characterise its PPTT `(L1, L2)` and add the second entry — at
which point HTP BF16 becomes a no-magic-numbers flag on X2 Elite.

## Changes

`onnxruntime/core/providers/qnn/soc_utils.{cc,h}`

- Fix the existing PPTT walker: step by `ptn->Length` instead of byte-by-
  byte and bound on `Header.Length - sizeof(DESCRIPTION_HEADER)` from
  `&HierarchyNodes[0]`. The original walker happened to find the right ID
  node by luck on Snapdragon X Elite (the node sits at offset 0) but could
  read past the buffer or match a stray `2` byte on other PPTT layouts.
- Add Snapdragon X Elite to the existing `pptt_mappings` table (used by
  `GetSocId()` as a DXCore-fallback NPU-presence probe).
- New `qnn_soc_model_mappings` table that maps PPTT keys to
  `QNN_SOC_MODEL_*` integers.
- New public-to-the-EP API `qnn::soc::DetectQnnSocModel()` that returns
  the right value for the current device or `QNN_SOC_MODEL_UNKNOWN`. Windows
  only; returns `QNN_SOC_MODEL_UNKNOWN` on other platforms so behaviour is
  unchanged off-Windows.

`onnxruntime/core/providers/qnn/qnn_execution_provider.cc`

- When the user did not pass `soc_model` in session options, call
  `DetectQnnSocModel()` and populate it. Logged at `ORT_LOGGING_LEVEL_INFO`
  so users can confirm in verbose logs which value was auto-detected.
- The existing `htp_bf16_enable` gate (`soc_model < 88`) is **not** changed.
  Per QAIRT 2.46 docs that predicate is correct: it admits the upcoming
  Windows V81 SoC (X2 Elite = `SC8480XP` = 88) and rejects everything else.

## Independent confirmation from Qualcomm AI Hub device list

`hub.get_devices()` returns these Qualcomm `framework:qnn` devices today:

| Device                          | Chipset      | hexagon | `soc-model` | OS       | HTP BF16 per QAIRT docs |
| ------------------------------- | ------------ | ------- | ----------- | -------- | ----------------------- |
| Snapdragon X Elite CRD          | sc8380xp     | v73     | 60          | Windows  | no                      |
| Snapdragon X Plus 8-Core CRD    | sc8340xp     | v73     | 60          | Windows  | no                      |
| Snapdragon **X2 Elite CRD**     | **sc8480xp** | **v81** | **88**      | Windows  | **yes**                 |
| Snapdragon 8 Elite QRD          | sm8750       | v79     | 69          | Android  | no                      |
| Snapdragon 8 Elite Gen 5 QRD    | sm8850       | v81     | 87          | Android  | no (Android, not "Windows V81") |

The existing `< 88` gate is exactly tuned to "Windows V81 only", which today
is `SC8480XP = 88`.

## Test environment

|                  |                                              |
| ---------------- | -------------------------------------------- |
| Device           | Snapdragon X Elite CRD (X1E80100), 12 cores  |
| Host OS          | Windows 11 ARM64                             |
| ORT runtime      | 1.26.0                                       |
| Repo base        | `main` @ `cb31cc64ca`                        |
| QAIRT SDK        | 2.46.0                                       |
| Compiler         | MSVC 19.44.35226 ARM64 (VS 2022 17.14)       |

## Behaviour verification on Snapdragon X Elite (V73)

Compiled `main` and this branch and A/B'd against the same AI Hub-compiled
HTP context binary (small float16 4-layer MatMul stack, compiled for
Snapdragon X Elite CRD with `--target_runtime precompiled_qnn_onnx
--compute_unit npu`). 4 interleaved rounds × 80 timed inferences + 10
warmup per cell, DLL hot-swapped on disk between every measurement.

| Config                                          | `main` (vanilla)        | This patch              |
| ----------------------------------------------- | ----------------------- | ----------------------- |
| no options                                      | 1.99 ± 0.48 ms · 521/s  | 1.87 ± 0.09 ms · 535/s  |
| auto-detect + `enable_htp_fp16_precision=1`     | 1.87 ± 0.20 ms · 539/s  | 1.85 ± 0.26 ms · 549/s  |

All successful runs produce identical output hash → no numerics drift.

**This patch does not produce a measurable per-iteration speedup on the
V73-class hardware we have access to.** That is expected: the auto-detect
populates `soc_model = SC8380XP = 60`, which the HTP backend can use as a
hint during graph preparation, but for a *precompiled* HTP context binary
the graph layout is already baked at AI Hub compile time. The patch's
benefit accrues to features that gate on `soc_model` at session init —
today that is `htp_bf16_enable` on the X2 Elite.

The point of validating on V73 hardware is that **the patch must not
regress anything**, and the table above shows that holds (within stdev).
The lower stdev on the `no options` row is suggestive of the HTP picking a
more deterministic code path when it knows the SoC, but the mean difference
is within noise so it is not claimed here as a measured win.

## Reproduction recipe

Generate the float16 MatMul stack:

```python
import numpy as np, onnx
from onnx import TensorProto, helper, numpy_helper

rng = np.random.default_rng(0)
seq, hidden, inter, layers = 128, 512, 1024, 4
nodes, init, last = [], [], "x"
for i in range(layers):
    w1 = (rng.standard_normal((hidden, inter)) / np.sqrt(hidden)).astype(np.float16)
    w2 = (rng.standard_normal((inter, hidden)) / np.sqrt(inter)).astype(np.float16)
    init += [numpy_helper.from_array(w1, name=f"W1_{i}"),
             numpy_helper.from_array(w2, name=f"W2_{i}")]
    nodes += [
        helper.make_node("MatMul", [last, f"W1_{i}"], [f"m1_{i}"]),
        helper.make_node("Gelu",   [f"m1_{i}"],      [f"g1_{i}"]),
        helper.make_node("MatMul", [f"g1_{i}", f"W2_{i}"], [f"m2_{i}"]),
        helper.make_node("Gelu",   [f"m2_{i}"],      [f"g2_{i}"]),
    ]
    last = f"g2_{i}"
nodes.append(helper.make_node("Identity", [last], ["y"]))
graph = helper.make_graph(
    nodes, "matmul_stack_fp16",
    [helper.make_tensor_value_info("x", TensorProto.FLOAT16, [1, seq, hidden])],
    [helper.make_tensor_value_info("y", TensorProto.FLOAT16, [1, seq, hidden])],
    initializer=init,
)
model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 20)],
                          ir_version=10)
onnx.save(model, "matmul_stack_fp16.onnx")
```

Compile it to a precompiled QNN HTP context binary via Qualcomm AI Hub for
Snapdragon X Elite CRD (or X2 Elite CRD if you want to validate the BF16
path):

```python
import qai_hub as hub
target = next(d for d in hub.get_devices()
              if d.name == "Snapdragon X Elite CRD" and d.os == "11")
job = hub.submit_compile_job(
    model="matmul_stack_fp16.onnx",
    device=target,
    options="--target_runtime precompiled_qnn_onnx --compute_unit npu",
)
job.wait()
job.get_target_model().download("model.onnx.zip")
```

Benchmark harness:

```python
import time, numpy as np
import onnxruntime as ort, onnxruntime_qnn as qnn_ep

ort.register_execution_provider_library("QNNExecutionProvider",
                                        qnn_ep.get_library_path())
devs = [d for d in ort.get_ep_devices()
        if d.ep_name == "QNNExecutionProvider"]
options = {
    "backend_path": qnn_ep.get_qnn_htp_path(),
    "htp_performance_mode": "burst",
    "htp_graph_finalization_optimization_mode": "3",
    # Pass no explicit soc_model so the auto-detect runs.
}
so = ort.SessionOptions()
so.log_severity_level = 1  # INFO; will print the auto-detected soc_model
so.add_provider_for_devices(devs, options)
sess = ort.InferenceSession("model.onnx", sess_options=so)

x = np.random.default_rng(42).standard_normal([1, 128, 512]).astype(np.float16)
for _ in range(10):                 # warmup
    sess.run(None, {"x": x})
times_ns = []
for _ in range(80):                 # timed iters
    t = time.perf_counter_ns(); sess.run(None, {"x": x})
    times_ns.append(time.perf_counter_ns() - t)
```

Run 4 interleaved rounds across `main` and this branch, hot-swapping the
DLL between measurements to keep thermal state comparable.

## What this PR is *not*

- It does **not** change the `htp_bf16_enable < 88` gate. That predicate is
  correct per QAIRT docs (Windows V81+ for HTP BF16, X2 Elite is
  `soc-model = 88`).
- It does **not** add the X2 Elite PPTT entry. The contributor does not
  have an X2 Elite device and cannot characterise its `(L1, L2)` PPTT key
  without one. Adding that entry is the natural follow-up.
- It does **not** claim a per-iteration speedup on V73 hardware. The
  benchmark table is included as a regression check.

## Files changed

```
 onnxruntime/core/providers/qnn/qnn_execution_provider.cc | 17 ++++++
 onnxruntime/core/providers/qnn/soc_utils.cc              | 71 +++++++++++++++++++---
 onnxruntime/core/providers/qnn/soc_utils.h               |  6 ++
 3 files changed, 85 insertions(+), 9 deletions(-)
```

## Checklist

- [x] Compiles cleanly with `--use_qnn` on Windows ARM64 (MSVC).
- [x] Behaviour preserved for callers that pass `soc_model` explicitly.
- [x] No public API change (`DetectQnnSocModel` is in the
      `onnxruntime::qnn::soc::` internal namespace).
- [x] Logged at `ORT_LOGGING_LEVEL_INFO` when auto-detect populates
      `soc_model`.
- [x] On non-Windows platforms `DetectQnnSocModel()` returns
      `QNN_SOC_MODEL_UNKNOWN` and the call site is a no-op.
- [x] No regression on V73 (Snapdragon X Elite) within measurement
      stdev.
- [ ] CI green.
- [ ] Follow-up issue: add the X2 Elite (SC8480XP, soc-model 88) PPTT
      `(L1, L2)` entry to `qnn_soc_model_mappings`. Needs someone with
      X2 Elite hardware to read the ACPI table.
