### PR TITLE
[QNN EP] Add support for Dropout Op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -20,6 +20,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateConvOpBuilder("Conv", *this);
   CreateConvOpBuilder("ConvTranspose", *this);
   CreateCumSumOpBuilder("CumSum", *this);
+  CreateDropoutOpBuilder("Dropout", *this);
   CreateEinsumOpBuilder("Einsum", *this);
   CreateExpandOpBuilder("Expand", *this);
   CreateFusedMatMulOpBuilder("FusedMatMul", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -60,6 +60,7 @@ const IOpBuilder* GetOpBuilder(const std::string& onnx_op_type);
 void CreateArgMaxMinOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateBatchNormalizationOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateCastOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateDropoutOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateClipOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateConcatOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateConvOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -262,6 +262,7 @@ class BaseOpBuilder : public IOpBuilder {
   static const std::pair<size_t, size_t> GetInputOutputCountQnnRequired(std::string onnx_op_type) {
     static const std::unordered_map<std::string, std::pair<size_t, size_t>> input_output_count_qnn_required = {
         {"BatchNormalization", {3, 1}},
+        {"Dropout", {1, 1}},
         {"GlobalAveragePool", {0, 1}},
         {"LayerNormalization", {0, 1}},
         {"MaxPool", {0, 1}}};

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/dropout_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/dropout_op_builder.cc
@@ -12,7 +12,7 @@ namespace qnn {
 // ONNX Dropout has no native QNN op. In inference mode (training_mode=false),
 // it is a pure identity on the data input. Output[0] is mapped to a QNN
 // Transpose with identity permutation (same approach as IdentityOpBuilder).
-// The optional mask output[1] is filled with a constant all-ones bool tensor.
+// The optional mask output[1] is produced via NOT(static_zeros) = all-ones bool tensor.
 class DropoutOpBuilder : public BaseOpBuilder {
  public:
   DropoutOpBuilder() : BaseOpBuilder("DropoutOpBuilder") {}
@@ -44,7 +44,7 @@ class DropoutOpBuilder : public BaseOpBuilder {
 };
 
 Ort::Status DropoutOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
-                                               const OrtNodeUnit& node_unit) const {
+                                              const OrtNodeUnit& node_unit) const {
   const auto& inputs = node_unit.Inputs();
 
   // training_mode is input[2] (opset >= 12). If present and non-empty, it must be a
@@ -66,10 +66,10 @@ Ort::Status DropoutOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper
 }
 
 Ort::Status DropoutOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
-                                             const OrtNodeUnit& node_unit,
-                                             const Ort::Logger& logger,
-                                             std::vector<std::string>& input_names,
-                                             bool do_op_validation) const {
+                                            const OrtNodeUnit& node_unit,
+                                            const Ort::Logger& logger,
+                                            std::vector<std::string>& input_names,
+                                            bool do_op_validation) const {
   if (do_op_validation) {
     RETURN_IF_ERROR(ExplicitOpCheck(qnn_model_wrapper, node_unit));
   }
@@ -79,10 +79,10 @@ Ort::Status DropoutOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 }
 
 Ort::Status DropoutOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
-                                                           const OrtNodeUnit& node_unit,
-                                                           std::vector<std::string>&& input_names,
-                                                           const Ort::Logger& logger,
-                                                           bool do_op_validation) const {
+                                                          const OrtNodeUnit& node_unit,
+                                                          std::vector<std::string>&& input_names,
+                                                          const Ort::Logger& logger,
+                                                          bool do_op_validation) const {
   // output[0]: identity via Transpose with identity permutation.
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape");
@@ -103,40 +103,51 @@ Ort::Status DropoutOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                  std::move(param_tensor_names), logger, do_op_validation,
                                  QNN_OP_TRANSPOSE));
 
-  // output[1]: optional mask — constant all-ones bool tensor matching the input shape.
+  // output[1]: optional mask — all-ones bool tensor, produced via NOT(static_zeros).
+  // QnnTensorWrapper only writes client_buf into the underlying QNN tensor for STATIC type, so a
+  // bare APP_READ tensor with static data would be uninitialized at runtime. A NOT node avoids a
+  // dangling graph output with no producing op.
   const auto& outputs = node_unit.Outputs();
   if (outputs.size() > 1 && outputs[1].Exists()) {
     const std::string& mask_name = outputs[1].name;
-    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(mask_name);
-    const Qnn_TensorType_t mask_tensor_type =
-        is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-    size_t num_elements = 1;
-    for (uint32_t dim : input_shape) {
-      num_elements *= dim;
+    if (qnn_model_wrapper.IsGraphOutput(mask_name)) {
+      size_t num_elements = 1;
+      for (uint32_t dim : input_shape) {
+        num_elements *= dim;
+      }
+
+      const std::string zeros_name = mask_name + "_not_input";
+      std::vector<uint8_t> zeros_data(num_elements, 0u);
+      QnnTensorWrapper zeros_wrapper(zeros_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_BOOL_8,
+                                     QnnQuantParamsWrapper(), std::vector<uint32_t>(input_shape),
+                                     std::move(zeros_data));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(zeros_wrapper)),
+                    "Dropout: failed to add mask zeros tensor.");
+
+      QnnTensorWrapper mask_wrapper(mask_name, QNN_TENSOR_TYPE_APP_READ, QNN_DATATYPE_BOOL_8,
+                                    QnnQuantParamsWrapper(), std::vector<uint32_t>(input_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mask_wrapper)),
+                    "Dropout: failed to add mask output tensor.");
+
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(node_unit, "_mask_not"),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_ELEMENT_WISE_NOT,
+                        {zeros_name}, {mask_name}, {}, do_op_validation),
+                    "Dropout: failed to create mask NOT node.");
     }
