### PR TITLE
[QNN EP] Route serializer-mode validation through active backend

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -364,13 +364,23 @@ QnnSerializerConfig* QnnBackendManager::GetQnnSerializerConfig() {
 // local files: Saver dumps to C++ sources and Ir to .dlc archives.
 // This information can be used to debug issues by replaying QNN API calls with another backend.
 Ort::Status QnnBackendManager::LoadQnnSerializerBackend() {
-  // Load the intended backend (e.g., HTP, CPU) to get its type and validator interface.
-  // The library handle is stored in validator_backend_lib_handle_ and kept alive for the
-  // lifetime of this object so that backendValidateOpConfig remains callable.
+  // Load the intended backend only to read its backendId; unload on scope exit. Do not retain
+  // it for validation — the serializer artifact is target-agnostic by design (see
+  // ValidateQnnNode in qnn_model_wrapper.cc).
+  void* backend_lib_handle = nullptr;
+  auto unload_backend_lib = gsl::finally([&] {
+    if (backend_lib_handle != nullptr) {
+      auto result = UnloadLib(backend_lib_handle);
+      if (!result.IsOK()) {
+        ORT_CXX_API_THROW("Failed to unload backend library.", ORT_EP_FAIL);
+      }
+    }
+  });
+
   QnnInterface_t* backend_interface_provider{nullptr};
   RETURN_IF_ERROR((GetQnnInterfaceProvider<QnnInterfaceGetProvidersFn_t, QnnInterface_t>(backend_path_.c_str(),
                                                                                          "QnnInterface_getProviders",
-                                                                                         &validator_backend_lib_handle_,
+                                                                                         &backend_lib_handle,
                                                                                          {QNN_API_VERSION_MAJOR,
                                                                                           QNN_API_VERSION_MINOR,
                                                                                           QNN_API_VERSION_PATCH},
@@ -380,9 +390,6 @@ Ort::Status QnnBackendManager::LoadQnnSerializerBackend() {
   backend_id_ = backend_interface_provider->backendId;
   backend_api_version_ = backend_interface_provider->apiVersion.backendApiVersion;
   SetQnnBackendType(backend_id_);
-
-  // Store the validator interface (e.g., HTP) for use in backendValidateOpConfig calls.
-  qnn_validator_interface_ = backend_interface_provider->QNN_INTERFACE_VER_NAME;
 
   // Load the serializer backend and set it as the activate backend.
   QnnInterface_t* serializer_interface_provider{nullptr};
@@ -1882,18 +1889,7 @@ Ort::Status QnnBackendManager::SetupBackend(
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeBackend succeed.");
   }
 
-  if (status.IsOK() && qnn_serializer_config_) {
-    status = InitializeQnnValidatorLog();
-    if (status.IsOK()) {
-      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeQnnValidatorLog succeed.");
-    }
-    if (status.IsOK()) {
-      status = InitializeValidatorBackend();
-    }
-    if (status.IsOK()) {
-      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeValidatorBackend succeed.");
-    }
-  }
+  // No validator-backend init: serializer-mode validation routes through qnn_interface_.
 
   if (status.IsOK()) {
     status = CreateDevice();

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -243,14 +243,10 @@ Ort::Status QnnModelWrapper::ValidateQnnNode(const std::string& node_name,
 }
 
 Ort::Status QnnModelWrapper::ValidateQnnNode(QnnOpConfigWrapper& op_config, std::string& error_msg) const {
-  bool ok;
-  if (backend_validator_handle_ != nullptr) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, "Op validation using validator backend (e.g. HTP).");
-
-    ok = op_config.QnnGraphOpValidation(qnn_validator_interface_, backend_validator_handle_, error_msg);
-  } else {
-    ok = op_config.QnnGraphOpValidation(qnn_interface_, backend_handle_, error_msg);
-  }
+  // Always validate via the active backend. In serializer mode (Ir/Saver), the host HTP shim
+  // would default to arch v68 with no device configured and falsely reject ops a real device
+  // accepts at finalize; the serializer's own permissive validator is the right oracle there.
+  bool ok = op_config.QnnGraphOpValidation(qnn_interface_, backend_handle_, error_msg);
   RETURN_IF_NOT(ok, error_msg.c_str());
   return Ort::Status();
 }

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -993,16 +993,16 @@ TEST_F(QnnHTPBackendTests, TestNHWCResizeShapeInference_qdq_sizes_opset18) {
   RunNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.quant.onnx", TestBackend::Htp);
 }
 
-// Test that QNN Ir generates the expected DLC file for a model meant to run on the QNN HTP backend,
-// using the HTP backend's validator.
-TEST_F(QnnHTPBackendTests, QnnIr_HtpValidator_OutputFiles) {
+// Regression test: serializer-mode validation must route through the active backend (QnnIr),
+// not the host HTP shim. Otherwise the host shim defaults to arch v68 and falsely rejects ops
+// whose kernels require v73+, producing N partitions / N DLCs instead of one. The test must
+// pass regardless of host HTP arch — no SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO.
+TEST_F(QnnHTPBackendTests, QnnIr_SerializerValidator_OutputFiles) {
   BackendSupport ir_backend_support = IsIRBackendSupported();
   if (ir_backend_support == BackendSupport::UNSUPPORTED) {
     GTEST_SKIP() << "QNN IR backend is not available! Skipping test.";
   }
   ASSERT_NE(ir_backend_support, BackendSupport::SUPPORT_ERROR) << "Failed to check if QNN IR backend is available.";
-
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   const std::filesystem::path qnn_dlc_dir = kDlcOutputDir;
@@ -1012,12 +1012,12 @@ TEST_F(QnnHTPBackendTests, QnnIr_HtpValidator_OutputFiles) {
   ASSERT_FALSE(std::filesystem::exists(qnn_dlc_dir));
 
   InitNHWCResizeModel(ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.onnx",
-                      TestBackend::Htp,      // backend (also used as the validator)
+                      TestBackend::Htp,      // intended runtime backend
                       registered_ep_device,  // registered_ep_device
-                      TestBackend::Ir);      // serializer backend
+                      TestBackend::Ir);      // serializer backend (also the validator)
 
-  // File names are taken from graph node names. Just make sure that we got one .dlc
-  // in the expected directory.
+  // A single consolidated DLC means the whole graph stayed in one QNN partition,
+  // i.e. validation did not fragment it.
   ASSERT_TRUE(std::filesystem::exists(qnn_dlc_dir));
 
   int file_count = 0;


### PR DESCRIPTION
Regression since https://github.com/onnxruntime/onnxruntime-qnn/commit/2366b4de8fec1a2be19814e8d71f89afbd8bd3c6#diff-8cfae0097130566222fad36cd050c46601190c3c7ef54a9448e93995766ce755. 

In serializer mode (dump_qnn_ir_dlc=1 or qnn_saver_path set), `QnnModelWrapper::ValidateQnnNode` now always calls QnnGraphOpValidation on the active interface (QnnIr / QnnSaver) instead of the host HTP backend.

Op-package validation against the host x86 libQnnHtp.so is unsafe at partition time: when no QnnDevice_create is invoked against it (the EP never does, and AI Hub compile flows do not pass htp_arch / soc_model), the host shim defaults its arch capability check to v68 and rejects ops whose kernels require v73+. This produced false-positive "QnnBackend_validateOpConfig() failed ... error code 3110" rejections for any model whose ops need a higher arch, fragmenting what should be a single DLC into one partition per rejected node.

Changes:
- LoadQnnSerializerBackend: load HTP into a scoped local for backendId discovery, unload on scope exit; do not retain qnn_validator_interface_
- SetupBackend: drop validator-backend init block (no longer needed)
- ValidateQnnNode: drop the validator-handle branch; always validate through qnn_interface_ / backend_handle_

Non-serializer flows (HTP/CPU/GPU execution) are unaffected: LoadBackend is unchanged, and validator_backend_handle_ was already null in those paths so they took the same code path before this change.