### PR TITLE
Add layernorm decomposition when scale/bais is not aligned with LN axes.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -516,11 +516,13 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   std::string current = ln_out_name;
 
   if (externalize_scale) {
-    // Owned copy: the externalize_bias=false path moves final_output_info.quant_param into the
-    // Mul output tensor below, so an alias-then-move on .quant_param would leave mul_out_qp
-    // dangling for the requant predicates / GetPerTensorScaleOffset reads.
-    const QnnQuantParamsWrapper mul_out_qp =
-        externalize_bias ? ln_intermediate_qp.Copy() : final_output_info.quant_param.Copy();
+    // Mul produces z*gamma, whose magnitude is bounded by gamma * sqrt(N-1) — well past
+    // ln_intermediate_qp's sqrt(N-1) range whenever |gamma| > 1. final_output_info.quant_param
+    // is sized for z*gamma+beta and trivially covers z*gamma. Owned copy: the
+    // externalize_bias=false branch moves .quant_param into the Mul output tensor below; the
+    // externalize_bias=true branch hands it to the Add output later. Either way, mul_out_qp must
+    // not alias storage that gets moved out before the requant predicates / scale reads run.
+    const QnnQuantParamsWrapper mul_out_qp = final_output_info.quant_param.Copy();
 
     // QNN ELEMENT_WISE_MULTIPLY requires both operands to share a dtype. In QDQ pipelines (e.g.
     // A16W8) the LN output adopts X's dtype while the user scale is still in its own (often
@@ -577,17 +579,17 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       mul_scale_name = requant_scale_name;
     }  // End of requantize scale
 
-    // Mul output: either an internal handoff to the Add (NATIVE, x_dtype, ln_intermediate_qp,
-    // x_shape) or the graph output (final_tensor_type, final dtype/qp/shape). Splitting the two
-    // cases makes the move-from-final_output_info contract obvious — the final-output branch is
-    // the sole writer, so reads of final_output_info.{quant_param,shape} below it are forbidden.
+    // Mul output: either an internal handoff to the Add (NATIVE, x_dtype, mul_out_qp, x_shape)
+    // or the graph output (final_tensor_type, final dtype/qp/shape). Splitting the two cases
+    // makes the move-from-final_output_info contract obvious — the final-output branch is the
+    // sole writer, so reads of final_output_info.{quant_param,shape} below it are forbidden.
     std::string mul_out_name;
     if (externalize_bias) {
       mul_out_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul_out");
       QnnTensorWrapper mul_out_tensor(mul_out_name,
                                       QNN_TENSOR_TYPE_NATIVE,
                                       x_qnn_data_type,
-                                      ln_intermediate_qp.Copy(),
+                                      mul_out_qp.Copy(),
                                       std::vector<uint32_t>(x_shape));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
                     "Failed to add decomposed Mul output tensor.");
@@ -613,8 +615,10 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   }
 
   if (externalize_bias) {
-    // Add LHS is the Mul output (when externalize_scale) or the LN output, both encoded with
-    // ln_intermediate_qp.
+    // Bias is the Add RHS; size it to cover beta directly. final_output_info.quant_param is
+    // sized for z*gamma+beta and so covers beta alone with room to spare. ln_intermediate_qp
+    // is too narrow here (its sqrt(N-1) range was sized for z, not beta — a bias whose magnitude
+    // exceeds sqrt(N-1) would silently saturate during requantize).
     std::string bias_name = input_names[2];
     TensorInfo bias_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[2], bias_info));
@@ -630,15 +634,15 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                     "LayerNorm decomposition: externalized bias must be a static initializer.");
       RETURN_IF_NOT(bias_info.quant_param.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm decomposition: externalized bias must be per-tensor quantized.");
-      RETURN_IF_NOT(ln_intermediate_qp.IsPerTensor(/*include_bw*/ true),
-                    "LayerNorm decomposition: requantized bias requires per-tensor intermediate quant params.");
+      RETURN_IF_NOT(final_output_info.quant_param.IsPerTensor(/*include_bw*/ true),
+                    "LayerNorm decomposition: requantized bias requires per-tensor final output quant params.");
 
       float src_scale = 0.0f;
       int32_t src_offset = 0;
       RETURN_IF_ERROR(bias_info.quant_param.GetPerTensorScaleOffset(src_scale, src_offset));
       float dst_scale = 0.0f;
       int32_t dst_offset = 0;
-      RETURN_IF_ERROR(ln_intermediate_qp.GetPerTensorScaleOffset(dst_scale, dst_offset));
+      RETURN_IF_ERROR(final_output_info.quant_param.GetPerTensorScaleOffset(dst_scale, dst_offset));
 
       // Allowlist bias dtypes upfront so a future QDQ pipeline emitting an unknown bias dtype
       // fails loudly here, rather than silently producing an all-zero requantized bias via the
@@ -671,7 +675,7 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       QnnTensorWrapper requant_bias_tensor(requant_bias_name,
                                            QNN_TENSOR_TYPE_STATIC,
                                            x_qnn_data_type,
-                                           ln_intermediate_qp.Copy(),
+                                           final_output_info.quant_param.Copy(),
                                            std::vector<uint32_t>(bias_info.shape),
                                            std::move(requant_bias));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(requant_bias_tensor)),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 #include <algorithm>
-#include <cassert>
 #include <cmath>
-#include <cstring>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
@@ -39,6 +37,7 @@ class LayerNormalizationOpBuilder : public BaseOpBuilder {
   // True iff `shape` (right-aligned to input_rank) has any non-1 dim at an axis < ln_axis.
   // Such dims fall outside QNN/ONNX LayerNorm's normalized axes [ln_axis, input_rank), so the
   // tensor cannot be fed directly to LayerNorm and must be applied via an outer Mul/Add instead.
+  // Precondition: shape.size() <= input_rank (enforced by IsOpSupported).
   static bool HasNonOneDimBeforeAxis(const std::vector<uint32_t>& shape,
                                      size_t input_rank,
                                      size_t ln_axis) {
@@ -65,6 +64,79 @@ class LayerNormalizationOpBuilder : public BaseOpBuilder {
                                        const Ort::Logger& logger) const ORT_MUST_USE_RESULT;
 };
 
+namespace {
+
+// Write `q` into the i-th element of a typed buffer based on `dtype`. Supports the four
+// 8/16-bit signed/unsigned fixed-point dtypes that utils::Quantize can saturate to.
+Ort::Status StoreQuantizedFixedPoint(Qnn_DataType_t dtype, uint8_t* dst, size_t i, int q) {
+  switch (dtype) {
+    case QNN_DATATYPE_SFIXED_POINT_8:
+      reinterpret_cast<int8_t*>(dst)[i] = static_cast<int8_t>(q);
+      return Ort::Status();
+    case QNN_DATATYPE_UFIXED_POINT_8:
+      reinterpret_cast<uint8_t*>(dst)[i] = static_cast<uint8_t>(q);
+      return Ort::Status();
+    case QNN_DATATYPE_SFIXED_POINT_16:
+      reinterpret_cast<int16_t*>(dst)[i] = static_cast<int16_t>(q);
+      return Ort::Status();
+    case QNN_DATATYPE_UFIXED_POINT_16:
+      reinterpret_cast<uint16_t*>(dst)[i] = static_cast<uint16_t>(q);
+      return Ort::Status();
+    default:
+      return MAKE_EP_FAIL("Unsupported fixed-point dtype for quantized store.");
+  }
+}
+
+// Requantize a per-tensor packed static buffer from (src_dtype, src_scale, src_offset) to
+// (dst_dtype, dst_scale, dst_offset). Source supports 8/16-bit signed and unsigned fixed-point
+// plus 32-bit signed (used for QDQ bias); destination supports 8/16-bit signed and unsigned
+// fixed-point (utils::Quantize cannot saturate to 32-bit). Resizes `dst` to the right byte
+// length. Caller is expected to have allowlisted `src_dtype` upfront for a clearer diagnostic.
+Ort::Status RequantizePerTensorStatic(const std::vector<uint8_t>& src,
+                                      Qnn_DataType_t src_dtype,
+                                      float src_scale,
+                                      int32_t src_offset,
+                                      Qnn_DataType_t dst_dtype,
+                                      float dst_scale,
+                                      int32_t dst_offset,
+                                      std::vector<uint8_t>& dst) {
+  auto load = [&](size_t i) -> int64_t {
+    switch (src_dtype) {
+      case QNN_DATATYPE_SFIXED_POINT_32:
+      case QNN_DATATYPE_INT_32:
+        return reinterpret_cast<const int32_t*>(src.data())[i];
+      case QNN_DATATYPE_SFIXED_POINT_16:
+        return reinterpret_cast<const int16_t*>(src.data())[i];
+      case QNN_DATATYPE_UFIXED_POINT_16:
+        return reinterpret_cast<const uint16_t*>(src.data())[i];
+      case QNN_DATATYPE_SFIXED_POINT_8:
+        return reinterpret_cast<const int8_t*>(src.data())[i];
+      case QNN_DATATYPE_UFIXED_POINT_8:
+        return reinterpret_cast<const uint8_t*>(src.data())[i];
+      default:
+        return 0;
+    }
+  };
+
+  const size_t src_elem = utils::GetElementSizeByType(src_dtype);
+  RETURN_IF_NOT(src_elem > 0 && src.size() % src_elem == 0,
+                "Requantize: source size is not a multiple of element size.");
+  const size_t dst_elem = utils::GetElementSizeByType(dst_dtype);
+  RETURN_IF_NOT(dst_elem > 0, "Requantize: unsupported destination element size.");
+
+  const size_t num = src.size() / src_elem;
+  dst.assign(num * dst_elem, 0);
+  for (size_t i = 0; i < num; ++i) {
+    const double dq = utils::Dequantize(src_offset, src_scale, static_cast<double>(load(i)));
+    int q = 0;
+    RETURN_IF_ERROR(utils::Quantize(dq, dst_scale, dst_offset, dst_dtype, q));
+    RETURN_IF_ERROR(StoreQuantizedFixedPoint(dst_dtype, dst.data(), i, q));
+  }
+  return Ort::Status();
+}
+
+}  // namespace
+
 Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                                        const OrtNodeUnit& node_unit,
                                                        const Ort::Logger& logger) const {
@@ -72,14 +144,30 @@ Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_mode
   const auto& outputs = node_unit.Outputs();
   RETURN_IF(outputs.size() > 1, "QNN LayerNorm only support 1 output.");
 
+  const auto& inputs = node_unit.Inputs();
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input_shape), "Cannot get shape of input 0");
+  const size_t input_rank = input_shape.size();
+
+  // Reject scale/bias whose rank exceeds X's rank. ONNX LN requires scale/B to broadcast to
+  // X.shape[axis:], so their rank cannot exceed input_rank. Letting such a model through would
+  // either underflow the prefix arithmetic in HasNonOneDimBeforeAxis or surface later as an opaque
+  // QNN shape-mismatch error; falling back to CPU EP here gives a clean diagnostic instead.
+  std::vector<uint32_t> scale_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[1].shape, scale_shape), "Cannot get shape of input 1 (scale)");
+  RETURN_IF(scale_shape.size() > input_rank,
+            "QNN LayerNorm: scale rank exceeds input rank; model violates ONNX broadcasting spec.");
+  if (inputs.size() > 2 && inputs[2].Exists()) {
+    std::vector<uint32_t> bias_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[2].shape, bias_shape), "Cannot get shape of input 2 (bias)");
+    RETURN_IF(bias_shape.size() > input_rank,
+              "QNN LayerNorm: bias rank exceeds input rank; model violates ONNX broadcasting spec.");
+  }
+
   // QNN Op validation can also do the same work, but the message is not so clear.
   // Explicit check and provide clear message here
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    std::vector<uint32_t> input_shape;
-    const auto& inputs = node_unit.Inputs();
-    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input_shape), "Cannot get shape of input 0");
-    const size_t input_rank = input_shape.size();
     int32_t default_axis = -1;
     Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
     RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
@@ -243,57 +331,33 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   TensorInfo final_output_info{};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], final_output_info));
 