-
-    std::vector<uint8_t> mask_data(num_elements, 1u);
-    QnnTensorWrapper mask_wrapper(mask_name,
-                                  mask_tensor_type,
-                                  QNN_DATATYPE_BOOL_8,
-                                  QnnQuantParamsWrapper(),
-                                  std::vector<uint32_t>(input_shape),
-                                  std::move(mask_data));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mask_wrapper)),
-                  "Dropout: failed to add mask output tensor.");
   }
 
   return Ort::Status();
 }
 
 Ort::Status DropoutOpBuilder::OverrideOutputQuantParam(QnnModelWrapper& qnn_model_wrapper,
-                                                        const OrtNodeUnit& node_unit,
-                                                        const Ort::Logger& logger,
-                                                        const std::vector<std::string>& input_names,
-                                                        size_t output_index,
-                                                        Qnn_DataType_t qnn_data_type,
-                                                        QnnQuantParamsWrapper& quant_param) const {
+                                                       const OrtNodeUnit& node_unit,
+                                                       const Ort::Logger& logger,
+                                                       const std::vector<std::string>& input_names,
+                                                       size_t output_index,
+                                                       Qnn_DataType_t qnn_data_type,
+                                                       QnnQuantParamsWrapper& quant_param) const {
   // output[0] is a pass-through — copy input quant params so scale/offset are preserved.
   if (output_index == 0 && quant_param.IsPerTensor()) {
     return SetOutputQParamEqualToInputIfNearlyEqual(qnn_model_wrapper, node_unit, logger, input_names,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/dropout_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/dropout_op_builder.cc
@@ -1,0 +1,153 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// ONNX Dropout has no native QNN op. In inference mode (training_mode=false),
+// it is a pure identity on the data input. Output[0] is mapped to a QNN
+// Transpose with identity permutation (same approach as IdentityOpBuilder).
+// The optional mask output[1] is filled with a constant all-ones bool tensor.
+class DropoutOpBuilder : public BaseOpBuilder {
+ public:
+  DropoutOpBuilder() : BaseOpBuilder("DropoutOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(DropoutOpBuilder);
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status OverrideOutputQuantParam(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       const Ort::Logger& logger,
+                                       const std::vector<std::string>& input_names,
+                                       size_t output_index,
+                                       Qnn_DataType_t qnn_data_type,
+                                       QnnQuantParamsWrapper& quant_param) const override ORT_MUST_USE_RESULT;
+
+ private:
+  Ort::Status ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const;
+};
+
+Ort::Status DropoutOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
+                                               const OrtNodeUnit& node_unit) const {
+  const auto& inputs = node_unit.Inputs();
+
+  // training_mode is input[2] (opset >= 12). If present and non-empty, it must be a
+  // constant false — QNN EP supports inference mode only.
+  if (inputs.size() > 2 && inputs[2].Exists()) {
+    const std::string& training_mode_name = inputs[2].name;
+    RETURN_IF(!qnn_model_wrapper.IsConstantInput(training_mode_name),
+              "Dropout: dynamic training_mode is not supported.");
+
+    TensorInfo tm_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], tm_info));
+    std::vector<uint8_t> tm_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(tm_info.initializer_tensor, tm_bytes));
+    RETURN_IF(!tm_bytes.empty() && tm_bytes[0] != 0,
+              "Dropout: training_mode=true is not supported.");
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status DropoutOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                             const OrtNodeUnit& node_unit,
+                                             const Ort::Logger& logger,
+                                             std::vector<std::string>& input_names,
+                                             bool do_op_validation) const {
+  if (do_op_validation) {
+    RETURN_IF_ERROR(ExplicitOpCheck(qnn_model_wrapper, node_unit));
+  }
+
+  // Only process data (input[0]). ratio and training_mode are ignored in inference mode.
+  return ProcessInput(qnn_model_wrapper, node_unit.Inputs()[0], logger, input_names);
+}
+
+Ort::Status DropoutOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                           const OrtNodeUnit& node_unit,
+                                                           std::vector<std::string>&& input_names,
+                                                           const Ort::Logger& logger,
+                                                           bool do_op_validation) const {
+  // output[0]: identity via Transpose with identity permutation.
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape");
+  uint32_t rank = static_cast<uint32_t>(input_shape.size());
+
+  std::vector<uint32_t> perm_data(rank);
+  for (uint32_t i = 0; i < rank; ++i) {
+    perm_data[i] = i;
+  }
+
+  QnnParamWrapper perm_param(node_unit.Index(), node_unit.Name(), QNN_OP_TRANSPOSE_PARAM_PERM,
+                             std::vector<uint32_t>{rank}, std::move(perm_data));
+  std::vector<std::string> param_tensor_names;
+  param_tensor_names.push_back(perm_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(perm_param));
+
+  RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names),
+                                 std::move(param_tensor_names), logger, do_op_validation,
+                                 QNN_OP_TRANSPOSE));
+
+  // output[1]: optional mask — constant all-ones bool tensor matching the input shape.
+  const auto& outputs = node_unit.Outputs();
+  if (outputs.size() > 1 && outputs[1].Exists()) {
+    const std::string& mask_name = outputs[1].name;
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(mask_name);
+    const Qnn_TensorType_t mask_tensor_type =
+        is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+    size_t num_elements = 1;
+    for (uint32_t dim : input_shape) {
+      num_elements *= dim;
+    }
+
+    std::vector<uint8_t> mask_data(num_elements, 1u);
+    QnnTensorWrapper mask_wrapper(mask_name,
+                                  mask_tensor_type,
+                                  QNN_DATATYPE_BOOL_8,
+                                  QnnQuantParamsWrapper(),
+                                  std::vector<uint32_t>(input_shape),
+                                  std::move(mask_data));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mask_wrapper)),
+                  "Dropout: failed to add mask output tensor.");
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status DropoutOpBuilder::OverrideOutputQuantParam(QnnModelWrapper& qnn_model_wrapper,
+                                                        const OrtNodeUnit& node_unit,
+                                                        const Ort::Logger& logger,
+                                                        const std::vector<std::string>& input_names,
+                                                        size_t output_index,
+                                                        Qnn_DataType_t qnn_data_type,
+                                                        QnnQuantParamsWrapper& quant_param) const {
+  // output[0] is a pass-through — copy input quant params so scale/offset are preserved.
+  if (output_index == 0 && quant_param.IsPerTensor()) {
+    return SetOutputQParamEqualToInputIfNearlyEqual(qnn_model_wrapper, node_unit, logger, input_names,
+                                                    0, output_index, qnn_data_type, quant_param);
+  }
+  return Ort::Status();
+}
+
+void CreateDropoutOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<DropoutOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/dropout_test.cc
+++ b/onnxruntime/test/providers/qnn/dropout_test.cc
@@ -74,11 +74,11 @@ static void RunDropoutTest(const TestInputDef<float>& data_def,
 }
 
 static void RunDropoutFP16Test(const TestInputDef<float>& data_def,
-                                const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
-                                ExpectedEPNodeAssignment expected_ep_assignment,
-                                bool with_mask = false,
-                                int opset = 13,
-                                float tolerance = 1e-5f) {
+                               const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                               ExpectedEPNodeAssignment expected_ep_assignment,
+                               bool with_mask = false,
+                               int opset = 13,
+                               float tolerance = 1e-5f) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
 
