### PR TITLE
[QNN EP] Conv BQ Phase 1: support Conv with block-quantized weight on HTP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -357,6 +357,23 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       const int64_t IC = static_cast<int64_t>(input_info.shape[1]);
       const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc (validated: IC % nb == 0)
       const int64_t block_size = IC / nb;
+      const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+
+      // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain.
+      // QNN BW_FLOAT_BLOCK only supports SFIXED_POINT_8 (signed); unsigned data must be converted.
+      // TransformUnsignedToSignedFixedPoint XORs the MSB of each packed element:
+      //   - UINT8 (bitwidth=8, mask=0x80): 1 byte/element — directly converts [0,255] → [-128,127].
+      //   - UINT4 (bitwidth=4, mask=0x88): after TransposeFromNchwToHwcn unpack, each byte holds
+      //     a UINT4 value in its lower nibble (upper nibble=0). XOR with 0x88 flips bits 3 and 7;
+      //     QNN reads only the lower nibble for bitwidth=4, so the result is equivalent to
+      //     flipping bit 3, which shifts [0,15] → signed-nibble-interpreted [-8,7] correctly.
+      const bool is_unsigned_weight = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
+                                       inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
+                                       inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+      if (is_unsigned_weight) {
+        RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor,
+                                                                   static_cast<int64_t>(bitwidth)));
+      }
 
       // QNN BW_FLOAT_BLOCK blockSize for HWCN weight: {1, 1, block_size, 1}.
       // Each block spans block_size consecutive IC elements; H and W dimensions are not blocked.
@@ -369,9 +386,11 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                     "QNN EP: BQ Conv scale size mismatch");
       // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
 
-      // Float offsets in [OC, nb] order, derived from zero_points: offset[i] = -zp[i].
-      // BW_FLOAT_BLOCK offsets are unconstrained floats; defaults to 0.0f when no zero_points.
-      std::vector<float> offsets_qnn(static_cast<size_t>(OC * nb), 0.0f);
+      // Float offsets in [OC, nb] order.
+      // Signed:   offset = -onnx_zp
+      // Unsigned: offset = (1 << (bits-1)) - onnx_zp   (compensates for unsigned→signed shift above)
+      const float unsigned_bias = is_unsigned_weight ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
+      std::vector<float> offsets_qnn(static_cast<size_t>(OC * nb), unsigned_bias);
       if (inputs[1].quant_param->zero_point != nullptr) {
         std::vector<int32_t> zp_values;
         ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
@@ -380,24 +399,18 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
         RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == OC * nb,
                       "QNN EP: BQ Conv zero_point size must match OC * num_blocks");
         for (size_t idx = 0; idx < static_cast<size_t>(OC * nb); ++idx) {
-          offsets_qnn[idx] = static_cast<float>(-zp_values[idx]);
+          offsets_qnn[idx] = unsigned_bias - static_cast<float>(zp_values[idx]);
         }
       }
 
       QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
                                             gsl::span<const float>(offsets_qnn),
-                                            GetBQBitwidth(inputs[1].type),
+                                            bitwidth,
                                             gsl::span<const uint32_t>(block_size_arr));
 
-      // Unpacked weight: each element occupies 1 byte regardless of bitwidth.
-      // Use signed or unsigned INT8 storage matching the weight element type.
-      const bool is_signed_weight = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2 ||
-                                     inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 ||
-                                     inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8);
-      const Qnn_DataType_t weight_qnn_dtype = is_signed_weight ? QNN_DATATYPE_SFIXED_POINT_8
-                                                               : QNN_DATATYPE_UFIXED_POINT_8;
+      // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
       QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
-                                         weight_qnn_dtype,
+                                         QNN_DATATYPE_SFIXED_POINT_8,
                                          std::move(bq_quant_params),
                                          std::move(hwcn_shape),
                                          std::move(unpacked_tensor));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -12,6 +12,7 @@
 namespace onnxruntime {
 namespace qnn {
 
+namespace {
 // HTP BQ Conv: supported bitwidths and their block_size divisor constraints.
 // block_size must be a multiple of the corresponding value (same as MatMulNBits HTP constraints).
 const std::unordered_map<uint32_t, int64_t> kHtpConvBQBitsAndBlockSizeMultipliers{
@@ -33,6 +34,7 @@ static uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
       return 0;
   }
 }
+}  // namespace
 
 // ONNX convolution types supported by this builder.
 // We translate node_unit.OpType() into this enum to avoid repeated string comparisons.
@@ -137,11 +139,9 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   // Validate quantization axis for per-channel quantized weights.
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    // Detect block-quantized weight. Two supported scale layouts:
-    //   (a) Standard (ONNX opset 21): scale rank == weight rank, e.g. [OC, IC/bs, H, W] for
-    //       axis=1; scale_shape[1] == IC/block_size < weight_shape[1].
-    //   (b) Legacy rank-2: [OC, num_blocks]; scale_shape[1] == IC/block_size.
-    // In both cases scale_shape[1] == num_blocks_per_oc for 1x1 or IC-axis blocking.
+    // Detect block-quantized weight. Per ONNX opset 21, the scale rank equals the weight
+    // rank: for a Conv2D weight [OC, IC, H, W] blocked on axis=1 the scale is
+    // [OC, IC/block_size, H, W], so scale_shape[1] == num_blocks_per_oc < weight_shape[1].
     if (inputs[1].quant_param.has_value() && inputs[1].quant_param->scale != nullptr) {
       const auto weight_scale_shape = utils::GetInitializerShape(inputs[1].quant_param->scale,
                                                                  qnn_model_wrapper.GetOrtApi());
@@ -150,11 +150,10 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
           weight_shape.size() != 4) {
         // BQ only supported for Conv2D (rank-4 weight); skip for Conv1D (rank-3) and Conv3D (rank-5).
       } else {
-        const bool is_rank2_scale = (weight_scale_shape.size() == 2);
-        const bool is_rankN_scale = (weight_scale_shape.size() == weight_shape.size() &&
+        const bool is_block_quant = (weight_scale_shape.size() == weight_shape.size() &&
                                      weight_scale_shape.size() > 1 &&
                                      weight_scale_shape[1] < weight_shape[1]);
-        if (is_rank2_scale || is_rankN_scale) {
+        if (is_block_quant) {
           const int64_t num_blocks_per_oc = weight_scale_shape[1];
           RETURN_IF(num_blocks_per_oc <= 0, "QNN EP: BQ num_blocks must be positive");
           const int64_t ic = static_cast<int64_t>(weight_shape[1]);
@@ -177,10 +176,10 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
 
           // Return success; full QNN validation is done in the NHWC IsOpSupported path.
           return Ort::Status();
-        }  // end is_rank2_scale || is_rankN_scale
+        }  // end is_block_quant
       }  // end else (weight shape obtainable)
     }  // end quant_param check
-
+    // checking for per-channel quantization
     const auto& input_1 = inputs[1];  // weight
     bool is_per_axis_quant = false;
     int64_t quant_axis = 0;
@@ -250,11 +249,9 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   //
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
 
-  // Detect block-quantized weight. Accepted scale layouts:
-  //   Standard (ONNX opset 21): scale rank == weight rank, scale_shape[1] < weight_shape[1].
-  //     Weight is always NCHW [OC,IC,H,W] in both NCHW and NHWC domains; IC at index 1.
-  //   Legacy rank-2: [OC, num_blocks].
-  // scale_shape[1] == num_blocks_per_oc in all supported cases.
+  // Detect block-quantized weight. Per ONNX opset 21, the scale rank equals the weight rank
+  // with scale_shape[1] < weight_shape[1] (the blocked IC axis). Weight is always NCHW
+  // [OC,IC,H,W] in both NCHW and NHWC domains; IC at index 1, so scale_shape[1] == num_blocks_per_oc.
   bool is_bq_weight = false;
   std::vector<int64_t> bq_scale_shape;
   if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
@@ -266,11 +263,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
         bq_scale_shape.size() > 1 &&
         bq_weight_shape.size() == 4) {  // BQ only for Conv2D (rank-4 weight); not Conv3D (rank-5)
       // Weight is NCHW [OC,IC,H,W]: IC is always at index 1.
-      const bool rank2 = (bq_scale_shape.size() == 2);
-      const bool rankN = (bq_scale_shape.size() == bq_weight_shape.size() &&
-                          bq_weight_shape.size() > 1 &&
-                          bq_scale_shape[1] < static_cast<int64_t>(bq_weight_shape[1]));
-      is_bq_weight = rank2 || rankN;
+      is_bq_weight = (bq_scale_shape.size() == bq_weight_shape.size() &&
+                      bq_scale_shape[1] < static_cast<int64_t>(bq_weight_shape[1]));
     }
   }
 
@@ -289,11 +283,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
     //                      LPBQ kernel (BLOCKWISE_EXPANSION) accepts INT16 as-is.
     if (!is_lpbq) {
-      const std::string act_name = input_names.back();  // copy before pop_back invalidates ref
+      const std::string act_name = input_names[0];  // activation (input 0), pushed by ProcessInput above
       const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
       const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
       if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
-        input_names.pop_back();
         const std::string fp16_act_name = utils::UniqueNameGenerator().New(act_name, "_fp16");
         std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
         QnnTensorWrapper fp16_act_wrapper(fp16_act_name, QNN_TENSOR_TYPE_NATIVE,
@@ -306,11 +299,11 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                           QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
                           {act_name}, {fp16_act_name}, {}, do_op_validation),
                       "Failed to add INT16→FP16 Dequantize node for BQ Conv activation.");
-        input_names.push_back(fp16_act_name);
+        input_names[0] = fp16_act_name;
       }
     }
 
-    // Common: transpose weight data from OIHW→HWCN (or CNHW→HWCN for ConvTranspose).
+    // Common: transpose weight data from OIHW→HWIO (or IOHW→HWIO for ConvTranspose).
     // TransposeFromNchwToHwcn unpacks INT4 to INT8 internally (1 byte per element).
     const bool is_3d = (input_info.shape.size() == 5);
     std::vector<uint8_t> unpacked_tensor;
@@ -541,8 +534,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
         RETURN_IF_NOT(quant_param_wrapper.IsPerTensor(),
                       "Conv's INT16 weight inputs only support INT16 per-tensor quantization");
 
-        // Pop Conv weight. Insert Convert op after Weight
-        input_names.pop_back();
+        // Insert Convert op after Weight, replacing the weight name (last element) in place.
         std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
 
         RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
@@ -555,7 +547,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                                                transformed_input1_shape,
                                                true,  // Symmetric
                                                do_op_validation));
-        input_names.push_back(convert_output_name);
+        input_names.back() = convert_output_name;
       }
     }
   }  // end else (non-BQ weight path)
@@ -578,7 +570,9 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor,
                                                               raw_bias_bytes));
       std::vector<float> bias_scale_vals;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scale_vals));
+      if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
+        RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scale_vals));
+      }
       const float bias_scale = bias_scale_vals.empty() ? 1.0f : bias_scale_vals[0];
 
       // Dequantize INT32 → FP16 (stored as uint16 in memory).

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -287,7 +287,11 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
       const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
       if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