-  QnnQuantParamsWrapper ln_intermediate_qp = final_output_info.quant_param.Copy();
-  QnnQuantParamsWrapper mul_intermediate_qp = final_output_info.quant_param.Copy();
-
-  // Quant params (when exists) for the LN intermediate (and the Mul-before-Add intermediate, when present).
-  // The LN op produces normalized values bounded by sqrt(N-1) (where N is the number of elements
-  // along the normalized axes), times the user scale if scale stays inside LN. Reusing
-  // final_output_info.quant_param here clips whenever the LN-stage range is wider than the final
-  // output's range — for instance when |user_scale| < 1 and bias is small, or in any path where
-  // an externalized Mul is sandwiched in front of an Add that narrows the range.
-  // Derive symmetric ranges per-stage instead, sized to the theoretical bound:
-  //   ln_out_range    = sqrt(N-1) * (externalize_scale ? 1 : max|user_scale|)
-  //   mul_out_range   = sqrt(N-1) * max|user_scale|       (only relevant when both are externalized)
-  if (final_output_info.quant_param.IsPerTensor(/*include_bw*/ true)) {
-    size_t norm_count = 1;
+  // ln_intermediate_qp: LN output. With externalize_scale, LN emits standardized values
+  // (|x| <= sqrt(N-1)); use a symmetric range over that bound so the external Mul isn't
+  // fed clipped values. Otherwise LN already applies the user scale — reuse final_output's
+  // qp, since the sqrt(N-1) bound assumes scale~=1 and loses precision at small scales.
+  QnnQuantParamsWrapper ln_intermediate_qp;
+  if (externalize_scale && final_output_info.quant_param.IsQuantized()) {
+    size_t num_norm_elems = 1;
     for (size_t i = ln_axis; i < x_shape.size(); ++i) {
-      norm_count *= static_cast<size_t>(x_shape[i]);
+      num_norm_elems *= static_cast<size_t>(x_shape[i]);
     }
-    const float ln_max_abs_normalized =
-        std::sqrt(std::max(static_cast<float>(norm_count) - 1.0f, 1.0f));
-
-    float user_scale_max_abs = 1.0f;
-    TensorInfo scale_info_for_range{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info_for_range));
-    if (scale_info_for_range.quant_param.IsPerTensor(/*include_bw*/ true)) {
-      float s_qmin = 0.0f;
-      float s_qmax = 0.0f;
-      RETURN_IF_ERROR(utils::GetQminQmax(scale_info_for_range.qnn_data_type, s_qmin, s_qmax));
-      const float s_scale = scale_info_for_range.quant_param.Get().scaleOffsetEncoding.scale;
-      const int32_t s_offset = scale_info_for_range.quant_param.Get().scaleOffsetEncoding.offset;
-      const double s_min = utils::Dequantize(s_offset, s_scale, s_qmin);
-      const double s_max = utils::Dequantize(s_offset, s_scale, s_qmax);
-      user_scale_max_abs = static_cast<float>(std::max(std::abs(s_min), std::abs(s_max)));
-    }
-
-    auto compute_intermediate_qp = [&](float range_abs, QnnQuantParamsWrapper& out_qp) -> Ort::Status {
-      const float k = std::max(range_abs, 1e-4f);
-      float interm_scale = 0.0f;
-      int32_t interm_offset = 0;
-      RETURN_IF_ERROR(utils::GetQuantParams(-k, k, x_qnn_data_type, interm_scale, interm_offset,
-                                            /*symmetric*/ false));
-      out_qp = QnnQuantParamsWrapper(interm_scale, interm_offset);
-      return Ort::Status();
-    };
-
-    const float ln_out_range_abs = externalize_scale
-                                       ? ln_max_abs_normalized
-                                       : ln_max_abs_normalized * user_scale_max_abs;
-    const float mul_out_range_abs = ln_max_abs_normalized * user_scale_max_abs;
-    RETURN_IF_ERROR(compute_intermediate_qp(ln_out_range_abs, ln_intermediate_qp));
-    RETURN_IF_ERROR(compute_intermediate_qp(mul_out_range_abs, mul_intermediate_qp));
-  }  // End of re-quantize LN quantparam
+    // Hard bound is sqrt(N-1), but real data sits within ~3-sigma; cap at min(sqrt(N-1), 3.0)
+    // so narrow dtypes (uint8: 256 levels) don't waste range on an unused tail. Values past 3.0
+    // saturate, but are rare enough not to dominate per-tensor error.
+    const float hard_bound = num_norm_elems > 1
+                                 ? std::sqrt(static_cast<float>(num_norm_elems - 1))
+                                 : 1.0f;
+    constexpr float kStatisticalLnBound = 3.0f;
+    const float ln_abs_max = std::min(hard_bound, kStatisticalLnBound);
+    float ln_scale = 0.0f;
+    int32_t ln_offset = 0;
+    RETURN_IF_ERROR(utils::GetQuantParams(-ln_abs_max, ln_abs_max, x_qnn_data_type,
+                                          ln_scale, ln_offset, /*symmetric=*/false));
+    ln_intermediate_qp = QnnQuantParamsWrapper(ln_scale, ln_offset);
+  } else {
+    // FP path
+    ln_intermediate_qp = final_output_info.quant_param.Copy();
+  }
 
   std::string ln_scale_name;
   if (!externalize_scale) {
@@ -322,35 +386,11 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       const int32_t quant_offset = scale_info.quant_param.Get().scaleOffsetEncoding.offset;
       int quant_one = 0;
       RETURN_IF_ERROR(utils::Quantize(1.0, quant_scale, quant_offset, scale_dtype, quant_one));
-      switch (scale_dtype) {
-        case QNN_DATATYPE_SFIXED_POINT_8: {
-          const_buf.resize(num_elems * sizeof(int8_t));
-          std::fill(reinterpret_cast<int8_t*>(const_buf.data()),
-                    reinterpret_cast<int8_t*>(const_buf.data()) + num_elems,
-                    static_cast<int8_t>(quant_one));
-          break;
-        }
-        case QNN_DATATYPE_UFIXED_POINT_8: {
-          const_buf.resize(num_elems * sizeof(uint8_t));
-          std::fill(const_buf.begin(), const_buf.end(), static_cast<uint8_t>(quant_one));
-          break;
-        }
-        case QNN_DATATYPE_SFIXED_POINT_16: {
-          const_buf.resize(num_elems * sizeof(int16_t));
-          std::fill(reinterpret_cast<int16_t*>(const_buf.data()),
-                    reinterpret_cast<int16_t*>(const_buf.data()) + num_elems,
-                    static_cast<int16_t>(quant_one));
-          break;
-        }
-        case QNN_DATATYPE_UFIXED_POINT_16: {
-          const_buf.resize(num_elems * sizeof(uint16_t));
-          std::fill(reinterpret_cast<uint16_t*>(const_buf.data()),
-                    reinterpret_cast<uint16_t*>(const_buf.data()) + num_elems,
-                    static_cast<uint16_t>(quant_one));
-          break;
-        }
-        default:
-          return MAKE_EP_FAIL("LayerNorm scale decomposition: unsupported quantized scale dtype.");
+      const size_t elem_bytes = utils::GetElementSizeByType(scale_dtype);
+      RETURN_IF_NOT(elem_bytes > 0, "LayerNorm scale decomposition: unsupported quantized scale dtype.");
+      const_buf.assign(num_elems * elem_bytes, 0);
+      for (size_t i = 0; i < num_elems; ++i) {
+        RETURN_IF_ERROR(StoreQuantizedFixedPoint(scale_dtype, const_buf.data(), i, quant_one));
       }
     } else {
       switch (scale_dtype) {
@@ -395,6 +435,25 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                 "Failed to add decomposed LN intermediate output tensor.");
 
   std::vector<std::string> ln_inputs = {input_names[0], ln_scale_name};
+
+#if QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 17 && QNN_API_VERSION_MINOR <= 20
+  // Mirror the ProcessInputs workaround: on QNN SDK 2.24-2.27 (API 2.17-2.20), an LN node without
+  // an explicit bias intermittently fails graph finalize on NPU. The decomposed path always emits
+  // LN with only {X, scale}, so synthesize a zero int32 bias here when the same prerequisites hold.
+  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    TensorInfo x_input_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], x_input_info));
+    TensorInfo scale_input_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_input_info));
+    if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_input_info.quant_param.IsQuantized()) {
+      const std::string bias_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_implicit_bias");
+      std::vector<uint32_t> bias_shape(x_shape.begin() + ln_axis, x_shape.end());
+      RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_input_info.quant_param,
+                                       std::move(bias_shape), bias_name, logger, ln_inputs));
+    }
+  }
+#endif
+
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_LAYER_NORM,
@@ -407,6 +466,63 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   std::string current = ln_out_name;
 
   if (externalize_scale) {
+    const QnnQuantParamsWrapper& mul_out_qp =
+        externalize_bias ? ln_intermediate_qp : final_output_info.quant_param;
+
+    // QNN ELEMENT_WISE_MULTIPLY requires both operands to share a dtype. In QDQ pipelines (e.g.
+    // A16W8) the LN output adopts X's dtype while the user scale is still in its own (often
+    // narrower) dtype. Requantize the static scale initializer to x_qnn_data_type so the Mul
+    // sees matching operand dtypes. ONNX LN spec demands X/scale/bias share dtype, so a mismatch
+    // here implies a quantized graph where the original initializer is available.
+    std::string mul_scale_name = input_names[1];
+    TensorInfo scale_info_for_mul{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info_for_mul));
+    if (scale_info_for_mul.qnn_data_type != x_qnn_data_type) {
+      RETURN_IF_NOT(scale_info_for_mul.is_initializer && scale_info_for_mul.initializer_tensor != nullptr,
+                    "LayerNorm decomposition: externalized scale must be a static initializer.");
+      RETURN_IF_NOT(scale_info_for_mul.quant_param.IsPerTensor(/*include_bw*/ true),
+                    "LayerNorm decomposition: externalized scale must be per-tensor quantized.");
+      RETURN_IF_NOT(mul_out_qp.IsPerTensor(/*include_bw*/ true),
+                    "LayerNorm decomposition: requantized scale requires per-tensor intermediate quant params.");
+
+      const float src_scale = scale_info_for_mul.quant_param.Get().scaleOffsetEncoding.scale;
+      const int32_t src_offset = scale_info_for_mul.quant_param.Get().scaleOffsetEncoding.offset;
+      const float dst_scale = mul_out_qp.Get().scaleOffsetEncoding.scale;
+      const int32_t dst_offset = mul_out_qp.Get().scaleOffsetEncoding.offset;
+
+      switch (scale_info_for_mul.qnn_data_type) {
+        case QNN_DATATYPE_SFIXED_POINT_16:
+        case QNN_DATATYPE_UFIXED_POINT_16:
+        case QNN_DATATYPE_SFIXED_POINT_8:
+        case QNN_DATATYPE_UFIXED_POINT_8:
+          break;
+        default:
+          return MAKE_EP_FAIL("LayerNorm decomposition: unsupported externalized scale dtype.");
+      }
+
+      std::vector<uint8_t> raw_scale;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info_for_mul.initializer_tensor, raw_scale));
+
+      std::vector<uint8_t> requant_scale;
+      RETURN_IF_ERROR(RequantizePerTensorStatic(raw_scale,
+                                                scale_info_for_mul.qnn_data_type,
+                                                src_scale, src_offset,
+                                                x_qnn_data_type,
+                                                dst_scale, dst_offset,
+                                                requant_scale));
+
+      const std::string requant_scale_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_scale_requant");
+      QnnTensorWrapper requant_scale_tensor(requant_scale_name,
+                                            QNN_TENSOR_TYPE_STATIC,
+                                            x_qnn_data_type,
+                                            mul_out_qp.Copy(),
+                                            std::vector<uint32_t>(scale_info_for_mul.shape),
+                                            std::move(requant_scale));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(requant_scale_tensor)),
+                    "Failed to add requantized scale tensor.");
+      mul_scale_name = requant_scale_name;
+    }  // End of requantize scale
+
     const std::string mul_out_name =
         externalize_bias ? utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul_out")
                          : final_output_name;
@@ -414,14 +530,14 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
         mul_out_name,
         externalize_bias ? QNN_TENSOR_TYPE_NATIVE : final_tensor_type,
         externalize_bias ? x_qnn_data_type : final_output_info.qnn_data_type,
-        externalize_bias ? mul_intermediate_qp.Copy() : std::move(final_output_info.quant_param),
+        externalize_bias ? ln_intermediate_qp.Copy() : std::move(final_output_info.quant_param),
         externalize_bias ? std::vector<uint32_t>(x_shape) : std::move(final_output_info.shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
                   "Failed to add decomposed Mul output tensor.");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_MULTIPLY,
-                                                  {current, input_names[1]},
+                                                  {current, mul_scale_name},
                                                   {mul_out_name},
                                                   {},
                                                   do_op_validation),
@@ -430,89 +546,66 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   }
 
   if (externalize_bias) {
-    const QnnQuantParamsWrapper& add_lhs_qp =
-        externalize_scale ? mul_intermediate_qp : ln_intermediate_qp;
-
+    // Add LHS is the Mul output (when externalize_scale) or the LN output, both encoded with
+    // ln_intermediate_qp.
     std::string bias_name = input_names[2];
     TensorInfo bias_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[2], bias_info));
 
     // QDQ pipelines feed LayerNorm's bias as int32 (matching ONNX LN's int32 beta convention).
     // QNN's LayerNorm op accepts that, but ELEMENT_WISE_ADD requires both operands to share a
