### PR TITLE
[QNN EP] Update default htp_graph_finalization_optimization_mode to O3

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -158,10 +158,12 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 
 |`"htp_graph_finalization_optimization_mode"`|Description|
 |---|---|
-|'0'|Default optimization mode.|
+|'0'|HTP's internal default (currently equivalent to '2').|
 |'1'|Faster preparation time, less optimal graph.|
 |'2'|Longer preparation time, more optimal graph.|
 |'3'|Longest preparation time, most optimal graph.|
+
+If `htp_graph_finalization_optimization_mode` is not specified, QNN EP uses `'3'`.
 
 |`"soc_model"`|Description|
 |---|---|
@@ -796,7 +798,7 @@ session = ort.InferenceSession("model.onnx", sess_options=sess_options)
 
 ### Important Considerations
 #### Feature Disabled if Number of Subgraphs is Less Than 5
-While graph composition is responsible for the majority of the preparation time, asynchronously finalizing the subgraphs cuts the total time down by a considerable amount, depending on the graph. For smaller models or models with only a few subgraphs, the overhead of setting up for parallel graph preparation will negate any possible performance gains and may actually result in worse performance. 
+While graph composition is responsible for the majority of the preparation time, asynchronously finalizing the subgraphs cuts the total time down by a considerable amount, depending on the graph. For smaller models or models with only a few subgraphs, the overhead of setting up for parallel graph preparation will negate any possible performance gains and may actually result in worse performance.
 
 #### Feature Disabled if `num_graph_prepare_threads` is 1
 This defeats the purpose of the feature, and enabling the feature will only add additional overhead from thread pool creation.

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -616,7 +616,7 @@ QnnEp::QnnEp(QnnEpFactory& factory,
   }
 
   // HTP graph finalization optimization mode
-  htp_graph_finalization_opt_mode_ = qnn::HtpGraphFinalizationOptimizationMode::kDefault;
+  htp_graph_finalization_opt_mode_ = qnn::HtpGraphFinalizationOptimizationMode::kMode3;
   std::string htp_graph_finalization_opt_mode_str;
   GetSessionConfigEntryOrDefault(ort_api,
                                  session_options_,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -198,7 +198,7 @@ class QnnEp : public OrtEp, public ApiPtrs {
   uint32_t default_rpc_control_latency_ = 0;
   uint32_t default_rpc_polling_time_ = 0;
   qnn::ModelSettings model_settings_ = {};
-  qnn::HtpGraphFinalizationOptimizationMode htp_graph_finalization_opt_mode_ = qnn::HtpGraphFinalizationOptimizationMode::kDefault;
+  qnn::HtpGraphFinalizationOptimizationMode htp_graph_finalization_opt_mode_ = qnn::HtpGraphFinalizationOptimizationMode::kMode3;
   int32_t vtcm_size_in_mb_ = 0;
   bool enable_HTP_FP16_precision_ = true;
 

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/README.md
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/README.md
@@ -44,7 +44,7 @@ Options:
             [QNN only] [backend_type]: QNN backend type. E.g., 'cpu', 'htp'. Mutually exclusive with 'backend_path'.
             [QNN only] [backend_path]: QNN backend path. E.g., '/folderpath/libQnnHtp.so', '/winfolderpath/QnnHtp.dll'. Mutually exclusive with 'backend_type'.
             [QNN only] [vtcm_mb]: QNN VTCM size in MB. default to 0(not set).
-            [QNN only] [htp_graph_finalization_optimization_mode]: QNN graph finalization optimization mode, options: '0', '1', '2', '3', default is '0'.
+            [QNN only] [htp_graph_finalization_optimization_mode]: QNN graph finalization optimization mode, options: '0', '1', '2', '3', default is '3'.
             [QNN only] [soc_model]: The SoC Model number. Refer to QNN SDK documentation for specific values. Defaults to '0' (unknown).
             [QNN only] [htp_arch]: The minimum HTP architecture. The driver will use ops compatible with this architecture. eg: '0', '68', '69', '73', '75'. Defaults to '0' (none).
             [QNN only] [enable_htp_fp16_precision]: Enable the HTP_FP16 precision so that the float32 model will be inferenced with fp16 precision.

--- a/onnxruntime/test/ep_weight_sharing_ctx_gen/command_args_parser.cc
+++ b/onnxruntime/test/ep_weight_sharing_ctx_gen/command_args_parser.cc
@@ -67,7 +67,7 @@ namespace qnnctxgen {
       "\t    [QNN only] [backend_type]: QNN backend type. E.g., 'cpu', 'htp'. Mutually exclusive with 'backend_path'.\n"
       "\t    [QNN only] [backend_path]: QNN backend path. E.g., '/folderpath/libQnnHtp.so', '/winfolderpath/QnnHtp.dll'. Mutually exclusive with 'backend_type'.\n"
       "\t    [QNN only] [vtcm_mb]: QNN VTCM size in MB. default to 0(not set).\n"
-      "\t    [QNN only] [htp_graph_finalization_optimization_mode]: QNN graph finalization optimization mode, options: '0', '1', '2', '3', default is '0'.\n"
+      "\t    [QNN only] [htp_graph_finalization_optimization_mode]: QNN graph finalization optimization mode, options: '0', '1', '2', '3', default is '3'.\n"
       "\t    [QNN only] [soc_model]: The SoC Model number. Refer to QNN SDK documentation for specific values. Defaults to '0' (unknown). \n"
       "\t    [QNN only] [htp_arch]: The minimum HTP architecture. The driver will use ops compatible with this architecture. eg: '0', '68', '69', '73', '75'. Defaults to '0' (none). \n"
       "\t    [QNN only] [enable_htp_fp16_precision]: Enable the HTP_FP16 precision so that the float32 model will be inferenced with fp16 precision. \n"


### PR DESCRIPTION
### Description
Change the default value of `htp_graph_finalization_optimization_mode` in QNN EP from unspecified (which falls through to HTP's internal default, currently `'2'` (O2) to `'3'` (O3).

When the user does not pass `htp_graph_finalization_optimization_mode`, QNN EP now configures the HTP graph with `QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG = 3`. Passing `'0'` explicitly still routes to HTP's internal default, and `'1'`/`'2'`/`'3'` behave as before.

### Motivation and Context
Users running models through framework integrations that don't expose QNN-specific provider options had no way to opt into the most optimal graph finalization mode, and were silently getting a less optimal default. Defaulting to `'3'` gives the best out-of-the-box performance while still allowing users to opt down to faster-prepare modes (`'1'`, `'2'`) or HTP's internal default (`'0' (O2)`) when they need shorter preparation time.