-        const std::string fp16_act_name = utils::UniqueNameGenerator().New(act_name, "_fp16");
+        // Reuse the original DequantizeLinear node's output name (the target Conv's input[0]) for the
+        // FP16 tensor. That tensor is conceptually the dequantized activation — exactly what this
+        // INT16→FP16 Dequantize produces — and QNN EP otherwise skips it, so the name is free and
+        // keeps the QNN graph aligned with the ONNX graph naming.
+        const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
         std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
         QnnTensorWrapper fp16_act_wrapper(fp16_act_name, QNN_TENSOR_TYPE_NATIVE,
                                           QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
@@ -1343,7 +1347,11 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     if (is_bq_conv && is_quantized_tensor) {
       // BQ Conv outputs FP16; downstream QDQ expects INT16.
       // Emit: Conv (FP16 output) → Quantize (FP16 → INT16 quantized output).
-      const std::string conv_fp16_out = utils::UniqueNameGenerator().New(output_name, "_fp16");
+      // Reuse the original QuantizeLinear node's input name (the target Conv's output[0]) for the
+      // FP16 tensor. That tensor is conceptually the un-quantized Conv output — exactly what this
+      // BQ Conv produces — and QNN EP otherwise skips it, so the name is free and keeps the QNN
+      // graph aligned with the ONNX graph naming.
+      const std::string conv_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
       QnnTensorWrapper fp16_out_wrapper(conv_fp16_out, QNN_TENSOR_TYPE_NATIVE,
                                         QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
                                         std::vector<uint32_t>(output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -12,6 +12,28 @@
 namespace onnxruntime {
 namespace qnn {
 
+// HTP BQ Conv: supported bitwidths and their block_size divisor constraints.
+// block_size must be a multiple of the corresponding value (same as MatMulNBits HTP constraints).
+const std::unordered_map<uint32_t, int64_t> kHtpConvBQBitsAndBlockSizeMultipliers{
+    {2, 16}, {4, 8}, {8, 4}};
+
+// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
+static uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
+  switch (onnx_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
 // ONNX convolution types supported by this builder.
 // We translate node_unit.OpType() into this enum to avoid repeated string comparisons.
 enum class OnnxConvType {
@@ -138,10 +160,20 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
           const int64_t ic = static_cast<int64_t>(weight_shape[1]);
           RETURN_IF(ic % num_blocks_per_oc != 0,
                     "QNN EP: Conv BQ: IC must be divisible by num_blocks_per_oc");
-          // Return success here; full QNN validation is done in the NHWC IsOpSupported path
-          // (line: if Domain==kMSInternalNHWCDomain → AddToModelBuilder(true)).
-          // Do NOT call AddToModelBuilder here — it would pollute the shared qnn_model_wrapper
-          // and cause all subsequent nodes to fail their IsOpSupported checks.
+
+          // Validate bitwidth (from weight element type) and block_size against HTP constraints.
+          const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+          const int64_t block_size = ic / num_blocks_per_oc;
+          auto bq_it = kHtpConvBQBitsAndBlockSizeMultipliers.find(bitwidth);
+          RETURN_IF(bq_it == kHtpConvBQBitsAndBlockSizeMultipliers.end(),
+                    ("QNN HTP Conv BQ: unsupported weight bitwidth=" +
+                     std::to_string(bitwidth)).c_str());
+          RETURN_IF(block_size % bq_it->second != 0,
+                    ("QNN HTP Conv BQ: block_size=" + std::to_string(block_size) +
+                     " must be a multiple of " + std::to_string(bq_it->second) +
+                     " for " + std::to_string(bitwidth) + "-bit weight").c_str());
+
+          // Return success; full QNN validation is done in the NHWC IsOpSupported path.
           return Ort::Status();
         }  // end is_rank2_scale || is_rankN_scale
       }  // end else (weight shape obtainable)
@@ -335,7 +367,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                     "QNN EP: BQ Conv scale size mismatch");
       // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
 
-      // Float offsets in [OC, nb] order: 0 for symmetric, -zp for asymmetric.
+      // Float offsets in [OC, nb] order, derived from zero_points: offset[i] = -zp[i].
+      // BW_FLOAT_BLOCK offsets are unconstrained floats; defaults to 0.0f when no zero_points.
       std::vector<float> offsets_qnn(static_cast<size_t>(OC * nb), 0.0f);
       if (inputs[1].quant_param->zero_point != nullptr) {
         std::vector<int32_t> zp_values;
@@ -351,12 +384,18 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
 
       QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
                                             gsl::span<const float>(offsets_qnn),
-                                            4u,  // bitwidth: INT4
+                                            GetBQBitwidth(inputs[1].type),
                                             gsl::span<const uint32_t>(block_size_arr));
 
-      // Use SFIXED_POINT_8: the unpacked 4-bit values are stored as int8 (1 per byte).
+      // Unpacked weight: each element occupies 1 byte regardless of bitwidth.
+      // Use signed or unsigned INT8 storage matching the weight element type.
+      const bool is_signed_weight = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2 ||
+                                     inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 ||
+                                     inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8);
+      const Qnn_DataType_t weight_qnn_dtype = is_signed_weight ? QNN_DATATYPE_SFIXED_POINT_8
+                                                                : QNN_DATATYPE_UFIXED_POINT_8;
       QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
-                                         QNN_DATATYPE_SFIXED_POINT_8,
+                                         weight_qnn_dtype,
                                          std::move(bq_quant_params),
                                          std::move(hwcn_shape),
                                          std::move(unpacked_tensor));
@@ -1243,12 +1282,10 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   // Detect BQ or LPBQ Conv from the weight tensor's quant encoding.
   // BQ  (BW_FLOAT_BLOCK):       Conv outputs FP16 → need FP16 intermediate + Convert(FP16→INT16).
   // LPBQ (BLOCKWISE_EXPANSION): Conv outputs INT16 → standard quantized output path.
+  // input_names[1] is the weight — IsOpSupported guarantees Conv has >= 2 inputs.
   bool is_bq_conv = false;
-  if (!input_names.empty()) {
-    const std::string& weight_name = input_names.size() >= 2 ? input_names[1] : input_names[0];
-    if (qnn_model_wrapper.IsQnnTensorWrapperExist(weight_name)) {
-      is_bq_conv = qnn_model_wrapper.GetQnnTensorWrapper(weight_name).GetQnnQuantParams().IsBlockQuantized();
-    }
+  if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1])) {
+    is_bq_conv = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized();
   }
 
   const auto& output_name = outputs[0].name;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -74,7 +74,30 @@ class ConvOpBuilder : public BaseOpBuilder {
 Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
                                          const Ort::Logger& logger) const {
-  if (node_unit.Domain() == kMSInternalNHWCDomain) {  // Use QNN validation API if layout is NHWC.
+  if (node_unit.Domain() == kMSInternalNHWCDomain) {
+    // For NHWC domain: detect BQ Conv and return success immediately.
+    // The weight remains NCHW [OC,IC,H,W] even in NHWC domain (QNN EP transposes it).
+    // Calling AddToModelBuilder(true) here would pollute the shared qnn_model_wrapper and
+    // cause the normal bias-requantization path to fail with block-quant params.
+    if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+      const auto& inputs = node_unit.Inputs();
+      if (inputs.size() >= 2 && inputs[1].quant_param.has_value() &&
+          inputs[1].quant_param->scale != nullptr) {
+        const auto wscale = utils::GetInitializerShape(inputs[1].quant_param->scale,
+                                                       qnn_model_wrapper.GetOrtApi());
+        std::vector<uint32_t> wshape;
+        if (wscale.size() > 1 && qnn_model_wrapper.GetOnnxShape(inputs[1].shape, wshape) &&
+            wshape.size() >= 2) {
+          const bool rank2 = (wscale.size() == 2);
+          // Weight is NCHW [OC,IC,H,W]: IC at index 1.
+          const bool rankN = (wscale.size() == wshape.size() &&
+                              wscale[1] < static_cast<int64_t>(wshape[1]));
+          if (rank2 || rankN) {
+            return Ort::Status();  // BQ Conv in NHWC: skip full validation
+          }
+        }
+      }
+    }
     return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
   }
 
@@ -115,6 +138,38 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   // Validate quantization axis for per-channel quantized weights.
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
+    // Detect block-quantized weight. Two supported scale layouts:
+    //   (a) Standard (ONNX opset 21): scale rank == weight rank, e.g. [OC, IC/bs, H, W] for
+    //       axis=1; scale_shape[1] == IC/block_size < weight_shape[1].
+    //   (b) Legacy rank-2: [OC, num_blocks]; scale_shape[1] == IC/block_size.
+    // In both cases scale_shape[1] == num_blocks_per_oc for 1x1 or IC-axis blocking.
+    if (inputs[1].quant_param.has_value() && inputs[1].quant_param->scale != nullptr) {
+      const auto weight_scale_shape = utils::GetInitializerShape(inputs[1].quant_param->scale,
+                                                                 qnn_model_wrapper.GetOrtApi());
+      std::vector<uint32_t> weight_shape;
+      if (!qnn_model_wrapper.GetOnnxShape(inputs[1].shape, weight_shape) ||
+          weight_shape.size() < 4) {
+        // Cannot get weight shape or wrong rank — skip BQ detection.
+      } else {
+        const bool is_rank2_scale = (weight_scale_shape.size() == 2);
+        const bool is_rankN_scale = (weight_scale_shape.size() == weight_shape.size() &&
+                                     weight_scale_shape.size() > 1 &&
+                                     weight_scale_shape[1] < weight_shape[1]);
+        if (is_rank2_scale || is_rankN_scale) {
+          const int64_t num_blocks_per_oc = weight_scale_shape[1];
+          RETURN_IF(num_blocks_per_oc <= 0, "QNN EP: BQ num_blocks must be positive");
+          const int64_t ic = static_cast<int64_t>(weight_shape[1]);
+          RETURN_IF(ic % num_blocks_per_oc != 0,
+                    "QNN EP: Conv BQ: IC must be divisible by num_blocks_per_oc");
+          // Return success here; full QNN validation is done in the NHWC IsOpSupported path
+          // (line: if Domain==kMSInternalNHWCDomain → AddToModelBuilder(true)).
+          // Do NOT call AddToModelBuilder here — it would pollute the shared qnn_model_wrapper
+          // and cause all subsequent nodes to fail their IsOpSupported checks.
+          return Ort::Status();
+        }  // end is_rank2_scale || is_rankN_scale
+      }  // end else (weight shape obtainable)
+    }  // end quant_param check
+
     const auto& input_1 = inputs[1];  // weight
     bool is_per_axis_quant = false;
     int64_t quant_axis = 0;
@@ -184,326 +239,423 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   //
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
 
-  //
-  // Input 1: weight. This input must be transposed manually by QNN EP.
-  //
-  {
+  // Detect block-quantized weight. Accepted scale layouts:
+  //   Standard (ONNX opset 21): scale rank == weight rank, scale_shape[1] < weight_shape[1].
+  //     Weight is always NCHW [OC,IC,H,W] in both NCHW and NHWC domains; IC at index 1.
+  //   Legacy rank-2: [OC, num_blocks].
+  // scale_shape[1] == num_blocks_per_oc in all supported cases.
+  bool is_bq_weight = false;
+  std::vector<int64_t> bq_scale_shape;
+  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+      inputs[1].quant_param.has_value() && inputs[1].quant_param->scale != nullptr) {
+    bq_scale_shape = utils::GetInitializerShape(inputs[1].quant_param->scale,
+                                                qnn_model_wrapper.GetOrtApi());
+    std::vector<uint32_t> bq_weight_shape;
+    if (qnn_model_wrapper.GetOnnxShape(inputs[1].shape, bq_weight_shape) &&
+        bq_scale_shape.size() > 1) {
+      // Weight is NCHW [OC,IC,H,W]: IC is always at index 1.
+      const bool rank2 = (bq_scale_shape.size() == 2);
+      const bool rankN = (bq_scale_shape.size() == bq_weight_shape.size() &&
+                          bq_weight_shape.size() > 1 &&
+                          bq_scale_shape[1] < static_cast<int64_t>(bq_weight_shape[1]));
+      is_bq_weight = rank2 || rankN;
+    }
+  }
+
+  if (is_bq_weight) {
+    // Determine BQ vs LPBQ by reading weight quant params via GetTensorInfo.
+    // When PR307 is active, Init() auto-converts BQ scales → LPBQ (BLOCKWISE_EXPANSION).
+    // Before PR307: Init() cannot handle block_size, so IsLPBQ() is false → BQ path.
     const std::string& input1_name = inputs[1].name;
     TensorInfo input_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
+    RETURN_IF(!input_info.is_initializer,
+              "QNN EP: BQ/LPBQ Conv weight must be a constant initializer");
 
-    std::string actual_name = input_info.is_initializer ? input1_name : utils::UniqueNameGenerator().New(input1_name, "_transpose");
-    input_names.push_back(actual_name);
+    const bool is_lpbq = input_info.quant_param.IsLPBQ();
 
-    std::vector<uint32_t> actual_shape;
-    actual_shape.resize(input_info.shape.size());
-
-    // Change shape to HWCN, it could be initializer or normal input
-    if (conv_type == OnnxConvType::kConv) {
-      RETURN_IF_ERROR(utils::NchwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
-    } else if (conv_type == OnnxConvType::kConvTranspose) {
-      RETURN_IF_ERROR(utils::CnhwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
-    } else {
-      return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
+    // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
+    //                      LPBQ kernel (BLOCKWISE_EXPANSION) accepts INT16 as-is.
+    if (!is_lpbq) {
+      const std::string act_name = input_names.back();  // copy before pop_back invalidates ref
+      const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
+      const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
+      if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
+        input_names.pop_back();
+        const std::string fp16_act_name = utils::UniqueNameGenerator().New(act_name, "_fp16");
+        std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
+        QnnTensorWrapper fp16_act_wrapper(fp16_act_name, QNN_TENSOR_TYPE_NATIVE,
+                                          QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                          std::vector<uint32_t>(act_shape));
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_act_wrapper)),
+                      "Failed to add FP16 activation tensor for BQ Conv.");
+        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                          utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
+                          QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                          {act_name}, {fp16_act_name}, {}, do_op_validation),
+                      "Failed to add INT16→FP16 Dequantize node for BQ Conv activation.");
+        input_names.push_back(fp16_act_name);
+      }
     }
 
-    bool is_3d = (input_info.shape.size() == 5);
-
+    // Common: transpose weight data from OIHW→HWCN (or CNHW→HWCN for ConvTranspose).
+    // TransposeFromNchwToHwcn unpacks INT4 to INT8 internally (1 byte per element).
+    const bool is_3d = (input_info.shape.size() == 5);
     std::vector<uint8_t> unpacked_tensor;
-    if (input_info.is_initializer) {
-      // Get transposed initializer bytes.
-      if (conv_type == OnnxConvType::kConv) {
-        RETURN_IF_ERROR(utils::TransposeFromNchwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
-      } else if (conv_type == OnnxConvType::kConvTranspose) {
-        RETURN_IF_ERROR(utils::TransposeFromCnhwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
-      } else {
-        return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
-      }
-
-      // Transpose quantization parameter's axis if this is using per-channel quantization.
-      if (input_info.quant_param.IsPerChannel()) {
-        std::vector<size_t> perm;
-        if (is_3d) {
-          perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
-        } else {
-          perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm : cnhw2hwcn_perm;
-        }
-        std::vector<size_t> perm_inv(perm.size());
-        RETURN_IF_ERROR(utils::InvertPerm<size_t>(perm, perm_inv));
-        RETURN_IF_ERROR(input_info.quant_param.HandleTranspose<size_t>(perm_inv));
-      }
+    if (conv_type == OnnxConvType::kConv) {
+      RETURN_IF_ERROR(utils::TransposeFromNchwToHwcn(qnn_model_wrapper,
+                                                     input_info.initializer_tensor,
+                                                     unpacked_tensor, is_3d));
     } else {
-      // Add transpose node above weight input.
-      RETURN_IF(input_info.quant_param.IsPerChannel(),
-                "Non-constant Conv inputs only support per-tensor quantization");
-      bool is_graph_input = qnn_model_wrapper.IsGraphInput(input1_name);
-      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Add HWCN Transpose node after input: " + input1_name).c_str());
+      RETURN_IF_ERROR(utils::TransposeFromCnhwToHwcn(qnn_model_wrapper,
+                                                     input_info.initializer_tensor,
+                                                     unpacked_tensor, is_3d));
+    }
+    std::vector<uint32_t> hwcn_shape(input_info.shape.size());
+    if (conv_type == OnnxConvType::kConv) {
+      RETURN_IF_ERROR(utils::NchwShapeToHwcn<uint32_t>(input_info.shape, hwcn_shape));
+    } else {
+      RETURN_IF_ERROR(utils::CnhwShapeToHwcn<uint32_t>(input_info.shape, hwcn_shape));
+    }
+    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(input1_name);
 
-      if (!qnn_model_wrapper.IsQnnTensorWrapperExist(input1_name)) {
-        QnnTensorWrapper weight_tensor_wrapper;
-        RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(inputs[1], weight_tensor_wrapper));
-        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)), "Failed to add weight tensor.");
+    if (is_lpbq) {
+      // LPBQ path (PR307 active): Init() already produced BLOCKWISE_EXPANSION quant params.
+      // Update the LPBQ axis for the HWCN transposition (PR307 extended HandleTranspose for LPBQ).
+      std::vector<size_t> perm;
+      if (is_3d) {
+        perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
+      } else {
+        perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm : cnhw2hwcn_perm;
+      }
+      std::vector<size_t> perm_inv(perm.size());
+      RETURN_IF_ERROR(utils::InvertPerm<size_t>(perm, perm_inv));
+      RETURN_IF_ERROR(input_info.quant_param.HandleTranspose<size_t>(perm_inv));
+
+      QnnTensorWrapper lpbq_weight_wrapper(input1_name, tensor_type,
+                                           input_info.qnn_data_type,
+                                           std::move(input_info.quant_param),
+                                           std::move(hwcn_shape),
+                                           std::move(unpacked_tensor));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(lpbq_weight_wrapper)),
+                    "Failed to add LPBQ Conv weight tensor.");
+    } else {
+      // BQ path: manually build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params.
+      const int64_t OC = static_cast<int64_t>(input_info.shape[0]);
+      const int64_t IC = static_cast<int64_t>(input_info.shape[1]);
+      const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc (validated: IC % nb == 0)
+      const int64_t block_size = IC / nb;
+
+      // QNN BW_FLOAT_BLOCK blockSize for HWCN weight: {1, 1, block_size, 1}.
+      // Each block spans block_size consecutive IC elements; H and W dimensions are not blocked.
+      const std::vector<uint32_t> block_size_arr = {1u, 1u, static_cast<uint32_t>(block_size), 1u};
+
+      // Read ONNX per-block float scales: flat [OC * nb] in OC-major order.
+      std::vector<float> scales_qnn;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, scales_qnn));
+      RETURN_IF_NOT(static_cast<int64_t>(scales_qnn.size()) == OC * nb,
+                    "QNN EP: BQ Conv scale size mismatch");
+      // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
+
+      // Float offsets in [OC, nb] order: 0 for symmetric, -zp for asymmetric.
+      std::vector<float> offsets_qnn(static_cast<size_t>(OC * nb), 0.0f);
+      if (inputs[1].quant_param->zero_point != nullptr) {
+        std::vector<int32_t> zp_values;
+        ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+        RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point,
+                                                           zp_values, zp_onnx_type));
+        for (int64_t oc = 0; oc < OC; ++oc) {
+          for (int64_t b = 0; b < nb; ++b) {
+            const size_t idx = static_cast<size_t>(oc * nb + b);
+            offsets_qnn[idx] = (idx < zp_values.size()) ? static_cast<float>(-zp_values[idx]) : 0.0f;
+          }
+        }
       }
 