-    // dtype, re-quantize the static int32 bias to match LN output dtype.
-    // ONNX requires LN input, scale and bias in same dtype, so when dtype mismatch, it must be a qdq graph.
+    // dtype — requantize the static int32 bias to match LN output dtype. ONNX requires X/scale/
+    // bias share dtype, so a mismatch here implies a QDQ graph with the original initializer.
     if (bias_info.qnn_data_type != x_qnn_data_type) {
       RETURN_IF_NOT(bias_info.is_initializer && bias_info.initializer_tensor != nullptr,
                     "LayerNorm decomposition: externalized bias must be a static initializer.");
       RETURN_IF_NOT(bias_info.quant_param.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm decomposition: externalized bias must be per-tensor quantized.");
-      RETURN_IF_NOT(add_lhs_qp.IsPerTensor(/*include_bw*/ true),
+      RETURN_IF_NOT(ln_intermediate_qp.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm decomposition: requantized bias requires per-tensor intermediate quant params.");
 
       const float src_scale = bias_info.quant_param.Get().scaleOffsetEncoding.scale;
       const int32_t src_offset = bias_info.quant_param.Get().scaleOffsetEncoding.offset;
-      const float dst_scale = add_lhs_qp.Get().scaleOffsetEncoding.scale;
-      const int32_t dst_offset = add_lhs_qp.Get().scaleOffsetEncoding.offset;
+      const float dst_scale = ln_intermediate_qp.Get().scaleOffsetEncoding.scale;
+      const int32_t dst_offset = ln_intermediate_qp.Get().scaleOffsetEncoding.offset;
+
+      // Allowlist bias dtypes upfront so a future QDQ pipeline emitting an unknown bias dtype
+      // fails loudly here, rather than silently producing an all-zero requantized bias via the
+      // helper's load default branch.
+      switch (bias_info.qnn_data_type) {
+        case QNN_DATATYPE_SFIXED_POINT_32:
+        case QNN_DATATYPE_INT_32:
+        case QNN_DATATYPE_SFIXED_POINT_16:
+        case QNN_DATATYPE_UFIXED_POINT_16:
+        case QNN_DATATYPE_SFIXED_POINT_8:
+        case QNN_DATATYPE_UFIXED_POINT_8:
+          break;
+        default:
+          return MAKE_EP_FAIL("LayerNorm decomposition: unsupported externalized bias dtype.");
+      }
 
       std::vector<uint8_t> raw_bias;
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias));
-      const size_t bias_elem_bytes = utils::GetElementSizeByType(bias_info.qnn_data_type);
-      RETURN_IF_NOT(bias_elem_bytes > 0 && raw_bias.size() % bias_elem_bytes == 0,
-                    "LayerNorm decomposition: bias raw data size is not a multiple of element size.");
-      const size_t num_bias_elems = raw_bias.size() / bias_elem_bytes;
 
-      auto load_q_value = [&](size_t i) -> int64_t {
-        switch (bias_info.qnn_data_type) {
-          case QNN_DATATYPE_SFIXED_POINT_32:
-          case QNN_DATATYPE_INT_32:
-            return static_cast<int64_t>(reinterpret_cast<const int32_t*>(raw_bias.data())[i]);
-          case QNN_DATATYPE_SFIXED_POINT_16:
-            return static_cast<int64_t>(reinterpret_cast<const int16_t*>(raw_bias.data())[i]);
-          case QNN_DATATYPE_UFIXED_POINT_16:
-            return static_cast<int64_t>(reinterpret_cast<const uint16_t*>(raw_bias.data())[i]);
-          case QNN_DATATYPE_SFIXED_POINT_8:
-            return static_cast<int64_t>(reinterpret_cast<const int8_t*>(raw_bias.data())[i]);
-          case QNN_DATATYPE_UFIXED_POINT_8:
-            return static_cast<int64_t>(reinterpret_cast<const uint8_t*>(raw_bias.data())[i]);
-          default:
-            return 0;
-        }
-      };
-
-      std::vector<uint8_t> requant_bias(num_bias_elems * utils::GetElementSizeByType(x_qnn_data_type), 0);
-      for (size_t i = 0; i < num_bias_elems; ++i) {
-        const double dequant_val = utils::Dequantize(src_offset, src_scale, static_cast<double>(load_q_value(i)));
-        int q = 0;
-        RETURN_IF_ERROR(utils::Quantize(dequant_val, dst_scale, dst_offset, x_qnn_data_type, q));
-        switch (x_qnn_data_type) {
-          case QNN_DATATYPE_SFIXED_POINT_8:
-            reinterpret_cast<int8_t*>(requant_bias.data())[i] = static_cast<int8_t>(q);
-            break;
-          case QNN_DATATYPE_UFIXED_POINT_8:
-            reinterpret_cast<uint8_t*>(requant_bias.data())[i] = static_cast<uint8_t>(q);
-            break;
-          case QNN_DATATYPE_SFIXED_POINT_16:
-            reinterpret_cast<int16_t*>(requant_bias.data())[i] = static_cast<int16_t>(q);
-            break;
-          case QNN_DATATYPE_UFIXED_POINT_16:
-            reinterpret_cast<uint16_t*>(requant_bias.data())[i] = static_cast<uint16_t>(q);
-            break;
-          default:
-            return MAKE_EP_FAIL("LayerNorm decomposition: unsupported intermediate dtype for bias requant.");
-        }
-      }
+      std::vector<uint8_t> requant_bias;
+      RETURN_IF_ERROR(RequantizePerTensorStatic(raw_bias,
+                                                bias_info.qnn_data_type,
+                                                src_scale, src_offset,
+                                                x_qnn_data_type,
+                                                dst_scale, dst_offset,
+                                                requant_bias));
 
       const std::string requant_bias_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_bias_requant");
       QnnTensorWrapper requant_bias_tensor(requant_bias_name,
                                            QNN_TENSOR_TYPE_STATIC,
                                            x_qnn_data_type,
-                                           add_lhs_qp.Copy(),
+                                           ln_intermediate_qp.Copy(),
                                            std::vector<uint32_t>(bias_info.shape),
                                            std::move(requant_bias));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(requant_bias_tensor)),
                     "Failed to add requantized bias tensor.");
       bias_name = requant_bias_name;
-    }
+    }  // end of requant bias
 
     QnnTensorWrapper add_out_tensor(final_output_name,
                                     final_tensor_type,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -179,9 +179,6 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   // outer Mul/Add that broadcasts across the batch), QNN can't consume them as LN scale/B.
   // Decide which side(s) to externalize:
   //   - scale misaligned -> externalize scale; bias must also be externalized whenever it exists,
-  //     because LN computes (norm*scale + bias). Pulling scale out as a trailing Mul would turn a
-  //     legal-shape bias inside LN into bias*scale_external, which both changes the math and
-  //     re-introduces the broadcast problem. So scale-out forces bias-out.
   //   - scale legal, bias misaligned -> keep LN(scale), externalize only the Add.
   const auto& inputs = node_unit.Inputs();
   const bool has_bias_input = inputs.size() > 2 && inputs[2].Exists();
@@ -237,10 +234,6 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                                                                   bool do_op_validation,
                                                                   const Ort::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
-  assert(externalize_scale || externalize_bias);
-  // externalize_bias implies a trailing Add fed by input_names[2], so the user must have provided
-  // a bias input.
-  assert(!externalize_bias || input_names.size() > 2);
 
   const auto& outputs = node_unit.Outputs();
   const std::string& final_output_name = outputs[0].name;
@@ -250,7 +243,10 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   TensorInfo final_output_info{};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], final_output_info));
 
-  // Quant params for the LN intermediate (and the Mul-before-Add intermediate, when present).
+  QnnQuantParamsWrapper ln_intermediate_qp = final_output_info.quant_param.Copy();
+  QnnQuantParamsWrapper mul_intermediate_qp = final_output_info.quant_param.Copy();
+
+  // Quant params (when exists) for the LN intermediate (and the Mul-before-Add intermediate, when present).
   // The LN op produces normalized values bounded by sqrt(N-1) (where N is the number of elements
   // along the normalized axes), times the user scale if scale stays inside LN. Reusing
   // final_output_info.quant_param here clips whenever the LN-stage range is wider than the final
@@ -259,15 +255,15 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   // Derive symmetric ranges per-stage instead, sized to the theoretical bound:
   //   ln_out_range    = sqrt(N-1) * (externalize_scale ? 1 : max|user_scale|)
   //   mul_out_range   = sqrt(N-1) * max|user_scale|       (only relevant when both are externalized)
-  size_t norm_count = 1;
-  for (size_t i = ln_axis; i < x_shape.size(); ++i) {
-    norm_count *= static_cast<size_t>(x_shape[i]);
-  }
-  const float ln_max_abs_normalized =
-      std::sqrt(std::max(static_cast<float>(norm_count) - 1.0f, 1.0f));
+  if (final_output_info.quant_param.IsPerTensor(/*include_bw*/ true)) {
+    size_t norm_count = 1;
+    for (size_t i = ln_axis; i < x_shape.size(); ++i) {
+      norm_count *= static_cast<size_t>(x_shape[i]);
+    }
+    const float ln_max_abs_normalized =
+        std::sqrt(std::max(static_cast<float>(norm_count) - 1.0f, 1.0f));
 
-  float user_scale_max_abs = 1.0f;
-  {
+    float user_scale_max_abs = 1.0f;
     TensorInfo scale_info_for_range{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info_for_range));
     if (scale_info_for_range.quant_param.IsPerTensor(/*include_bw*/ true)) {
@@ -280,31 +276,25 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       const double s_max = utils::Dequantize(s_offset, s_scale, s_qmax);
       user_scale_max_abs = static_cast<float>(std::max(std::abs(s_min), std::abs(s_max)));
     }
-  }
 
-  auto compute_intermediate_qp = [&](float range_abs, QnnQuantParamsWrapper& out_qp) -> Ort::Status {
-    const float k = std::max(range_abs, 1e-4f);
-    float interm_scale = 0.0f;
-    int32_t interm_offset = 0;
-    RETURN_IF_ERROR(utils::GetQuantParams(-k, k, x_qnn_data_type, interm_scale, interm_offset,
-                                          /*symmetric*/ false));
-    out_qp = QnnQuantParamsWrapper(interm_scale, interm_offset);
-    return Ort::Status();
-  };
+    auto compute_intermediate_qp = [&](float range_abs, QnnQuantParamsWrapper& out_qp) -> Ort::Status {
+      const float k = std::max(range_abs, 1e-4f);
+      float interm_scale = 0.0f;
+      int32_t interm_offset = 0;
+      RETURN_IF_ERROR(utils::GetQuantParams(-k, k, x_qnn_data_type, interm_scale, interm_offset,
+                                            /*symmetric*/ false));
+      out_qp = QnnQuantParamsWrapper(interm_scale, interm_offset);
+      return Ort::Status();
+    };
 
-  QnnQuantParamsWrapper ln_intermediate_qp = final_output_info.quant_param.Copy();
-  QnnQuantParamsWrapper mul_intermediate_qp = final_output_info.quant_param.Copy();
-  if (final_output_info.quant_param.IsPerTensor(/*include_bw*/ true)) {
     const float ln_out_range_abs = externalize_scale
                                        ? ln_max_abs_normalized
                                        : ln_max_abs_normalized * user_scale_max_abs;
     const float mul_out_range_abs = ln_max_abs_normalized * user_scale_max_abs;
     RETURN_IF_ERROR(compute_intermediate_qp(ln_out_range_abs, ln_intermediate_qp));
     RETURN_IF_ERROR(compute_intermediate_qp(mul_out_range_abs, mul_intermediate_qp));
-  }
+  }  // End of re-quantize LN quantparam
 
-  // The LN node's scale input: either the user's (when scale stays inside) or a constant 1.0
-  // tensor of shape X.shape[axis:] that we synthesize here.
   std::string ln_scale_name;
   if (!externalize_scale) {
     ln_scale_name = input_names[1];
@@ -312,8 +302,8 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     // Match the synthesized ones tensor to the user-provided scale's dtype + quant params so the
     // LN op sees the type it expects in slot 1. Encoding 1.0 in the user's quant scheme is what
     // makes this an identity scale at runtime.
-    TensorInfo user_scale_info{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], user_scale_info));
+    TensorInfo scale_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info));
 
     std::vector<uint32_t> norm_shape(x_shape.begin() + ln_axis, x_shape.end());
     size_t num_elems = 1;
@@ -321,15 +311,15 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       num_elems *= static_cast<size_t>(d);
     }
 
-    const Qnn_DataType_t scale_dtype = user_scale_info.qnn_data_type;
+    const Qnn_DataType_t scale_dtype = scale_info.qnn_data_type;
     std::vector<uint8_t> const_buf;
 
