### PR TITLE
[QNN EP] CI: Skip Artifactory steps on fork PRs

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -110,6 +110,10 @@ env:
   TEST_ARCHIVE_EXT: "${{ inputs.target_os == 'linux' && 'tar.bz2' || 'zip' }}"
 
   ORT_VERSION_SUFFIX: "${{ inputs.version_suffix != '' && inputs.version_suffix || '' }}"
+  # Materialize for step-level `if` checks: GitHub Actions does not allow `env`/`secrets`
+  # contexts in job-level `if`, so jobs gate on `github.event.pull_request.head.repo.fork`
+  # while steps gate on `env.BUILD_ARTIFACTORY_REPO != ''`. Both signals skip Artifactory
+  # work on fork PRs (where this secret is empty).
   BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
 
   BUILD_SOURCEBRANCH: "${{ github.ref }}"
@@ -160,7 +164,8 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
-        if: ${{ always() && inputs.run_tests && inputs.build_test_same_runner }} # always run even if the previous step fails
+        # Skipped on fork PRs: the action creates a check run, which the fork-PR GITHUB_TOKEN cannot do.
+        if: ${{ always() && inputs.run_tests && inputs.build_test_same_runner && github.event.pull_request.head.repo.fork != true }}
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}-test-results
           group_reports: false