+      QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
+                                            gsl::span<const float>(offsets_qnn),
+                                            4u,  // bitwidth: INT4
+                                            gsl::span<const uint32_t>(block_size_arr));
+
+      // Use SFIXED_POINT_8: the unpacked 4-bit values are stored as int8 (1 per byte).
+      QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
+                                         QNN_DATATYPE_SFIXED_POINT_8,
+                                         std::move(bq_quant_params),
+                                         std::move(hwcn_shape),
+                                         std::move(unpacked_tensor));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bq_weight_wrapper)),
+                    "Failed to add BQ Conv weight tensor.");
+    }
+    input_names.push_back(input1_name);
+  } else {
+    //
+    // Input 1: weight. This input must be transposed manually by QNN EP.
+    //
+    {
+      const std::string& input1_name = inputs[1].name;
+      TensorInfo input_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
+
+      std::string actual_name = input_info.is_initializer ? input1_name : utils::UniqueNameGenerator().New(input1_name, "_transpose");
+      input_names.push_back(actual_name);
+
+      std::vector<uint32_t> actual_shape;
+      actual_shape.resize(input_info.shape.size());
+
+      // Change shape to HWCN, it could be initializer or normal input
       if (conv_type == OnnxConvType::kConv) {
-        RETURN_IF_ERROR(qnn_model_wrapper.AddNchwToHwcnTranspose(node_unit.Index(),
-                                                                 input1_name,
-                                                                 actual_name,
-                                                                 input_info.shape,
-                                                                 actual_shape,
-                                                                 input_info.qnn_data_type,
-                                                                 input_info.quant_param,
-                                                                 do_op_validation,
-                                                                 is_graph_input,
-                                                                 false,
-                                                                 is_3d));
+        RETURN_IF_ERROR(utils::NchwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
       } else if (conv_type == OnnxConvType::kConvTranspose) {
-        RETURN_IF_ERROR(qnn_model_wrapper.AddCnhwToHwcnTranspose(node_unit.Index(),
-                                                                 input1_name,
-                                                                 actual_name,
-                                                                 input_info.shape,
-                                                                 actual_shape,
-                                                                 input_info.qnn_data_type,
-                                                                 input_info.quant_param,
-                                                                 do_op_validation,
-                                                                 is_graph_input,
-                                                                 false,
-                                                                 is_3d));
+        RETURN_IF_ERROR(utils::CnhwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
       } else {
         return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
       }
+
+      bool is_3d = (input_info.shape.size() == 5);
+
+      std::vector<uint8_t> unpacked_tensor;
+      if (input_info.is_initializer) {
+        // Get transposed initializer bytes.
+        if (conv_type == OnnxConvType::kConv) {
+          RETURN_IF_ERROR(utils::TransposeFromNchwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
+        } else if (conv_type == OnnxConvType::kConvTranspose) {
+          RETURN_IF_ERROR(utils::TransposeFromCnhwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
+        } else {
+          return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
+        }
+
+        // Transpose quantization parameter's axis if this is using per-channel quantization.
+        if (input_info.quant_param.IsPerChannel()) {
+          std::vector<size_t> perm;
+          if (is_3d) {
+            perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
+          } else {
+            perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm : cnhw2hwcn_perm;
+          }
+          std::vector<size_t> perm_inv(perm.size());
+          RETURN_IF_ERROR(utils::InvertPerm<size_t>(perm, perm_inv));
+          RETURN_IF_ERROR(input_info.quant_param.HandleTranspose<size_t>(perm_inv));
+        }
+      } else {
+        // Add transpose node above weight input.
+        RETURN_IF(input_info.quant_param.IsPerChannel(),
+                  "Non-constant Conv inputs only support per-tensor quantization");
+        bool is_graph_input = qnn_model_wrapper.IsGraphInput(input1_name);
+        ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Add HWCN Transpose node after input: " + input1_name).c_str());
+
+        if (!qnn_model_wrapper.IsQnnTensorWrapperExist(input1_name)) {
+          QnnTensorWrapper weight_tensor_wrapper;
+          RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(inputs[1], weight_tensor_wrapper));
+          RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)), "Failed to add weight tensor.");
+        }
+
+        if (conv_type == OnnxConvType::kConv) {
+          RETURN_IF_ERROR(qnn_model_wrapper.AddNchwToHwcnTranspose(node_unit.Index(),
+                                                                   input1_name,
+                                                                   actual_name,
+                                                                   input_info.shape,
+                                                                   actual_shape,
+                                                                   input_info.qnn_data_type,
+                                                                   input_info.quant_param,
+                                                                   do_op_validation,
+                                                                   is_graph_input,
+                                                                   false,
+                                                                   is_3d));
+        } else if (conv_type == OnnxConvType::kConvTranspose) {
+          RETURN_IF_ERROR(qnn_model_wrapper.AddCnhwToHwcnTranspose(node_unit.Index(),
+                                                                   input1_name,
+                                                                   actual_name,
+                                                                   input_info.shape,
+                                                                   actual_shape,
+                                                                   input_info.qnn_data_type,
+                                                                   input_info.quant_param,
+                                                                   do_op_validation,
+                                                                   is_graph_input,
+                                                                   false,
+                                                                   is_3d));
+        } else {
+          return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
+        }
+      }
+
+      Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(actual_name);
+      QnnTensorWrapper input_tensorwrapper(actual_name, tensor_type, input_info.qnn_data_type,
+                                           std::move(input_info.quant_param),
+                                           std::move(actual_shape), std::move(unpacked_tensor));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
+
+      // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to signed symmetric int16)
+      // to avoid a QNN validation failure.
+      //
+      // QNN graph WITHOUT workaround (fails validation):
+      //     input_0_uint16 ---> Conv ---> output_uint16
+      //                         ^
+      //                         |
+      //     input_1_uint16 -----+
+      //
+      // QNN graph WITH workaround (passes validation):
+      //     input_0_uint16 ----------------------> Conv ---> output_uint16
+      //                                            ^
+      //                                            |
+      //     input_1_uint16 --> Convert(to int16) --+
+
+      std::string weight_input_name = input_names.back();
+      const auto& weight_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(weight_input_name);
+
+      if (weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
+        const auto& quant_param_wrapper = weight_tensor_wrapper.GetQnnQuantParams();
+        const Qnn_QuantizeParams_t& quant_param = quant_param_wrapper.Get();
+        const auto& transformed_input1_shape = weight_tensor_wrapper.GetTensorDims();
+
+        RETURN_IF_NOT(quant_param_wrapper.IsPerTensor(),
+                      "Conv's INT16 weight inputs only support INT16 per-tensor quantization");
+
+        // Pop Conv weight. Insert Convert op after Weight
+        input_names.pop_back();
+        std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
+
+        RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
+                                               weight_input_name,
+                                               convert_output_name,
+                                               QNN_DATATYPE_UFIXED_POINT_16,
+                                               QNN_DATATYPE_SFIXED_POINT_16,
+                                               quant_param.scaleOffsetEncoding.offset,
+                                               quant_param.scaleOffsetEncoding.scale,
+                                               transformed_input1_shape,
+                                               true,  // Symmetric
+                                               do_op_validation));
+        input_names.push_back(convert_output_name);
+      }
     }
-
-    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(actual_name);
-    QnnTensorWrapper input_tensorwrapper(actual_name, tensor_type, input_info.qnn_data_type,
-                                         std::move(input_info.quant_param),
-                                         std::move(actual_shape), std::move(unpacked_tensor));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
-
-    // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to signed symmetric int16)
-    // to avoid a QNN validation failure.
-    //
-    // QNN graph WITHOUT workaround (fails validation):
-    //     input_0_uint16 ---> Conv ---> output_uint16
-    //                         ^
-    //                         |
-    //     input_1_uint16 -----+
-    //
-    // QNN graph WITH workaround (passes validation):
-    //     input_0_uint16 ----------------------> Conv ---> output_uint16
-    //                                            ^
-    //                                            |
-    //     input_1_uint16 --> Convert(to int16) --+
-
-    std::string weight_input_name = input_names.back();
-    const auto& weight_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(weight_input_name);
-
-    if (weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
-      const auto& quant_param_wrapper = weight_tensor_wrapper.GetQnnQuantParams();
-      const Qnn_QuantizeParams_t& quant_param = quant_param_wrapper.Get();
-      const auto& transformed_input1_shape = weight_tensor_wrapper.GetTensorDims();
-
-      RETURN_IF_NOT(quant_param_wrapper.IsPerTensor(),
-                    "Conv's INT16 weight inputs only support INT16 per-tensor quantization");
-
-      // Pop Conv weight. Insert Convert op after Weight
-      input_names.pop_back();
-      std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
-
-      RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
-                                             weight_input_name,
-                                             convert_output_name,
-                                             QNN_DATATYPE_UFIXED_POINT_16,
-                                             QNN_DATATYPE_SFIXED_POINT_16,
-                                             quant_param.scaleOffsetEncoding.offset,
-                                             quant_param.scaleOffsetEncoding.scale,
-                                             transformed_input1_shape,
-                                             true,  // Symmetric
-                                             do_op_validation));
-      input_names.push_back(convert_output_name);
-    }
-  }
+  }  // end else (non-BQ weight path)
 
   //
   // Input 2: bias
   //
   const bool has_bias_input = num_inputs == 3;
   if (has_bias_input) {
-    const auto& bias_input = inputs[2];
-    TensorInfo bias_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_input, bias_info));
+    // For BQ Conv: QNN BW_FLOAT_BLOCK Conv2d requires FP32 bias (even though activation is FP16).
+    // The bias in the QDQ NodeUnit is an INT32 quantized initializer — dequantize it to FP32.
+    if (is_bq_weight) {
+      TensorInfo bias_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
+      RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
 
-    // For static quantized bias, handle requantization if needed
-    if (bias_info.is_initializer && bias_info.quant_param.IsQuantized()) {
-      // Get activation and weight quantization parameters
-      TensorInfo input0_info = {};
-      TensorInfo input1_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
+      // Read the INT32 quantized bias and its scale, then dequantize to FP16.
+      // QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
+      std::vector<uint8_t> raw_bias_bytes;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor,
+                                                              raw_bias_bytes));
+      std::vector<float> bias_scale_vals;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scale_vals));
+      const float bias_scale = bias_scale_vals.empty() ? 1.0f : bias_scale_vals[0];
 
-      if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
-        // Get activation scale (must be per-tensor for Conv)
-        float activation_scale = 1.0f;
-        const auto& act_quant_params = input0_info.quant_param.Get();
-        if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-          activation_scale = act_quant_params.scaleOffsetEncoding.scale;
-        } else if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-          activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
-        }
+      // Dequantize INT32 → FP16 (stored as uint16 in memory).
+      const size_t num_elems = bias_info.shape[0];
+      RETURN_IF_NOT(raw_bias_bytes.size() == num_elems * sizeof(int32_t), "BQ bias size mismatch");
+      std::vector<uint8_t> fp16_bias_bytes(num_elems * sizeof(uint16_t));
+      const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_bias_bytes.data());
+      auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
+      for (size_t i = 0; i < num_elems; ++i) {
+        const float f = static_cast<float>(i32_ptr[i]) * bias_scale;
+        const Ort::Float16_t fp16_val(f);
+        memcpy(&u16_ptr[i], &fp16_val.val, sizeof(uint16_t));
+      }
 
-        // Get weight scales (per-tensor or per-channel)
-        std::vector<float> weights_scales;
+      const std::string fp16_bias_name = utils::UniqueNameGenerator().New(inputs[2].name, "_fp16");
+      QnnTensorWrapper fp16_bias_wrapper(fp16_bias_name, QNN_TENSOR_TYPE_STATIC,
+                                         QNN_DATATYPE_FLOAT_16,
+                                         QnnQuantParamsWrapper(),
+                                         std::vector<uint32_t>(bias_info.shape),
+                                         std::move(fp16_bias_bytes));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_bias_wrapper)),
+                    "Failed to add FP16 bias for BQ Conv.");
+      input_names.push_back(fp16_bias_name);
+    } else {
+      const auto& bias_input = inputs[2];
+      TensorInfo bias_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_input, bias_info));
 
-        if (input1_info.quant_param.IsPerTensor()) {
-          // Handle per-tensor quantization (encodings 0 and 2)
-          const auto& weight_quant_params = input1_info.quant_param.Get();
+      // For static quantized bias, handle requantization if needed
+      if (bias_info.is_initializer && bias_info.quant_param.IsQuantized()) {
+        // Get activation and weight quantization parameters
+        TensorInfo input0_info = {};
+        TensorInfo input1_info = {};
+        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
+        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
 
-          if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-            weights_scales.push_back(weight_quant_params.scaleOffsetEncoding.scale);
-          } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-            weights_scales.push_back(weight_quant_params.bwScaleOffsetEncoding.scale);
+        if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
+          // Get activation scale (must be per-tensor for Conv)
+          float activation_scale = 1.0f;
+          const auto& act_quant_params = input0_info.quant_param.Get();
+          if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+            activation_scale = act_quant_params.scaleOffsetEncoding.scale;
+          } else if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+            activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
           }
-        } else {
-          // Handle per-channel quantization (encodings 1 and 3)
-          const auto& weight_quant_params = input1_info.quant_param.Get();
 
-          if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-            if (weight_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr &&
-                weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0) {
-              for (size_t i = 0; i < weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets; ++i) {
-                weights_scales.push_back(weight_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
-              }
+          // Get weight scales (per-tensor or per-channel)
+          std::vector<float> weights_scales;
+
+          if (input1_info.quant_param.IsPerTensor()) {
+            // Handle per-tensor quantization (encodings 0 and 2)
+            const auto& weight_quant_params = input1_info.quant_param.Get();
+
+            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+              weights_scales.push_back(weight_quant_params.scaleOffsetEncoding.scale);
+            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+              weights_scales.push_back(weight_quant_params.bwScaleOffsetEncoding.scale);
             }
-          } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-            if (weight_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr &&
-                weight_quant_params.bwAxisScaleOffsetEncoding.numElements > 0) {
-              for (size_t i = 0; i < weight_quant_params.bwAxisScaleOffsetEncoding.numElements; ++i) {
-                weights_scales.push_back(weight_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
-              }
-            }
-          }
-        }
-
-        // Safety check to prevent crashes
-        RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
-
-        // Check bias quantization type
-        if (bias_info.quant_param.IsPerTensor()) {
-          float bias_scale = 0.0f;
-          int32_t bias_offset = 0;
-          const auto& bias_quant_params = bias_info.quant_param.Get();
-          if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-            bias_scale = bias_quant_params.scaleOffsetEncoding.scale;
-            bias_offset = bias_quant_params.scaleOffsetEncoding.offset;
-          } else if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-            bias_scale = bias_quant_params.bwScaleOffsetEncoding.scale;
-            bias_offset = bias_quant_params.bwScaleOffsetEncoding.offset;
           } else {
-            return MAKE_EP_FAIL("Unsupported bias quantization encoding for per-tensor quantization.");
-          }
+            // Handle per-channel quantization (encodings 1 and 3)
+            const auto& weight_quant_params = input1_info.quant_param.Get();
 