-    if (user_scale_info.quant_param.IsQuantized()) {
+    if (scale_info.quant_param.IsQuantized()) {
       // Per-tensor or per-channel quantized: quantize 1.0 using the user scale's params and fill.
-      RETURN_IF_NOT(user_scale_info.quant_param.IsPerTensor(/*include_bw*/ true),
+      RETURN_IF_NOT(scale_info.quant_param.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm scale decomposition: per-channel quantized scale is not supported.");
-      const float quant_scale = user_scale_info.quant_param.Get().scaleOffsetEncoding.scale;
-      const int32_t quant_offset = user_scale_info.quant_param.Get().scaleOffsetEncoding.offset;
+      const float quant_scale = scale_info.quant_param.Get().scaleOffsetEncoding.scale;
+      const int32_t quant_offset = scale_info.quant_param.Get().scaleOffsetEncoding.offset;
       int quant_one = 0;
       RETURN_IF_ERROR(utils::Quantize(1.0, quant_scale, quant_offset, scale_dtype, quant_one));
       switch (scale_dtype) {
@@ -385,7 +375,7 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     QnnTensorWrapper scale_one_tensor(ln_scale_name,
                                       QNN_TENSOR_TYPE_STATIC,
                                       scale_dtype,
-                                      user_scale_info.quant_param.Copy(),
+                                      scale_info.quant_param.Copy(),
                                       std::move(norm_shape),
                                       std::move(const_buf));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(scale_one_tensor)),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <cassert>
+#include <cstring>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
@@ -31,6 +32,35 @@ class LayerNormalizationOpBuilder : public BaseOpBuilder {
                                           std::vector<std::string>&& input_names,
                                           const Ort::Logger& logger,
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+ private:
+  // True iff `shape` (right-aligned to input_rank) has any non-1 dim at an axis < ln_axis.
+  // Such dims fall outside QNN/ONNX LayerNorm's normalized axes [ln_axis, input_rank), so the
+  // tensor cannot be fed directly to LayerNorm and must be applied via an outer Mul/Add instead.
+  static bool HasNonOneDimBeforeAxis(const std::vector<uint32_t>& shape,
+                                     size_t input_rank,
+                                     size_t ln_axis) {
+    const size_t prefix = input_rank - shape.size();
+    for (size_t i = 0; i < shape.size(); ++i) {
+      const size_t aligned_axis = prefix + i;
+      if (aligned_axis < ln_axis && shape[i] != 1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Ort::Status BuildDecomposedLayerNorm(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       const std::vector<std::string>& input_names,
+                                       std::vector<std::string>&& param_tensor_names,
+                                       const std::vector<uint32_t>& x_shape,
+                                       Qnn_DataType_t x_qnn_data_type,
+                                       size_t ln_axis,
+                                       bool externalize_scale,
+                                       bool externalize_bias,
+                                       bool do_op_validation,
+                                       const Ort::Logger& logger) const ORT_MUST_USE_RESULT;
 };
 
 Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
@@ -142,10 +172,240 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   param_tensor_names.push_back(axes_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(axes_param));
 
+  // ONNX LayerNormalization requires scale/B to broadcast to X.shape[axis:]. If the user-provided
+  // scale or bias has non-1 dims at axes outside [axis, rank) (e.g. they were folded in by an
+  // outer Mul/Add that broadcasts across the batch), QNN can't consume them as LN scale/B.
+  // Decide which side(s) to externalize:
+  //   - scale misaligned -> externalize scale; bias must also be externalized whenever it exists,
+  //     because LN computes (norm*scale + bias). Pulling scale out as a trailing Mul would turn a
+  //     legal-shape bias inside LN into bias*scale_external, which both changes the math and
+  //     re-introduces the broadcast problem. So scale-out forces bias-out.
+  //   - scale legal, bias misaligned -> keep LN(scale), externalize only the Add.
+  const auto& inputs = node_unit.Inputs();
+  const bool has_bias_input = inputs.size() > 2 && inputs[2].Exists();
+  TensorInfo scale_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], scale_info));
+  const bool scale_misaligned =
+      HasNonOneDimBeforeAxis(scale_info.shape, input_rank, static_cast<size_t>(default_axis));
+
+  bool bias_misaligned = false;
+  if (has_bias_input) {
+    TensorInfo bias_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
+    bias_misaligned =
+        HasNonOneDimBeforeAxis(bias_info.shape, input_rank, static_cast<size_t>(default_axis));
+  }
+
+  const bool externalize_scale = scale_misaligned;
+  const bool externalize_bias = has_bias_input && (bias_misaligned || scale_misaligned);
+
+  if (externalize_scale || externalize_bias) {
+    TensorInfo x_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], x_info));
+    return BuildDecomposedLayerNorm(qnn_model_wrapper,
+                                    node_unit,
+                                    input_names,
+                                    std::move(param_tensor_names),
+                                    input_shape,
+                                    x_info.qnn_data_type,
+                                    static_cast<size_t>(default_axis),
+                                    externalize_scale,
+                                    externalize_bias,
+                                    do_op_validation,
+                                    logger);
+  }
+
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
                                  std::move(input_names),
                                  std::move(param_tensor_names),
                                  logger, do_op_validation, GetQnnOpType(node_unit.OpType())));
+
+  return Ort::Status();
+}
+
+Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrapper& qnn_model_wrapper,
+                                                                  const OrtNodeUnit& node_unit,
+                                                                  const std::vector<std::string>& input_names,
+                                                                  std::vector<std::string>&& param_tensor_names,
+                                                                  const std::vector<uint32_t>& x_shape,
+                                                                  Qnn_DataType_t x_qnn_data_type,
+                                                                  size_t ln_axis,
+                                                                  bool externalize_scale,
+                                                                  bool externalize_bias,
+                                                                  bool do_op_validation,
+                                                                  const Ort::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  assert(externalize_scale || externalize_bias);
+  // externalize_bias implies a trailing Add fed by input_names[2], so the user must have provided
+  // a bias input.
+  assert(!externalize_bias || input_names.size() > 2);
+
+  const auto& outputs = node_unit.Outputs();
+  const std::string& final_output_name = outputs[0].name;
+  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
+  const Qnn_TensorType_t final_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  TensorInfo final_output_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], final_output_info));
+
+  // The LN node's scale input: either the user's (when scale stays inside) or a constant 1.0
+  // tensor of shape X.shape[axis:] that we synthesize here.
+  std::string ln_scale_name;
+  if (!externalize_scale) {
+    ln_scale_name = input_names[1];
+  } else {
+    // Match the synthesized ones tensor to the user-provided scale's dtype + quant params so the
+    // LN op sees the type it expects in slot 1. Encoding 1.0 in the user's quant scheme is what
+    // makes this an identity scale at runtime.
+    TensorInfo user_scale_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], user_scale_info));
+
+    std::vector<uint32_t> norm_shape(x_shape.begin() + ln_axis, x_shape.end());
+    size_t num_elems = 1;
+    for (uint32_t d : norm_shape) {
+      num_elems *= static_cast<size_t>(d);
+    }
+
+    const Qnn_DataType_t scale_dtype = user_scale_info.qnn_data_type;
+    std::vector<uint8_t> const_buf;
+
+    if (user_scale_info.quant_param.IsQuantized()) {
+      // Per-tensor or per-channel quantized: quantize 1.0 using the user scale's params and fill.
+      RETURN_IF_NOT(user_scale_info.quant_param.IsPerTensor(/*include_bw*/ true),
+                    "LayerNorm scale decomposition: per-channel quantized scale is not supported.");
+      const float quant_scale = user_scale_info.quant_param.Get().scaleOffsetEncoding.scale;
+      const int32_t quant_offset = user_scale_info.quant_param.Get().scaleOffsetEncoding.offset;
+      int quant_one = 0;
+      RETURN_IF_ERROR(utils::Quantize(1.0, quant_scale, quant_offset, scale_dtype, quant_one));
+      switch (scale_dtype) {
+        case QNN_DATATYPE_SFIXED_POINT_8: {
+          const_buf.resize(num_elems * sizeof(int8_t));
+          std::fill(reinterpret_cast<int8_t*>(const_buf.data()),
+                    reinterpret_cast<int8_t*>(const_buf.data()) + num_elems,
+                    static_cast<int8_t>(quant_one));
+          break;
+        }
+        case QNN_DATATYPE_UFIXED_POINT_8: {
+          const_buf.resize(num_elems * sizeof(uint8_t));
+          std::fill(const_buf.begin(), const_buf.end(), static_cast<uint8_t>(quant_one));
+          break;
+        }
+        case QNN_DATATYPE_SFIXED_POINT_16: {
+          const_buf.resize(num_elems * sizeof(int16_t));
+          std::fill(reinterpret_cast<int16_t*>(const_buf.data()),
+                    reinterpret_cast<int16_t*>(const_buf.data()) + num_elems,
+                    static_cast<int16_t>(quant_one));
+          break;
+        }
+        case QNN_DATATYPE_UFIXED_POINT_16: {
+          const_buf.resize(num_elems * sizeof(uint16_t));
+          std::fill(reinterpret_cast<uint16_t*>(const_buf.data()),
+                    reinterpret_cast<uint16_t*>(const_buf.data()) + num_elems,
+                    static_cast<uint16_t>(quant_one));
+          break;
+        }
+        default:
+          return MAKE_EP_FAIL("LayerNorm scale decomposition: unsupported quantized scale dtype.");
+      }
+    } else {
+      switch (scale_dtype) {
+        case QNN_DATATYPE_FLOAT_32: {
+          const_buf.resize(num_elems * sizeof(float));
+          float* p = reinterpret_cast<float*>(const_buf.data());
+          std::fill(p, p + num_elems, 1.0f);
+          break;
+        }
+        case QNN_DATATYPE_FLOAT_16: {
+          const_buf.resize(num_elems * sizeof(Ort::Float16_t));
+          Ort::Float16_t* p = reinterpret_cast<Ort::Float16_t*>(const_buf.data());
+          std::fill(p, p + num_elems, static_cast<Ort::Float16_t>(1.0f));
+          break;
+        }
+        default:
+          return MAKE_EP_FAIL("LayerNorm scale decomposition: unsupported float scale dtype.");
+      }
+    }
+
+    ln_scale_name = utils::UniqueNameGenerator().New(node_unit, "_ln_scale_one");
+    QnnTensorWrapper scale_one_tensor(ln_scale_name,
+                                      QNN_TENSOR_TYPE_STATIC,
+                                      scale_dtype,
+                                      user_scale_info.quant_param.Copy(),
+                                      std::move(norm_shape),
+                                      std::move(const_buf));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(scale_one_tensor)),
+                  "Failed to add LN identity scale tensor.");
+  }
+
+  // The Add (if present) is always last and writes to final_output_name. If only Mul is present,
+  // Mul writes to final_output_name. Earlier intermediates (LN, optional Mul-before-Add) are NATIVE
+  // tensors of x_shape and x dtype.
+  // Intermediate tensors need valid quant encoding when x_qnn_data_type is a quantized type;
+  // an empty QnnQuantParamsWrapper would fail QNN validation and at runtime would dequantize as
+  // (val - 0) * 0 = 0. Reuse the final output's quant params (Copy() so the move at the end of
+  // the function still works for the Add output). Range may be coarser than ideal for the LN
+  // output when scale/bias shift it, but it's well-formed.
+  const std::string ln_out_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_out");
+  QnnTensorWrapper ln_out_tensor(ln_out_name,
+                                  QNN_TENSOR_TYPE_NATIVE,
+                                  x_qnn_data_type,
+                                  final_output_info.quant_param.Copy(),
+                                  std::vector<uint32_t>(x_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(ln_out_tensor)),
+                "Failed to add decomposed LN intermediate output tensor.");
+
+  std::vector<std::string> ln_inputs = {input_names[0], ln_scale_name};
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_LAYER_NORM,
+                                                std::move(ln_inputs),
+                                                {ln_out_name},
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
+                "Failed to add decomposed LayerNorm node.");
+
+  std::string current = ln_out_name;
+
+  if (externalize_scale) {
+    const std::string mul_out_name =
+        externalize_bias ? utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul_out")
+                         : final_output_name;
+    QnnTensorWrapper mul_out_tensor(
+        mul_out_name,
+        externalize_bias ? QNN_TENSOR_TYPE_NATIVE : final_tensor_type,
+        externalize_bias ? x_qnn_data_type : final_output_info.qnn_data_type,
+        externalize_bias ? final_output_info.quant_param.Copy() : std::move(final_output_info.quant_param),
+        externalize_bias ? std::vector<uint32_t>(x_shape) : std::move(final_output_info.shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
+                  "Failed to add decomposed Mul output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul"),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_MULTIPLY,
+                                                  {current, input_names[1]},
+                                                  {mul_out_name},
+                                                  {},
+                                                  do_op_validation),
+                  "Failed to add decomposed Mul node.");
+    current = mul_out_name;
+  }
+
+  if (externalize_bias) {
+    QnnTensorWrapper add_out_tensor(final_output_name,
+                                    final_tensor_type,
+                                    final_output_info.qnn_data_type,
+                                    std::move(final_output_info.quant_param),
+                                    std::move(final_output_info.shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_out_tensor)),
+                  "Failed to add decomposed Add output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_add"),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_ADD,
+                                                  {current, input_names[2]},
+                                                  {final_output_name},
+                                                  {},
+                                                  do_op_validation),
+                  "Failed to add decomposed Add node.");
+  }
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstring>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -248,6 +250,59 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   TensorInfo final_output_info{};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], final_output_info));
 
+  // Quant params for the LN intermediate (and the Mul-before-Add intermediate, when present).
+  // The LN op produces normalized values bounded by sqrt(N-1) (where N is the number of elements
+  // along the normalized axes), times the user scale if scale stays inside LN. Reusing
+  // final_output_info.quant_param here clips whenever the LN-stage range is wider than the final
+  // output's range — for instance when |user_scale| < 1 and bias is small, or in any path where
+  // an externalized Mul is sandwiched in front of an Add that narrows the range.
+  // Derive symmetric ranges per-stage instead, sized to the theoretical bound:
+  //   ln_out_range    = sqrt(N-1) * (externalize_scale ? 1 : max|user_scale|)
+  //   mul_out_range   = sqrt(N-1) * max|user_scale|       (only relevant when both are externalized)
+  size_t norm_count = 1;
+  for (size_t i = ln_axis; i < x_shape.size(); ++i) {
+    norm_count *= static_cast<size_t>(x_shape[i]);
+  }
+  const float ln_max_abs_normalized =
+      std::sqrt(std::max(static_cast<float>(norm_count) - 1.0f, 1.0f));
+
+  float user_scale_max_abs = 1.0f;
+  {
+    TensorInfo scale_info_for_range{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info_for_range));
+    if (scale_info_for_range.quant_param.IsPerTensor(/*include_bw*/ true)) {
+      float s_qmin = 0.0f;
+      float s_qmax = 0.0f;
+      RETURN_IF_ERROR(utils::GetQminQmax(scale_info_for_range.qnn_data_type, s_qmin, s_qmax));
+      const float s_scale = scale_info_for_range.quant_param.Get().scaleOffsetEncoding.scale;
+      const int32_t s_offset = scale_info_for_range.quant_param.Get().scaleOffsetEncoding.offset;
+      const double s_min = utils::Dequantize(s_offset, s_scale, s_qmin);
+      const double s_max = utils::Dequantize(s_offset, s_scale, s_qmax);
+      user_scale_max_abs = static_cast<float>(std::max(std::abs(s_min), std::abs(s_max)));
+    }
+  }
+
+  auto compute_intermediate_qp = [&](float range_abs, QnnQuantParamsWrapper& out_qp) -> Ort::Status {
+    const float k = std::max(range_abs, 1e-4f);
+    float interm_scale = 0.0f;
+    int32_t interm_offset = 0;
+    RETURN_IF_ERROR(utils::GetQuantParams(-k, k, x_qnn_data_type, interm_scale, interm_offset,
+                                          /*symmetric*/ false));
+    out_qp = QnnQuantParamsWrapper(interm_scale, interm_offset);
+    return Ort::Status();
+  };
+
+  QnnQuantParamsWrapper ln_intermediate_qp = final_output_info.quant_param.Copy();
+  QnnQuantParamsWrapper mul_intermediate_qp = final_output_info.quant_param.Copy();
+  if (final_output_info.quant_param.IsPerTensor(/*include_bw*/ true)) {
+    const float ln_out_range_abs = externalize_scale
+                                       ? ln_max_abs_normalized
+                                       : ln_max_abs_normalized * user_scale_max_abs;
+    const float mul_out_range_abs = ln_max_abs_normalized * user_scale_max_abs;
+    RETURN_IF_ERROR(compute_intermediate_qp(ln_out_range_abs, ln_intermediate_qp));
+    RETURN_IF_ERROR(compute_intermediate_qp(mul_out_range_abs, mul_intermediate_qp));
+  }
+
   // The LN node's scale input: either the user's (when scale stays inside) or a constant 1.0
   // tensor of shape X.shape[axis:] that we synthesize here.
   std::string ln_scale_name;