@@ -167,11 +167,11 @@ TEST_F(QnnHTPBackendTests, Dropout_FP16_WithMask) {
 // ---------------------------------------------------------------------------
 
 static void RunDropoutHTPBF16Test(const TestInputDef<float>& data_def,
-                                   const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
-                                   ExpectedEPNodeAssignment expected_ep_assignment,
-                                   bool with_mask = false,
-                                   int opset = 13,
-                                   float tolerance = 1e-5f) {
+                                  const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                  ExpectedEPNodeAssignment expected_ep_assignment,
+                                  bool with_mask = false,
+                                  int opset = 13,
+                                  float tolerance = 1e-5f) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["htp_bf16_enable"] = "1";

--- a/onnxruntime/test/providers/qnn/dropout_test.cc
+++ b/onnxruntime/test/providers/qnn/dropout_test.cc
@@ -1,0 +1,235 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "core/graph/onnx_protobuf.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Dropout has no QDQ variant (float-only type constraints).
+//
+// In inference mode (training_mode absent or false) Dropout is a pure identity:
+//   output = data,  mask = all-ones bool tensor.
+
+// Builds a Dropout test model.
+//   with_mask: if true, the optional mask output is included in the graph.
+template <typename DataType>
+inline GetTestModelFn BuildDropoutTestCase(const TestInputDef<DataType>& data_def,
+                                           const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                           bool with_mask = false) {
+  return [data_def, attrs, with_mask](ModelTestBuilder& builder) {
+    MakeTestInput<DataType>(builder, "data", data_def);
+
+    builder.MakeOutput("output");
+    std::vector<std::string> output_names = {"output"};
+
+    if (with_mask) {
+      builder.MakeOutput("mask");
+      output_names.push_back("mask");
+    }
+
+    builder.AddNode("Dropout_node", "Dropout", {"data"}, output_names, kOnnxDomain, attrs);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test runner helpers
+// ---------------------------------------------------------------------------
+
+static void RunDropoutTest(const TestInputDef<float>& data_def,
+                           const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                           ExpectedEPNodeAssignment expected_ep_assignment,
+                           bool with_mask = false,
+                           const std::string& backend_name = "cpu",
+                           int opset = 13,
+                           float fp32_abs_err = 1e-5f,
+                           bool enable_htp_fp16_precision = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  if (enable_htp_fp16_precision) {
+#if defined(_WIN32)
+    SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#endif
+#if defined(__linux__) && !defined(__aarch64__)
+    provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+    provider_options["enable_htp_fp16_precision"] = "1";
+  }
+
+  RunQnnModelTest(BuildDropoutTestCase<float>(data_def, attrs, with_mask),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  fp32_abs_err);
+}
+
+static void RunDropoutFP16Test(const TestInputDef<float>& data_def,
+                                const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                ExpectedEPNodeAssignment expected_ep_assignment,
+                                bool with_mask = false,
+                                int opset = 13,
+                                float tolerance = 1e-5f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  TestInputDef<Ort::Float16_t> data_fp16 = ConvertToFP16InputDef(data_def);
+
+  RunQnnModelTest(BuildDropoutTestCase<Ort::Float16_t>(data_fp16, attrs, with_mask),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  tolerance);
+}
+
+// ---------------------------------------------------------------------------
+// CPU tests
+// ---------------------------------------------------------------------------
+
+TEST_F(QnnCPUBackendTests, Dropout_Default) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, Dropout_WithMask) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All,
+                 /*with_mask=*/true);
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// ---------------------------------------------------------------------------
+// HTP FP32 tests
+// x86_64 and ARM64 Windows, x86_64 and ARM64 Linux
+// ---------------------------------------------------------------------------
+
+TEST_F(QnnHTPBackendTests, Dropout_FP32_Default) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All,
+                 /*with_mask=*/false,
+                 "htp", 13, 1e-5f);
+}
+
+TEST_F(QnnHTPBackendTests, Dropout_FP32_WithMask) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All,
+                 /*with_mask=*/true,
+                 "htp", 13, 1e-5f);
+}
+
+// FP32 executed at FP16 precision on HTP.
+TEST_F(QnnHTPBackendTests, Dropout_FP32_as_FP16) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All,
+                 /*with_mask=*/false,
+                 "htp", 13, 0.01f, /*enable_htp_fp16_precision=*/true);
+}
+
+// ---------------------------------------------------------------------------
+// HTP native FP16 tests
+// ---------------------------------------------------------------------------
+
+TEST_F(QnnHTPBackendTests, Dropout_FP16) {
+  RunDropoutFP16Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                     {},
+                     ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, Dropout_FP16_WithMask) {
+  RunDropoutFP16Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                     {},
+                     ExpectedEPNodeAssignment::All,
+                     /*with_mask=*/true);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+// ---------------------------------------------------------------------------
+// HTP BF16 tests only on ARM64 Architecture (opset 22 adds bfloat16 to type constraints;)
+// v81+ required
+// ---------------------------------------------------------------------------
+
+static void RunDropoutHTPBF16Test(const TestInputDef<float>& data_def,
+                                   const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                   ExpectedEPNodeAssignment expected_ep_assignment,
+                                   bool with_mask = false,
+                                   int opset = 13,
+                                   float tolerance = 1e-5f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["htp_bf16_enable"] = "1";
+  provider_options["soc_model"] = "88";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildDropoutTestCase<float>(data_def, attrs, with_mask),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  tolerance);
+}
+
+TEST_F(QnnHTPBackendTests, Dropout_HTP_BF16_Default) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V79);
+  RunDropoutHTPBF16Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                        {},
+                        ExpectedEPNodeAssignment::All,
+                        /*with_mask=*/false,
+                        /*opset=*/22);
+}
+
+TEST_F(QnnHTPBackendTests, Dropout_HTP_BF16_WithMask) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V79);
+  RunDropoutHTPBF16Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                        {},
+                        ExpectedEPNodeAssignment::All,
+                        /*with_mask=*/true,
+                        /*opset=*/22);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
+
+#if defined(_M_ARM64)
+
+// ---------------------------------------------------------------------------
+// GPU tests
+// ---------------------------------------------------------------------------
+
+TEST_F(QnnGPUBackendTests, Dropout_Default) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All,
+                 /*with_mask=*/false,
+                 "gpu");
+}
+
+TEST_F(QnnGPUBackendTests, Dropout_WithMask) {
+  RunDropoutTest(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-10.0f, 10.0f, 6)),
+                 {},
+                 ExpectedEPNodeAssignment::All,
+                 /*with_mask=*/true,
+                 "gpu");
+}
+
+#endif  // defined(_M_ARM64)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description


