### PR TITLE
[QNN EP] Support NonZero with dynamic output shape via QNN max-shape + EP shape propagation

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/nonzero_op_builder.cc
@@ -45,15 +45,15 @@ Ort::Status NonZeroOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_NOT(qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::HTP,
                 "NonZero is only supported on HTP backend.");
 
-  // NonZero output must have a static shape (no dynamic dims).
-  // The ONNX model should set the output shape to [rank, num_elements] where num_elements
-  // is the total number of elements in the input.
-  const auto& output = node_unit.Outputs()[0];
-  std::vector<uint32_t> output_shape;
-  RETURN_IF_NOT(QnnModelWrapper::GetOnnxShape(output.shape, output_shape),
-                "NonZero output shape must be static. Set shape to [rank, num_elements].");
+  // Input shape must be static so we can compute the maximum possible output size.
+  // The output shape will be overridden to [rank, num_elements] regardless of what
+  // ORT's shape inference produced (which is typically dynamic for NonZero).
+  const auto& input = node_unit.Inputs()[0];
+  std::vector<uint32_t> input_shape_check;
+  RETURN_IF_NOT(QnnModelWrapper::GetOnnxShape(input.shape, input_shape_check),
+                "NonZero requires static input shape to compute max output size.");
 
-  const std::string& output_name = output.name;
+  const std::string& output_name = node_unit.Outputs()[0].name;
   if (qnn_model_wrapper.IsGraphOutput(output_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
                 "NonZero output is a graph output. QNN HTP pads unused elements with -1.");
@@ -137,6 +137,11 @@ Ort::Status NonZeroOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   const auto& outputs = node_unit.Outputs();
   const std::string& output_name = outputs[0].name;
   bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
+
+  // Register max-shape override so downstream ops see a static shape even when ORT's
+  // shape inference produced dynamic dims for this NonZero output.
+  qnn_model_wrapper.SetTensorShapeOverride(
+      output_name, {static_cast<int64_t>(input_rank), static_cast<int64_t>(num_elements)});
 
   Qnn_DataType_t output_data_type = QNN_DATATYPE_INT_32;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -838,8 +838,13 @@ Ort::Status QnnModelWrapper::GetTensorInfo(const OrtNodeUnitIODef& tensor, Tenso
                                         tensor.type,
                                         tensor_info.qnn_data_type));
 