@@ -339,18 +394,13 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
 
   // The Add (if present) is always last and writes to final_output_name. If only Mul is present,
   // Mul writes to final_output_name. Earlier intermediates (LN, optional Mul-before-Add) are NATIVE
-  // tensors of x_shape and x dtype.
-  // Intermediate tensors need valid quant encoding when x_qnn_data_type is a quantized type;
-  // an empty QnnQuantParamsWrapper would fail QNN validation and at runtime would dequantize as
-  // (val - 0) * 0 = 0. Reuse the final output's quant params (Copy() so the move at the end of
-  // the function still works for the Add output). Range may be coarser than ideal for the LN
-  // output when scale/bias shift it, but it's well-formed.
+  // tensors of x_shape and x dtype, with the symmetric range derived above from X's input range.
   const std::string ln_out_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_out");
   QnnTensorWrapper ln_out_tensor(ln_out_name,
-                                  QNN_TENSOR_TYPE_NATIVE,
-                                  x_qnn_data_type,
-                                  final_output_info.quant_param.Copy(),
-                                  std::vector<uint32_t>(x_shape));
+                                 QNN_TENSOR_TYPE_NATIVE,
+                                 x_qnn_data_type,
+                                 ln_intermediate_qp.Copy(),
+                                 std::vector<uint32_t>(x_shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(ln_out_tensor)),
                 "Failed to add decomposed LN intermediate output tensor.");
 
@@ -374,7 +424,7 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
         mul_out_name,
         externalize_bias ? QNN_TENSOR_TYPE_NATIVE : final_tensor_type,
         externalize_bias ? x_qnn_data_type : final_output_info.qnn_data_type,
-        externalize_bias ? final_output_info.quant_param.Copy() : std::move(final_output_info.quant_param),
+        externalize_bias ? mul_intermediate_qp.Copy() : std::move(final_output_info.quant_param),
         externalize_bias ? std::vector<uint32_t>(x_shape) : std::move(final_output_info.shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
                   "Failed to add decomposed Mul output tensor.");
@@ -390,6 +440,90 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   }
 
   if (externalize_bias) {
+    const QnnQuantParamsWrapper& add_lhs_qp =
+        externalize_scale ? mul_intermediate_qp : ln_intermediate_qp;
+
+    std::string bias_name = input_names[2];
+    TensorInfo bias_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[2], bias_info));
+
+    // QDQ pipelines feed LayerNorm's bias as int32 (matching ONNX LN's int32 beta convention).
+    // QNN's LayerNorm op accepts that, but ELEMENT_WISE_ADD requires both operands to share a
+    // dtype, re-quantize the static int32 bias to match LN output dtype.
+    // ONNX requires LN input, scale and bias in same dtype, so when dtype mismatch, it must be a qdq graph.
+    if (bias_info.qnn_data_type != x_qnn_data_type) {
+      RETURN_IF_NOT(bias_info.is_initializer && bias_info.initializer_tensor != nullptr,
+                    "LayerNorm decomposition: externalized bias must be a static initializer.");
+      RETURN_IF_NOT(bias_info.quant_param.IsPerTensor(/*include_bw*/ true),
+                    "LayerNorm decomposition: externalized bias must be per-tensor quantized.");
+      RETURN_IF_NOT(add_lhs_qp.IsPerTensor(/*include_bw*/ true),
+                    "LayerNorm decomposition: requantized bias requires per-tensor intermediate quant params.");
+
+      const float src_scale = bias_info.quant_param.Get().scaleOffsetEncoding.scale;
+      const int32_t src_offset = bias_info.quant_param.Get().scaleOffsetEncoding.offset;
+      const float dst_scale = add_lhs_qp.Get().scaleOffsetEncoding.scale;
+      const int32_t dst_offset = add_lhs_qp.Get().scaleOffsetEncoding.offset;
+
+      std::vector<uint8_t> raw_bias;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias));
+      const size_t bias_elem_bytes = utils::GetElementSizeByType(bias_info.qnn_data_type);
+      RETURN_IF_NOT(bias_elem_bytes > 0 && raw_bias.size() % bias_elem_bytes == 0,
+                    "LayerNorm decomposition: bias raw data size is not a multiple of element size.");
+      const size_t num_bias_elems = raw_bias.size() / bias_elem_bytes;
+
+      auto load_q_value = [&](size_t i) -> int64_t {
+        switch (bias_info.qnn_data_type) {
+          case QNN_DATATYPE_SFIXED_POINT_32:
+          case QNN_DATATYPE_INT_32:
+            return static_cast<int64_t>(reinterpret_cast<const int32_t*>(raw_bias.data())[i]);
+          case QNN_DATATYPE_SFIXED_POINT_16:
+            return static_cast<int64_t>(reinterpret_cast<const int16_t*>(raw_bias.data())[i]);
+          case QNN_DATATYPE_UFIXED_POINT_16:
+            return static_cast<int64_t>(reinterpret_cast<const uint16_t*>(raw_bias.data())[i]);
+          case QNN_DATATYPE_SFIXED_POINT_8:
+            return static_cast<int64_t>(reinterpret_cast<const int8_t*>(raw_bias.data())[i]);
+          case QNN_DATATYPE_UFIXED_POINT_8:
+            return static_cast<int64_t>(reinterpret_cast<const uint8_t*>(raw_bias.data())[i]);
+          default:
+            return 0;
+        }
+      };
+
+      std::vector<uint8_t> requant_bias(num_bias_elems * utils::GetElementSizeByType(x_qnn_data_type), 0);
+      for (size_t i = 0; i < num_bias_elems; ++i) {
+        const double dequant_val = utils::Dequantize(src_offset, src_scale, static_cast<double>(load_q_value(i)));
+        int q = 0;
+        RETURN_IF_ERROR(utils::Quantize(dequant_val, dst_scale, dst_offset, x_qnn_data_type, q));
+        switch (x_qnn_data_type) {
+          case QNN_DATATYPE_SFIXED_POINT_8:
+            reinterpret_cast<int8_t*>(requant_bias.data())[i] = static_cast<int8_t>(q);
+            break;
+          case QNN_DATATYPE_UFIXED_POINT_8:
+            reinterpret_cast<uint8_t*>(requant_bias.data())[i] = static_cast<uint8_t>(q);
+            break;
+          case QNN_DATATYPE_SFIXED_POINT_16:
+            reinterpret_cast<int16_t*>(requant_bias.data())[i] = static_cast<int16_t>(q);
+            break;
+          case QNN_DATATYPE_UFIXED_POINT_16:
+            reinterpret_cast<uint16_t*>(requant_bias.data())[i] = static_cast<uint16_t>(q);
+            break;
+          default:
+            return MAKE_EP_FAIL("LayerNorm decomposition: unsupported intermediate dtype for bias requant.");
+        }
+      }
+
+      const std::string requant_bias_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_bias_requant");
+      QnnTensorWrapper requant_bias_tensor(requant_bias_name,
+                                           QNN_TENSOR_TYPE_STATIC,
+                                           x_qnn_data_type,
+                                           add_lhs_qp.Copy(),
+                                           std::vector<uint32_t>(bias_info.shape),
+                                           std::move(requant_bias));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(requant_bias_tensor)),
+                    "Failed to add requantized bias tensor.");
+      bias_name = requant_bias_name;
+    }
+
     QnnTensorWrapper add_out_tensor(final_output_name,
                                     final_tensor_type,
                                     final_output_info.qnn_data_type,
@@ -400,7 +534,7 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_add"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_ADD,
-                                                  {current, input_names[2]},
+                                                  {current, bias_name},
                                                   {final_output_name},
                                                   {},
                                                   do_op_validation),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -34,13 +35,10 @@ class LayerNormalizationOpBuilder : public BaseOpBuilder {
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
  private:
-  // True iff `shape` (right-aligned to input_rank) has any non-1 dim at an axis < ln_axis.
-  // Such dims fall outside QNN/ONNX LayerNorm's normalized axes [ln_axis, input_rank), so the
-  // tensor cannot be fed directly to LayerNorm and must be applied via an outer Mul/Add instead.
-  // Precondition: shape.size() <= input_rank (enforced by IsOpSupported).
   static bool HasNonOneDimBeforeAxis(const std::vector<uint32_t>& shape,
                                      size_t input_rank,
                                      size_t ln_axis) {
+    assert(shape.size() <= input_rank);
     const size_t prefix = input_rank - shape.size();
     for (size_t i = 0; i < shape.size(); ++i) {
       const size_t aligned_axis = prefix + i;
@@ -51,15 +49,23 @@ class LayerNormalizationOpBuilder : public BaseOpBuilder {
     return false;
   }
 
+  // Bundles the shape/dtype/axis/policy decisions taken in ProcessAttributesAndOutputs and
+  // forwarded into BuildDecomposedLayerNorm. Keeping them in a struct keeps the function signature
+  // readable; the fields are all small and copy-cheap. x_shape is stored by value so the plan
+  // doesn't dangle if a future caller defers / stores it.
+  struct DecomposedLayerNormPlan {
+    std::vector<uint32_t> x_shape;
+    Qnn_DataType_t x_qnn_data_type;
+    size_t ln_axis;
+    bool externalize_scale;
+    bool externalize_bias;
+  };
+
   Ort::Status BuildDecomposedLayerNorm(QnnModelWrapper& qnn_model_wrapper,
                                        const OrtNodeUnit& node_unit,
                                        const std::vector<std::string>& input_names,
                                        std::vector<std::string>&& param_tensor_names,
-                                       const std::vector<uint32_t>& x_shape,
-                                       Qnn_DataType_t x_qnn_data_type,
-                                       size_t ln_axis,
-                                       bool externalize_scale,
-                                       bool externalize_bias,
+                                       const DecomposedLayerNormPlan& plan,
                                        bool do_op_validation,
                                        const Ort::Logger& logger) const ORT_MUST_USE_RESULT;
 };
@@ -92,6 +98,30 @@ Ort::Status StoreQuantizedFixedPoint(Qnn_DataType_t dtype, uint8_t* dst, size_t 
 // plus 32-bit signed (used for QDQ bias); destination supports 8/16-bit signed and unsigned
 // fixed-point (utils::Quantize cannot saturate to 32-bit). Resizes `dst` to the right byte
 // length. Caller is expected to have allowlisted `src_dtype` upfront for a clearer diagnostic.
+Ort::Status LoadFixedPointAsInt64(Qnn_DataType_t src_dtype, const uint8_t* src, size_t i,
+                                  /*out*/ int64_t& value) {
+  switch (src_dtype) {
+    case QNN_DATATYPE_SFIXED_POINT_32:
+    case QNN_DATATYPE_INT_32:
+      value = reinterpret_cast<const int32_t*>(src)[i];
+      return Ort::Status();
+    case QNN_DATATYPE_SFIXED_POINT_16:
+      value = reinterpret_cast<const int16_t*>(src)[i];
+      return Ort::Status();
+    case QNN_DATATYPE_UFIXED_POINT_16:
+      value = reinterpret_cast<const uint16_t*>(src)[i];
+      return Ort::Status();
+    case QNN_DATATYPE_SFIXED_POINT_8:
+      value = reinterpret_cast<const int8_t*>(src)[i];
+      return Ort::Status();
+    case QNN_DATATYPE_UFIXED_POINT_8:
+      value = reinterpret_cast<const uint8_t*>(src)[i];
+      return Ort::Status();
+    default:
+      return MAKE_EP_FAIL("Requantize: unsupported source fixed-point dtype.");
+  }
+}
+
 Ort::Status RequantizePerTensorStatic(const std::vector<uint8_t>& src,
                                       Qnn_DataType_t src_dtype,
                                       float src_scale,
@@ -99,38 +129,43 @@ Ort::Status RequantizePerTensorStatic(const std::vector<uint8_t>& src,
                                       Qnn_DataType_t dst_dtype,
                                       float dst_scale,
                                       int32_t dst_offset,
+                                      const Ort::Logger& logger,
                                       std::vector<uint8_t>& dst) {
-  auto load = [&](size_t i) -> int64_t {
-    switch (src_dtype) {
-      case QNN_DATATYPE_SFIXED_POINT_32:
-      case QNN_DATATYPE_INT_32:
-        return reinterpret_cast<const int32_t*>(src.data())[i];
-      case QNN_DATATYPE_SFIXED_POINT_16:
-        return reinterpret_cast<const int16_t*>(src.data())[i];
-      case QNN_DATATYPE_UFIXED_POINT_16:
-        return reinterpret_cast<const uint16_t*>(src.data())[i];
-      case QNN_DATATYPE_SFIXED_POINT_8:
-        return reinterpret_cast<const int8_t*>(src.data())[i];
-      case QNN_DATATYPE_UFIXED_POINT_8:
-        return reinterpret_cast<const uint8_t*>(src.data())[i];
-      default:
-        return 0;
-    }
-  };
-
   const size_t src_elem = utils::GetElementSizeByType(src_dtype);
   RETURN_IF_NOT(src_elem > 0 && src.size() % src_elem == 0,
                 "Requantize: source size is not a multiple of element size.");
   const size_t dst_elem = utils::GetElementSizeByType(dst_dtype);
   RETURN_IF_NOT(dst_elem > 0, "Requantize: unsupported destination element size.");
 
+  // utils::Quantize silently saturates. Track per-element clipping and warn once at end so the
+  // caller (and downstream debuggers) get a signal that the requantized buffer is lossy beyond
+  // normal rounding. Callers can decide whether to tolerate or fall back; this is purely a
+  // visibility fix for the silent-saturation failure mode.
+  int dst_qmin = 0;
+  int dst_qmax = 0;
+  RETURN_IF_ERROR(utils::GetQminQmax(dst_dtype, dst_qmin, dst_qmax));
+  size_t saturated_count = 0;
+
   const size_t num = src.size() / src_elem;
   dst.assign(num * dst_elem, 0);
   for (size_t i = 0; i < num; ++i) {
-    const double dq = utils::Dequantize(src_offset, src_scale, static_cast<double>(load(i)));
+    int64_t loaded = 0;
+    RETURN_IF_ERROR(LoadFixedPointAsInt64(src_dtype, src.data(), i, loaded));
+    const double dq = utils::Dequantize(src_offset, src_scale, static_cast<double>(loaded));
+    const int unclipped =
+        static_cast<int>(std::round((dq / static_cast<double>(dst_scale)) - static_cast<double>(dst_offset)));
+    if (unclipped < dst_qmin || unclipped > dst_qmax) {
+      ++saturated_count;
+    }
     int q = 0;
     RETURN_IF_ERROR(utils::Quantize(dq, dst_scale, dst_offset, dst_dtype, q));
     RETURN_IF_ERROR(StoreQuantizedFixedPoint(dst_dtype, dst.data(), i, q));
+  }
+  if (saturated_count > 0) {
+    const std::string msg = "LayerNorm decomposition: requantized static tensor saturated " +
+                            std::to_string(saturated_count) + " of " + std::to_string(num) +
+                            " elements; downstream output will be silently clipped.";
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING, msg.c_str());
   }
   return Ort::Status();
 }
@@ -168,10 +203,11 @@ Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_mode
   // Explicit check and provide clear message here
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    int32_t default_axis = -1;
+    int32_t ln_axis = -1;
     Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
-    RETURN_IF(static_cast<size_t>(default_axis) != input_rank - 1, "QNN LayerNorm for HTP only support axis with last input dimension");
+    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, ln_axis));
+    RETURN_IF(static_cast<size_t>(ln_axis) != input_rank - 1,
+              "QNN LayerNorm on HTP only supports normalization along the last axis.");
   }
 
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
@@ -202,25 +238,6 @@ Ort::Status LayerNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
     RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[BIAS_IDX], logger, input_names));
   }
 