Implements the `Dropout` ONNX operator (opsets 7–22) for the QNN Execution Provider across CPU, HTP (FP32, FP16, BF16), and GPU backends.

`Dropout` has no native `QNN Op`, and ONNX Dropout is a pure identity in inference mode (`training_mode = false`), the operator is decomposed into **two independent QNN nodes**:

```
                    ┌──────────────────────────────────────────────────────────────┐
                    │                QNN subgraph for Dropout                      │
                    │                                                              │
                    │   Node 1                                                     │
data (float) ───────►  QNN_OP_TRANSPOSE                                ───────────► output (float)
                    │  perm = [0, 1, ..., N-1]  (identity permutation)             │
                    │                                                              │
                    │   Node 2                                                     │
zeros (STATIC bool) ►  QNN_OP_ELEMENT_WISE_NOT                         ───────────► mask (bool, optional)
all-zeros constant  │  NOT(0) = 1  →  all-ones                                     │
                    │                                                              │
                    └──────────────────────────────────────────────────────────────┘
```

- **Node 1** — `QNN_OP_TRANSPOSE` with an identity permutation passes `data` through unchanged to `output`.
- **Node 2** — `QNN_OP_ELEMENT_WISE_NOT` applied to a static all-zeros `BOOL_8` constant produces `mask` as an all-ones bool tensor. This node is only added when `mask` is a graph output.