-          // Check if bias_offset = 0 AND bias_scale = (weights_scale[0] * activation_scale)
-          if (bias_offset == 0 && utils::CheckBiasScaleMatch(bias_scale, weights_scales[0], activation_scale, 1e-5f)) {
-            // No change needed - scales match and offset is 0
-          } else {
-            ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing per-tensor bias " + bias_input.name).c_str());
-            // Need to requantize the bias tensor
-            std::vector<uint8_t> original_bias_data;
-            RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
-
-            std::vector<float> current_scales = {bias_scale};
-            std::vector<int32_t> current_offsets = {bias_offset};
-            std::vector<uint8_t> requantized_bias_data;
-            std::vector<float> new_scales;
-            std::vector<int32_t> new_offsets;
-
-            RETURN_IF_ERROR(utils::RequantizeBiasTensor(
-                original_bias_data, bias_info.shape, current_scales, current_offsets,
-                weights_scales, activation_scale, bias_info.qnn_data_type,
-                requantized_bias_data, new_scales, new_offsets));
-
-            // Create new tensor wrapper with requantized data
-            std::string bias_name = bias_input.name;
-            QnnQuantParamsWrapper new_quant_params(new_scales[0], new_offsets[0]);
-            QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
-                                                std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
-                                                std::move(requantized_bias_data));
-            RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)), "Failed to add requantized bias tensor.");
-            input_names.push_back(bias_name);
-            return Ort::Status();  // We've handled the bias, return early
-          }
-        } else {
-          // Handle per-channel bias
-          const auto& bias_quant_params = bias_info.quant_param.Get();
-
-          if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET ||
-              bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-            // Extract scales and offsets based on encoding type
-            std::vector<float> current_scales;
-            std::vector<int32_t> current_offsets;
-            int32_t quant_axis = 0;
-            size_t num_channels = 0;
-
-            if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-              // Safety checks for AXIS_SCALE_OFFSET encoding
-              RETURN_IF_NOT(bias_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr,
-                            "Invalid bias quantization parameters: scaleOffset is null");
-              RETURN_IF_NOT(bias_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0,
-                            "Invalid bias quantization parameters: numScaleOffsets is zero");
-
-              num_channels = bias_quant_params.axisScaleOffsetEncoding.numScaleOffsets;
-              quant_axis = bias_quant_params.axisScaleOffsetEncoding.axis;
-              for (size_t i = 0; i < num_channels; ++i) {
-                current_scales.push_back(bias_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
-                current_offsets.push_back(bias_quant_params.axisScaleOffsetEncoding.scaleOffset[i].offset);
+            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+              if (weight_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr &&
+                  weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0) {
+                for (size_t i = 0; i < weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets; ++i) {
+                  weights_scales.push_back(weight_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
+                }
               }
-            } else {  // QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET
-              // Safety checks for BW_AXIS_SCALE_OFFSET encoding
-              RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr,
-                            "Invalid bias quantization parameters: scales is null");
-              RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.offsets != nullptr,
-                            "Invalid bias quantization parameters: offsets is null");
-              RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.numElements > 0,
-                            "Invalid bias quantization parameters: numElements is zero");
-
-              num_channels = bias_quant_params.bwAxisScaleOffsetEncoding.numElements;
-              quant_axis = bias_quant_params.bwAxisScaleOffsetEncoding.axis;
-              for (size_t i = 0; i < num_channels; ++i) {
-                current_scales.push_back(bias_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
-                current_offsets.push_back(bias_quant_params.bwAxisScaleOffsetEncoding.offsets[i]);
+            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+              if (weight_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr &&
+                  weight_quant_params.bwAxisScaleOffsetEncoding.numElements > 0) {
+                for (size_t i = 0; i < weight_quant_params.bwAxisScaleOffsetEncoding.numElements; ++i) {
+                  weights_scales.push_back(weight_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
+                }
               }
             }
+          }
 
-            // Check if all offsets are 0 and scales match expected values
-            bool all_offsets_zero = true;
-            bool all_scales_match = true;
+          // Safety check to prevent crashes
+          RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
 
-            for (size_t i = 0; i < num_channels; ++i) {
-              if (current_offsets[i] != 0) {
-                all_offsets_zero = false;
-              }
-
-              // Calculate expected scale for this channel
-              // Use the corresponding weight scale if available, otherwise use the first one
-              float weight_scale = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
-
-              if (!utils::CheckBiasScaleMatch(current_scales[i], weight_scale, activation_scale, 1e-5f)) {
-                all_scales_match = false;
-              }
-            }
-
-            if (all_offsets_zero && all_scales_match) {
-              // No change needed - scales match and offsets are 0
+          // Check bias quantization type
+          if (bias_info.quant_param.IsPerTensor()) {
+            float bias_scale = 0.0f;
+            int32_t bias_offset = 0;
+            const auto& bias_quant_params = bias_info.quant_param.Get();
+            if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+              bias_scale = bias_quant_params.scaleOffsetEncoding.scale;
+              bias_offset = bias_quant_params.scaleOffsetEncoding.offset;
+            } else if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+              bias_scale = bias_quant_params.bwScaleOffsetEncoding.scale;
+              bias_offset = bias_quant_params.bwScaleOffsetEncoding.offset;
             } else {
-              // Need to requantize per-channel bias
-              ORT_CXX_LOG(logger,
-                          ORT_LOGGING_LEVEL_VERBOSE,
-                          ("Requantizing per-channel bias " + bias_input.name).c_str());
+              return MAKE_EP_FAIL("Unsupported bias quantization encoding for per-tensor quantization.");
+            }
 
-              // Get current bias data and requantize
+            // Check if bias_offset = 0 AND bias_scale = (weights_scale[0] * activation_scale)
+            if (bias_offset == 0 && utils::CheckBiasScaleMatch(bias_scale, weights_scales[0], activation_scale, 1e-5f)) {
+              // No change needed - scales match and offset is 0
+            } else {
+              ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing per-tensor bias " + bias_input.name).c_str());
+              // Need to requantize the bias tensor
               std::vector<uint8_t> original_bias_data;
               RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
 
+              std::vector<float> current_scales = {bias_scale};
+              std::vector<int32_t> current_offsets = {bias_offset};
               std::vector<uint8_t> requantized_bias_data;
               std::vector<float> new_scales;
               std::vector<int32_t> new_offsets;
@@ -511,12 +663,11 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
               RETURN_IF_ERROR(utils::RequantizeBiasTensor(
                   original_bias_data, bias_info.shape, current_scales, current_offsets,
                   weights_scales, activation_scale, bias_info.qnn_data_type,
-                  requantized_bias_data, new_scales, new_offsets,
-                  quant_axis));
+                  requantized_bias_data, new_scales, new_offsets));
 
               // Create new tensor wrapper with requantized data
               std::string bias_name = bias_input.name;
-              QnnQuantParamsWrapper new_quant_params(new_scales, new_offsets, quant_axis, false);
+              QnnQuantParamsWrapper new_quant_params(new_scales[0], new_offsets[0]);
               QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
                                                   std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
                                                   std::move(requantized_bias_data));
@@ -524,13 +675,106 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
               input_names.push_back(bias_name);
               return Ort::Status();  // We've handled the bias, return early
             }
+          } else {
+            // Handle per-channel bias
+            const auto& bias_quant_params = bias_info.quant_param.Get();
+
+            if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET ||
+                bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+              // Extract scales and offsets based on encoding type
+              std::vector<float> current_scales;
+              std::vector<int32_t> current_offsets;
+              int32_t quant_axis = 0;
+              size_t num_channels = 0;
+
+              if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+                // Safety checks for AXIS_SCALE_OFFSET encoding
+                RETURN_IF_NOT(bias_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr,
+                              "Invalid bias quantization parameters: scaleOffset is null");
+                RETURN_IF_NOT(bias_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0,
+                              "Invalid bias quantization parameters: numScaleOffsets is zero");
+
+                num_channels = bias_quant_params.axisScaleOffsetEncoding.numScaleOffsets;
+                quant_axis = bias_quant_params.axisScaleOffsetEncoding.axis;
+                for (size_t i = 0; i < num_channels; ++i) {
+                  current_scales.push_back(bias_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
+                  current_offsets.push_back(bias_quant_params.axisScaleOffsetEncoding.scaleOffset[i].offset);
+                }
+              } else {  // QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET
+                // Safety checks for BW_AXIS_SCALE_OFFSET encoding
+                RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr,
+                              "Invalid bias quantization parameters: scales is null");
+                RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.offsets != nullptr,
+                              "Invalid bias quantization parameters: offsets is null");
+                RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.numElements > 0,
+                              "Invalid bias quantization parameters: numElements is zero");
+
+                num_channels = bias_quant_params.bwAxisScaleOffsetEncoding.numElements;
+                quant_axis = bias_quant_params.bwAxisScaleOffsetEncoding.axis;
+                for (size_t i = 0; i < num_channels; ++i) {
+                  current_scales.push_back(bias_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
+                  current_offsets.push_back(bias_quant_params.bwAxisScaleOffsetEncoding.offsets[i]);
+                }
+              }
+
+              // Check if all offsets are 0 and scales match expected values
+              bool all_offsets_zero = true;
+              bool all_scales_match = true;
+
+              for (size_t i = 0; i < num_channels; ++i) {
+                if (current_offsets[i] != 0) {
+                  all_offsets_zero = false;
+                }
+
+                // Calculate expected scale for this channel
+                // Use the corresponding weight scale if available, otherwise use the first one
+                float weight_scale = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
+
+                if (!utils::CheckBiasScaleMatch(current_scales[i], weight_scale, activation_scale, 1e-5f)) {
+                  all_scales_match = false;
+                }
+              }
+
+              if (all_offsets_zero && all_scales_match) {
+                // No change needed - scales match and offsets are 0
+              } else {
+                // Need to requantize per-channel bias
+                ORT_CXX_LOG(logger,
+                            ORT_LOGGING_LEVEL_VERBOSE,
+                            ("Requantizing per-channel bias " + bias_input.name).c_str());
+
+                // Get current bias data and requantize
+                std::vector<uint8_t> original_bias_data;
+                RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
+
+                std::vector<uint8_t> requantized_bias_data;
+                std::vector<float> new_scales;
+                std::vector<int32_t> new_offsets;
+
+                RETURN_IF_ERROR(utils::RequantizeBiasTensor(
+                    original_bias_data, bias_info.shape, current_scales, current_offsets,
+                    weights_scales, activation_scale, bias_info.qnn_data_type,
+                    requantized_bias_data, new_scales, new_offsets,
+                    quant_axis));
+
+                // Create new tensor wrapper with requantized data
+                std::string bias_name = bias_input.name;
+                QnnQuantParamsWrapper new_quant_params(new_scales, new_offsets, quant_axis, false);
+                QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
+                                                    std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
+                                                    std::move(requantized_bias_data));
+                RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)), "Failed to add requantized bias tensor.");
+                input_names.push_back(bias_name);
+                return Ort::Status();  // We've handled the bias, return early
+              }
+            }
           }
         }
       }
-    }
 
-    // Process bias normally (non-quantized or static non-quantized or scales already match)
-    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, bias_input, logger, input_names));
+      // Process bias normally (non-quantized or static non-quantized or scales already match)
+      RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, bias_input, logger, input_names));
+    }  // end else (non-BQ bias path)
   }
 
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 16 && QNN_API_VERSION_MINOR <= 18)
@@ -1019,6 +1263,17 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
   RETURN_IF_ERROR(utils::GetQnnDataType(is_quantized_tensor, output_type, qnn_data_type));
 
+  // Detect BQ or LPBQ Conv from the weight tensor's quant encoding.
+  // BQ  (BW_FLOAT_BLOCK):       Conv outputs FP16 → need FP16 intermediate + Convert(FP16→INT16).
+  // LPBQ (BLOCKWISE_EXPANSION): Conv outputs INT16 → standard quantized output path.
+  bool is_bq_conv = false;
+  if (!input_names.empty()) {
+    const std::string& weight_name = input_names.size() >= 2 ? input_names[1] : input_names[0];
+    if (qnn_model_wrapper.IsQnnTensorWrapperExist(weight_name)) {
+      is_bq_conv = qnn_model_wrapper.GetQnnTensorWrapper(weight_name).GetQnnQuantParams().IsBlockQuantized();
+    }
+  }
+
   const auto& output_name = outputs[0].name;
   if (is_1d_conv) {
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
@@ -1054,17 +1309,48 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   } else {
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
     Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-    QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
-                                          std::move(output_quantize_param), std::move(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  output_node_type,
-                                                  std::move(input_names),
-                                                  {output_name},
-                                                  std::move(param_tensor_names),
-                                                  do_op_validation),
-                  "Failed to add node.");
+
+    if (is_bq_conv && is_quantized_tensor) {
+      // BQ Conv outputs FP16; downstream QDQ expects INT16.
+      // Emit: Conv (FP16 output) → Quantize (FP16 → INT16 quantized output).
+      const std::string conv_fp16_out = utils::UniqueNameGenerator().New(output_name, "_fp16");
+      QnnTensorWrapper fp16_out_wrapper(conv_fp16_out, QNN_TENSOR_TYPE_NATIVE,
+                                        QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                        std::vector<uint32_t>(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_out_wrapper)),
+                    "Failed to add FP16 Conv BQ output tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                    output_node_type,
+                                                    std::move(input_names),
+                                                    {conv_fp16_out},
+                                                    std::move(param_tensor_names),
+                                                    do_op_validation),
+                    "Failed to add BQ Conv node.");
+      // INT16 quantized output tensor consumed by downstream nodes.
+      QnnTensorWrapper int16_out_wrapper(output_name, tensor_type, qnn_data_type,
+                                         std::move(output_quantize_param),
+                                         std::move(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                    "Failed to add INT16 BQ Conv output tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(output_name, "_fp16_quantize"),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                        {conv_fp16_out}, {output_name}, {}, do_op_validation),
+                    "Failed to add FP16→INT16 Quantize node for BQ Conv output.");
+    } else {
+      QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
+                                            std::move(output_quantize_param), std::move(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                    output_node_type,
+                                                    std::move(input_names),
+                                                    {output_name},
+                                                    std::move(param_tensor_names),
+                                                    do_op_validation),
+                    "Failed to add node.");
+    }
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -74,30 +74,7 @@ class ConvOpBuilder : public BaseOpBuilder {
 Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
                                          const Ort::Logger& logger) const {
-  if (node_unit.Domain() == kMSInternalNHWCDomain) {
-    // For NHWC domain: detect BQ Conv and return success immediately.
-    // The weight remains NCHW [OC,IC,H,W] even in NHWC domain (QNN EP transposes it).
-    // Calling AddToModelBuilder(true) here would pollute the shared qnn_model_wrapper and
-    // cause the normal bias-requantization path to fail with block-quant params.
-    if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
-      const auto& inputs = node_unit.Inputs();
-      if (inputs.size() >= 2 && inputs[1].quant_param.has_value() &&
-          inputs[1].quant_param->scale != nullptr) {
-        const auto wscale = utils::GetInitializerShape(inputs[1].quant_param->scale,
-                                                       qnn_model_wrapper.GetOrtApi());
-        std::vector<uint32_t> wshape;
-        if (wscale.size() > 1 && qnn_model_wrapper.GetOnnxShape(inputs[1].shape, wshape) &&
-            wshape.size() >= 2) {
-          const bool rank2 = (wscale.size() == 2);
-          // Weight is NCHW [OC,IC,H,W]: IC at index 1.
-          const bool rankN = (wscale.size() == wshape.size() &&
-                              wscale[1] < static_cast<int64_t>(wshape[1]));
-          if (rank2 || rankN) {
-            return Ort::Status();  // BQ Conv in NHWC: skip full validation
-          }
-        }
-      }
-    }
+  if (node_unit.Domain() == kMSInternalNHWCDomain) {  // Use QNN validation API if layout is NHWC.
     return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
   }
 
@@ -148,8 +125,8 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                                                  qnn_model_wrapper.GetOrtApi());
       std::vector<uint32_t> weight_shape;
       if (!qnn_model_wrapper.GetOnnxShape(inputs[1].shape, weight_shape) ||
-          weight_shape.size() < 4) {
-        // Cannot get weight shape or wrong rank — skip BQ detection.
+          weight_shape.size() != 4) {
+        // BQ only supported for Conv2D (rank-4 weight); skip for Conv1D (rank-3) and Conv3D (rank-5).
       } else {
         const bool is_rank2_scale = (weight_scale_shape.size() == 2);
         const bool is_rankN_scale = (weight_scale_shape.size() == weight_shape.size() &&
@@ -252,7 +229,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                                                 qnn_model_wrapper.GetOrtApi());
     std::vector<uint32_t> bq_weight_shape;
     if (qnn_model_wrapper.GetOnnxShape(inputs[1].shape, bq_weight_shape) &&
-        bq_scale_shape.size() > 1) {
+        bq_scale_shape.size() > 1 &&
+        bq_weight_shape.size() == 4) {  // BQ only for Conv2D (rank-4 weight); not Conv3D (rank-5)
       // Weight is NCHW [OC,IC,H,W]: IC is always at index 1.
       const bool rank2 = (bq_scale_shape.size() == 2);
       const bool rankN = (bq_scale_shape.size() == bq_weight_shape.size() &&
@@ -364,11 +342,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
         ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
         RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point,
                                                            zp_values, zp_onnx_type));
-        for (int64_t oc = 0; oc < OC; ++oc) {
-          for (int64_t b = 0; b < nb; ++b) {
-            const size_t idx = static_cast<size_t>(oc * nb + b);
-            offsets_qnn[idx] = (idx < zp_values.size()) ? static_cast<float>(-zp_values[idx]) : 0.0f;
-          }
+        RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == OC * nb,
+                      "QNN EP: BQ Conv zero_point size must match OC * num_blocks");
+        for (size_t idx = 0; idx < static_cast<size_t>(OC * nb); ++idx) {
+          offsets_qnn[idx] = static_cast<float>(-zp_values[idx]);
         }
       }
 
@@ -534,8 +511,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   //
   const bool has_bias_input = num_inputs == 3;
   if (has_bias_input) {
-    // For BQ Conv: QNN BW_FLOAT_BLOCK Conv2d requires FP32 bias (even though activation is FP16).
-    // The bias in the QDQ NodeUnit is an INT32 quantized initializer — dequantize it to FP32.
+    // For BQ Conv: QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
+    // The bias in the QDQ NodeUnit is an INT32 quantized initializer — dequantize it to FP16.
     if (is_bq_weight) {
       TensorInfo bias_info = {};
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -167,11 +167,13 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
           auto bq_it = kHtpConvBQBitsAndBlockSizeMultipliers.find(bitwidth);
           RETURN_IF(bq_it == kHtpConvBQBitsAndBlockSizeMultipliers.end(),
                     ("QNN HTP Conv BQ: unsupported weight bitwidth=" +
-                     std::to_string(bitwidth)).c_str());
+                     std::to_string(bitwidth))
+                        .c_str());
           RETURN_IF(block_size % bq_it->second != 0,
                     ("QNN HTP Conv BQ: block_size=" + std::to_string(block_size) +
                      " must be a multiple of " + std::to_string(bq_it->second) +
-                     " for " + std::to_string(bitwidth) + "-bit weight").c_str());
+                     " for " + std::to_string(bitwidth) + "-bit weight")
+                        .c_str());
 
           // Return success; full QNN validation is done in the NHWC IsOpSupported path.
           return Ort::Status();