-#if QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 17 && QNN_API_VERSION_MINOR <= 20
-  if (!has_bias_input && IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
-    // Bias is implicit. QNN SDK 2.24 to 2.27 (QNN API version 2.17 to 2.20) has a validation bug for
-    // implicit bias inputs, so provide an explicit bias of all 0 (quantized int32).
-    TensorInfo x_input_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[X_IDX], x_input_info));
-
-    TensorInfo scale_input_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_input_info));
-
-    if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_input_info.quant_param.IsQuantized()) {
-      const std::string bias_name = qnn::utils::UniqueNameGenerator().New(node_unit, "_implicit_bias");
-      std::vector<uint32_t> bias_shape = scale_input_info.shape;
-      RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_input_info.quant_param,
-                                       std::move(bias_shape), bias_name, logger, input_names));
-    }
-  }
-#endif
-
   return Ort::Status();
 }
 
@@ -246,13 +263,17 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of input 0");
   const size_t input_rank = input_shape.size();
-  int32_t default_axis = -1;
+  int32_t ln_axis = -1;
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
-  size_t axes_rank = input_rank - static_cast<size_t>(default_axis);
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, ln_axis));
+  // ProcessAxisAttribute is supposed to normalize ln_axis into [0, input_rank); range-check before
+  // the subtract so a malformed axis fails loudly instead of underflowing axes_rank to ~SIZE_MAX.
+  RETURN_IF(ln_axis < 0 || static_cast<size_t>(ln_axis) >= input_rank,
+            "QNN LayerNorm: axis out of range after normalization.");
+  size_t axes_rank = input_rank - static_cast<size_t>(ln_axis);
   std::vector<uint32_t> axes(axes_rank, 0);
   std::vector<uint32_t> axes_shape{SafeInt<uint32_t>(axes_rank)};
-  axes[0] = static_cast<uint32_t>(default_axis);
+  axes[0] = static_cast<uint32_t>(ln_axis);
   for (size_t i = 1; i < axes.size(); ++i) {
     axes[i] = axes[i - 1] + 1;
   }
@@ -273,14 +294,14 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   TensorInfo scale_info{};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], scale_info));
   const bool scale_misaligned =
-      HasNonOneDimBeforeAxis(scale_info.shape, input_rank, static_cast<size_t>(default_axis));
+      HasNonOneDimBeforeAxis(scale_info.shape, input_rank, static_cast<size_t>(ln_axis));
 
   bool bias_misaligned = false;
   if (has_bias_input) {
     TensorInfo bias_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
     bias_misaligned =
-        HasNonOneDimBeforeAxis(bias_info.shape, input_rank, static_cast<size_t>(default_axis));
+        HasNonOneDimBeforeAxis(bias_info.shape, input_rank, static_cast<size_t>(ln_axis));
   }
 
   const bool externalize_scale = scale_misaligned;
@@ -289,18 +310,38 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   if (externalize_scale || externalize_bias) {
     TensorInfo x_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], x_info));
+    DecomposedLayerNormPlan plan{
+        /*x_shape=*/input_shape,
+        /*x_qnn_data_type=*/x_info.qnn_data_type,
+        /*ln_axis=*/static_cast<size_t>(ln_axis),
+        /*externalize_scale=*/externalize_scale,
+        /*externalize_bias=*/externalize_bias,
+    };
     return BuildDecomposedLayerNorm(qnn_model_wrapper,
                                     node_unit,
                                     input_names,
                                     std::move(param_tensor_names),
-                                    input_shape,
-                                    x_info.qnn_data_type,
-                                    static_cast<size_t>(default_axis),
-                                    externalize_scale,
-                                    externalize_bias,
+                                    plan,
                                     do_op_validation,
                                     logger);
   }
+
+#if QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 17 && QNN_API_VERSION_MINOR <= 20
+  // Bias is implicit. QNN SDK 2.24 to 2.27 (QNN API version 2.17 to 2.20) has a validation bug for
+  // implicit bias inputs, so provide an explicit bias of all 0 (quantized int32). Done here (after
+  // the decomposition branch) so the synthesized tensor is never orphaned by the decomposed path,
+  // which builds its own LN input list and applies the same workaround independently.
+  if (!has_bias_input && IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    TensorInfo x_input_info{};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], x_input_info));
+    if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_info.quant_param.IsQuantized()) {
+      const std::string bias_name = utils::UniqueNameGenerator().New(node_unit, "_implicit_bias");
+      std::vector<uint32_t> bias_shape = scale_info.shape;
+      RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_info.quant_param,
+                                       std::move(bias_shape), bias_name, logger, input_names));
+    }
+  }
+#endif
 
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
                                  std::move(input_names),
@@ -314,14 +355,14 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                                                                   const OrtNodeUnit& node_unit,
                                                                   const std::vector<std::string>& input_names,
                                                                   std::vector<std::string>&& param_tensor_names,
-                                                                  const std::vector<uint32_t>& x_shape,
-                                                                  Qnn_DataType_t x_qnn_data_type,
-                                                                  size_t ln_axis,
-                                                                  bool externalize_scale,
-                                                                  bool externalize_bias,
+                                                                  const DecomposedLayerNormPlan& plan,
                                                                   bool do_op_validation,
                                                                   const Ort::Logger& logger) const {
-  ORT_UNUSED_PARAMETER(logger);
+  const std::vector<uint32_t>& x_shape = plan.x_shape;
+  const Qnn_DataType_t x_qnn_data_type = plan.x_qnn_data_type;
+  const size_t ln_axis = plan.ln_axis;
+  const bool externalize_scale = plan.externalize_scale;
+  const bool externalize_bias = plan.externalize_bias;
 
   const auto& outputs = node_unit.Outputs();
   const std::string& final_output_name = outputs[0].name;
@@ -359,6 +400,11 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     ln_intermediate_qp = final_output_info.quant_param.Copy();
   }
 
+  // Fetch scale_info once; used by the synth-ones branch, the SDK 2.17-2.20 implicit-bias guard,
+  // and the requantize-scale path. Each of those used to fetch independently.
+  TensorInfo scale_info{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info));
+
   std::string ln_scale_name;
   if (!externalize_scale) {
     ln_scale_name = input_names[1];
@@ -366,9 +412,6 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     // Match the synthesized ones tensor to the user-provided scale's dtype + quant params so the
     // LN op sees the type it expects in slot 1. Encoding 1.0 in the user's quant scheme is what
     // makes this an identity scale at runtime.
-    TensorInfo scale_info{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info));
-
     std::vector<uint32_t> norm_shape(x_shape.begin() + ln_axis, x_shape.end());
     size_t num_elems = 1;
     for (uint32_t d : norm_shape) {
@@ -382,10 +425,19 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       // Per-tensor or per-channel quantized: quantize 1.0 using the user scale's params and fill.
       RETURN_IF_NOT(scale_info.quant_param.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm scale decomposition: per-channel quantized scale is not supported.");
-      const float quant_scale = scale_info.quant_param.Get().scaleOffsetEncoding.scale;
-      const int32_t quant_offset = scale_info.quant_param.Get().scaleOffsetEncoding.offset;
+      float quant_scale = 0.0f;
+      int32_t quant_offset = 0;
+      RETURN_IF_ERROR(scale_info.quant_param.GetPerTensorScaleOffset(quant_scale, quant_offset));
       int quant_one = 0;
       RETURN_IF_ERROR(utils::Quantize(1.0, quant_scale, quant_offset, scale_dtype, quant_one));
+      // utils::Quantize silently saturates. If the user's scale can't represent 1.0 within an
+      // LSB (e.g. small-amplitude gamma like u8 over [0, 0.005] → quant_one rounds to 51000 and
+      // clips to 255 ≈ 0.005), the synthesized "ones" tensor is silently off by orders of
+      // magnitude. Reject so the node falls back to CPU.
+      const double deq_one = utils::Dequantize(quant_offset, quant_scale, static_cast<double>(quant_one));
+      RETURN_IF_NOT(std::abs(deq_one - 1.0) <= static_cast<double>(quant_scale),
+                    "LayerNorm scale decomposition: user scale's quantization range cannot represent 1.0; "
+                    "synthesized identity scale would saturate.");
       const size_t elem_bytes = utils::GetElementSizeByType(scale_dtype);
       RETURN_IF_NOT(elem_bytes > 0, "LayerNorm scale decomposition: unsupported quantized scale dtype.");
       const_buf.assign(num_elems * elem_bytes, 0);
@@ -443,12 +495,10 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
     TensorInfo x_input_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], x_input_info));
-    TensorInfo scale_input_info{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_input_info));
-    if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_input_info.quant_param.IsQuantized()) {
+    if (x_input_info.quant_param.IsPerTensor(/*include_bw*/ true) && scale_info.quant_param.IsQuantized()) {
       const std::string bias_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_implicit_bias");
       std::vector<uint32_t> bias_shape(x_shape.begin() + ln_axis, x_shape.end());
-      RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_input_info.quant_param,
+      RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, x_input_info.quant_param, scale_info.quant_param,
                                        std::move(bias_shape), bias_name, logger, ln_inputs));
     }
   }