The two nodes are completely independent. `Transpose` produces only `output`; `ELEMENT_WISE_NOT` produces only `mask`

---

### Motivation / Context

`Dropout` was previously unsupported in QNN. Without this op the `QNN EP` falls back to the `CPU` for any graph that includes a `Dropout` node, even at inference time where the op does nothing.

ONNX defines `Dropout` as https://onnx.ai/onnx/operators/onnx__Dropout.html

| Opset | Change |
|-------|--------|
| 1–6   | `ratio` is an attribute; no `mask` output |
| 7–9   | `ratio` attribute; optional `mask` output added |
| 10–11 | `seed` attribute added |
| 12–21 | `ratio` and `training_mode` become **inputs**; `seed` attribute kept |
| 22    | `bfloat16` added to `T` type constraints |

This implementation supports all opsets 7–22. At opsets ≥ 12, `ratio` and `training_mode` are inputs; `training_mode` is validated to be a constant `false` (or absent) and then ignored. At opset 22 the `bfloat16` path is exercised by the `HTP BF16` tests.

---

## Files changed

| File | Change |
|------|--------|
| `core/providers/qnn/builder/opbuilder/dropout_op_builder.cc` | `DropoutOpBuilder` implementation |
| `core/providers/qnn/builder/op_builder_factory.h` | Add `CreateDropoutOpBuilder` declaration |
| `core/providers/qnn/builder/op_builder_factory.cc` | Register `"Dropout"` |
| `test/providers/qnn/dropout_test.cc` | Unit tests for all backends and data types |

---

## Implementation notes

**No QDQ variant**: ONNX Dropout has float-only type constraints (`T ∈ {float16, float, double, bfloat16}`), so no QDQ path is needed or registered.

**`training_mode` guard** (`ExplicitOpCheck`): If `inputs[2]` exists and is non-empty, it must be a constant initializer equal to `0`. Dynamic or `true` values cause the node to fall back to the CPU EP.

**Quant param passthrough** (`OverrideOutputQuantParam`): For quantized graphs, output[0]'s scale/offset is copied from input[0] via `SetOutputQParamEqualToInputIfNearlyEqual`, preserving accuracy through the identity.

**Mask output*: Materialised as a static `QNN_DATATYPE_BOOL_8` tensor (`QNN_TENSOR_TYPE_APP_READ` when it is a graph output, `QNN_TENSOR_TYPE_NATIVE` otherwise) filled with `1`. No `QNN op` is added for the mask; it is a constant tensor.