@@ -393,7 +395,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                                      inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 ||
                                      inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8);
       const Qnn_DataType_t weight_qnn_dtype = is_signed_weight ? QNN_DATATYPE_SFIXED_POINT_8
-                                                                : QNN_DATATYPE_UFIXED_POINT_8;
+                                                               : QNN_DATATYPE_UFIXED_POINT_8;
       QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
                                          weight_qnn_dtype,
                                          std::move(bq_quant_params),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -564,8 +564,9 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
       RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
 
-      // Read the INT32 quantized bias and its scale, then dequantize to FP16.
+      // Read the INT32 quantized bias and its scale(s), then dequantize to FP16.
       // QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
+      // Bias scale may be per-tensor (1 value) or per-channel (one value per output channel).
       std::vector<uint8_t> raw_bias_bytes;
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor,
                                                               raw_bias_bytes));
@@ -573,16 +574,22 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
         RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scale_vals));
       }
-      const float bias_scale = bias_scale_vals.empty() ? 1.0f : bias_scale_vals[0];
 
-      // Dequantize INT32 → FP16 (stored as uint16 in memory).
+      // Dequantize INT32 → FP16 (stored as uint16 in memory): bias[i] = q[i] * scale[i or 0].
       const size_t num_elems = bias_info.shape[0];
       RETURN_IF_NOT(raw_bias_bytes.size() == num_elems * sizeof(int32_t), "BQ bias size mismatch");
+      // Scale is per-tensor (1), per-channel (num_elems == OC), or absent (defaults to 1.0f).
+      const bool is_per_channel_bias = bias_scale_vals.size() == num_elems;
+      RETURN_IF_NOT(bias_scale_vals.size() <= 1 || is_per_channel_bias,
+                    "QNN EP: BQ Conv bias scale count must be 1 (per-tensor) or OC (per-channel)");
       std::vector<uint8_t> fp16_bias_bytes(num_elems * sizeof(uint16_t));
       const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_bias_bytes.data());
       auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
       for (size_t i = 0; i < num_elems; ++i) {
-        const float f = static_cast<float>(i32_ptr[i]) * bias_scale;
+        const float scale = bias_scale_vals.empty() ? 1.0f
+                                                    : (is_per_channel_bias ? bias_scale_vals[i]
+                                                                           : bias_scale_vals[0]);
+        const float f = static_cast<float>(i32_ptr[i]) * scale;
         const Ort::Float16_t fp16_val(f);
         memcpy(&u16_ptr[i], &fp16_val.val, sizeof(uint16_t));
       }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -1047,7 +1047,7 @@ void QnnModelWrapper::GetGraphInputOutputTensorWrapper(const std::vector<std::st
 
 Ort::Status QnnModelWrapper::UnpackInitializerData(const OrtValueInfo* initializer,
                                                    std::vector<uint8_t>& unpacked_tensor,
-                                                   const bool unpack_4_bit_to_8_bit) const {
+                                                   const bool unpack_sub_byte_to_8_bit) const {
   const ORTCHAR_T* model_path = nullptr;
   ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.Graph_GetModelPath(&ort_graph_, &model_path));
   RETURN_IF_ERROR(utils::UnpackInitializerData(api_ptrs_.ort_api,
@@ -1062,20 +1062,21 @@ Ort::Status QnnModelWrapper::UnpackInitializerData(const OrtValueInfo* initializ
   ONNXTensorElementDataType onnx_data_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
   ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetTensorElementType(tensor_type_and_shape_info, &onnx_data_type));
 
-  // If unpack_4_bit_to_8_bit is true, we need to unpack it because QNN HTP treats int4 as a full int8.
-  if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4) {
+  // If unpack_sub_byte_to_8_bit is true, unpack 2-bit/4-bit elements to one byte each because
+  // QNN HTP treats sub-byte int2/int4 as a full int8.
+  if (unpack_sub_byte_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4) {
     std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
     const size_t num_int4_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
     RETURN_IF_ERROR(utils::UnpackInt4ToInt8<true>(num_int4_elems, unpacked_tensor));
-  } else if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4) {
+  } else if (unpack_sub_byte_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4) {
     std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
     const size_t num_uint4_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
     RETURN_IF_ERROR(utils::UnpackInt4ToInt8<false>(num_uint4_elems, unpacked_tensor));
-  } else if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2) {
+  } else if (unpack_sub_byte_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2) {
     std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
     const size_t num_int2_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
     RETURN_IF_ERROR(utils::UnpackInt2ToInt8<true>(num_int2_elems, unpacked_tensor));
-  } else if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2) {
+  } else if (unpack_sub_byte_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2) {
     std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
     const size_t num_uint2_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
     RETURN_IF_ERROR(utils::UnpackInt2ToInt8<false>(num_uint2_elems, unpacked_tensor));

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -744,6 +744,16 @@ Ort::Status QnnModelWrapper::UnpackZeroPoints(const OrtValueInfo* zp_tensor,
   };
 
   switch (onnx_data_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2: {  // INT2 zero-points are unpacked as 8-bit values for QNN
+      auto int8_span = ReinterpretAsSpan<const int8_t>(gsl::make_span(initializer_bytes));
+      std::transform(int8_span.begin(), int8_span.end(), std::back_inserter(zero_points),
+                     [](int8_t masked_zp) -> int32_t {
+                       // Undo the lower-2-bit masking applied during unpacking to recover the true signed value.
+                       int8_t zp = Int2x4::SignExtendLower2Bits(std::byte(masked_zp));
+                       return -static_cast<int32_t>(zp);
+                     });
+      break;
+    }
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4: {  // INT4 zero-points are unpacked as 8-bit values for QNN
       auto int8_span = ReinterpretAsSpan<const int8_t>(gsl::make_span(initializer_bytes));
       std::transform(int8_span.begin(), int8_span.end(), std::back_inserter(zero_points),
@@ -760,6 +770,7 @@ Ort::Status QnnModelWrapper::UnpackZeroPoints(const OrtValueInfo* zp_tensor,
       transform_zero_points(ReinterpretAsSpan<const int8_t>(gsl::make_span(initializer_bytes)));
       break;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:  // UINT4 zero-points are unpacked as 8-bit values for QNN
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:  // UINT2 zero-points are unpacked as 8-bit values for QNN
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
       transform_zero_points(ReinterpretAsSpan<const uint8_t>(gsl::make_span(initializer_bytes)));
       break;
@@ -1051,7 +1062,6 @@ Ort::Status QnnModelWrapper::UnpackInitializerData(const OrtValueInfo* initializ
   ONNXTensorElementDataType onnx_data_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
   ORT_CXX_RETURN_ON_API_FAIL(api_ptrs_.ort_api.GetTensorElementType(tensor_type_and_shape_info, &onnx_data_type));
 
-  // If this is an int4,
   // If unpack_4_bit_to_8_bit is true, we need to unpack it because QNN HTP treats int4 as a full int8.
   if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4) {
     std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
@@ -1061,6 +1071,14 @@ Ort::Status QnnModelWrapper::UnpackInitializerData(const OrtValueInfo* initializ
     std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
     const size_t num_uint4_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
     RETURN_IF_ERROR(utils::UnpackInt4ToInt8<false>(num_uint4_elems, unpacked_tensor));
+  } else if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2) {
+    std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
+    const size_t num_int2_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+    RETURN_IF_ERROR(utils::UnpackInt2ToInt8<true>(num_int2_elems, unpacked_tensor));
+  } else if (unpack_4_bit_to_8_bit && onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2) {
+    std::vector<int64_t> shape = utils::GetInitializerShape(initializer, api_ptrs_.ort_api);
+    const size_t num_uint2_elems = std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+    RETURN_IF_ERROR(utils::UnpackInt2ToInt8<false>(num_uint2_elems, unpacked_tensor));
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -354,7 +354,7 @@ class QnnModelWrapper {
 
   Ort::Status UnpackInitializerData(const OrtValueInfo* initializer,
                                     std::vector<uint8_t>& unpacked_tensor,
-                                    const bool unpack_4_bit_to_8_bit = true) const;
+                                    const bool unpack_sub_byte_to_8_bit = true) const;
 
   QnnBackendType GetQnnBackendType() const { return qnn_backend_type_; }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -87,6 +87,8 @@ size_t GetElementSizeByType(const Qnn_DataType_t& data_type) {
 
 size_t GetElementSizeByType(ONNXTensorElementDataType elem_type) {
   const static std::unordered_map<ONNXTensorElementDataType, size_t> elem_type_to_size = {
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2, sizeof(Int2x4)},
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2, sizeof(UInt2x4)},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, sizeof(Int4x2)},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, sizeof(UInt4x2)},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, sizeof(int8_t)},
@@ -111,6 +113,8 @@ size_t GetElementSizeByType(ONNXTensorElementDataType elem_type) {
 
 std::string_view GetElementNameByType(ONNXTensorElementDataType elem_type) {
   const static std::unordered_map<ONNXTensorElementDataType, std::string_view> elem_type_to_name = {
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2, "int2_t"},
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2, "uint2_t"},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, "int4_t"},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, "uint4_t"},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, "int8_t"},
@@ -861,12 +865,14 @@ bool OnnxDataTypeToQnnDataType(const ONNXTensorElementDataType onnx_data_type,
   };
 
   const std::unordered_map<ONNXTensorElementDataType, Qnn_DataType_t> onnx_to_qnn_data_type_quantized = {
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2, QNN_DATATYPE_SFIXED_POINT_8},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, QNN_DATATYPE_SFIXED_POINT_8},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, QNN_DATATYPE_SFIXED_POINT_8},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, QNN_DATATYPE_SFIXED_POINT_16},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, QNN_DATATYPE_SFIXED_POINT_32},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, QNN_DATATYPE_INT_64},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, QNN_DATATYPE_UFIXED_POINT_8},
+      {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2, QNN_DATATYPE_UFIXED_POINT_8},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, QNN_DATATYPE_UFIXED_POINT_8},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16, QNN_DATATYPE_UFIXED_POINT_16},
       {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32, QNN_DATATYPE_UFIXED_POINT_32},