@@ -466,8 +516,11 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
   std::string current = ln_out_name;
 
   if (externalize_scale) {
-    const QnnQuantParamsWrapper& mul_out_qp =
-        externalize_bias ? ln_intermediate_qp : final_output_info.quant_param;
+    // Owned copy: the externalize_bias=false path moves final_output_info.quant_param into the
+    // Mul output tensor below, so an alias-then-move on .quant_param would leave mul_out_qp
+    // dangling for the requant predicates / GetPerTensorScaleOffset reads.
+    const QnnQuantParamsWrapper mul_out_qp =
+        externalize_bias ? ln_intermediate_qp.Copy() : final_output_info.quant_param.Copy();
 
     // QNN ELEMENT_WISE_MULTIPLY requires both operands to share a dtype. In QDQ pipelines (e.g.
     // A16W8) the LN output adopts X's dtype while the user scale is still in its own (often
@@ -475,22 +528,22 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     // sees matching operand dtypes. ONNX LN spec demands X/scale/bias share dtype, so a mismatch
     // here implies a quantized graph where the original initializer is available.
     std::string mul_scale_name = input_names[1];
-    TensorInfo scale_info_for_mul{};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info_for_mul));
-    if (scale_info_for_mul.qnn_data_type != x_qnn_data_type) {
-      RETURN_IF_NOT(scale_info_for_mul.is_initializer && scale_info_for_mul.initializer_tensor != nullptr,
+    if (scale_info.qnn_data_type != x_qnn_data_type) {
+      RETURN_IF_NOT(scale_info.is_initializer && scale_info.initializer_tensor != nullptr,
                     "LayerNorm decomposition: externalized scale must be a static initializer.");
-      RETURN_IF_NOT(scale_info_for_mul.quant_param.IsPerTensor(/*include_bw*/ true),
+      RETURN_IF_NOT(scale_info.quant_param.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm decomposition: externalized scale must be per-tensor quantized.");
       RETURN_IF_NOT(mul_out_qp.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm decomposition: requantized scale requires per-tensor intermediate quant params.");
 
-      const float src_scale = scale_info_for_mul.quant_param.Get().scaleOffsetEncoding.scale;
-      const int32_t src_offset = scale_info_for_mul.quant_param.Get().scaleOffsetEncoding.offset;
-      const float dst_scale = mul_out_qp.Get().scaleOffsetEncoding.scale;
-      const int32_t dst_offset = mul_out_qp.Get().scaleOffsetEncoding.offset;
+      float src_scale = 0.0f;
+      int32_t src_offset = 0;
+      RETURN_IF_ERROR(scale_info.quant_param.GetPerTensorScaleOffset(src_scale, src_offset));
+      float dst_scale = 0.0f;
+      int32_t dst_offset = 0;
+      RETURN_IF_ERROR(mul_out_qp.GetPerTensorScaleOffset(dst_scale, dst_offset));
 
-      switch (scale_info_for_mul.qnn_data_type) {
+      switch (scale_info.qnn_data_type) {
         case QNN_DATATYPE_SFIXED_POINT_16:
         case QNN_DATATYPE_UFIXED_POINT_16:
         case QNN_DATATYPE_SFIXED_POINT_8:
@@ -501,14 +554,15 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       }
 
       std::vector<uint8_t> raw_scale;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info_for_mul.initializer_tensor, raw_scale));
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info.initializer_tensor, raw_scale));
 
       std::vector<uint8_t> requant_scale;
       RETURN_IF_ERROR(RequantizePerTensorStatic(raw_scale,
-                                                scale_info_for_mul.qnn_data_type,
+                                                scale_info.qnn_data_type,
                                                 src_scale, src_offset,
                                                 x_qnn_data_type,
                                                 dst_scale, dst_offset,
+                                                logger,
                                                 requant_scale));
 
       const std::string requant_scale_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_scale_requant");
@@ -516,24 +570,37 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                                             QNN_TENSOR_TYPE_STATIC,
                                             x_qnn_data_type,
                                             mul_out_qp.Copy(),
-                                            std::vector<uint32_t>(scale_info_for_mul.shape),
+                                            std::vector<uint32_t>(scale_info.shape),
                                             std::move(requant_scale));
       RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(requant_scale_tensor)),
                     "Failed to add requantized scale tensor.");
       mul_scale_name = requant_scale_name;
     }  // End of requantize scale
 
-    const std::string mul_out_name =
-        externalize_bias ? utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul_out")
-                         : final_output_name;
-    QnnTensorWrapper mul_out_tensor(
-        mul_out_name,
-        externalize_bias ? QNN_TENSOR_TYPE_NATIVE : final_tensor_type,
-        externalize_bias ? x_qnn_data_type : final_output_info.qnn_data_type,
-        externalize_bias ? ln_intermediate_qp.Copy() : std::move(final_output_info.quant_param),
-        externalize_bias ? std::vector<uint32_t>(x_shape) : std::move(final_output_info.shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
-                  "Failed to add decomposed Mul output tensor.");
+    // Mul output: either an internal handoff to the Add (NATIVE, x_dtype, ln_intermediate_qp,
+    // x_shape) or the graph output (final_tensor_type, final dtype/qp/shape). Splitting the two
+    // cases makes the move-from-final_output_info contract obvious — the final-output branch is
+    // the sole writer, so reads of final_output_info.{quant_param,shape} below it are forbidden.
+    std::string mul_out_name;
+    if (externalize_bias) {
+      mul_out_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul_out");
+      QnnTensorWrapper mul_out_tensor(mul_out_name,
+                                      QNN_TENSOR_TYPE_NATIVE,
+                                      x_qnn_data_type,
+                                      ln_intermediate_qp.Copy(),
+                                      std::vector<uint32_t>(x_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
+                    "Failed to add decomposed Mul output tensor.");
+    } else {
+      mul_out_name = final_output_name;
+      QnnTensorWrapper mul_out_tensor(mul_out_name,
+                                      final_tensor_type,
+                                      final_output_info.qnn_data_type,
+                                      std::move(final_output_info.quant_param),
+                                      std::move(final_output_info.shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_out_tensor)),
+                    "Failed to add decomposed Mul output tensor.");
+    }
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul"),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_MULTIPLY,
@@ -552,10 +619,12 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     TensorInfo bias_info{};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[2], bias_info));
 
-    // QDQ pipelines feed LayerNorm's bias as int32 (matching ONNX LN's int32 beta convention).
-    // QNN's LayerNorm op accepts that, but ELEMENT_WISE_ADD requires both operands to share a
-    // dtype — requantize the static int32 bias to match LN output dtype. ONNX requires X/scale/
-    // bias share dtype, so a mismatch here implies a QDQ graph with the original initializer.
+    // QDQ pipelines feed LayerNorm's bias as int32 to satisfy QNN's quantized-LN bias convention
+    // (ONNX LN itself requires B to share X's dtype — the int32 only appears once the QDQ pipeline
+    // has rewritten it). QNN's LayerNorm op accepts the int32, but ELEMENT_WISE_ADD requires both
+    // operands to share a dtype — requantize the static bias to match LN output dtype. The ONNX-
+    // level dtype-match invariant means a mismatch here implies a QDQ graph with the original
+    // initializer available.
     if (bias_info.qnn_data_type != x_qnn_data_type) {
       RETURN_IF_NOT(bias_info.is_initializer && bias_info.initializer_tensor != nullptr,
                     "LayerNorm decomposition: externalized bias must be a static initializer.");
@@ -564,10 +633,12 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
       RETURN_IF_NOT(ln_intermediate_qp.IsPerTensor(/*include_bw*/ true),
                     "LayerNorm decomposition: requantized bias requires per-tensor intermediate quant params.");
 
-      const float src_scale = bias_info.quant_param.Get().scaleOffsetEncoding.scale;
-      const int32_t src_offset = bias_info.quant_param.Get().scaleOffsetEncoding.offset;
-      const float dst_scale = ln_intermediate_qp.Get().scaleOffsetEncoding.scale;
-      const int32_t dst_offset = ln_intermediate_qp.Get().scaleOffsetEncoding.offset;
+      float src_scale = 0.0f;
+      int32_t src_offset = 0;
+      RETURN_IF_ERROR(bias_info.quant_param.GetPerTensorScaleOffset(src_scale, src_offset));
+      float dst_scale = 0.0f;
+      int32_t dst_offset = 0;
+      RETURN_IF_ERROR(ln_intermediate_qp.GetPerTensorScaleOffset(dst_scale, dst_offset));
 
       // Allowlist bias dtypes upfront so a future QDQ pipeline emitting an unknown bias dtype
       // fails loudly here, rather than silently producing an all-zero requantized bias via the
@@ -593,6 +664,7 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                                                 src_scale, src_offset,
                                                 x_qnn_data_type,
                                                 dst_scale, dst_offset,
+                                                logger,
                                                 requant_bias));
 
       const std::string requant_bias_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_bias_requant");

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -68,6 +68,24 @@ class QnnQuantParamsWrapper {
             (include_bw && params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET));
   }
 
+  // Read (scale, offset) for a per-tensor encoding, dispatching on the active union member.
+  // 8/16/32-bit lives in scaleOffsetEncoding; 4-bit lives in bwScaleOffsetEncoding — they are
+  // separate union members, so reading the wrong one yields garbage. Caller must have verified
+  // IsPerTensor(/*include_bw*/ true).
+  Ort::Status GetPerTensorScaleOffset(/*out*/ float& scale, /*out*/ int32_t& offset) const {
+    if (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+      scale = params_.scaleOffsetEncoding.scale;
+      offset = params_.scaleOffsetEncoding.offset;
+      return Ort::Status();
+    }
+    if (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+      scale = params_.bwScaleOffsetEncoding.scale;
+      offset = params_.bwScaleOffsetEncoding.offset;
+      return Ort::Status();
+    }
+    return MAKE_EP_FAIL("GetPerTensorScaleOffset: encoding is not per-tensor.");
+  }
+
   bool IsPerChannel() const {
     return params_.encodingDefinition == QNN_DEFINITION_DEFINED &&
            (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET ||

--- a/onnxruntime/test/providers/qnn/layernormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/layernormalization_test.cc
@@ -137,7 +137,8 @@ static void RunLayerNormQDQTest(const TestInputDef<float>& input_def,
                                 const TestInputDef<float>& bias_def,
                                 const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                                 ExpectedEPNodeAssignment expected_ep_assignment,
-                                bool use_contrib_qdq_ops = false) {
+                                bool use_contrib_qdq_ops = false,
+                                QDQTolerance tolerance = QDQTolerance()) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -147,7 +148,8 @@ static void RunLayerNormQDQTest(const TestInputDef<float>& input_def,
                                                                          use_contrib_qdq_ops),
                        provider_options,
                        17,  // opset
-                       expected_ep_assignment);
+                       expected_ep_assignment,
+                       tolerance);
 }
 
 // Test that QNN HTP only supports axis = -1 (i.e., last dimension).
@@ -271,6 +273,37 @@ TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_BiasAligned) {
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
       {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All);
+}
+
+// 16-bit activations + 8-bit weights through the decomposition path. Exercises the 16-bit
+// const_buf dispatch in the synthesized identity scale and the 16-bit branches of bias
+// requantization (which the 8/8 decomposition tests above don't cover).
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleAndBiasMisaligned_A16W8) {
+  RunLayerNormQDQTest<uint16_t, uint8_t>(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.1f, 1.0f, 6)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.0f, 1.0f, 6)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All,
+      true);  // Use 'com.microsoft' Q/DQ ops (uint16).
+}
+
+// Higher-rank case with mid-axis misalignment: X=[2,4,8,16], scale=[1,4,1,16], axis=-1.
+// The decomposed path emits LN -> Mul -> Add — three quantization stages instead of CPU
+// EP's single monolithic LN — and at uint8 (256 levels) on this 16-element normalized
+// axis, each stage's rounding adds up to ~1.5x default tolerance per element. The CPU
+// QDQ baseline itself drifts >10% at the most-affected elements, so the qdq_diff
+// criterion isn't a meaningful precision target here; what we exercise instead is the
+// build/validate path under A16W8 (which gives uint16 input/output headroom for the
+// trailing Q stages).
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_HighRank_MidAxisMisaligned) {
+  RunLayerNormQDQTest<uint16_t, uint8_t>(
+      TestInputDef<float>({2, 4, 8, 16}, false, GetFloatDataInRange(0.0f, 10.0f, 1024)),
+      TestInputDef<float>({1, 4, 1, 16}, true, GetFloatDataInRange(0.1f, 1.0f, 64)),
+      TestInputDef<float>({1, 4, 1, 16}, true, GetFloatDataInRange(0.0f, 1.0f, 64)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All,
+      true);  // Use 'com.microsoft' Q/DQ ops (uint16).
 }
 
 static void RunLayerNormTest(const TestInputDef<float>& input_def,

--- a/onnxruntime/test/providers/qnn/layernormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/layernormalization_test.cc
@@ -239,7 +239,7 @@ TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleAndBiasMisaligned) {
 
 // final_tensor_type / final_output_info.{qnn_data_type, quant_param, shape}).
 TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_NoBias) {
-  //scale misaligned, no bias -> LN, Mul (final)
+  // scale misaligned, no bias -> LN, Mul (final)
   RunLayerNormQDQTest<uint8_t, uint8_t>(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.1f, 1.0f, 6)),
@@ -273,18 +273,12 @@ TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_BiasAligned) {
       ExpectedEPNodeAssignment::All);
 }
 
-// ----- Non-QDQ (FP32 lowered to FP16) tests on the HTP backend -----------------------
-// QNN HTP requires fp16 to run float models; enable_htp_fp16_precision lowers fp32
-// inputs/weights to fp16 internally. These tests exercise the LayerNorm op-builder paths
-// without QDQ Q/DQ pairs, so intermediate quant params don't enter the picture and the
-// decomposition path is validated purely on shape/dtype handling.
-
-static void RunLayerNormHtpFp16Test(const TestInputDef<float>& input_def,
-                                    const TestInputDef<float>& scale_def,
-                                    const TestInputDef<float>& bias_def,
-                                    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
-                                    ExpectedEPNodeAssignment expected_ep_assignment,
-                                    float fp32_abs_err = 0.01f) {
+static void RunLayerNormTest(const TestInputDef<float>& input_def,
+                             const TestInputDef<float>& scale_def,
+                             const TestInputDef<float>& bias_def,
+                             const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                             ExpectedEPNodeAssignment expected_ep_assignment,
+                             float fp32_abs_err = 0.01f) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -296,9 +290,9 @@ static void RunLayerNormHtpFp16Test(const TestInputDef<float>& input_def,
   GetTestModelFn model_fn =
       bias_def.GetShape().empty()
           ? BuildOpTestCase<float>("layer_norm_node", "LayerNormalization",
-                                    {input_def, scale_def}, {}, attrs)
+                                   {input_def, scale_def}, {}, attrs)
           : BuildOpTestCase<float, int64_t>("layer_norm_node", "LayerNormalization",
-                                             {input_def, scale_def}, {}, {bias_def}, attrs);
+                                            {input_def, scale_def}, {}, {bias_def}, attrs);
 
   RunQnnModelTest(model_fn,
                   provider_options,
@@ -307,9 +301,8 @@ static void RunLayerNormHtpFp16Test(const TestInputDef<float>& input_def,
                   fp32_abs_err);
 }
 
