### PR TITLE
Avoid bundling PDB zip into the regular Windows archive artifact

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -142,18 +142,6 @@ jobs:
           ${{ inputs.build_aar == true && '--build-aar' || '' }}
           ${{inputs.upload_test_archive == true && 'archive' || 'build'}}_ort_${{inputs.target_os}}_${{ inputs.target_arch }}
 
-      - name: Build Windows ${{ inputs.target_arch }} PDB Archive
-        if: ${{ inputs.build_pdb_archive && inputs.target_os == 'windows' }}
-        run: >
-          python.exe tools/ci_build/pkg_assets.py
-          --source_dir ${{ github.workspace }}
-          --build_dir ${{ github.workspace }}/build/${{ inputs.target_os }}-${{ inputs.target_arch }}
-          --config Release
-          --pdb_only
-          --target_arch ${{ inputs.target_arch }}
-          ${{ env.BUILD_CONFIG_DIR == 'Release' && '--use_ninja' || '' }}
-          ${{ env.ORT_VERSION_SUFFIX != '' && format('--version_suffix {0}', env.ORT_VERSION_SUFFIX) || '' }}
-
       - name: Test ${{inputs.target_os}} ${{ inputs.target_arch }} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
         if: ${{ inputs.run_tests && inputs.build_test_same_runner }}
         run: >
@@ -236,6 +224,18 @@ jobs:
         with:
           name: "${{inputs.target_os}}-${{ inputs.target_arch }}-pom"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.pom"
+
+      - name: Build Windows ${{ inputs.target_arch }} PDB Archive
+        if: ${{ inputs.build_pdb_archive && inputs.target_os == 'windows' }}
+        run: >
+          python.exe tools/ci_build/pkg_assets.py
+          --source_dir ${{ github.workspace }}
+          --build_dir ${{ github.workspace }}/build/${{ inputs.target_os }}-${{ inputs.target_arch }}
+          --config Release
+          --pdb_only
+          --target_arch ${{ inputs.target_arch }}
+          ${{ env.BUILD_CONFIG_DIR == 'Release' && '--use_ninja' || '' }}
+          ${{ env.ORT_VERSION_SUFFIX != '' && format('--version_suffix {0}', env.ORT_VERSION_SUFFIX) || '' }}
 
       - name: Upload PDB Archive to Artifactory
         if: ${{ inputs.upload_pdb_archive && inputs.target_os == 'windows' && env.BUILD_ARTIFACTORY_REPO != '' }}


### PR DESCRIPTION
### Description
Move the "Build Windows <arch> PDB Archive" step from right after the main build to right before "Upload PDB Archive to  Artifactory". With this ordering, the PDB zip does not yet exist in dist/ when the regular archive upload runs, so its glob can only match the regular zip. The dedicated PDB upload still picks up the PDB zip via its `*-pdb.zip` glob.


### Motivation and Context
The "Upload Archive to Artifactory" step uses the glob `dist/onnxruntime-qnn*.zip`, which matches both the regular zip  (`onnxruntime-qnn-<ver>-win-<arch>.zip`) and the PDB zip (`onnxruntime-qnn-<ver>-win-<arch>-pdb.zip`) that the prior step just produced in the same dist/ folder. As a result, the `windows-<arch>-py<vsn>-zip` artifact ended up containing both the regular archive and the PDB archive, while the dedicated `windows-<arch>-py<vsn>-pdb-zip` artifact had only the PDB.