@@ -1705,6 +1711,8 @@ Ort::Status UnpackInitializerData(const OrtApi& ort_api,
 #endif
     CASE_UNPACK_INT4(INT4, Int4x2, int32_data_size);
     CASE_UNPACK_INT4(UINT4, UInt4x2, int32_data_size);
+    CASE_UNPACK_INT2(INT2, Int2x4, int32_data_size);
+    CASE_UNPACK_INT2(UINT2, UInt2x4, int32_data_size);
     default:
       return MAKE_EP_FAIL(("Unsupported type: " + std::to_string(onnx_data_type)).c_str());
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -375,6 +375,34 @@ Ort::Status UnpackInt4ToInt8(size_t num_int4_elems, std::vector<uint8_t>& data_b
   return Ort::Status();
 }
 
+// Re-writes a buffer of packed 2-bit elements to a buffer of unpacked 8-bit elements.
+// QNN requires that 2-bit weights are unpacked to 8-bit (stored in lower 2 bits).
+template <bool Signed>
+Ort::Status UnpackInt2ToInt8(size_t num_int2_elems, std::vector<uint8_t>& data_bytes) {
+  if constexpr (Signed) {  // INT2
+    std::vector<uint8_t> packed_int2_bytes = std::move(data_bytes);
+    data_bytes = std::vector<uint8_t>(num_int2_elems);
+
+    auto dst = gsl::make_span(reinterpret_cast<int8_t*>(data_bytes.data()), data_bytes.size());
+    auto src = gsl::make_span(reinterpret_cast<const Int2x4*>(packed_int2_bytes.data()), packed_int2_bytes.size());
+    RETURN_IF_NOT(Int2x4::Unpack(dst, src), "Failed to unpack Tensor<Int2x4> for QNN");
+
+    // Mask off top 6 bits (keep lower 2 bits), consistent with the INT4 masking workaround for QNN.
+    for (size_t i = 0; i < dst.size(); i++) {
+      dst[i] &= 0x03;  // e.g., -1 (0b11111111) becomes 3 (0b00000011)
+    }
+  } else {  // UINT2
+    std::vector<uint8_t> packed_uint2_bytes = std::move(data_bytes);
+    data_bytes = std::vector<uint8_t>(num_int2_elems);
+
+    auto dst = gsl::make_span(reinterpret_cast<uint8_t*>(data_bytes.data()), data_bytes.size());
+    auto src = gsl::make_span(reinterpret_cast<const UInt2x4*>(packed_uint2_bytes.data()), packed_uint2_bytes.size());
+    RETURN_IF_NOT(UInt2x4::Unpack(dst, src), "Failed to unpack Tensor<UInt2x4> for QNN");
+  }
+
+  return Ort::Status();
+}
+
 // This function exploits bit-manipulation trick to transform from unsigned to signed.
 // Formally, an unsigned value subtracts zero point (i.e.,  1 << (bits - 1)) to become a signed value. This subtraction
 // is essentially "flipping" the most-significant bit, which can be achieved through XOR with the zero point. While
@@ -706,6 +734,58 @@ Ort::Status RequantizeBiasTensor(const std::vector<uint8_t>& original_bias_data,
     }                                                                                                          \
                                                                                                                \
     /* Resize output buffer and copy data */                                                                   \
+    unpacked_tensor.resize(tensor_byte_size);                                                                  \
+    if (data != nullptr && tensor_byte_size > 0) {                                                             \
+      std::memcpy(unpacked_tensor.data(), data, tensor_byte_size);                                             \
+    }                                                                                                          \
+    return Ort::Status();                                                                                      \
+  }
+
+// Analogous to CASE_UNPACK_INT4 but for 2-bit types (4 elements per byte).
+// Uses CalcNumInt2Quads instead of CalcNumInt4Pairs.
+#define CASE_UNPACK_INT2(TYPE, ELEMENT_TYPE, DATA_SIZE)                                                        \
+  case ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_##TYPE: {                                      \
+    const OrtTypeInfo* type_info_##TYPE = nullptr;                                                             \
+    auto status = ort_api.GetValueInfoTypeInfo(initializer, &type_info_##TYPE);                                \
+    if (status != nullptr) {                                                                                   \
+      return MAKE_EP_FAIL("Failed to get value info type info");                                               \
+    }                                                                                                          \
+    const OrtTensorTypeAndShapeInfo* tensor_type_and_shape_info_##TYPE = nullptr;                              \
+    status = ort_api.CastTypeInfoToTensorInfo(type_info_##TYPE, &tensor_type_and_shape_info_##TYPE);           \
+    if (status != nullptr) {                                                                                   \
+      return MAKE_EP_FAIL("Failed to cast type info to tensor info");                                          \
+    }                                                                                                          \
+    size_t num_dims_##TYPE = 0;                                                                                \
+    status = ort_api.GetDimensionsCount(tensor_type_and_shape_info_##TYPE, &num_dims_##TYPE);                  \
+    if (status != nullptr) {                                                                                   \
+      return MAKE_EP_FAIL("Failed to get dimensions count");                                                   \
+    }                                                                                                          \
+    std::vector<int64_t> dims_##TYPE(num_dims_##TYPE);                                                         \
+    status = ort_api.GetDimensions(tensor_type_and_shape_info_##TYPE, dims_##TYPE.data(), dims_##TYPE.size()); \
+    if (status != nullptr) {                                                                                   \
+      return MAKE_EP_FAIL("Failed to get dimensions");                                                         \
+    }                                                                                                          \
+                                                                                                               \
+    size_t element_count = 1;                                                                                  \
+    for (size_t i = 0; i < num_dims_##TYPE; ++i) {                                                             \
+      element_count *= static_cast<size_t>(dims_##TYPE[i]);                                                    \
+    }                                                                                                          \
+                                                                                                               \
+    /* Calculate packed element count and tensor byte size for INT2/UINT2 (4 elements per byte) */             \
+    size_t packed_element_count = ELEMENT_TYPE::CalcNumInt2Quads(element_count);                               \
+    size_t tensor_byte_size = packed_element_count * sizeof(ELEMENT_TYPE);                                     \
+                                                                                                               \
+    const OrtValue* initializer_value = nullptr;                                                               \
+    status = ort_api.ValueInfo_GetInitializerValue(initializer, &initializer_value);                           \
+    if (status != nullptr) {                                                                                   \
+      return MAKE_EP_FAIL("Failed to get initializer value");                                                  \
+    }                                                                                                          \
+    const void* data = nullptr;                                                                                \
+    status = ort_api.GetTensorData(initializer_value, &data);                                                  \
+    if (status != nullptr) {                                                                                   \
+      return MAKE_EP_FAIL("Failed to get tensor data");                                                        \
+    }                                                                                                          \
+                                                                                                               \
     unpacked_tensor.resize(tensor_byte_size);                                                                  \
     if (data != nullptr && tensor_byte_size > 0) {                                                             \
       std::memcpy(unpacked_tensor.data(), data, tensor_byte_size);                                             \

--- a/onnxruntime/core/providers/qnn/common/int2.h
+++ b/onnxruntime/core/providers/qnn/common/int2.h
@@ -1,0 +1,165 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+// QNN-EP COPY START
+// Below are Int2 dtype utilities copied from
+// onnxruntime/include/onnxruntime/core/framework/int2.h directly.
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+#include <gsl/gsl>
+
+namespace onnxruntime {
+namespace qnn {
+
+template <bool Signed>
+struct Int2Traits;
+
+template <>
+struct Int2Traits<true> {
+  using UnpackedType = int8_t;
+  static constexpr int8_t min_val = -2;
+  static constexpr int8_t max_val = 1;
+};
+
+template <>
+struct Int2Traits<false> {
+  using UnpackedType = uint8_t;
+  static constexpr uint8_t min_val = 0;
+  static constexpr uint8_t max_val = 3;
+};
+
+/// <summary>
+/// Stores 4 packed 2-bit elements in 1 byte.
+/// Packing follows ONNX spec: x0 | (x1 << 2) | (x2 << 4) | (x3 << 6)
+/// </summary>
+/// <typeparam name="Signed">Set to true if signed int2, or false if unsigned uint2.</typeparam>
+template <bool Signed>
+struct Int2x4Base {
+  using UnpackedType = typename Int2Traits<Signed>::UnpackedType;
+  static constexpr UnpackedType min_val = Int2Traits<Signed>::min_val;
+  static constexpr UnpackedType max_val = Int2Traits<Signed>::max_val;
+
+  std::byte bits_{};
+
+  Int2x4Base() = default;
+
+  explicit Int2x4Base(std::byte bits) {
+    bits_ = bits;
+  }
+
+  Int2x4Base(UnpackedType val0, UnpackedType val1, UnpackedType val2, UnpackedType val3) {
+    bits_ = static_cast<std::byte>(
+        (val0 & 0x3) |
+        ((val1 & 0x3) << 2) |
+        ((val2 & 0x3) << 4) |
+        ((val3 & 0x3) << 6));
+  }
+
+  static inline int8_t SignExtendLower2Bits(std::byte bits) {
+    // Sign-extend lower 2-bits by left shifting and then doing an arithmetic right shift.
+    constexpr uint8_t shift = (sizeof(int32_t) * 8) - 2;
+    return static_cast<int8_t>((static_cast<int32_t>(bits) << shift) >> shift);
+  }
+
+  inline UnpackedType GetElem(size_t index) const {
+    assert(index <= 3);
+    const uint8_t shift = 2 * static_cast<uint8_t>(index);
+    const std::byte val = (bits_ >> shift) & std::byte{0x3};
+
+    if constexpr (Signed) {
+      return SignExtendLower2Bits(val);
+    } else {
+      return static_cast<UnpackedType>(val);
+    }
+  }
+
+  inline void SetElem(size_t index, UnpackedType val) {
+    assert(index <= 3);
+    const uint8_t shift = 2 * static_cast<uint8_t>(index);
+    const std::byte clear_mask = ~(std::byte{0x3} << shift);
+
+    bits_ &= clear_mask;                                    // Clear 2-bit element to 0
+    bits_ |= static_cast<std::byte>((val & 0x3) << shift);  // Set 2-bit element to val
+  }
+
+  inline std::byte ToBits() const {
+    return bits_;
+  }
+
+  static size_t CalcNumInt2Quads(size_t num_int2_elems) {
+    return (num_int2_elems + 3) / 4;
+  }
+
+  /// <summary>
+  /// Copy a source buffer of 2-bit elements (packed) into a destination buffer of 8-bit elements (unpacked).
+  /// </summary>
+  static bool Unpack(gsl::span<UnpackedType> dst, gsl::span<const Int2x4Base<Signed>> src) {
+    if (CalcNumInt2Quads(dst.size()) != src.size()) {
+      return false;
+    }
+
+    if (src.empty()) {
+      return true;
+    }
+
+    for (size_t i = 0; i < dst.size(); i++) {
+      size_t byte_idx = i >> 2;   // i / 4
+      size_t elem_idx = i & 0x3;  // i % 4
+      dst[i] = src[byte_idx].GetElem(elem_idx);
+    }
+
+    return true;
+  }
+
+  /// <summary>
+  /// Copy a source buffer of 8-bit elements (unpacked) into a destination buffer of 2-bit elements (packed).
+  /// </summary>
+  static bool Pack(gsl::span<Int2x4Base<Signed>> dst, gsl::span<const UnpackedType> src) {
+    if (CalcNumInt2Quads(src.size()) != dst.size()) {
+      return false;
+    }
+
+    if (src.empty()) {
+      return true;
+    }
+
+    size_t src_i = 0;
+    size_t dst_i = 0;
+    const size_t full_quads = src.size() / 4;
+
+    for (; dst_i < full_quads; dst_i++) {
+      dst[dst_i] = Int2x4Base<Signed>(src[src_i], src[src_i + 1], src[src_i + 2], src[src_i + 3]);
+      src_i += 4;
+    }
+
+    // Handle remaining elements (1-3)
+    if (src_i < src.size()) {
+      UnpackedType vals[4] = {0, 0, 0, 0};
+      size_t remaining = src.size() - src_i;
+      for (size_t j = 0; j < remaining; j++) {
+        vals[j] = src[src_i + j];
+      }
+      dst[dst_i] = Int2x4Base<Signed>(vals[0], vals[1], vals[2], vals[3]);
+    }
+
+    return true;
+  }
+
+  /// <summary>
+  /// Returns hierarchical indices for a packed int2 element from the given element index.
+  /// </summary>
+  static inline std::pair<size_t, size_t> GetTensorElemIndices(size_t index) {
+    return {index >> 2, index & 0x3};
+  }
+};
+
+using Int2x4 = Int2x4Base<true>;
+using UInt2x4 = Int2x4Base<false>;
+static_assert(sizeof(Int2x4) == sizeof(std::byte));
+static_assert(sizeof(UInt2x4) == sizeof(std::byte));
+// QNN-EP COPY END
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -33,6 +33,7 @@
 #include "onnxruntime_session_options_config_keys.h"
 
 #include "core/providers/qnn/common/int4.h"
+#include "core/providers/qnn/common/int2.h"
 #include "core/providers/qnn/common/qnn_safeint.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -32,8 +32,8 @@
 #include "onnxruntime_run_options_config_keys.h"
 #include "onnxruntime_session_options_config_keys.h"
 
-#include "core/providers/qnn/common/int4.h"
 #include "core/providers/qnn/common/int2.h"
+#include "core/providers/qnn/common/int4.h"
 #include "core/providers/qnn/common/qnn_safeint.h"
 
 namespace onnxruntime {

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -2901,17 +2901,18 @@ namespace {
 
 // Builds the ONNX QDQ graph for a BQ (block-quantized weight) 2D Conv.
 //   - activation: uint16 per-tensor symmetric Q/DQ
-//   - weight: INT4 initializer + DQ with block_size attribute and rank-2
-//             float scale [OC, num_blocks] (num_blocks = IC / block_size)
+//   - weight: INT4 or INT8 initializer + DQ with block_size attribute and rank-4
+//             float scale [OC, IC/block_size, 1, 1] (axis=1, IC is the blocked dimension)
 //   - output: uint16 per-tensor symmetric Q/DQ
 //
-// Scale layout [OC, num_blocks]: scale[oc * num_blocks + b] is the per-block
-// float scale for output channel oc, IC-block b.
+// weight_bits: 4 for INT4 (default), 8 for INT8, 2 for INT2.
+// block_size constraints: must be a multiple of 8 (4-bit), 4 (8-bit), or 16 (2-bit) per HTP.
 GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
                                      const std::vector<int64_t>& weight_shape,
                                      int64_t block_size,
-                                     bool include_bias = false) {
-  return [input_shape, weight_shape, block_size, include_bias](ModelTestBuilder& builder) -> void {
+                                     bool include_bias = false,
+                                     int weight_bits = 4) {
+  return [input_shape, weight_shape, block_size, include_bias, weight_bits](ModelTestBuilder& builder) -> void {
     const int64_t OC = weight_shape[0];
     const int64_t IC = weight_shape[1];
     const int64_t kH = weight_shape.size() >= 4 ? weight_shape[2] : 1;
@@ -2934,20 +2935,34 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     builder.AddNode("act_dql", "DequantizeLinear",
                     {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
 
-    // ── Weight: INT4 initializer → DQ(block_size, axis=1) ───────────────────
-    // ONNX opset 21 block quantization: scale rank == weight rank.
-    // axis=1 (IC dimension), block_size=bs → scale shape [OC, IC/bs, 1, 1].
+    // ── Weight initializer + DQ(block_size, axis=1) ──────────────────────────
+    // Scale rank == weight rank per ONNX opset 21: [OC, IC/block_size, 1, 1].
     const std::vector<int64_t> scale_shape{OC, num_blocks, 1, 1};
     builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
 
-    // INT4 weight in range [-3, 3] (symmetric, zero_point = 0).
     const size_t num_elems = static_cast<size_t>(OC * IC * kH * kW);
-    std::vector<Int4x2> weight_data(Int4x2::CalcNumInt4Pairs(num_elems));
-    for (size_t i = 0; i < num_elems; ++i) {
-      const int8_t v = static_cast<int8_t>((i % 7) - 3);  // [-3..3]
-      weight_data[i >> 1].SetElem(i & 1, v);
+    if (weight_bits == 4) {
+      // INT4 weight in range [-3, 3] (symmetric).
+      std::vector<Int4x2> weight_data(Int4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 1].SetElem(i & 1, static_cast<int8_t>((i % 7) - 3));
+      }
+      builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, weight_data);
+    } else if (weight_bits == 2) {
+      // INT2 weight in range [-1, 1] (symmetric, 4 elements per byte).
+      std::vector<Int2x4> weight_data(Int2x4::CalcNumInt2Quads(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 2].SetElem(i & 3, static_cast<int8_t>((i % 3) - 1));
+      }
+      builder.MakeInitializer<Int2x4>("weight_quant", weight_shape, weight_data);
+    } else {
+      // INT8 weight in range [-63, 63] (symmetric).
+      std::vector<int8_t> weight_data(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i] = static_cast<int8_t>((i % 127) - 63);
+      }
+      builder.MakeInitializer<int8_t>("weight_quant", weight_shape, weight_data);
     }
-    builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, weight_data);
 
     // DQ with block_size; omit zero_point (symmetric). axis=1: IC is the blocked dimension.
     builder.AddNode("weight_dql", "DequantizeLinear",
@@ -3068,6 +3083,65 @@ TEST_F(QnnHTPBackendTests, ConvBQ_ExistingPerChannel_Unaffected) {
       ExpectedEPNodeAssignment::All,
       false,  // use_qdq_contrib_ops
       21);    // opset
+}
+
+// ── BQ Conv bitwidth / block_size variants ───────────────────────────────────
+// INT4, block_size=16: still a valid HTP multiple-of-8 block size.
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/16,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/4),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// INT8, block_size=4: minimum valid HTP multiple-of-4 block size for 8-bit.
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize4) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/4,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/8),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// INT8, block_size=8: larger block size, still a valid HTP multiple-of-4.
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize8) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/8,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/8),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// INT2, block_size=16: minimum valid HTP multiple-of-16 block size for 2-bit.
+// DISABLED: ORT's CPU DequantizeLinear kernel does not yet support tensor(int2).
+// Re-enable once ORT adds INT2 DQ support (the Int2x4 test infrastructure is ready).
+TEST_F(QnnHTPBackendTests, DISABLED_ConvBQ_U16Int2_1x1_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/16,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/2),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -2884,6 +2884,209 @@ TEST_F(QnnHTPBackendTests, ConvU8U8S32_LargeInput_Dilations_Pads) {
                                      "NOTSET",                                                  // auto_pad
                                      ExpectedEPNodeAssignment::All);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block-Quantized Conv (BQ Phase 1)
+//
+// ONNX graph pattern:
+//   input → Q(u16) → DQ → Conv ← DQ(Int4, block_size, axis=0) → Q(u16) → DQ
+//
+// The weight DQ node uses a rank-2 float scale tensor [OC, num_blocks] where
+// num_blocks = IC / block_size. QNN EP maps this to the BW_FLOAT_BLOCK kernel
+// (FP16 activation) with an INT16→FP16 Convert before Conv and FP16→INT16
+// Convert after Conv.
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// Builds the ONNX QDQ graph for a BQ (block-quantized weight) 2D Conv.
+//   - activation: uint16 per-tensor symmetric Q/DQ
+//   - weight: INT4 initializer + DQ with block_size attribute and rank-2
+//             float scale [OC, num_blocks] (num_blocks = IC / block_size)
+//   - output: uint16 per-tensor symmetric Q/DQ
+//
+// Scale layout [OC, num_blocks]: scale[oc * num_blocks + b] is the per-block
+// float scale for output channel oc, IC-block b.
+GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
+                                     const std::vector<int64_t>& weight_shape,
+                                     int64_t block_size,
+                                     bool include_bias = false) {
+  return [input_shape, weight_shape, block_size, include_bias](ModelTestBuilder& builder) -> void {
+    const int64_t OC = weight_shape[0];
+    const int64_t IC = weight_shape[1];
+    const int64_t kH = weight_shape.size() >= 4 ? weight_shape[2] : 1;
+    const int64_t kW = weight_shape.size() >= 4 ? weight_shape[3] : 1;
+    const int64_t num_blocks = IC / block_size;  // caller ensures IC % block_size == 0
+
+    // ── Activation: float → Q(uint16) → DQ ──────────────────────────────────
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // uint16 symmetric per-tensor: scale = 2/65534, zp = 32767 (~[-1, 1])
+    const float act_scale = 2.0f / 65534.0f;
+    const uint16_t act_zp = 32767;
+    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
+    builder.AddNode("act_ql", "QuantizeLinear",
+                    {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
+    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
+    builder.AddNode("act_dql", "DequantizeLinear",
+                    {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
+
+    // ── Weight: INT4 initializer → DQ(block_size, axis=1) ───────────────────
+    // ONNX opset 21 block quantization: scale rank == weight rank.
+    // axis=1 (IC dimension), block_size=bs → scale shape [OC, IC/bs, 1, 1].
+    const std::vector<int64_t> scale_shape{OC, num_blocks, 1, 1};
+    builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
+
+    // INT4 weight in range [-3, 3] (symmetric, zero_point = 0).
+    const size_t num_elems = static_cast<size_t>(OC * IC * kH * kW);
+    std::vector<Int4x2> weight_data(Int4x2::CalcNumInt4Pairs(num_elems));
+    for (size_t i = 0; i < num_elems; ++i) {
+      const int8_t v = static_cast<int8_t>((i % 7) - 3);  // [-3..3]
+      weight_data[i >> 1].SetElem(i & 1, v);
+    }
+    builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, weight_data);
+
+    // DQ with block_size; omit zero_point (symmetric). axis=1: IC is the blocked dimension.
+    builder.AddNode("weight_dql", "DequantizeLinear",
+                    {"weight_quant", "weight_scale"},
+                    {"weight_dql_out"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(1)),
+                     builder.MakeScalarAttribute("block_size", block_size)});
+
+    // ── Conv ─────────────────────────────────────────────────────────────────
+    std::vector<std::string> conv_inputs{"act_dql_out", "weight_dql_out"};
+    if (include_bias) {
+      // Use INT32-quantized bias directly (no QL node — avoids ORT QL opset validation for INT32).
+      // OrtConvNodeGroupSelector requires bias DQL input type == INT32 (qnn_ep_utils.cc:741).
+      const float bias_scale = act_scale * 0.03f;
+      builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
+      builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
+      builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(OC), 0));
+      builder.AddNode("bias_dql", "DequantizeLinear",
+                      {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
+      conv_inputs.push_back("bias_dql_out");
+    }
+    builder.AddNode("conv", "Conv",
+                    conv_inputs, {"conv_out"}, kOnnxDomain,
+                    {builder.MakeStringAttribute("auto_pad", "NOTSET"),
+                     builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}),
+                     builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0})});
+
+    // ── Output: Conv → Q(uint16) → DQ → graph output ─────────────────────────
+    const float out_scale = 2.0f / 65534.0f;
+    const uint16_t out_zp = 32767;
+    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
+    builder.AddNode("out_ql", "QuantizeLinear",
+                    {"conv_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
+    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
+    builder.MakeOutput("output");
+    builder.AddNode("out_dql", "DequantizeLinear",
+                    {"out_ql_out", "out_dql_scale", "out_ql_zp"}, {"output"});
+  };
+}
+
+ProviderOptions GetBQConvProviderOptions() {
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  // On the x86_64 Linux HTP simulator, specify SM8850 to enable BW_FLOAT_BLOCK support.
+  // On real ARM64 hardware, the SoC model is auto-detected by QNN EP.
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return opts;
+}
+
+}  // namespace
+
+// 1x1 Conv, INT4 weight, block_size=8, uint16 activation, no bias.
+// Validates that the BW_FLOAT_BLOCK kernel is reached (BQ path in conv_op_builder).
+// in0: u16, weight: int4 (scale=[4,2], block_size=8), out: u16
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  const std::filesystem::path json_dir = "ConvBQ_NoBias_dump";
+  std::filesystem::create_directories(json_dir);  // keep on failure for inspection
+
+  ProviderOptions opts = GetBQConvProviderOptions();
+  opts["dump_json_qnn_graph"] = "1";
+  opts["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/8,
+                                      /*bias=*/false),
+                  opts,
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::Some,
+                  /*fp32_abs_err=*/1e-2f,
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_outputs=*/false);
+}
+
+// 1x1 Conv with bias. Exercises the bias pass-through in the BQ bias path.
+// in0: u16, weight: int4 (scale=[4,2], block_size=8), bias: f32, out: u16
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_WithBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  const std::filesystem::path json_dir = "ConvBQ_WithBias_dump";
+  std::filesystem::create_directories(json_dir);
+  ProviderOptions opts = GetBQConvProviderOptions();
+  opts["dump_json_qnn_graph"] = "1";
+  opts["json_qnn_graph_dir"] = json_dir.string();
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/8,
+                                      /*bias=*/true),
+                  opts,
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::Some,
+                  1e-2f,
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_outputs=*/false);
+}
+
+// 1x1 Conv with larger IC and more blocks per channel.
+// weight: int4 (IC=32, block_size=8, 4 blocks per OC), scale=[8,4]
+// in0: u16, out: u16
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_MultiBlock) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{8, 32, 1, 1},
+                                      /*block_size=*/8),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::Some,
+                  1e-2f,
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_outputs=*/false);
+}
+
+// Regression: existing per-channel INT4 Conv (no block_size) continues to work.
+// Reuses RunHTPConvOpPerChannelTest to confirm the BQ detection does not interfere.
+TEST_F(QnnHTPBackendTests, ConvBQ_ExistingPerChannel_Unaffected) {
+  // This duplicates ConvU16S4S32_PerChannel to act as a regression guard.
+  RunHTPConvOpPerChannelTest<uint16_t, Int4x2>(
+      "Conv",
+      TestInputDef<float>({1, 2, 4, 4}, false,
+                          GetFloatDataInRange(0.0f, 1.0f, SizeOfShape({1, 2, 4, 4}))),
+      TestInputDef<float>({3, 2, 2, 2}, true,
+                          GetFloatDataInRange(-1.0f, 5.0f, SizeOfShape({3, 2, 2, 2}))),
+      TestInputDef<float>({3}, true, GetFloatDataInRange(-1.0f, 1.0f, 3)),
+      0,             // weight quant axis
+      {1, 1},        // strides
+      {0, 0, 0, 0},  // pads
+      {1, 1},        // dilations
+      1,             // group
+      "NOTSET",
+      ExpectedEPNodeAssignment::All,
+      false,  // use_qdq_contrib_ops
+      21);    // opset
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if defined(_M_ARM64)

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -2909,14 +2909,17 @@ namespace {
 // block_size constraints: must be a multiple of 8 (4-bit), 4 (8-bit), or 16 (2-bit) per HTP.
 // weight_is_unsigned: true → use UINT weight type (UINT4 or UINT8); tests the
 //   unsigned→signed conversion path in conv_op_builder.cc (TransformUnsignedToSignedFixedPoint).
+// bias_per_channel: when include_bias is true, true → per-channel bias scale ([OC] values,
+//   axis=0); false → per-tensor bias scale (scalar). Exercises both bias dequant paths.
 GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
                                      const std::vector<int64_t>& weight_shape,
                                      int64_t block_size,
                                      bool include_bias = false,
                                      int weight_bits = 4,
-                                     bool weight_is_unsigned = false) {
+                                     bool weight_is_unsigned = false,
+                                     bool bias_per_channel = false) {
   return [input_shape, weight_shape, block_size, include_bias, weight_bits,
-          weight_is_unsigned](ModelTestBuilder& builder) -> void {
+          weight_is_unsigned, bias_per_channel](ModelTestBuilder& builder) -> void {
     const int64_t OC = weight_shape[0];
     const int64_t IC = weight_shape[1];
     const int64_t kH = weight_shape.size() >= 4 ? weight_shape[2] : 1;
@@ -3001,12 +3004,29 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     if (include_bias) {
       // Use INT32-quantized bias directly (no QL node — avoids ORT QL opset validation for INT32).
       // OrtConvNodeGroupSelector requires bias DQL input type == INT32 (qnn_ep_utils.cc:741).
-      const float bias_scale = act_scale * 0.03f;
-      builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
-      builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
-      builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(OC), 0));
-      builder.AddNode("bias_dql", "DequantizeLinear",
-                      {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
+      if (bias_per_channel) {
+        // Per-channel bias: distinct quantized value and scale per output channel (DQ axis=0).
+        // Non-zero quant values ensure the per-channel scale indexing is actually exercised.
+        // Omit zero_point (symmetric): ORT per-axis DQ requires zp be null or 1D of size OC.
+        std::vector<int32_t> bias_quant(static_cast<size_t>(OC));
+        std::vector<float> bias_scales(static_cast<size_t>(OC));
+        for (size_t i = 0; i < bias_quant.size(); ++i) {
+          bias_quant[i] = static_cast<int32_t>(i) - static_cast<int32_t>(OC) / 2;
+          bias_scales[i] = act_scale * (0.02f + 0.01f * static_cast<float>(i));
+        }
+        builder.Make1DInitializer<int32_t>("bias_quant", bias_quant);
+        builder.Make1DInitializer<float>("bias_scale", bias_scales);
+        builder.AddNode("bias_dql", "DequantizeLinear",
+                        {"bias_quant", "bias_scale"}, {"bias_dql_out"}, "",
+                        {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+      } else {
+        const float bias_scale = act_scale * 0.03f;
+        builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
+        builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
+        builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(OC), 0));
+        builder.AddNode("bias_dql", "DequantizeLinear",
+                        {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
+      }
       conv_inputs.push_back("bias_dql_out");
     }
     builder.AddNode("conv", "Conv",
@@ -3068,6 +3088,23 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_WithBias) {
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
                                       /*bias=*/true),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// 1x1 Conv with per-channel quantized bias (DQ axis=0, [OC] scales).
+// Exercises the per-channel branch of the INT32→FP16 bias dequantization.
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_WithBiasPerChannel) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/8,
+                                      /*bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/true),
                   GetBQConvProviderOptions(),
                   /*opset=*/21,
                   ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3005,53 +3005,38 @@ ProviderOptions GetBQConvProviderOptions() {
 }  // namespace
 
 // 1x1 Conv, INT4 weight, block_size=8, uint16 activation, no bias.
-// Validates that the BW_FLOAT_BLOCK kernel is reached (BQ path in conv_op_builder).
-// in0: u16, weight: int4 (scale=[4,2], block_size=8), out: u16
+// in0: u16, weight: int4 (scale=[4,2,1,1], block_size=8), out: u16
+// Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_NoBias) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
-  const std::filesystem::path json_dir = "ConvBQ_NoBias_dump";
-  std::filesystem::create_directories(json_dir);  // keep on failure for inspection
-
-  ProviderOptions opts = GetBQConvProviderOptions();
-  opts["dump_json_qnn_graph"] = "1";
-  opts["json_qnn_graph_dir"] = json_dir.string();
-
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
                                       /*bias=*/false),
-                  opts,
+                  GetBQConvProviderOptions(),
                   /*opset=*/21,
-                  ExpectedEPNodeAssignment::Some,
-                  /*fp32_abs_err=*/1e-2f,
-                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
-                  /*verify_outputs=*/false);
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
 }
 
-// 1x1 Conv with bias. Exercises the bias pass-through in the BQ bias path.
-// in0: u16, weight: int4 (scale=[4,2], block_size=8), bias: f32, out: u16
+// 1x1 Conv with bias. Exercises the INT32→FP16 bias dequantization path.
+// in0: u16, weight: int4 (scale=[4,2,1,1], block_size=8), bias: int32 DQ, out: u16
+// Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_WithBias) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
-  const std::filesystem::path json_dir = "ConvBQ_WithBias_dump";
-  std::filesystem::create_directories(json_dir);
-  ProviderOptions opts = GetBQConvProviderOptions();
-  opts["dump_json_qnn_graph"] = "1";
-  opts["json_qnn_graph_dir"] = json_dir.string();
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
                                       /*bias=*/true),