-// Standard LN: 1D scale/bias on the last axis. Single LN node; no decomposition.
-TEST_F(QnnHTPBackendTests, LayerNorm_FP32_LastAxis_StandardLN) {
-  RunLayerNormHtpFp16Test(
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_standard_test) {
+  RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(-0.1f, 0.1f, 3)),
@@ -318,8 +311,8 @@ TEST_F(QnnHTPBackendTests, LayerNorm_FP32_LastAxis_StandardLN) {
 }
 
 // Standard LN with no bias.
-TEST_F(QnnHTPBackendTests, LayerNorm_FP32_LastAxis_NoBias) {
-  RunLayerNormHtpFp16Test(
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_no_bais) {
+  RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
       TestInputDef<float>(),  // No bias.
@@ -328,8 +321,8 @@ TEST_F(QnnHTPBackendTests, LayerNorm_FP32_LastAxis_NoBias) {
 }
 
 // Decomposition path: scale + bias both misaligned. Lowers to LN, Mul (intermediate), Add (final).
-TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_ScaleAndBiasMisaligned) {
-  RunLayerNormHtpFp16Test(
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_scale_and_bias_misaligned) {
+  RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(-0.1f, 0.1f, 6)),
@@ -338,8 +331,8 @@ TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_ScaleAndBiasMisaligned) {
 }
 
 // Decomposition path: scale misaligned, no bias. Lowers to LN, Mul (final).
-TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_ScaleMisaligned_NoBias) {
-  RunLayerNormHtpFp16Test(
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_scale_misaligned_no_bias) {
+  RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
       TestInputDef<float>(),  // No bias.
@@ -348,8 +341,8 @@ TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_ScaleMisaligned_NoBias) {
 }
 
 // Decomposition path: bias misaligned, scale aligned. Lowers to LN(scale), Add (final).
-TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_BiasMisaligned_ScaleAligned) {
-  RunLayerNormHtpFp16Test(
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_bias_misaligned) {
+  RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(-0.1f, 0.1f, 6)),

--- a/onnxruntime/test/providers/qnn/layernormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/layernormalization_test.cc
@@ -225,6 +225,138 @@ TEST_F(QnnHTPBackendTests, DISABLED_LayerNorm1D_LastAxis_DynamicScale) {
                                         ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleAndBiasMisaligned) {
+  // scale + bias both misaligned -> LN, Mul (intermediate), Add (final)
+  RunLayerNormQDQTest<uint8_t, uint8_t>(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+      // Full-rank scale with non-1 dim before the normalized axis -> externalize_scale.
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.1f, 1.0f, 6)),
+      // Full-rank bias with non-1 dim before the normalized axis -> externalize_bias.
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.0f, 1.0f, 6)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// final_tensor_type / final_output_info.{qnn_data_type, quant_param, shape}).
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_NoBias) {
+  //scale misaligned, no bias -> LN, Mul (final)
+  RunLayerNormQDQTest<uint8_t, uint8_t>(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.1f, 1.0f, 6)),
+      TestInputDef<float>(),  // No bias.
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_BiasMisaligned_ScaleAligned) {
+  // scale aligned, bias misaligned -> LN(scale), Add (final)
+  RunLayerNormQDQTest<uint8_t, uint8_t>(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+      // 1D scale aligned with X.shape[axis:]=[3], does not need externalization.
+      TestInputDef<float>({3}, true, GetFloatDataInRange(0.1f, 1.0f, 3)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.0f, 1.0f, 6)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// scale misaligned, bias shape is legal on its own -> scale-out forces bias-out, so still
+// LN, Mul (intermediate), Add (final). Verifies the policy that bias gets pulled out alongside
+// scale even when its own shape would have been consumable by LN.
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_BiasAligned) {
+  RunLayerNormQDQTest<uint8_t, uint8_t>(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+      // Full-rank scale with non-1 dim before normalized axis -> externalize_scale.
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.1f, 1.0f, 6)),
+      // 1D bias aligned with X.shape[axis:]=[3]; legal inside LN, but bias-out is forced by scale-out.
+      TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// ----- Non-QDQ (FP32 lowered to FP16) tests on the HTP backend -----------------------
+// QNN HTP requires fp16 to run float models; enable_htp_fp16_precision lowers fp32
+// inputs/weights to fp16 internally. These tests exercise the LayerNorm op-builder paths
+// without QDQ Q/DQ pairs, so intermediate quant params don't enter the picture and the
+// decomposition path is validated purely on shape/dtype handling.
+
+static void RunLayerNormHtpFp16Test(const TestInputDef<float>& input_def,
+                                    const TestInputDef<float>& scale_def,
+                                    const TestInputDef<float>& bias_def,
+                                    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                    ExpectedEPNodeAssignment expected_ep_assignment,
+                                    float fp32_abs_err = 0.01f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_htp_fp16_precision"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  GetTestModelFn model_fn =
+      bias_def.GetShape().empty()
+          ? BuildOpTestCase<float>("layer_norm_node", "LayerNormalization",
+                                    {input_def, scale_def}, {}, attrs)
+          : BuildOpTestCase<float, int64_t>("layer_norm_node", "LayerNormalization",
+                                             {input_def, scale_def}, {}, {bias_def}, attrs);
+
+  RunQnnModelTest(model_fn,
+                  provider_options,
+                  17,  // opset
+                  expected_ep_assignment,
+                  fp32_abs_err);
+}
+
+// Standard LN: 1D scale/bias on the last axis. Single LN node; no decomposition.
+TEST_F(QnnHTPBackendTests, LayerNorm_FP32_LastAxis_StandardLN) {
+  RunLayerNormHtpFp16Test(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+      TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
+      TestInputDef<float>({3}, true, GetFloatDataInRange(-0.1f, 0.1f, 3)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// Standard LN with no bias.
+TEST_F(QnnHTPBackendTests, LayerNorm_FP32_LastAxis_NoBias) {
+  RunLayerNormHtpFp16Test(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+      TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
+      TestInputDef<float>(),  // No bias.
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// Decomposition path: scale + bias both misaligned. Lowers to LN, Mul (intermediate), Add (final).
+TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_ScaleAndBiasMisaligned) {
+  RunLayerNormHtpFp16Test(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(-0.1f, 0.1f, 6)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// Decomposition path: scale misaligned, no bias. Lowers to LN, Mul (final).
+TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_ScaleMisaligned_NoBias) {
+  RunLayerNormHtpFp16Test(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
+      TestInputDef<float>(),  // No bias.
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+// Decomposition path: bias misaligned, scale aligned. Lowers to LN(scale), Add (final).
+TEST_F(QnnHTPBackendTests, LayerNorm_FP32_Decomposed_BiasMisaligned_ScaleAligned) {
+  RunLayerNormHtpFp16Test(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+      TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(-0.1f, 0.1f, 6)),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      ExpectedEPNodeAssignment::All);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/layernormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/layernormalization_test.cc
@@ -239,7 +239,6 @@ TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleAndBiasMisaligned) {
       ExpectedEPNodeAssignment::All);
 }
 
-// final_tensor_type / final_output_info.{qnn_data_type, quant_param, shape}).
 TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_NoBias) {
   // scale misaligned, no bias -> LN, Mul (final)
   RunLayerNormQDQTest<uint8_t, uint8_t>(
@@ -261,20 +260,6 @@ TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_BiasMisaligned_ScaleAligned) {
       ExpectedEPNodeAssignment::All);
 }
 
-// scale misaligned, bias shape is legal on its own -> scale-out forces bias-out, so still
-// LN, Mul (intermediate), Add (final). Verifies the policy that bias gets pulled out alongside
-// scale even when its own shape would have been consumable by LN.
-TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleMisaligned_BiasAligned) {
-  RunLayerNormQDQTest<uint8_t, uint8_t>(
-      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
-      // Full-rank scale with non-1 dim before normalized axis -> externalize_scale.
-      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.1f, 1.0f, 6)),
-      // 1D bias aligned with X.shape[axis:]=[3]; legal inside LN, but bias-out is forced by scale-out.
-      TestInputDef<float>({3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
-      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
-      ExpectedEPNodeAssignment::All);
-}
-
 // 16-bit activations + 8-bit weights through the decomposition path. Exercises the 16-bit
 // const_buf dispatch in the synthesized identity scale and the 16-bit branches of bias
 // requantization (which the 8/8 decomposition tests above don't cover).
@@ -288,22 +273,19 @@ TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_ScaleAndBiasMisaligned_A16W8) {
       true);  // Use 'com.microsoft' Q/DQ ops (uint16).
 }
 
-// Higher-rank case with mid-axis misalignment: X=[2,4,8,16], scale=[1,4,1,16], axis=-1.
-// The decomposed path emits LN -> Mul -> Add — three quantization stages instead of CPU
-// EP's single monolithic LN — and at uint8 (256 levels) on this 16-element normalized
-// axis, each stage's rounding adds up to ~1.5x default tolerance per element. The CPU
-// QDQ baseline itself drifts >10% at the most-affected elements, so the qdq_diff
-// criterion isn't a meaningful precision target here; what we exercise instead is the
-// build/validate path under A16W8 (which gives uint16 input/output headroom for the
-// trailing Q stages).
-TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_HighRank_MidAxisMisaligned) {
-  RunLayerNormQDQTest<uint16_t, uint8_t>(
-      TestInputDef<float>({2, 4, 8, 16}, false, GetFloatDataInRange(0.0f, 10.0f, 1024)),
-      TestInputDef<float>({1, 4, 1, 16}, true, GetFloatDataInRange(0.1f, 1.0f, 64)),
-      TestInputDef<float>({1, 4, 1, 16}, true, GetFloatDataInRange(0.0f, 1.0f, 64)),
+// Small-amplitude scale forces the synthesized "ones" tensor to saturate when quantized
+// in the user's scheme: u8 over [0, 0.005] gives scale ≈ 1.96e-5, so round(1.0/scale) =
+// 51000 saturates to 255 ≈ 0.005 — a 200× silent error in the identity scale. The op
+// builder detects the saturation (deq != 1.0 within an LSB) and rejects the decomposition,
+// so QNN reports the node as unsupported and the model falls back to CPU EP.
+TEST_F(QnnHTPBackendTests, LayerNorm_Decomposed_SmallAmplitudeScale_FallsBack) {
+  RunLayerNormQDQTest<uint8_t, uint8_t>(
+      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+      // Tight scale range [0, 0.005] -> u8 quant scale ≈ 1.96e-5; quantizing 1.0 saturates.
+      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.0f, 0.005f, 6)),
+      TestInputDef<float>(),
       {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
-      ExpectedEPNodeAssignment::All,
-      true);  // Use 'com.microsoft' Q/DQ ops (uint16).
+      ExpectedEPNodeAssignment::None);
 }
 
 static void RunLayerNormTest(const TestInputDef<float>& input_def,
@@ -344,7 +326,7 @@ TEST_F(QnnHTPBackendTests, LayerNorm_fp_standard_test) {
 }
 
 // Standard LN with no bias.
-TEST_F(QnnHTPBackendTests, LayerNorm_fp_no_bais) {
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_no_bias) {
   RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
@@ -353,31 +335,14 @@ TEST_F(QnnHTPBackendTests, LayerNorm_fp_no_bais) {
       ExpectedEPNodeAssignment::All);
 }
 
-// Decomposition path: scale + bias both misaligned. Lowers to LN, Mul (intermediate), Add (final).
-TEST_F(QnnHTPBackendTests, LayerNorm_fp_scale_and_bias_misaligned) {
+// FP decomposition: scale + bias both misaligned. Exercises the FP branch of the synthesized
+// "ones" tensor (FLOAT_32 / FLOAT_16 dispatch) plus both Mul and Add lowerings in one shot.
+// The other two FP misalignment shapes (scale-only, bias-only) hit the same FP synth-ones
+// codepath and are already covered structurally by the QDQ Decomposed_* triplet.
+TEST_F(QnnHTPBackendTests, LayerNorm_fp_decomposed) {
   RunLayerNormTest(
       TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
-      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(-0.1f, 0.1f, 6)),
-      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
-      ExpectedEPNodeAssignment::All);
-}
-
-// Decomposition path: scale misaligned, no bias. Lowers to LN, Mul (final).
-TEST_F(QnnHTPBackendTests, LayerNorm_fp_scale_misaligned_no_bias) {
-  RunLayerNormTest(
-      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
-      TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
-      TestInputDef<float>(),  // No bias.
-      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
-      ExpectedEPNodeAssignment::All);
-}
-
-// Decomposition path: bias misaligned, scale aligned. Lowers to LN(scale), Add (final).
-TEST_F(QnnHTPBackendTests, LayerNorm_fp_bias_misaligned) {
-  RunLayerNormTest(
-      TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
-      TestInputDef<float>({3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
       TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(-0.1f, 0.1f, 6)),
       {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
       ExpectedEPNodeAssignment::All);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Onnx allow scale/bias is not aligned with LN's axes. e.g. [1, 4, 8] ->LN(scale=(4, 8), axes=2), but QNN expects scale has only 1 on none normalized dims. Same for bias.
This PR will decompose such LN to LN -> Mul (scale) + Add (bias) to extend QNN support to align with ONNX models.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