@@ -179,7 +184,9 @@ jobs:
           path: |
             ${{ github.workspace }}/build/${{inputs.target_os}}-${{inputs.target_arch}}/${{ env.BUILD_CONFIG_DIR }}/*.results.xml
 
+      # Artifactory steps are no-ops on fork PRs (secrets unavailable). The build/in-runner tests still validate the change.
       - name: Setup JFrog CLI
+        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -189,49 +196,49 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Upload Test Archive to Artifactory
-        if: ${{ inputs.upload_test_archive }}
+        if: ${{ inputs.upload_test_archive && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-tests"
           src_pattern: "onnxruntime-tests-${{inputs.target_os}}-${{ inputs.target_arch }}.${{ env.TEST_ARCHIVE_EXT }}"
 
       - name: Upload Wheel to Artifactory
-        if: ${{ inputs.upload_wheel }}
+        if: ${{ inputs.upload_wheel && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-wheels"
           src_pattern: "${{ inputs.target_os }}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime_qnn*.whl"
 
       - name: Upload NuGet to Artifactory
-        if: ${{ inputs.upload_nuget }}
+        if: ${{ inputs.upload_nuget && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-nuget"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/Qualcomm.ML.OnnxRuntime.QNN*.nupkg"
 
       - name: Upload Archive to Artifactory
-        if: ${{ inputs.upload_archive }}
+        if: ${{ inputs.upload_archive && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-${{ inputs.target_os == 'linux' && 'tgz' || 'zip' }}"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime-qnn*.${{ inputs.target_os == 'linux' && 'tgz' || 'zip' }}"
 
       - name: Upload AAR to Artifactory
-        if: ${{ inputs.upload_aar }}
+        if: ${{ inputs.upload_aar && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{inputs.target_os}}-${{ inputs.target_arch }}-aar"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.aar"
 
       - name: Upload POM to Artifactory
-        if: ${{ inputs.upload_aar }}
+        if: ${{ inputs.upload_aar && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{inputs.target_os}}-${{ inputs.target_arch }}-pom"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.pom"
 
       - name: Upload PDB Archive to Artifactory
-        if: ${{ inputs.upload_pdb_archive && inputs.target_os == 'windows' }}
+        if: ${{ inputs.upload_pdb_archive && inputs.target_os == 'windows' && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-pdb-zip"
@@ -239,7 +246,8 @@ jobs:
 
   test:
     name: "test-${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}"
-    if: ${{ inputs.run_tests && !inputs.build_test_same_runner }}
+    # Cross-runner test stage requires Artifactory hand-off from build; skip on fork PRs where secrets are unavailable.
+    if: ${{ inputs.run_tests && !inputs.build_test_same_runner && github.event.pull_request.head.repo.fork != true }}
     needs: [build]
     runs-on: ["self-hosted", "${{inputs.target_os}}", "${{ inputs.test_runner_arch }}", "Test"]
     defaults:
@@ -295,7 +303,8 @@ jobs:
 
   test-wheel:
     name: "test-${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}-wheel-smoke"
-    if: ${{ inputs.test_wheel }}
+    # Wheel smoke test downloads the wheel from Artifactory; skip on fork PRs where secrets are unavailable.
+    if: ${{ inputs.test_wheel && github.event.pull_request.head.repo.fork != true }}
     needs: [build]
     runs-on: ["self-hosted", "${{inputs.target_os}}", "${{ inputs.test_runner_arch }}", "Test"]
     defaults:

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -64,7 +64,8 @@ jobs:
       run_tests: false
 
   test-linux-aarch64-oe-gcc11_2:
-    if: ${{ inputs.do_all }}
+    # Downstream tests need the Artifactory upload from build-linux-aarch64-oe-gcc11_2; skip on fork PRs.
+    if: ${{ inputs.do_all && github.event.pull_request.head.repo.fork != true }}
     needs: [build-linux-aarch64-oe-gcc11_2]
     uses: ./.github/workflows/qualcomm-internal-qdc-test.yml
     secrets: inherit
@@ -144,7 +145,9 @@ jobs:
         with:
           submodules: recursive
 
+      # Artifactory steps are no-ops on fork PRs (secrets unavailable). The build still validates the change.
       - name: Setup JFrog CLI
+        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -158,13 +161,15 @@ jobs:
           python3 qcom/build_and_test.py archive_ort_android_aarch64
 
       - name: Upload Test Archive to Artifactory
+        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "android-aarch64-pyNone-tests"
           src_pattern: onnxruntime-tests-android-aarch64.zip
 
   test-android-aarch64:
-    if: ${{ inputs.do_all }}
+    # Downstream tests need the Artifactory upload from build-android-aarch64; skip on fork PRs.
+    if: ${{ inputs.do_all && github.event.pull_request.head.repo.fork != true }}
     needs: [build-android-aarch64]
     uses: ./.github/workflows/qualcomm-internal-qdc-test.yml
     secrets: inherit

--- a/.github/workflows/qualcomm-internal-qdc-test.yml
+++ b/.github/workflows/qualcomm-internal-qdc-test.yml
@@ -38,6 +38,8 @@ env:
 jobs:
   test:
     name: "test-${{inputs.target_os}}-${{inputs.target_arch}}-pynone"
+    # QDC tests pull artifacts from Artifactory; skip on fork PRs where secrets are unavailable.
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
     runs-on: ["self-hosted", "Linux", "QDC"]
     defaults:
       run:


### PR DESCRIPTION
Fork PRs do not receive repo secrets, so BUILD_ARTIFACTORY_REPO is empty and qcom/scripts/artifactory/artifactory.py raises before any artifact hand-off can succeed. Gate Artifactory-touching steps and downstream test jobs that depend on Artifactory hand-off:

* Step-level: env.BUILD_ARTIFACTORY_REPO != '' on Setup JFrog CLI and every Upload * to Artifactory step in the build job.
* Job-level: github.event.pull_request.head.repo.fork != true on the cross-runner test, test-wheel, test-android-aarch64, test-linux-aarch64-oe-gcc11_2, and the qdc-test reusable job.

The two-style split is required because GitHub Actions does not allow env or secrets contexts in jobs.<job_id>.if. Both signals skip Artifactory work on fork PRs and behave unchanged for push, merge_group, schedule, workflow_dispatch, internal PRs, and reusable workflow_call chains (release-nightly etc. all evaluate fork to null).

Also gates the build-job Publish Test Report step, since mikepenz/action-junit-report creates a check run which the fork-PR GITHUB_TOKEN lacks permission to do.