-                  opts,
+                  GetBQConvProviderOptions(),
                   /*opset=*/21,
-                  ExpectedEPNodeAssignment::Some,
-                  1e-2f,
-                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
-                  /*verify_outputs=*/false);
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
 }
 
 // 1x1 Conv with larger IC and more blocks per channel.
-// weight: int4 (IC=32, block_size=8, 4 blocks per OC), scale=[8,4]
-// in0: u16, out: u16
+// weight: int4 (IC=32, block_size=8, 4 blocks/OC), scale=[8,4,1,1]
+// Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_MultiBlock) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
@@ -3059,10 +3044,8 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_MultiBlock) {
                                       /*block_size=*/8),
                   GetBQConvProviderOptions(),
                   /*opset=*/21,
-                  ExpectedEPNodeAssignment::Some,
-                  1e-2f,
-                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
-                  /*verify_outputs=*/false);
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
 }
 
 // Regression: existing per-channel INT4 Conv (no block_size) continues to work.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -2905,14 +2905,18 @@ namespace {
 //             float scale [OC, IC/block_size, 1, 1] (axis=1, IC is the blocked dimension)
 //   - output: uint16 per-tensor symmetric Q/DQ
 //
-// weight_bits: 4 for INT4 (default), 8 for INT8, 2 for INT2.
+// weight_bits: 4 for INT4/UINT4 (default), 8 for INT8/UINT8, 2 for INT2.
 // block_size constraints: must be a multiple of 8 (4-bit), 4 (8-bit), or 16 (2-bit) per HTP.
+// weight_is_unsigned: true → use UINT weight type (UINT4 or UINT8); tests the
+//   unsigned→signed conversion path in conv_op_builder.cc (TransformUnsignedToSignedFixedPoint).
 GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
                                      const std::vector<int64_t>& weight_shape,
                                      int64_t block_size,
                                      bool include_bias = false,
-                                     int weight_bits = 4) {
-  return [input_shape, weight_shape, block_size, include_bias, weight_bits](ModelTestBuilder& builder) -> void {
+                                     int weight_bits = 4,
+                                     bool weight_is_unsigned = false) {
+  return [input_shape, weight_shape, block_size, include_bias, weight_bits,
+          weight_is_unsigned](ModelTestBuilder& builder) -> void {
     const int64_t OC = weight_shape[0];
     const int64_t IC = weight_shape[1];
     const int64_t kH = weight_shape.size() >= 4 ? weight_shape[2] : 1;
@@ -2941,20 +2945,41 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
 
     const size_t num_elems = static_cast<size_t>(OC * IC * kH * kW);
-    if (weight_bits == 4) {
+    if (weight_bits == 4 && !weight_is_unsigned) {
       // INT4 weight in range [-3, 3] (symmetric).
       std::vector<Int4x2> weight_data(Int4x2::CalcNumInt4Pairs(num_elems));
       for (size_t i = 0; i < num_elems; ++i) {
         weight_data[i >> 1].SetElem(i & 1, static_cast<int8_t>((i % 7) - 3));
       }
       builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, weight_data);
-    } else if (weight_bits == 2) {
+    } else if (weight_bits == 4 && weight_is_unsigned) {
+      // UINT4 weight in range [0, 14] (asymmetric-like; symmetric around 7 with zp omitted).
+      std::vector<UInt4x2> weight_data(UInt4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 1].SetElem(i & 1, static_cast<uint8_t>(i % 15));
+      }
+      builder.MakeInitializer<UInt4x2>("weight_quant", weight_shape, weight_data);
+    } else if (weight_bits == 2 && !weight_is_unsigned) {
       // INT2 weight in range [-1, 1] (symmetric, 4 elements per byte).
       std::vector<Int2x4> weight_data(Int2x4::CalcNumInt2Quads(num_elems));
       for (size_t i = 0; i < num_elems; ++i) {
         weight_data[i >> 2].SetElem(i & 3, static_cast<int8_t>((i % 3) - 1));
       }
       builder.MakeInitializer<Int2x4>("weight_quant", weight_shape, weight_data);
+    } else if (weight_bits == 2 && weight_is_unsigned) {
+      // UINT2 weight in range [0, 3] (full unsigned 2-bit range, 4 elements per byte).
+      std::vector<UInt2x4> weight_data(UInt2x4::CalcNumInt2Quads(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 2].SetElem(i & 3, static_cast<uint8_t>(i % 4));
+      }
+      builder.MakeInitializer<UInt2x4>("weight_quant", weight_shape, weight_data);
+    } else if (weight_is_unsigned) {
+      // UINT8 weight in range [0, 126] (symmetric around 63 with zp omitted).
+      std::vector<uint8_t> weight_data(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i] = static_cast<uint8_t>(i % 127);
+      }
+      builder.MakeInitializer<uint8_t>("weight_quant", weight_shape, weight_data);
     } else {
       // INT8 weight in range [-63, 63] (symmetric).
       std::vector<int8_t> weight_data(num_elems);
@@ -3128,20 +3153,94 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize8) {
                   /*fp32_abs_err=*/1e-2f);
 }
 
-// INT2, block_size=16: minimum valid HTP multiple-of-16 block size for 2-bit.
-// DISABLED: ORT's CPU DequantizeLinear kernel does not yet support tensor(int2).
-// Re-enable once ORT adds INT2 DQ support (the Int2x4 test infrastructure is ready).
-TEST_F(QnnHTPBackendTests, DISABLED_ConvBQ_U16Int2_1x1_BlockSize16) {
+// INT2, block_size=16: ORT rejects tensor(int2) as a DequantizeLinear input type at model
+// load time (ONNX type check), so session initialization throws. Use EXPECT_THROW to
+// actively guard against silent regressions. When ONNX spec and ORT model validation
+// accept tensor(int2), replace with a normal RunQnnModelTest (verify_outputs=false until
+// the CPU DQ kernel also supports int2).
+TEST_F(QnnHTPBackendTests, ConvBQ_U16Int2_1x1_BlockSize16) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
-  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
-                                      /*weight=*/{4, 32, 1, 1},
-                                      /*block_size=*/16,
+  EXPECT_THROW(
+      RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{4, 32, 1, 1},
+                                          /*block_size=*/16,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/2),
+                      GetBQConvProviderOptions(),
+                      /*opset=*/21,
+                      ExpectedEPNodeAssignment::All,
+                      /*fp32_abs_err=*/0.0f,
+                      OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                      /*verify_outputs=*/false),
+      std::exception);
+}
+
+// UINT2, block_size=16: same blocker as ConvBQ_U16Int2_1x1_BlockSize16.
+TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt2_1x1_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  EXPECT_THROW(
+      RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{4, 32, 1, 1},
+                                          /*block_size=*/16,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/2,
+                                          /*weight_is_unsigned=*/true),
+                      GetBQConvProviderOptions(),
+                      /*opset=*/21,
+                      ExpectedEPNodeAssignment::All,
+                      /*fp32_abs_err=*/0.0f,
+                      OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                      /*verify_outputs=*/false),
+      std::exception);
+}
+
+// UINT4 weight, block_size=8: exercises TransformUnsignedToSignedFixedPoint for 4-bit.
+// in0: u16, weight: uint4 (scale=[4,2,1,1], block_size=8), out: u16
+TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt4_1x1_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/8,
                                       /*bias=*/false,