-  // Fill in shape.
-  RETURN_IF_NOT(GetOnnxShape(tensor.shape, tensor_info.shape), "Cannot get shape");
+  // Fill in shape. Check the per-build shape override map first (set by ops like NonZero that use
+  // QNN max-shape semantics when ORT's inference produced dynamic dims).
+  const auto* shape_override = GetTensorShapeOverride(name);
+  const auto& eff_shape = shape_override
+                              ? std::optional<std::vector<int64_t>>(*shape_override)
+                              : tensor.shape;
+  RETURN_IF_NOT(GetOnnxShape(eff_shape, tensor_info.shape), "Cannot get shape");
 
   // Fill in initializer info.
   tensor_info.is_initializer = IsConstantInput(name);

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -247,6 +247,19 @@ class QnnModelWrapper {
 
   Ort::Status GetTensorInfo(const OrtNodeUnitIODef& tensor, TensorInfo& tensor_info) const;
 
+  // Register a static shape override for a tensor whose ORT shape is dynamic (e.g., NonZero output).
+  // Used to propagate QNN-specific max-shape semantics through the graph so downstream op builders
+  // see static shapes even when ORT's shape inference produced dynamic dimensions.
+  void SetTensorShapeOverride(const std::string& tensor_name, std::vector<int64_t> shape) {
+    tensor_shape_overrides_[tensor_name] = std::move(shape);
+  }
+
+  // Returns a pointer to the override shape if one was registered, or nullptr if none.
+  const std::vector<int64_t>* GetTensorShapeOverride(const std::string& tensor_name) const {
+    auto it = tensor_shape_overrides_.find(tensor_name);
+    return (it != tensor_shape_overrides_.end()) ? &it->second : nullptr;
+  }
+
   Ort::Status AddCastNode(const std::string& cast_node_name,
                           const std::string& input_name,
                           const std::string& output_name,
@@ -515,6 +528,11 @@ class QnnModelWrapper {
   const ApiPtrs api_ptrs_;
 
   std::unordered_map<std::string, std::string>* tensor_name_overrides_ = nullptr;
+
+  // Per-build shape overrides: maps tensor name → static shape. Op builders (e.g., NonZero) register
+  // overrides here when QNN uses max-shape semantics that differ from ORT's dynamic inference result.
+  // GetTensorInfo() consults this map before using ORT's shape, enabling downstream ops to see static shapes.
+  std::unordered_map<std::string, std::vector<int64_t>> tensor_shape_overrides_;
 
   // Tensor names produced by compile-time Q/DQ folds; chained across hops.
   std::unordered_set<std::string> folded_constant_tensors_;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -11,6 +11,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_shape_inference.h"
 #include "core/providers/qnn/builder/qnn_node_group/cast_lone_q_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/dq_conv_integer_fusion.h"
@@ -54,14 +55,25 @@ class QnnNodeUnitWrapper : public IQnnNodeGroup {
                                           node_unit_->Name() + "` will not be assigned to QNN EP.")
                                              .c_str());
 
-    return op_builder->IsOpSupported(qmw, *node_unit_, logger);
+    Ort::Status status = op_builder->IsOpSupported(qmw, *node_unit_, logger);
+    if (status.IsOK()) {
+      // After successful validation, propagate any shape overrides this node produces so that
+      // downstream nodes see static shapes during their own IsOpSupported calls.
+      TryPropagateShapeOverrides(qmw, *node_unit_);
+    }
+    return status;
   }
 
   Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override {
     const std::string& op_type = node_unit_->OpType();
     const auto* op_builder = qnn::GetOpBuilder(op_type);
     RETURN_IF_NOT(op_builder != nullptr, ("[QNN EP]: Missing OpBuilder for OpType " + op_type).c_str());
-    return op_builder->AddToModelBuilder(qmw, *node_unit_, logger, /*do_op_validation*/ false);
+    Ort::Status status = op_builder->AddToModelBuilder(qmw, *node_unit_, logger, /*do_op_validation*/ false);
+    if (status.IsOK()) {
+      // Propagate shape overrides into the compile-time qmw so subsequent nodes can get static shapes.
+      TryPropagateShapeOverrides(qmw, *node_unit_);
+    }
+    return status;
   }
 
   gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override {

--- a/onnxruntime/core/providers/qnn/builder/qnn_shape_inference.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_shape_inference.cc
@@ -1,0 +1,228 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_shape_inference.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+bool TryPropagateShapeOverrides(QnnModelWrapper& qmw, const OrtNodeUnit& node_unit) {
+  // Check whether any output already needs an override (dynamic from ORT + not yet set).
+  bool any_needs_override = false;
+  for (const auto& output : node_unit.Outputs()) {
+    std::vector<uint32_t> dummy;
+    if (!QnnModelWrapper::GetOnnxShape(output.shape, dummy) &&
+        qmw.GetTensorShapeOverride(output.name) == nullptr) {
+      any_needs_override = true;
+      break;
+    }
+  }
+  if (!any_needs_override) return false;
+
+  // Get an input's effective shape (ORT shape overridden by the shape-override map if present).
+  // Returns nullopt if the shape cannot be determined.
+  auto get_input_shape = [&](size_t idx) -> std::optional<std::vector<uint32_t>> {
+    const auto& inputs = node_unit.Inputs();
+    if (idx >= inputs.size()) return std::nullopt;
+    TensorInfo info;
+    if (!qmw.GetTensorInfo(inputs[idx], info).IsOK()) return std::nullopt;
+    return info.shape;
+  };
+
+  // Register a shape override for output[out_idx] only if the shape is still dynamic.
+  bool any_registered = false;
+  auto try_register = [&](size_t out_idx, const std::vector<uint32_t>& shape) {
+    const auto& outputs = node_unit.Outputs();
+    if (out_idx >= outputs.size()) return;
+    const std::string& name = outputs[out_idx].name;
+
+    // Skip if ORT already has a static shape or we already have an override.
+    std::vector<uint32_t> dummy;
+    if (QnnModelWrapper::GetOnnxShape(outputs[out_idx].shape, dummy)) return;
+    if (qmw.GetTensorShapeOverride(name) != nullptr) return;
+
+    std::vector<int64_t> shape_i64(shape.begin(), shape.end());
+    qmw.SetTensorShapeOverride(name, std::move(shape_i64));
+    any_registered = true;
+  };
+
+  // Read an int64 vector from a constant initializer input (for opset-13+ ops where axes are
+  // passed as a tensor rather than an attribute).
+  auto read_const_int64_input = [&](size_t idx) -> std::optional<std::vector<int64_t>> {
+    const auto& inputs = node_unit.Inputs();
+    if (idx >= inputs.size()) return std::nullopt;
+    const OrtValueInfo* tensor = qmw.GetConstantTensor(inputs[idx].name);
+    if (tensor == nullptr) return std::nullopt;
+    std::vector<uint8_t> bytes;
+    if (!qmw.UnpackInitializerData(tensor, bytes).IsOK()) return std::nullopt;
+    if (bytes.empty() || bytes.size() % sizeof(int64_t) != 0) return std::nullopt;
+    const size_t n = bytes.size() / sizeof(int64_t);
+    std::vector<int64_t> values(n);
+    std::memcpy(values.data(), bytes.data(), bytes.size());
+    return values;
+  };
+
+  const std::string& op_type = node_unit.OpType();
+  OrtNodeAttrHelper attrs(node_unit);
+
+  if (op_type == "Cast") {
+    auto s = get_input_shape(0);
+    if (s) try_register(0, *s);
+
+  } else if (op_type == "Identity") {
+    auto s = get_input_shape(0);
+    if (s) try_register(0, *s);
+
+  } else if (op_type == "Transpose") {
+    auto s = get_input_shape(0);
+    if (!s) return false;
+    std::vector<int64_t> perm = attrs.Get("perm", std::vector<int64_t>{});
+    if (perm.empty()) {
+      perm.resize(s->size());
+      std::iota(perm.rbegin(), perm.rend(), int64_t{0});
+    }
+    if (perm.size() != s->size()) return false;
+    std::vector<uint32_t> out_shape(s->size());
+    for (size_t i = 0; i < perm.size(); ++i) {
+      out_shape[i] = (*s)[static_cast<size_t>(perm[i])];
+    }
+    try_register(0, out_shape);
+
+  } else if (op_type == "Gather") {
+    // output shape: data.shape[:axis] + indices.shape + data.shape[axis+1:]
+    auto data_shape = get_input_shape(0);
+    auto idx_shape = get_input_shape(1);
+    if (!data_shape || !idx_shape) return false;
+
+    int64_t rank = static_cast<int64_t>(data_shape->size());
+    int64_t axis = attrs.Get("axis", int64_t{0});
+    if (axis < 0) axis += rank;
+    if (axis < 0 || axis >= rank) return false;
+
+    std::vector<uint32_t> out_shape;
+    for (int64_t i = 0; i < axis; ++i) out_shape.push_back((*data_shape)[static_cast<size_t>(i)]);
+    for (auto d : *idx_shape) out_shape.push_back(d);
+    for (int64_t i = axis + 1; i < rank; ++i) out_shape.push_back((*data_shape)[static_cast<size_t>(i)]);
+    try_register(0, out_shape);
+
+  } else if (op_type == "GatherElements") {
+    // Output shape = indices shape (same rank and shape as data, element-wise gather).
+    auto idx_shape = get_input_shape(1);
+    if (idx_shape) try_register(0, *idx_shape);
+
+  } else if (op_type == "GatherND") {
+    // output shape: indices.shape[:-1] + data.shape[batch_dims + indices.shape[-1]:]
+    auto data_shape = get_input_shape(0);
+    auto idx_shape = get_input_shape(1);
+    if (!data_shape || !idx_shape || idx_shape->empty()) return false;
+
+    int64_t batch_dims = attrs.Get("batch_dims", int64_t{0});
+    uint32_t slice_depth = idx_shape->back();
+    size_t data_start = static_cast<size_t>(batch_dims) + static_cast<size_t>(slice_depth);
+    if (data_start > data_shape->size()) return false;
+
+    std::vector<uint32_t> out_shape;
+    for (size_t i = 0; i + 1 < idx_shape->size(); ++i) out_shape.push_back((*idx_shape)[i]);
+    for (size_t i = data_start; i < data_shape->size(); ++i) out_shape.push_back((*data_shape)[i]);
+    try_register(0, out_shape);
+
+  } else if (op_type == "ScatterElements" || op_type == "Scatter") {
+    // Output shape = data (input[0]) shape.
+    auto s = get_input_shape(0);
+    if (s) try_register(0, *s);
+
+  } else if (op_type == "ScatterND") {
+    // Output shape = data (input[0]) shape.
+    auto s = get_input_shape(0);
+    if (s) try_register(0, *s);
+
+  } else if (op_type == "Squeeze") {
+    auto s = get_input_shape(0);
+    if (!s) return false;
+
+    // In opset < 13, axes is an attribute; in opset >= 13 it is input[1].
+    std::optional<std::vector<int64_t>> axes = attrs.GetInt64s("axes");
+    if (!axes) axes = read_const_int64_input(1);  // opset 13+ input tensor
+    if (!axes) return false;
+
+    int64_t rank = static_cast<int64_t>(s->size());
+    std::unordered_set<int64_t> axes_set;
+    for (auto ax : *axes) {
+      if (ax < 0) ax += rank;
+      axes_set.insert(ax);
+    }
+    std::vector<uint32_t> out_shape;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (!axes_set.count(i)) out_shape.push_back((*s)[static_cast<size_t>(i)]);
+    }
+    try_register(0, out_shape);
+
+  } else if (op_type == "Unsqueeze") {
+    auto s = get_input_shape(0);
+    if (!s) return false;
+
+    std::optional<std::vector<int64_t>> axes = attrs.GetInt64s("axes");
+    if (!axes) axes = read_const_int64_input(1);
+    if (!axes) return false;
+
+    int64_t new_rank = static_cast<int64_t>(s->size()) + static_cast<int64_t>(axes->size());
+    std::unordered_set<int64_t> axes_set;
+    for (auto ax : *axes) {
+      if (ax < 0) ax += new_rank;
+      axes_set.insert(ax);
+    }
+    std::vector<uint32_t> out_shape;
+    int src_i = 0;
+    for (int64_t i = 0; i < new_rank; ++i) {
+      if (axes_set.count(i)) {
+        out_shape.push_back(1);
+      } else {
+        out_shape.push_back((*s)[static_cast<size_t>(src_i++)]);
+      }
+    }
+    try_register(0, out_shape);
+
+  } else if (op_type == "Flatten") {
+    auto s = get_input_shape(0);
+    if (!s) return false;
+    int64_t axis = attrs.Get("axis", int64_t{1});
+    int64_t rank = static_cast<int64_t>(s->size());
+    if (axis < 0) axis += rank;
+    if (axis < 0 || axis > rank) return false;
+    uint32_t outer = 1, inner = 1;
+    for (int64_t i = 0; i < axis; ++i) outer *= (*s)[static_cast<size_t>(i)];
+    for (int64_t i = axis; i < rank; ++i) inner *= (*s)[static_cast<size_t>(i)];
+    try_register(0, {outer, inner});
+
+  } else if (op_type == "Concat") {
+    int64_t axis = attrs.Get("axis", int64_t{0});
+    auto first_shape = get_input_shape(0);
+    if (!first_shape) return false;
+    if (axis < 0) axis += static_cast<int64_t>(first_shape->size());
+    if (axis < 0 || static_cast<size_t>(axis) >= first_shape->size()) return false;
+
+    std::vector<uint32_t> out_shape(*first_shape);
+    const auto& inputs = node_unit.Inputs();
+    for (size_t i = 1; i < inputs.size(); ++i) {
+      auto s = get_input_shape(i);
+      if (!s || s->size() != first_shape->size()) return false;
+      out_shape[static_cast<size_t>(axis)] += (*s)[static_cast<size_t>(axis)];
+    }
+    try_register(0, out_shape);
+  }
+
+  return any_registered;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_shape_inference.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_shape_inference.h
@@ -1,0 +1,25 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// For each output of node_unit whose ORT shape is dynamic (negative or missing dimensions),
+// tries to compute a static shape from the (possibly overridden) input shapes and registers
+// it in qmw via SetTensorShapeOverride. Called once per node in topological order so that
+// shape overrides propagate transitively through the subgraph.
+//
+// Returns true if at least one output shape override was newly registered.
+//
+// Note: QNN EP is a plugin shared library and does not link against the ONNX schema
+// registry. Shape formulas are implemented directly for the ops that appear downstream
+// of NonZero in practice. Unknown op types are silently skipped.
+bool TryPropagateShapeOverrides(QnnModelWrapper& qmw, const OrtNodeUnit& node_unit);
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/nonzero_test.cc
+++ b/onnxruntime/test/providers/qnn/nonzero_test.cc
@@ -34,6 +34,20 @@ static GetTestModelFn BuildNonZeroTestCase(const std::vector<int64_t>& input_sha
   };
 }
 
+// Variant of BuildNonZeroTestCase that leaves the output shape as dynamic ({-1, -1}),
+// matching what standard ONNX models produce from ORT's shape inference.
+template <typename DataType>
+static GetTestModelFn BuildNonZeroTestCaseDynamicOutput(const std::vector<int64_t>& input_shape,
+                                                        const std::vector<DataType>& input_data) {
+  TestInputDef<DataType> input_def(input_shape, false, input_data);
+  return [input_def](ModelTestBuilder& builder) {
+    MakeTestInput<DataType>(builder, "X", input_def);
+    builder.AddNode("nonzero_node", "NonZero", {"X"}, {"Y"}, kOnnxDomain);
+    // Dynamic output shape: -1 = unknown at model-build time. QNN EP must infer max shape internally.
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{-1, -1});
+  };
+}
+
 static ProviderOptions HtpProviderOptions() {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -259,17 +273,75 @@ TEST_F(QnnHTPBackendTests, NonZero_Gather_1D_Int32) {
   }
 }
 