-                                      /*weight_bits=*/2),
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/true),
                   GetBQConvProviderOptions(),
                   /*opset=*/21,
                   ExpectedEPNodeAssignment::All,
                   /*fp32_abs_err=*/1e-2f);
+}
+
+// UINT4 weight with bias: verifies unsigned weight path works with the FP16 bias dequantization.
+TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt4_1x1_WithBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/8,
+                                      /*bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/true),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// UINT8 weight, block_size=4: exercises TransformUnsignedToSignedFixedPoint for 8-bit.
+// block_size=4 is the minimum valid HTP multiple for 8-bit block quantization.
+// Tolerance 2e-2f: UINT8 weights [0,126] produce larger FP16 intermediate values than INT4/INT8,
+// leading to slightly larger rounding differences between CPU (FP32) and QNN (FP16).
+TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt8_1x1_BlockSize4) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/4,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/8,
+                                      /*weight_is_unsigned=*/true),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-2f);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3048,7 +3048,7 @@ ProviderOptions GetBQConvProviderOptions() {
 // in0: u16, weight: int4 (scale=[4,2,1,1], block_size=8), out: u16
 // Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_NoBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
@@ -3063,7 +3063,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_NoBias) {
 // in0: u16, weight: int4 (scale=[4,2,1,1], block_size=8), bias: int32 DQ, out: u16
 // Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_WithBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
@@ -3078,7 +3078,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_WithBias) {
 // weight: int4 (IC=32, block_size=8, 4 blocks/OC), scale=[8,4,1,1]
 // Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_MultiBlock) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                       /*weight=*/{8, 32, 1, 1},
                                       /*block_size=*/8),
@@ -3113,7 +3113,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_ExistingPerChannel_Unaffected) {
 // ── BQ Conv bitwidth / block_size variants ───────────────────────────────────
 // INT4, block_size=16: still a valid HTP multiple-of-8 block size.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_BlockSize16) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                       /*weight=*/{4, 32, 1, 1},
                                       /*block_size=*/16,
@@ -3127,7 +3127,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int4_1x1_BlockSize16) {
 
 // INT8, block_size=4: minimum valid HTP multiple-of-4 block size for 8-bit.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize4) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/4,
@@ -3141,7 +3141,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize4) {
 
 // INT8, block_size=8: larger block size, still a valid HTP multiple-of-4.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize8) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                       /*weight=*/{4, 32, 1, 1},
                                       /*block_size=*/8,
@@ -3159,7 +3159,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize8) {
 // accept tensor(int2), replace with a normal RunQnnModelTest (verify_outputs=false until
 // the CPU DQ kernel also supports int2).
 TEST_F(QnnHTPBackendTests, ConvBQ_U16Int2_1x1_BlockSize16) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   EXPECT_THROW(
       RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                           /*weight=*/{4, 32, 1, 1},
@@ -3177,7 +3177,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int2_1x1_BlockSize16) {
 
 // UINT2, block_size=16: same blocker as ConvBQ_U16Int2_1x1_BlockSize16.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt2_1x1_BlockSize16) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   EXPECT_THROW(
       RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                           /*weight=*/{4, 32, 1, 1},
@@ -3197,7 +3197,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt2_1x1_BlockSize16) {
 // UINT4 weight, block_size=8: exercises TransformUnsignedToSignedFixedPoint for 4-bit.
 // in0: u16, weight: uint4 (scale=[4,2,1,1], block_size=8), out: u16
 TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt4_1x1_NoBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
@@ -3212,7 +3212,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt4_1x1_NoBias) {
 
 // UINT4 weight with bias: verifies unsigned weight path works with the FP16 bias dequantization.
 TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt4_1x1_WithBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/8,
@@ -3230,7 +3230,7 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt4_1x1_WithBias) {
 // Tolerance 2e-2f: UINT8 weights [0,126] produce larger FP16 intermediate values than INT4/INT8,
 // leading to slightly larger rounding differences between CPU (FP32) and QNN (FP16).
 TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt8_1x1_BlockSize4) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
                                       /*weight=*/{4, 16, 1, 1},
                                       /*block_size=*/4,

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3153,45 +3153,44 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16Int8_1x1_BlockSize8) {
                   /*fp32_abs_err=*/1e-2f);
 }
 
-// INT2, block_size=16: ORT rejects tensor(int2) as a DequantizeLinear input type at model
-// load time (ONNX type check), so session initialization throws. Use EXPECT_THROW to
-// actively guard against silent regressions. When ONNX spec and ORT model validation
-// accept tensor(int2), replace with a normal RunQnnModelTest (verify_outputs=false until
-// the CPU DQ kernel also supports int2).
-TEST_F(QnnHTPBackendTests, ConvBQ_U16Int2_1x1_BlockSize16) {
+// INT2, block_size=16: DISABLED. Two independent blockers:
+//   1. ORT CPU backend does not support 2-bit Q/DQ — it rejects tensor(int2) as a
+//      DequantizeLinear input type at model load time (ONNX type check).
+//   2. QAIRT HTP backend does not support 2-bit BQ until QAIRT 2.47.
+// Re-enable once both are available (with verify_outputs=false until the CPU DQ
+// kernel supports int2 for accuracy comparison).
+TEST_F(QnnHTPBackendTests, DISABLED_ConvBQ_U16Int2_1x1_BlockSize16) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  EXPECT_THROW(
-      RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
-                                          /*weight=*/{4, 32, 1, 1},
-                                          /*block_size=*/16,
-                                          /*bias=*/false,
-                                          /*weight_bits=*/2),
-                      GetBQConvProviderOptions(),
-                      /*opset=*/21,
-                      ExpectedEPNodeAssignment::All,
-                      /*fp32_abs_err=*/0.0f,
-                      OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
-                      /*verify_outputs=*/false),
-      std::exception);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/16,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/2),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/0.0f,
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_outputs=*/false);
 }
 
-// UINT2, block_size=16: same blocker as ConvBQ_U16Int2_1x1_BlockSize16.
-TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt2_1x1_BlockSize16) {
+// UINT2, block_size=16: DISABLED. Same blockers as ConvBQ_U16Int2_1x1_BlockSize16 —
+// ORT CPU backend does not support 2-bit Q/DQ, and QAIRT HTP backend does not
+// support 2-bit BQ until QAIRT 2.47.
+TEST_F(QnnHTPBackendTests, DISABLED_ConvBQ_U16UInt2_1x1_BlockSize16) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  EXPECT_THROW(
-      RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
-                                          /*weight=*/{4, 32, 1, 1},
-                                          /*block_size=*/16,
-                                          /*bias=*/false,
-                                          /*weight_bits=*/2,
-                                          /*weight_is_unsigned=*/true),
-                      GetBQConvProviderOptions(),
-                      /*opset=*/21,
-                      ExpectedEPNodeAssignment::All,
-                      /*fp32_abs_err=*/0.0f,
-                      OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
-                      /*verify_outputs=*/false),
-      std::exception);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/16,
+                                      /*bias=*/false,
+                                      /*weight_bits=*/2,
+                                      /*weight_is_unsigned=*/true),
+                  GetBQConvProviderOptions(),
+                  /*opset=*/21,
+                  ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/0.0f,
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_outputs=*/false);
 }
 
 // UINT4 weight, block_size=8: exercises TransformUnsignedToSignedFixedPoint for 4-bit.

--- a/onnxruntime/test/unittest_util/model_test_builder.h
+++ b/onnxruntime/test/unittest_util/model_test_builder.h
@@ -20,6 +20,7 @@
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_cxx_api.h"
 #include "test/util/include/int4.h"
+#include "test/util/include/int2.h"
 #include "test/unittest_util/framework_test_utils.h"
 #include "test/util/include/test_random_seed.h"
 
@@ -216,6 +217,12 @@ struct IsTypeQuantLinearCompatible<Int4x2> : std::true_type {};
 template <>
 struct IsTypeQuantLinearCompatible<UInt4x2> : std::true_type {};
 
+template <>
+struct IsTypeQuantLinearCompatible<Int2x4> : std::true_type {};
+
+template <>
+struct IsTypeQuantLinearCompatible<UInt2x4> : std::true_type {};
+
 template <typename T>
 struct IsTypeDequantLinearCompatible : IsByteType<T> {};
 
@@ -233,6 +240,12 @@ struct IsTypeDequantLinearCompatible<Int4x2> : std::true_type {};
 
 template <>
 struct IsTypeDequantLinearCompatible<UInt4x2> : std::true_type {};
+
+template <>
+struct IsTypeDequantLinearCompatible<Int2x4> : std::true_type {};
+
+template <>
+struct IsTypeDequantLinearCompatible<UInt2x4> : std::true_type {};
 
 class ModelTestBuilder {
  public:
@@ -685,6 +698,10 @@ class ModelTestBuilder {
       return ONNX_NAMESPACE::TensorProto_DataType_UINT4;
     } else if constexpr (std::is_same_v<T, Int4x2>) {
       return ONNX_NAMESPACE::TensorProto_DataType_INT4;
+    } else if constexpr (std::is_same_v<T, UInt2x4>) {
+      return ONNX_NAMESPACE::TensorProto_DataType_UINT2;
+    } else if constexpr (std::is_same_v<T, Int2x4>) {
+      return ONNX_NAMESPACE::TensorProto_DataType_INT2;
     } else {
       return ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
     }

--- a/onnxruntime/test/util/include/int2.h
+++ b/onnxruntime/test/util/include/int2.h
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// QNN-EP COPY START
+// Below are Int2 dtype utilities copied from
+// onnxruntime/include/onnxruntime/core/framework/int2.h directly.
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+#include <gsl/gsl>
+
+namespace onnxruntime {
+namespace test {
+
+template <bool Signed>
+struct Int2Traits;
+
+template <>
+struct Int2Traits<true> {
+  using UnpackedType = int8_t;
+  static constexpr int8_t min_val = -2;
+  static constexpr int8_t max_val = 1;
+};
+
+template <>
+struct Int2Traits<false> {
+  using UnpackedType = uint8_t;
+  static constexpr uint8_t min_val = 0;
+  static constexpr uint8_t max_val = 3;
+};
+
+/// <summary>
+/// Stores 4 packed 2-bit elements in 1 byte.
+/// Packing follows ONNX spec: x0 | (x1 << 2) | (x2 << 4) | (x3 << 6)
+/// </summary>
+/// <typeparam name="Signed">Set to true if signed int2, or false if unsigned uint2.</typeparam>
+template <bool Signed>
+struct Int2x4Base {
+  using UnpackedType = typename Int2Traits<Signed>::UnpackedType;
+  static constexpr UnpackedType min_val = Int2Traits<Signed>::min_val;
+  static constexpr UnpackedType max_val = Int2Traits<Signed>::max_val;
+
+  std::byte bits_{};
+
+  Int2x4Base() = default;
+
+  explicit Int2x4Base(std::byte bits) {
+    bits_ = bits;
+  }
+
+  Int2x4Base(UnpackedType val0, UnpackedType val1, UnpackedType val2, UnpackedType val3) {
+    bits_ = static_cast<std::byte>(
+        (val0 & 0x3) |
+        ((val1 & 0x3) << 2) |
+        ((val2 & 0x3) << 4) |
+        ((val3 & 0x3) << 6));
+  }
+
+  static inline int8_t SignExtendLower2Bits(std::byte bits) {
+    // Sign-extend lower 2-bits by left shifting and then doing an arithmetic right shift.
+    constexpr uint8_t shift = (sizeof(int32_t) * 8) - 2;
+    return static_cast<int8_t>((static_cast<int32_t>(bits) << shift) >> shift);
+  }
+
+  inline UnpackedType GetElem(size_t index) const {
+    assert(index <= 3);
+    const uint8_t shift = 2 * static_cast<uint8_t>(index);
+    const std::byte val = (bits_ >> shift) & std::byte{0x3};
+
+    if constexpr (Signed) {
+      return SignExtendLower2Bits(val);
+    } else {
+      return static_cast<UnpackedType>(val);
+    }
+  }
+
+  inline void SetElem(size_t index, UnpackedType val) {
+    assert(index <= 3);
+    const uint8_t shift = 2 * static_cast<uint8_t>(index);
+    const std::byte clear_mask = ~(std::byte{0x3} << shift);
+
+    bits_ &= clear_mask;                                     // Clear 2-bit element to 0
+    bits_ |= static_cast<std::byte>((val & 0x3) << shift);  // Set 2-bit element to val
+  }
+
+  inline std::byte ToBits() const {
+    return bits_;
+  }
+
+  /// <summary>
+  /// Calculates the number of packed byte units needed to store the given number of 2-bit elements.
+  /// Each byte stores 4 x 2-bit elements.
+  /// </summary>
+  static size_t CalcNumInt2Quads(size_t num_int2_elems) {
+    return (num_int2_elems + 3) / 4;
+  }
+
+  /// <summary>
+  /// Copy a source buffer of 2-bit elements (packed) into a destination buffer of 8-bit elements (unpacked).
+  /// </summary>
+  static bool Unpack(gsl::span<UnpackedType> dst, gsl::span<const Int2x4Base<Signed>> src) {
+    if (CalcNumInt2Quads(dst.size()) != src.size()) {
+      return false;
+    }
+
+    if (src.empty()) {
+      return true;
+    }
+
+    for (size_t i = 0; i < dst.size(); i++) {
+      size_t byte_idx = i >> 2;   // i / 4
+      size_t elem_idx = i & 0x3;  // i % 4
+      dst[i] = src[byte_idx].GetElem(elem_idx);
+    }
+
+    return true;
+  }
+
+  /// <summary>
+  /// Copy a source buffer of 8-bit elements (unpacked) into a destination buffer of 2-bit elements (packed).
+  /// </summary>
+  static bool Pack(gsl::span<Int2x4Base<Signed>> dst, gsl::span<const UnpackedType> src) {
+    if (CalcNumInt2Quads(src.size()) != dst.size()) {
+      return false;
+    }
+
+    if (src.empty()) {
+      return true;
+    }
+
+    size_t src_i = 0;
+    size_t dst_i = 0;
+    const size_t full_quads = src.size() / 4;
+
+    for (; dst_i < full_quads; dst_i++) {
+      dst[dst_i] = Int2x4Base<Signed>(src[src_i], src[src_i + 1], src[src_i + 2], src[src_i + 3]);
+      src_i += 4;
+    }
+
+    // Handle remaining elements (1-3)
+    if (src_i < src.size()) {
+      UnpackedType vals[4] = {0, 0, 0, 0};
+      size_t remaining = src.size() - src_i;
+      for (size_t j = 0; j < remaining; j++) {
+        vals[j] = src[src_i + j];
+      }
+      dst[dst_i] = Int2x4Base<Signed>(vals[0], vals[1], vals[2], vals[3]);
+    }
+
+    return true;
+  }
+
+  /// <summary>
+  /// Returns hierarchical indices for a packed int2 element from the given element index.
+  /// </summary>
+  static inline std::pair<size_t, size_t> GetTensorElemIndices(size_t index) {
+    return {index >> 2, index & 0x3};
+  }
+};
+
+using Int2x4 = Int2x4Base<true>;
+using UInt2x4 = Int2x4Base<false>;
+static_assert(sizeof(Int2x4) == sizeof(std::byte));
+static_assert(sizeof(UInt2x4) == sizeof(std::byte));
+// QNN-EP COPY END
+
+}  // namespace test
+}  // namespace onnxruntime

--- a/onnxruntime/test/util/include/int2.h
+++ b/onnxruntime/test/util/include/int2.h
@@ -80,7 +80,7 @@ struct Int2x4Base {
     const uint8_t shift = 2 * static_cast<uint8_t>(index);
     const std::byte clear_mask = ~(std::byte{0x3} << shift);
 
-    bits_ &= clear_mask;                                     // Clear 2-bit element to 0
+    bits_ &= clear_mask;                                    // Clear 2-bit element to 0
     bits_ |= static_cast<std::byte>((val & 0x3) << shift);  // Set 2-bit element to val
   }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Enables block-quantized weight Conv on QNN HTP via the BW_FLOAT_BLOCK kernel (BQ path)
- Add int2 support in core and test framework
- Add corresponding unit tests

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Support Block Quantization in QNN