-// Negative test: NonZero with dynamic output shape should not be assigned to QNN EP.
-TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape_Negative) {
-  auto build_model = [](ModelTestBuilder& builder) {
-    TestInputDef<float> input_def({2, 3}, false, {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f});
-    MakeTestInput<float>(builder, "X", input_def);
-    builder.AddNode("nonzero_node", "NonZero", {"X"}, {"Y"}, kOnnxDomain);
-    // Dynamic output shape: [rank, -1]
-    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{2, -1});
+// Dynamic output shape test: output declared as {-1, -1} (standard ONNX model output from ORT shape inference).
+// QNN EP must compute the max-shape internally from the input shape and accept the node.
+TEST_F(QnnHTPBackendTests, NonZero_DynamicOutputShape) {
+  RunNonZeroTest(BuildNonZeroTestCaseDynamicOutput<float>(
+                     {2, 3}, {1.0f, 0.0f, 3.0f, 0.0f, 5.0f, 0.0f}),
+                 11, ExpectedEPNodeAssignment::All);
+}
+
+// NonZero → Gather chain with dynamic NonZero output shape.
+// NonZero output is declared as {-1, -1} (as ORT's shape inference would produce).
+// Shape propagation must compute Gather's output shape from the overridden NonZero max-shape.
+// Input is all-nonzero to avoid CPU/QNN mismatch from -1 padding entries.
+TEST_F(QnnHTPBackendTests, NonZero_Gather_Chain_DynamicShape) {
+  std::vector<float> mask_data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};  // all non-zero
+  std::vector<int32_t> data = {10, 20, 30, 40, 50};
+  int64_t n = 5;
+
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  auto build_model = [mask_data, data, n](ModelTestBuilder& builder) {
+    TestInputDef<float> mask_def({n}, false, mask_data);
+    MakeTestInput<float>(builder, "mask", mask_def);
+
+    // NonZero with dynamic output shape (no static dims declared — standard ONNX model).
+    builder.AddNode("nonzero_node", "NonZero", {"mask"}, {"nonzero_out"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("nonzero_out", std::vector<int64_t>{-1, -1});
+
+    // Reshape [1, n] -> [n] to get 1D indices
+    builder.Make1DInitializer<int64_t>("reshape_shape", {n});
+    builder.AddNode("reshape_node", "Reshape", {"nonzero_out", "reshape_shape"}, {"indices_i64"}, kOnnxDomain);
+
+    // Cast int64 -> int32 (HTP requires int32 indices)
+    builder.AddNode("cast_node", "Cast", {"indices_i64"}, {"indices_i32"}, kOnnxDomain,
+                    {test::MakeAttribute("to", int64_t(ONNX_NAMESPACE::TensorProto_DataType_INT32))});
+
+    // Gather data[indices]
+    builder.MakeInitializer<int32_t>("data", {n}, data);
+    builder.AddNode("gather_node", "Gather", {"data", "indices_i32"}, {"output"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", int64_t(0))});
+    builder.MakeOutput<int32_t>("output", std::vector<int64_t>{-1});
   };
 
-  RunNonZeroTest(build_model, 11, ExpectedEPNodeAssignment::None);
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  build_model(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  std::vector<Ort::Value> expected;
+  InferenceModelCPU(model_data, "NonZero_Gather_Chain_CPU", helper.feeds_, expected);
+
+  std::vector<Ort::Value> actual;
+  InferenceModel(model_data, "NonZero_Gather_Chain_QNN", HtpProviderOptions(),
+                 ExpectedEPNodeAssignment::All, helper.feeds_, actual);
+
+  // output index 1 is the Gather result (index 0 is the NonZero graph output)
+  auto exp_shape = expected[1].GetTensorTypeAndShapeInfo().GetShape();
+  auto act_shape = actual[1].GetTensorTypeAndShapeInfo().GetShape();
+  ASSERT_EQ(exp_shape, act_shape);
+  auto cnt = expected[1].GetTensorTypeAndShapeInfo().GetElementCount();
+  const int32_t* ep = expected[1].GetTensorData<int32_t>();
+  const int32_t* ap = actual[1].GetTensorData<int32_t>();
+  for (size_t i = 0; i < cnt; ++i) EXPECT_EQ(ep[i], ap[i]) << " at index " << i;
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This change makes QNN EP accept standard ONNX models by:
1. Removing the static output shape requirement from NonZero's IsOpSupported and instead requiring only a static INPUT shape (needed to compute max capacity).
2. Having NonZero's ProcessAttributesAndOutputs register a shape override {rank, total_elements} in QnnModelWrapper before building the QNN node chain.
3. Adding a shape override map (tensor_shape_overrides_) to QnnModelWrapper. GetTensorInfo() consults this map first so any op builder transparently receives the corrected shape when it queries an input's TensorInfo.
4. Adding a central TryPropagateShapeOverrides() utility (qnn_shape_inference.cc) that, for any node whose ORT output shape is still dynamic, computes a static output shape from the (possibly overridden) input shapes. Covers: Transpose, Gather, GatherElements, GatherND, ScatterElements, ScatterND, Cast, Identity, Squeeze, Unsqueeze, Flatten, Concat.
5. Calling TryPropagateShapeOverrides() from QnnNodeUnitWrapper::IsSupported and AddToModelBuilder in qnn_node_group.cc so the propagation chain runs automatically in topological order for the entire subgraph.

Tests: add BuildNonZeroTestCaseDynamicOutput helper, convert the negative dynamic-shape test to a positive test, and add a NonZero→Gather chain test that exercises end-to-end shape propagation.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- ONNX NonZero has dynamic output shape semantics; ORT's shape inference produces {-1, -1} for the output. Previously QNN EP rejected NonZero unless the model explicitly baked in a static output shape — a non-standard contract.

