### PR TITLE
Avoid private ORT Core header in Test Framework - Phase 3: Handle device/model compatibility testcases

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -144,6 +144,7 @@ code = 'PRIVATE-ORT-HEADERS'
 include_patterns = [
     'onnxruntime/core/providers/qnn/**/*.h',
     'onnxruntime/core/providers/qnn/**/*.cc',
+    'cmake/external/onnxruntime_prebuilt.cmake',
     'cmake/onnxruntime_providers_qnn.cmake',
     'cmake/onnxruntime_unittests.cmake',
 ]

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -145,6 +145,7 @@ include_patterns = [
     'onnxruntime/core/providers/qnn/**/*.h',
     'onnxruntime/core/providers/qnn/**/*.cc',
     'cmake/onnxruntime_providers_qnn.cmake',
+    'cmake/onnxruntime_unittests.cmake',
 ]
 command = [
     'python',

--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -24,6 +24,7 @@ if(onnxruntime_ORT_HOME)
     message(STATUS "Use prebuilt from MS only at ${onnxruntime_ORT_HOME}. ORT Core will NOT be built from source")
     set(ORT_BUILD_COMMAND ${CMAKE_COMMAND} -E echo "Skipping ORT_BUILD_COMMAND")
     set(ORT_PREBUILT_SOURCE "${onnxruntime_ORT_HOME}/lib")
+    set(ONNXRUNTIME_APPLICATION_INCLUDES "${onnxruntime_ORT_HOME}/include")
 else()
     # Use Python to run build.py
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
@@ -120,6 +121,12 @@ else()
         # Single-config generators: executable is directly in build directory
         set(ORT_PREBUILT_SOURCE "${ORT_BUILD_DIR}/${CMAKE_BUILD_TYPE}")
     endif()
+
+    set(ONNXRUNTIME_APPLICATION_INCLUDES
+        # For onnxruntime_cxx_api.h
+        "${ORT_SOURCE_DIR}/include/onnxruntime/core/session"
+        # For cpu_provider_factory.h (Note: cpu_provider_factory.h is a public header released in ORT prebuilt)
+        "${ORT_SOURCE_DIR}/include/onnxruntime/core/providers/cpu")
 endif()
 
 # Define platform-specific file lists.
@@ -216,10 +223,6 @@ ExternalProject_Add(
     USES_TERMINAL_BUILD ON
 )
 
-# TODO: In long-term, we aim to remove the dependency of QNN-EP plugin library on ORT Core
-set(ONNXRUNTIME_APPLICATION_SOURCE_ROOT "${ORT_SOURCE_DIR}/onnxruntime")
-set(ONNXRUNTIME_APPLICATION_INCLUDE_ROOT "${ORT_SOURCE_DIR}/include/onnxruntime")
-
 # Create imported target for ONNX Runtime
 add_library(onnxruntime SHARED IMPORTED GLOBAL)
 add_dependencies(onnxruntime ort_core_target)
@@ -229,9 +232,6 @@ if(NOT ANDROID)
     add_library(onnxruntime_providers_shared SHARED IMPORTED GLOBAL)
     add_dependencies(onnxruntime_providers_shared ort_core_target)
 endif()
-
-# Hack since cmake check the existence of INTERFACE_INCLUDE_DIRECTORIES
-file(MAKE_DIRECTORY ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT})
 
 # Platform-specific library configuration
 if(WIN32)

--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -45,9 +45,9 @@
 
   add_dependencies(onnxruntime_providers_qnn ort_core_target)
 
-  message(STATUS ONNXRUNTIME_APPLICATION_SOURCE_ROOT ${ONNXRUNTIME_APPLICATION_SOURCE_ROOT})
+  message(STATUS "ONNXRUNTIME_APPLICATION_INCLUDES: " ${ONNXRUNTIME_APPLICATION_INCLUDES})
   target_include_directories(onnxruntime_providers_qnn PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-                                                               ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session
+                                                               ${ONNXRUNTIME_APPLICATION_INCLUDES}
                                                                ${onnxruntime_QNN_HOME}/include/QNN
                                                                ${onnxruntime_QNN_HOME}/include)
 

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 set(TEST_SRC_DIR ${ONNXRUNTIME_ROOT}/test)
-set(TEST_INC_DIR ${ONNXRUNTIME_APPLICATION_SOURCE_ROOT})
 
 # Exclude files based on CMake options.
 function(filter_test_srcs test_srcs_var)
@@ -95,7 +94,6 @@ function(AddTest)
   endif()
 
   onnxruntime_add_include_to_target(${_UT_TARGET} date::date flatbuffers::flatbuffers)
-  target_include_directories(${_UT_TARGET} PRIVATE ${TEST_INC_DIR})
 
   if(MSVC)
     target_compile_options(${_UT_TARGET} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /utf-8>"
@@ -234,8 +232,7 @@ onnxruntime_add_include_to_target(onnxruntime_test_utils GTest::gtest GTest::gmo
                                   safeint_interface Eigen3::Eigen ${GSL_TARGET} date::date ${ABSEIL_LIBS})
 add_dependencies(onnxruntime_test_utils ${onnxruntime_EXTERNAL_DEPENDENCIES})
 target_include_directories(onnxruntime_test_utils PUBLIC "${TEST_SRC_DIR}/util/include"
-                           PRIVATE
-                           ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session
+                           PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDES}
                            )
 set_target_properties(onnxruntime_test_utils PROPERTIES FOLDER "ONNXRuntimeTest")
 source_group(TREE ${TEST_SRC_DIR} FILES ${onnxruntime_test_utils_src})
@@ -255,7 +252,7 @@ onnxruntime_add_static_library(onnxruntime_unittest_utils ${onnxruntime_unittest
 add_dependencies(onnxruntime_unittest_utils ort_core_target)
 
 target_include_directories(onnxruntime_unittest_utils PRIVATE
-                           ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session
+                           ${ONNXRUNTIME_APPLICATION_INCLUDES}
                            "${TEST_SRC_DIR}/util/include"
                            )
 
@@ -345,16 +342,13 @@ block()
     target_compile_definitions(onnxruntime_provider_test PRIVATE ORT_UNIT_TEST_BUILD)
   endif()
 
-  # For onnxruntime_cxx_api.h
-  target_include_directories(onnxruntime_provider_test PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session)
-
-  # For cpu_provider_factory.h (Note: cpu_provider_factory.h is a public header released in ORT prebuilt)
-  target_include_directories(onnxruntime_provider_test PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/providers/cpu)
+  # Dependency on ORT Core public header files
+  target_include_directories(onnxruntime_provider_test PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDES})
 
   add_custom_command(
     TARGET onnxruntime_provider_test POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${ONNXRUNTIME_APPLICATION_SOURCE_ROOT}/test/testdata
+    ${ort_core_SOURCE_DIR}/onnxruntime/test/testdata
     $<TARGET_FILE_DIR:onnxruntime_provider_test>/testdata
   )
 
@@ -419,7 +413,7 @@ endif()
       ${ep_weight_sharing_ctx_gen_src_patterns}
       )
     onnxruntime_add_executable(ep_weight_sharing_ctx_gen ${ep_weight_sharing_ctx_gen_src})
-    target_include_directories(ep_weight_sharing_ctx_gen PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session)
+    target_include_directories(ep_weight_sharing_ctx_gen PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDES})
     if (WIN32)
       target_compile_options(ep_weight_sharing_ctx_gen PRIVATE ${disabled_warnings})
       if (NOT DEFINED SYS_PATH_LIB)

--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -225,7 +225,6 @@ if(MSVC)
   target_compile_options(onnxruntime_test_utils PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /wd6326>"
                 "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/wd6326>")
 else()
-  target_include_directories(onnxruntime_test_utils PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${ONNXRUNTIME_ROOT})
   if (HAS_CHARACTER_CONVERSION)
     target_compile_options(onnxruntime_test_utils PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-error=character-conversion>")
   endif()
@@ -236,8 +235,6 @@ onnxruntime_add_include_to_target(onnxruntime_test_utils GTest::gtest GTest::gmo
 add_dependencies(onnxruntime_test_utils ${onnxruntime_EXTERNAL_DEPENDENCIES})
 target_include_directories(onnxruntime_test_utils PUBLIC "${TEST_SRC_DIR}/util/include"
                            PRIVATE
-                           ${ONNXRUNTIME_APPLICATION_SOURCE_ROOT}
-                           ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}
                            ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session
                            )
 set_target_properties(onnxruntime_test_utils PROPERTIES FOLDER "ONNXRuntimeTest")
@@ -258,8 +255,6 @@ onnxruntime_add_static_library(onnxruntime_unittest_utils ${onnxruntime_unittest
 add_dependencies(onnxruntime_unittest_utils ort_core_target)
 
 target_include_directories(onnxruntime_unittest_utils PRIVATE
-                           ${ONNXRUNTIME_APPLICATION_SOURCE_ROOT}
-                           ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}
                            ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session
                            "${TEST_SRC_DIR}/util/include"
                            )
@@ -349,8 +344,6 @@ block()
     # the rest of the test binary.
     target_compile_definitions(onnxruntime_provider_test PRIVATE ORT_UNIT_TEST_BUILD)
   endif()
-
-  target_include_directories(onnxruntime_provider_test PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT})
 
   # For onnxruntime_cxx_api.h
   target_include_directories(onnxruntime_provider_test PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session)
@@ -446,23 +439,6 @@ endif()
 
     set_target_properties(ep_weight_sharing_ctx_gen PROPERTIES FOLDER "ONNXRuntimeTest")
   endif()
-
-  # the debug node IO functionality uses static variables, so it is best tested
-  # in its own process
-  if(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS)
-    AddTest(
-      TARGET onnxruntime_test_debug_node_inputs_outputs
-      SOURCES
-        "${TEST_SRC_DIR}/debug_node_inputs_outputs/debug_node_inputs_outputs_utils_test.cc"
-        "${TEST_SRC_DIR}/providers/provider_test_utils.h"
-        ${onnxruntime_unittest_main_src}
-      LIBS ${onnxruntime_test_providers_libs} ${onnxruntime_test_common_libs}
-      DEPENDS ${all_dependencies}
-    )
-
-    target_compile_definitions(onnxruntime_test_debug_node_inputs_outputs
-      PRIVATE DEBUG_NODE_INPUTS_OUTPUTS)
-  endif(onnxruntime_DEBUG_NODE_INPUTS_OUTPUTS)
 
   #some ETW tools
   if(WIN32 AND onnxruntime_ENABLE_INSTRUMENT)

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -354,7 +354,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
   // EP has not been created yet. Create a temporary QNN EP for validation.
   const auto provider_prefix = GetProviderOptionPrefix(factory->ep_name_);
 
-  // Determine backend type from the provided devices (prefer NPU, then GPU).
+  // Determine backend type from the provided devices (Only supports NPU currently).
   std::string backend_type;
   for (size_t i = 0; i < num_devices; ++i) {
     auto device_type = factory->ort_api.HardwareDevice_Type(devices[i]);
@@ -363,9 +363,12 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
       break;
     }
   }
-  RETURN_IF(backend_type.empty(),
-            "Currently QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl only supports OrtHardwareDeviceType_NPU, but "
-            "no OrtHardwareDeviceType_NPU is found in the `devices` argument.");
+  if (backend_type.empty()) {
+    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+    return factory->ort_api.CreateStatus(ORT_EP_FAIL,
+                                         "Currently QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl only supports OrtHardwareDeviceType_NPU, but "
+                                         "no OrtHardwareDeviceType_NPU is found in the `devices` argument.");
+  }
 
   using SessionOptionsUniquePtr = std::unique_ptr<OrtSessionOptions, std::function<void(OrtSessionOptions*)>>;
   OrtSessionOptions* temp_session_options = nullptr;

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -364,17 +364,23 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
     }
   }
   RETURN_IF(backend_type.empty(),
-    "Currently QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl only supports OrtHardwareDeviceType_NPU, but "
-    "no OrtHardwareDeviceType_NPU is found in the `devices` argument.");
+            "Currently QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl only supports OrtHardwareDeviceType_NPU, but "
+            "no OrtHardwareDeviceType_NPU is found in the `devices` argument.");
 
   using SessionOptionsUniquePtr = std::unique_ptr<OrtSessionOptions, std::function<void(OrtSessionOptions*)>>;
   OrtSessionOptions* temp_session_options = nullptr;
-  RETURN_IF_NOT_NULL(factory->ort_api.CreateSessionOptions(&temp_session_options));
+  if (OrtStatus* _status = factory->ort_api.CreateSessionOptions(&temp_session_options)) {
+    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+    return _status;
+  }
   SessionOptionsUniquePtr session_options(temp_session_options, factory->ort_api.ReleaseSessionOptions);
 
-  RETURN_IF_NOT_NULL(factory->ort_api.AddSessionConfigEntry(session_options.get(),
-                                                            (provider_prefix + "backend_type").c_str(),
-                                                            backend_type.c_str()));
+  if (OrtStatus* _status = factory->ort_api.AddSessionConfigEntry(session_options.get(),
+                                                                  (provider_prefix + "backend_type").c_str(),
+                                                                  backend_type.c_str())) {
+    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+    return _status;
+  }
 
   if (!OrtLoggingManager::HasDefaultLogger()) {
     *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -384,7 +384,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
 
   if (!OrtLoggingManager::HasDefaultLogger()) {
     *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return factory->ort_api.CreateStatus(ORT_FAIL, "Default logger is not available for model compatibility check.");
+    return factory->ort_api.CreateStatus(ORT_EP_FAIL, "Default logger is not available for model compatibility check.");
   }
   const OrtLogger* logger = OrtLoggingManager::GetDefaultLoggerPtr();
 
@@ -393,10 +393,10 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
     temp_qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *session_options.get(), logger);
   } catch (const std::exception& e) {
     *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return factory->ort_api.CreateStatus(ORT_FAIL, e.what());
+    return factory->ort_api.CreateStatus(ORT_EP_FAIL, e.what());
   } catch (...) {
     *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return factory->ort_api.CreateStatus(ORT_FAIL, "Unknown exception occurred while creating temporary QNN EP for compatibility check.");
+    return factory->ort_api.CreateStatus(ORT_EP_FAIL, "Unknown exception occurred while creating temporary QNN EP for compatibility check.");
   }
 
   return temp_qnn_ep->ValidateCompiledModelCompatibilityInfo(devices,

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -344,17 +344,65 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
     _Out_ OrtCompiledModelCompatibility* model_compatibility) noexcept {
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
 
-  if (factory->qnn_ep_ == nullptr) {
-    // Currently we require EP must first be created as QNN backend is mandatory for validating the compatibility.
-    // Possibly consider creating a fake EP for validation only if necessary.
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return factory->ort_api.CreateStatus(ORT_EP_FAIL, "Unable to validate model compatibility without EP created.");
+  if (factory->qnn_ep_ != nullptr) {
+    return factory->qnn_ep_->ValidateCompiledModelCompatibilityInfo(devices,
+                                                                    num_devices,
+                                                                    compatibility_info,
+                                                                    model_compatibility);
   }
 
-  return factory->qnn_ep_->ValidateCompiledModelCompatibilityInfo(devices,
-                                                                  num_devices,
-                                                                  compatibility_info,
-                                                                  model_compatibility);
+  // EP has not been created yet. Create a temporary QNN EP for validation.
+  const auto provider_prefix = GetProviderOptionPrefix(factory->ep_name_);
+
+  // Determine backend type from the provided devices (prefer NPU, then GPU).
+  std::string backend_type;
+  for (size_t i = 0; i < num_devices; ++i) {
+    auto device_type = factory->ort_api.HardwareDevice_Type(devices[i]);
+    auto it = kSupportedBackendTypes.find(device_type);
+    if (it != kSupportedBackendTypes.end()) {
+      if (device_type == OrtHardwareDeviceType_NPU) {
+        backend_type = it->second;
+        break;
+      } else if (backend_type.empty() && device_type != OrtHardwareDeviceType_CPU) {
+        backend_type = it->second;
+      }
+    }
+  }
+
+  if (backend_type.empty()) {
+    backend_type = "htp";  // Default to HTP if no suitable device found.
+  }
+
+  using SessionOptionsUniquePtr = std::unique_ptr<OrtSessionOptions, std::function<void(OrtSessionOptions*)>>;
+  OrtSessionOptions* temp_session_options = nullptr;
+  RETURN_IF_NOT_NULL(factory->ort_api.CreateSessionOptions(&temp_session_options));
+  SessionOptionsUniquePtr session_options(temp_session_options, factory->ort_api.ReleaseSessionOptions);
+
+  RETURN_IF_NOT_NULL(factory->ort_api.AddSessionConfigEntry(session_options.get(),
+                                                            (provider_prefix + "backend_type").c_str(),
+                                                            backend_type.c_str()));
+
+  if (!OrtLoggingManager::HasDefaultLogger()) {
+    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+    return factory->ort_api.CreateStatus(ORT_FAIL, "Default logger is not available for model compatibility check.");
+  }
+  const OrtLogger* logger = OrtLoggingManager::GetDefaultLoggerPtr();
+
+  std::unique_ptr<QnnEp> temp_qnn_ep;
+  try {
+    temp_qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *session_options.get(), logger);
+  } catch (const std::exception& e) {
+    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+    return factory->ort_api.CreateStatus(ORT_FAIL, e.what());
+  } catch (...) {
+    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+    return factory->ort_api.CreateStatus(ORT_FAIL, "Unknown exception occurred while creating temporary QNN EP for compatibility check.");
+  }
+
+  return temp_qnn_ep->ValidateCompiledModelCompatibilityInfo(devices,
+                                                             num_devices,
+                                                             compatibility_info,
+                                                             model_compatibility);
 }
 
 OrtStatus* ORT_API_CALL QnnEpFactory::GetHardwareDeviceIncompatibilityDetailsImpl(

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -358,20 +358,14 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
   std::string backend_type;
   for (size_t i = 0; i < num_devices; ++i) {
     auto device_type = factory->ort_api.HardwareDevice_Type(devices[i]);
-    auto it = kSupportedBackendTypes.find(device_type);
-    if (it != kSupportedBackendTypes.end()) {
-      if (device_type == OrtHardwareDeviceType_NPU) {
-        backend_type = it->second;
-        break;
-      } else if (backend_type.empty() && device_type != OrtHardwareDeviceType_CPU) {
-        backend_type = it->second;
-      }
+    if (device_type == OrtHardwareDeviceType_NPU) {
+      backend_type = "htp";
+      break;
     }
   }
-
-  if (backend_type.empty()) {
-    backend_type = "htp";  // Default to HTP if no suitable device found.
-  }
+  RETURN_IF(backend_type.empty(),
+    "Currently QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl only supports OrtHardwareDeviceType_NPU, but "
+    "no OrtHardwareDeviceType_NPU is found in the `devices` argument.");
 
   using SessionOptionsUniquePtr = std::unique_ptr<OrtSessionOptions, std::function<void(OrtSessionOptions*)>>;
   OrtSessionOptions* temp_session_options = nullptr;

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -8,9 +8,6 @@
 
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
-#include "test/unittest_util/tester_types.h"
-
-#include "core/graph/onnx_protobuf.h"
 
 #include "gtest/gtest.h"
 
@@ -137,7 +134,7 @@ void _BuildGRUTestCase(ModelTestBuilder& builder,
 
   builder.AddNode("gru", "GRU", input_names, output_names, "", attrs);
 
-  ORT_UNUSED_PARAMETER(output_qparams);
+  QNN_TEST_UNUSED_PARAMETER(output_qparams);
   if constexpr (kIsU8) {
     size_t i = 0;
     if (has_Y) {

--- a/onnxruntime/test/providers/qnn/lstm_test.cc
+++ b/onnxruntime/test/providers/qnn/lstm_test.cc
@@ -8,7 +8,6 @@
 
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
-#include "test/unittest_util/tester_types.h"
 
 #include "gtest/gtest.h"
 

--- a/onnxruntime/test/providers/qnn/qnn_device_compatibility_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_device_compatibility_test.cc
@@ -110,6 +110,7 @@ TEST_F(QnnDeviceCompatibilityTests, NPUDeviceWithQualcommVendorIsCompatible) {
 
   ASSERT_NE(registered_ep_device, nullptr);
 
+  // Create a mock NPU device with Qualcomm vendor ID
   ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
@@ -141,6 +142,7 @@ TEST_F(QnnDeviceCompatibilityTests, GPUDeviceWithQualcommVendorIsCompatible) {
 
   ASSERT_NE(registered_ep_device, nullptr);
 
+  // Create a mock GPU device with Qualcomm vendor ID
   ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
@@ -379,6 +381,7 @@ TEST_F(QnnDeviceCompatibilityTests, GPUDeviceIncompatibilityDetailsWithDriverInc
 
   ASSERT_NE(registered_ep_device, nullptr);
 
+  // Create a mock GPU device with Qualcomm vendor ID
   ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id));
 
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
@@ -429,6 +432,7 @@ TEST_F(QnnDeviceCompatibilityTests, NPUDeviceIncompatibilityDetailsWithDeviceInc
 
   ASSERT_NE(registered_ep_device, nullptr);
 
+  // Create a mock NPU device with Qualcomm vendor ID
   ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id));
 
   OrtDeviceEpIncompatibilityDetails* details = nullptr;

--- a/onnxruntime/test/providers/qnn/qnn_device_compatibility_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_device_compatibility_test.cc
@@ -8,9 +8,8 @@
 #include <vector>
 #include <iostream>
 
-#include "core/session/abi_devices.h"
-#include "core/session/onnxruntime_cxx_api.h"
-#include "core/session/onnxruntime_session_options_config_keys.h"
+#include "onnxruntime_cxx_api.h"
+#include "onnxruntime_session_options_config_keys.h"
 
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/util/include/api_asserts.h"
@@ -35,41 +34,57 @@ class QnnDeviceCompatibilityTests : public ::testing::Test {
     api_ = &Ort::GetApi();
     ASSERT_NE(api_, nullptr);
 
+    // Get the ORT EP API
+    ep_api_ = &Ort::GetEpApi();
+    ASSERT_NE(ep_api_, nullptr);
+
     env_ = static_cast<OrtEnv*>(*ort_env);
     ASSERT_NE(env_, nullptr);
   }
 
-  // Helper function to create a mock hardware device
-  OrtHardwareDevice CreateMockDevice(OrtHardwareDeviceType type, uint32_t vendor_id) {
-    OrtHardwareDevice device{};
-    device.type = type;
-    device.vendor_id = vendor_id;
-    device.device_id = 0;
-    return device;
+  void TearDown() override {
+    if (mock_hw_device != nullptr) {
+      ep_api_->ReleaseHardwareDevice(mock_hw_device);
+    }
   }
 
+  // Helper function to create a mock hardware device
+  OrtStatus* CreateMockHardwareDevice(OrtHardwareDeviceType type, uint32_t vendor_id) {
+    return ep_api_->CreateHardwareDevice(
+        type,
+        vendor_id,
+        0 /* device_id */,
+        "QCOM" /* vendor_name */,
+        nullptr /* metadata */,
+        &mock_hw_device);
+  }
+
+  const uint32_t qualcomm_vendor_id{'Q' | ('C' << 8) | ('O' << 16) | ('M' << 24)};
+  OrtHardwareDevice* mock_hw_device{};
+
   const OrtApi* api_ = nullptr;
+  const OrtEpApi* ep_api_ = nullptr;
   OrtEnv* env_ = nullptr;
 };
 
 // Test that CPU devices are compatible
 TEST_F(QnnDeviceCompatibilityTests, CPUDeviceIsCompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "cpu";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
 
   // Create a mock CPU device
-  OrtHardwareDevice cpu_device = CreateMockDevice(OrtHardwareDeviceType_CPU, 0);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_CPU, 0));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &cpu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Verify compatible (no incompatibility reasons)
@@ -86,26 +101,21 @@ TEST_F(QnnDeviceCompatibilityTests, CPUDeviceIsCompatible) {
 
 // Test that NPU devices with Qualcomm vendor ID are compatible
 TEST_F(QnnDeviceCompatibilityTests, NPUDeviceWithQualcommVendorIsCompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "htp";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
 
-  // Get the Qualcomm vendor ID from the factory
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
-
-  // Create a mock NPU device with Qualcomm vendor ID
-  OrtHardwareDevice npu_device = CreateMockDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &npu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Verify compatible (no incompatibility reasons)
@@ -122,26 +132,21 @@ TEST_F(QnnDeviceCompatibilityTests, NPUDeviceWithQualcommVendorIsCompatible) {
 
 // Test that GPU devices with Qualcomm vendor ID are compatible
 TEST_F(QnnDeviceCompatibilityTests, GPUDeviceWithQualcommVendorIsCompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "gpu";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
 
-  // Get the Qualcomm vendor ID from the factory
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
-
-  // Create a mock GPU device with Qualcomm vendor ID
-  OrtHardwareDevice gpu_device = CreateMockDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &gpu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Check if GPU device is incompatible for any reason - if so, skip this test
@@ -165,27 +170,23 @@ TEST_F(QnnDeviceCompatibilityTests, GPUDeviceWithQualcommVendorIsCompatible) {
 
 // Test that NPU devices with non-Qualcomm vendor ID are incompatible
 TEST_F(QnnDeviceCompatibilityTests, NPUDeviceWithNonQualcommVendorIsIncompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "htp";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
-
-  // Get the Qualcomm vendor ID from the factory
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
 
   // Create a mock NPU device with a different vendor ID (not Qualcomm)
   uint32_t non_qualcomm_vendor_id = qualcomm_vendor_id + 1;
-  OrtHardwareDevice npu_device = CreateMockDevice(OrtHardwareDeviceType_NPU, non_qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_NPU, non_qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &npu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Verify incompatible (should have incompatibility reasons)
@@ -198,27 +199,23 @@ TEST_F(QnnDeviceCompatibilityTests, NPUDeviceWithNonQualcommVendorIsIncompatible
 
 // Test that GPU devices with non-Qualcomm vendor ID are incompatible
 TEST_F(QnnDeviceCompatibilityTests, GPUDeviceWithNonQualcommVendorIsIncompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "gpu";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
-
-  // Get the Qualcomm vendor ID from the factory
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
 
   // Create a mock GPU device with a different vendor ID (not Qualcomm)
   uint32_t non_qualcomm_vendor_id = qualcomm_vendor_id + 1;
-  OrtHardwareDevice gpu_device = CreateMockDevice(OrtHardwareDeviceType_GPU, non_qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_GPU, non_qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &gpu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Verify incompatible (should have incompatibility reasons)
@@ -232,22 +229,22 @@ TEST_F(QnnDeviceCompatibilityTests, GPUDeviceWithNonQualcommVendorIsIncompatible
 // Test that CPU device incompatibility details include MISSING_DEPENDENCY and QNN_COMMON_ERROR_PLATFORM_NOT_SUPPORTED
 // Note: This should be tested by manually removing the CPU dependency
 TEST_F(QnnDeviceCompatibilityTests, CPUDeviceIncompatibilityDetailsWithMissingDependency) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "cpu";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
 
   // Create a mock CPU device
-  OrtHardwareDevice cpu_device = CreateMockDevice(OrtHardwareDeviceType_CPU, 0);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_CPU, 0));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &cpu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Check if device is compatible - if so, skip this test
@@ -276,26 +273,22 @@ TEST_F(QnnDeviceCompatibilityTests, CPUDeviceIncompatibilityDetailsWithMissingDe
 // Test that NPU device incompatibility details include MISSING_DEPENDENCY and QNN_COMMON_ERROR_PLATFORM_NOT_SUPPORTED
 // Note: This should be tested by manually removing the NPU dependency
 TEST_F(QnnDeviceCompatibilityTests, NPUDeviceIncompatibilityDetailsWithMissingDependency) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "htp";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
-
-  // Get the Qualcomm vendor ID from the factory
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
 
   // Create a mock NPU device with Qualcomm vendor ID
-  OrtHardwareDevice npu_device = CreateMockDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &npu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Check if device is compatible - if so, skip this test
@@ -324,26 +317,22 @@ TEST_F(QnnDeviceCompatibilityTests, NPUDeviceIncompatibilityDetailsWithMissingDe
 // Test that GPU device incompatibility details include MISSING_DEPENDENCY and QNN_COMMON_ERROR_PLATFORM_NOT_SUPPORTED
 // Note: This should be tested by manually removing the GPU dependency
 TEST_F(QnnDeviceCompatibilityTests, GPUDeviceIncompatibilityDetailsWithMissingDependency) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "gpu";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
-
-  // Get the Qualcomm vendor ID from the factory
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
 
   // Create a mock GPU device with Qualcomm vendor ID
-  OrtHardwareDevice gpu_device = CreateMockDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id));
 
   // Check compatibility using the ORT C API
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &gpu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   // Check if device is compatible - if so, skip this test
@@ -381,22 +370,20 @@ TEST_F(QnnDeviceCompatibilityTests, GPUDeviceIncompatibilityDetailsWithMissingDe
 // Skipped when the backend is fully compatible or when the library itself is missing.
 // Note: This should be tested by manually removing the GPU driver library
 TEST_F(QnnDeviceCompatibilityTests, GPUDeviceIncompatibilityDetailsWithDriverIncompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "gpu";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
 
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
-  OrtHardwareDevice gpu_device = CreateMockDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_GPU, qualcomm_vendor_id));
 
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &gpu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   uint32_t reasons_bitmask = 0;
@@ -433,22 +420,20 @@ TEST_F(QnnDeviceCompatibilityTests, GPUDeviceIncompatibilityDetailsWithDriverInc
 // Skipped when the backend is fully compatible or when the failure is not DEVICE_INCOMPATIBLE.
 // Note: This should be tested by manually removing the NPU driver library
 TEST_F(QnnDeviceCompatibilityTests, NPUDeviceIncompatibilityDetailsWithDeviceIncompatible) {
-  onnxruntime::ProviderOptions options;
+  ProviderOptions options;
   options["backend_type"] = "htp";
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, onnxruntime::kQnnExecutionProvider, options);
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
 
   ASSERT_NE(registered_ep_device, nullptr);
-  ASSERT_NE(registered_ep_device->ep_factory, nullptr);
 
-  uint32_t qualcomm_vendor_id = registered_ep_device->ep_factory->GetVendorId(registered_ep_device->ep_factory);
-  OrtHardwareDevice npu_device = CreateMockDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id);
+  ASSERT_ORTSTATUS_OK(CreateMockHardwareDevice(OrtHardwareDeviceType_NPU, qualcomm_vendor_id));
 
   OrtDeviceEpIncompatibilityDetails* details = nullptr;
   ASSERT_ORTSTATUS_OK(api_->GetHardwareDeviceEpIncompatibilityDetails(
-      env_, onnxruntime::kQnnExecutionProvider, &npu_device, &details));
+      env_, kQnnExecutionProvider, mock_hw_device, &details));
   ASSERT_NE(details, nullptr);
 
   uint32_t reasons_bitmask = 0;

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -1074,11 +1074,10 @@ void EpCtxCpuNodeWithExternalIniFileTestBody(bool expect_external_ini_file, bool
   if (load_model_from_buffer) {
     std::vector<char> buffer;
     {
-      std::ifstream file(model_with_ext, std::ios::binary | std::ios::ate);
+      buffer.resize(std::filesystem::file_size(model_with_ext));
+      std::ifstream file(model_with_ext, std::ios::binary);
       if (!file)
         throw std::runtime_error("Error reading model");
-      buffer.resize(static_cast<size_t>(file.tellg()));
-      file.seekg(0, std::ios::beg);
       if (!file.read(buffer.data(), buffer.size()))
         throw std::runtime_error("Error reading model");
     }
@@ -1660,11 +1659,10 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCacheNonEmbedModeTest) {
   // load the model from file
   std::vector<char> buffer;
   {
-    std::ifstream file(context_binary_file, std::ios::binary | std::ios::ate);
+    buffer.resize(std::filesystem::file_size(context_binary_file));
+    std::ifstream file(context_binary_file, std::ios::binary);
     if (!file)
       throw std::runtime_error("Error reading model");
-    buffer.resize(static_cast<size_t>(file.tellg()));
-    file.seekg(0, std::ios::beg);
     if (!file.read(buffer.data(), buffer.size()))
       throw std::runtime_error("Error reading model");
   }

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3632,18 +3632,6 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate) {
   TestModelCompatibilityApiValidate(test_info, OrtCompiledModelCompatibility_EP_SUPPORTED_OPTIMAL);
 }
 
-TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_NoEp) {
-  RegisteredEpDeviceUniquePtr registered_ep_device;
-  Ort::SessionOptions so;
-  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, {{"backend_type", "htp"}});
-
-  const OrtEpDevice* ep_device = registered_ep_device.get();
-  OrtCompiledModelCompatibility out_status = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
-  OrtStatus* status = Ort::GetApi().GetModelCompatibilityForEpDevices(&ep_device, 1, "", &out_status);
-  ASSERT_EQ(status, nullptr);
-  ASSERT_EQ(out_status, OrtCompiledModelCompatibility_EP_NOT_APPLICABLE);
-}
-
 TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_DiffBackend) {
   CompatibilityTestInfo test_info;
   test_info.backend_id = QNN_BACKEND_ID_CPU;

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -6,14 +6,9 @@
 #include <filesystem>
 #include <string>
 
-#include "core/session/onnxruntime_cxx_api.h"
-#include "core/session/onnxruntime_ep_device_ep_metadata_keys.h"
-#include "core/session/onnxruntime_session_options_config_keys.h"
-#include "core/session/inference_session.h"
-#include "core/graph/model_saving_options.h"
-#include "core/session/utils.h"
-#include "core/session/abi_devices.h"
-#include "core/session/abi_session_options_impl.h"
+#include "onnxruntime_cxx_api.h"
+#include "onnxruntime_ep_device_ep_metadata_keys.h"
+#include "onnxruntime_session_options_config_keys.h"
 
 #include "test/providers/qnn/qnn_test_utils.h"
 
@@ -261,7 +256,7 @@ struct TestModel {
   }
 
   bool Save(const ORTCHAR_T* path) const {
-    std::ofstream ofs(PathString(path), std::ios::binary);
+    std::ofstream ofs(path, std::ios::binary);
     return builder->model_.SerializeToOstream(&ofs);
   }
 };
@@ -273,7 +268,7 @@ static void CreateTestModel(test::GetTestModelFn graph_builder,
                             int onnx_opset_version,
                             OrtLoggingLevel log_severity,
                             TestModel& test_model) {
-  ORT_UNUSED_PARAMETER(log_severity);
+  QNN_TEST_UNUSED_PARAMETER(log_severity);
   const std::unordered_map<std::string, int> domain_to_version = {{"", onnx_opset_version}, {kMSDomain, 1}};
 
   test_model.builder = std::make_unique<ModelTestBuilder>();
@@ -1082,7 +1077,7 @@ void EpCtxCpuNodeWithExternalIniFileTestBody(bool expect_external_ini_file, bool
       std::ifstream file(model_with_ext, std::ios::binary | std::ios::ate);
       if (!file)
         throw std::runtime_error("Error reading model");
-      buffer.resize(narrow<size_t>(file.tellg()));
+      buffer.resize(static_cast<size_t>(file.tellg()));
       file.seekg(0, std::ios::beg);
       if (!file.read(buffer.data(), buffer.size()))
         throw std::runtime_error("Error reading model");
@@ -1668,7 +1663,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCacheNonEmbedModeTest) {
     std::ifstream file(context_binary_file, std::ios::binary | std::ios::ate);
     if (!file)
       throw std::runtime_error("Error reading model");
-    buffer.resize(narrow<size_t>(file.tellg()));
+    buffer.resize(static_cast<size_t>(file.tellg()));
     file.seekg(0, std::ios::beg);
     if (!file.read(buffer.data(), buffer.size()))
       throw std::runtime_error("Error reading model");
@@ -1683,6 +1678,7 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCacheNonEmbedModeTest) {
   Ort::SessionOptions so;  // No need to set the context file path in so since it's load from file
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
+
 #ifdef _WIN32
   std::wstring ctx_model_file(context_binary_file.begin(), context_binary_file.end());
 #else
@@ -1746,8 +1742,8 @@ TEST_F(QnnHTPBackendTests, QnnContextBinaryCache_InvalidGraph) {
   std::string qnn_ctx_model_data;
   model_proto.SerializeToString(&qnn_ctx_model_data);
 
-  RunOptions run_options;
-  run_options.run_tag = "logger0";
+  Ort::RunOptions run_options;
+  run_options.SetRunTag("logger0");
 
   Ort::SessionOptions so;
   so.SetLogId("logger0");
@@ -2619,25 +2615,19 @@ TEST_F(QnnHTPBackendTests, LoadFromArrayWithQnnEpContextGenPathValidation) {
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  ORT_TRY {
+  try {
     Ort::Session session1(*ort_env, model_data_span.data(), model_data_span.size(), so);
-  }
-  ORT_CATCH(const std::exception& e) {
-    ORT_HANDLE_EXCEPTION([&e]() {
-      std::string e_message1(std::string(e.what()));
-      ASSERT_TRUE(e_message1.find("Please specify a valid ep.context_file_path") != std::string::npos);
-    });
+  } catch (const std::exception& e) {
+    std::string e_message1(std::string(e.what()));
+    ASSERT_TRUE(e_message1.find("Please specify a valid ep.context_file_path") != std::string::npos);
   }
 
-  ORT_TRY {
+  try {
     so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, "");
     Ort::Session session2(*ort_env, model_data_span.data(), model_data_span.size(), so);
-  }
-  ORT_CATCH(const std::exception& ex) {
-    ORT_HANDLE_EXCEPTION([&ex]() {
-      std::string e_message2(std::string(ex.what()));
-      ASSERT_TRUE(e_message2.find("Please specify a valid ep.context_file_path") != std::string::npos);
-    });
+  } catch (const std::exception& ex) {
+    std::string e_message2(std::string(ex.what()));
+    ASSERT_TRUE(e_message2.find("Please specify a valid ep.context_file_path") != std::string::npos);
   }
 }
 
@@ -2741,9 +2731,9 @@ static OrtStatus* ORT_API_CALL TestWriteToStream(void* stream_state, const void*
 
 // Implementation of OrtOutStreamWriteFunc that directly returns an OrtStatus indicating an error.
 static OrtStatus* ORT_API_CALL ReturnStatusFromStream(void* stream_state, const void* buffer, size_t buffer_num_bytes) {
-  ORT_UNUSED_PARAMETER(stream_state);
-  ORT_UNUSED_PARAMETER(buffer);
-  ORT_UNUSED_PARAMETER(buffer_num_bytes);
+  QNN_TEST_UNUSED_PARAMETER(stream_state);
+  QNN_TEST_UNUSED_PARAMETER(buffer);
+  QNN_TEST_UNUSED_PARAMETER(buffer_num_bytes);
   return Ort::GetApi().CreateStatus(ORT_FAIL, "Error from OrtOutStreamWriteFunc callback");
 }
 
@@ -2968,7 +2958,7 @@ static OrtStatus* ORT_API_CALL TestHandleInitializerDataFunc(void* state,
                                                              OrtExternalInitializerInfo** c_new_external_info) {
   Ort::Status final_status{nullptr};
 
-  ORT_TRY {
+  try {
     CustomInitializerHandlerState* custom_state = reinterpret_cast<CustomInitializerHandlerState*>(state);
 
     if (std::string("constant") == initializer_name) {
@@ -2997,16 +2987,10 @@ static OrtStatus* ORT_API_CALL TestHandleInitializerDataFunc(void* state,
     }
 
     *c_new_external_info = new_external_info.release();
-  }
-  ORT_CATCH(const Ort::Exception& ex) {
-    ORT_HANDLE_EXCEPTION(([&ex, &final_status]() {
-      final_status = Ort::Status{ex};
-    }));
-  }
-  ORT_CATCH(const std::exception& ex) {
-    ORT_HANDLE_EXCEPTION(([&ex, &final_status]() {
-      final_status = Ort::Status(ex.what(), ORT_FAIL);
-    }));
+  } catch (const Ort::Exception& ex) {
+    final_status = Ort::Status{ex};
+  } catch (const std::exception& ex) {
+    final_status = Ort::Status(ex.what(), ORT_FAIL);
   }
 
   return final_status.release();
@@ -3076,7 +3060,7 @@ static OrtStatus* ORT_API_CALL ReuseExternalInitializers(void* state,
                                                          OrtExternalInitializerInfo** new_external_info) {
   Ort::Status final_status{nullptr};
 
-  ORT_TRY {
+  try {
     // If the original initializer was stored in an external file, keep it there (just for testing).
     if (external_info != nullptr) {
       Ort::ConstExternalInitializerInfo info(external_info);
@@ -3103,16 +3087,10 @@ static OrtStatus* ORT_API_CALL ReuseExternalInitializers(void* state,
 
     // If not originally external, save it within the generated compiled model
     *new_external_info = nullptr;
-  }
-  ORT_CATCH(const Ort::Exception& ex) {
-    ORT_HANDLE_EXCEPTION(([&ex, &final_status]() {
-      final_status = Ort::Status{ex};
-    }));
-  }
-  ORT_CATCH(const std::exception& ex) {
-    ORT_HANDLE_EXCEPTION(([&ex, &final_status]() {
-      final_status = Ort::Status(ex.what(), ORT_FAIL);
-    }));
+  } catch (const Ort::Exception& ex) {
+    final_status = Ort::Status{ex};
+  } catch (const std::exception& ex) {
+    final_status = Ort::Status(ex.what(), ORT_FAIL);
   }
 
   return final_status.release();
@@ -3235,14 +3213,11 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_DisabledWhenContextCacheNotSet) {
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
   // since ep.context_enable was not set. Session falls back to normal (non-prepare_only) mode.
-  ORT_TRY {
+  try {
     Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
     SUCCEED();
-  }
-  ORT_CATCH(const std::exception& e) {
-    ORT_HANDLE_EXCEPTION([&e]() {
-      FAIL() << "Session creation should not throw: " << e.what();
-    });
+  } catch (const std::exception& e) {
+    FAIL() << "Session creation should not throw: " << e.what();
   }
 }
 
@@ -3297,14 +3272,11 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_RunReturnsError) {
   const char* input_names[] = {input_name_ptr.get()};
   const char* output_names[] = {output_name_ptr.get()};
 
-  ORT_TRY {
+  try {
     session.Run(Ort::RunOptions{}, input_names, ort_inputs.data(), 1, output_names, 1);
     FAIL() << "Expected Session.Run() to fail in prepare_only mode";
-  }
-  ORT_CATCH(const std::exception& e) {
-    ORT_HANDLE_EXCEPTION([&e]() {
-      ASSERT_THAT(e.what(), testing::HasSubstr("prepare_only mode"));
-    });
+  } catch (const std::exception& e) {
+    ASSERT_THAT(e.what(), testing::HasSubstr("prepare_only mode"));
   }
 
   CleanUpCtxFile(ctx_path);
@@ -3415,7 +3387,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbTradRtHnrd
   QnnHtpDevice_Arch_t htp_arch = QnnHTPBackendTests::GetPlatformAttributes().htp_arch;
   auto hnrd_test_handle = std::make_unique<HnrdTestHandle>(static_cast<uint32_t>(htp_arch));
 
-  ORT_TRY {
+  try {
     {
       Ort::SessionOptions so;
       RegisteredEpDeviceUniquePtr registered_ep_device;
@@ -3425,12 +3397,9 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbTradRtHnrd
     }
     // Compare to ModelCompatibility_SelfValidate_CbHnrdRtTrad, this testcase could get here if driver is as new as
     // compiled SDK.
-  }
-  ORT_CATCH(const Ort::Exception& e) {
-    ORT_HANDLE_EXCEPTION([&e]() {
-      std::string message(e.what());
-      ASSERT_TRUE(message.find("Compiled model is not supported by execution provider") != std::string::npos);
-    });
+  } catch (const Ort::Exception& e) {
+    std::string message(e.what());
+    ASSERT_TRUE(message.find("Compiled model is not supported by execution provider") != std::string::npos);
   }
 
   std::filesystem::remove(output_model_file);
@@ -3465,7 +3434,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbHnrdRtTrad
 
   hnrd_test_handle.reset();
 
-  ORT_TRY {
+  try {
     {
       Ort::SessionOptions so;
       RegisteredEpDeviceUniquePtr registered_ep_device;
@@ -3474,12 +3443,9 @@ TEST_F(QnnHTPBackendTests, DISABLED_ModelCompatibility_SelfValidate_CbHnrdRtTrad
       ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, output_model_file.wstring().c_str(), so));
     }
     FAIL() << "Expect compiled model not supported by execution provider.";  // Should not get here.
-  }
-  ORT_CATCH(const Ort::Exception& e) {
-    ORT_HANDLE_EXCEPTION([&e]() {
-      std::string message(e.what());
-      ASSERT_TRUE(message.find("Compiled model is not supported by execution provider") != std::string::npos);
-    });
+  } catch (const Ort::Exception& e) {
+    std::string message(e.what());
+    ASSERT_TRUE(message.find("Compiled model is not supported by execution provider") != std::string::npos);
   }
 
   std::filesystem::remove(output_model_file);
@@ -3639,16 +3605,26 @@ static void TestModelCompatibilityApiValidate(const CompatibilityTestInfo& test_
                        kQnnExecutionProvider,
                        {{"backend_type", "htp"}, {"num_graph_prepare_threads", "1"}});
 
-  OrtEpFactory* ep_factory = registered_ep_device->GetMutableFactory();
-  OrtEp* ep = nullptr;
-  ep_factory->CreateEp(ep_factory, nullptr, nullptr, 0, so, nullptr, &ep);
+  const OrtEpDevice* const* ep_devices = nullptr;
+  size_t num_ep_devices = 0;
+  Ort::GetApi().GetEpDevices(*GetOrtEnv(), &ep_devices, &num_ep_devices);
+  const OrtEpDevice* qcom_npu_device = nullptr;
+  for (size_t i = 0; i < num_ep_devices; i++) {
+    const char* name = Ort::GetApi().EpDevice_EpName(ep_devices[i]);
+    const OrtHardwareDevice* ep_hw_device = Ort::GetApi().EpDevice_Device(ep_devices[i]);
+    if (name && std::string(name) == kQnnExecutionProvider &&
+        Ort::GetApi().HardwareDevice_Type(ep_hw_device) == OrtHardwareDeviceType_NPU) {
+      qcom_npu_device = ep_devices[i];
+    }
+  }
 
-  const OrtEpDevice* ep_device = registered_ep_device.get();
-  OrtCompiledModelCompatibility out_status;
-  Ort::GetApi().GetModelCompatibilityForEpDevices(&ep_device, 1, test_info.ToString().c_str(), &out_status);
+  if (qcom_npu_device == nullptr) {
+    GTEST_SKIP() << "No QNN NPU EP device found";
+  }
+
+  OrtCompiledModelCompatibility out_status = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
+  Ort::GetApi().GetModelCompatibilityForEpDevices(&qcom_npu_device, 1, test_info.ToString().c_str(), &out_status);
   ASSERT_EQ(out_status, expected_compatibility);
-
-  ep_factory->ReleaseEp(ep_factory, ep);
 }
 
 TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate) {
@@ -3664,10 +3640,10 @@ TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_NoEp) {
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, {{"backend_type", "htp"}});
 
   const OrtEpDevice* ep_device = registered_ep_device.get();
-  OrtCompiledModelCompatibility out_status;
+  OrtCompiledModelCompatibility out_status = OrtCompiledModelCompatibility_EP_UNSUPPORTED;
   OrtStatus* status = Ort::GetApi().GetModelCompatibilityForEpDevices(&ep_device, 1, "", &out_status);
-  std::string message(Ort::GetApi().GetErrorMessage(status));
-  ASSERT_TRUE(message.find("Unable to validate model compatibility without EP created.") != std::string::npos);
+  ASSERT_EQ(status, nullptr);
+  ASSERT_EQ(out_status, OrtCompiledModelCompatibility_EP_NOT_APPLICABLE);
 }
 
 TEST_F(QnnHTPBackendTests, ModelCompatibility_ApiValidate_DiffBackend) {

--- a/onnxruntime/test/util/include/test_utils.h
+++ b/onnxruntime/test/util/include/test_utils.h
@@ -12,17 +12,19 @@
 #include <vector>
 
 #include <gsl/gsl>
-#include "core/framework/execution_provider.h"
-#include "core/framework/framework_common.h"
-#include "core/framework/ort_value.h"
-#include "core/providers/cpu/cpu_execution_provider.h"
-#include "core/session/onnxruntime_c_api.h"
-#include "core/session/onnxruntime_cxx_api.h"
-#include "test/util/include/inference_session_wrapper.h"
+#include "onnxruntime_c_api.h"
+#include "onnxruntime_cxx_api.h"
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#endif
+#include <onnx/onnx_pb.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 namespace onnxruntime {
-struct SessionOptions;
-
 namespace test {
 
 // If set to All: verify the entire graph is taken by ep
@@ -78,58 +80,6 @@ void RunWithEP(Ort::Session& ort_session,
                const Ort::RunOptions& ort_ro,
                const std::unordered_map<std::string, Ort::Value>& feeds,
                std::vector<Ort::Value>& output_vals);
-
-// Tests model loading only.
-// This can be used to test EPs in builds where only loading (and not running) of a model is supported.
-// Calls `check_graph` on the graph of the loaded model.
-void TestModelLoad(ModelPathOrBytes model_path_or_bytes,
-                   std::unique_ptr<IExecutionProvider> execution_provider,
-                   const std::function<void(const Ort::Session&)>& check_graph);
-
-// Tests model loading only.
-// The check graph function verifies the expected EP node assignment.
-inline void TestModelLoad(ModelPathOrBytes model_path_or_bytes,
-                          std::unique_ptr<IExecutionProvider> execution_provider,
-                          ExpectedEPNodeAssignment expected_node_assignment) {
-  auto check_node_assignment =
-      [provider_type = execution_provider->Type(), expected_node_assignment](const Ort::Session& current_session) {
-        VerifyEPNodeAssignment(current_session, provider_type, expected_node_assignment);
-      };
-  TestModelLoad(model_path_or_bytes, std::move(execution_provider), check_node_assignment);
-}
-
-// Check equality of two shapes. Can successfully complete only if rank are equal and all dimensions are equal.
-// The way we define dimension equality is that:
-// 1. if both dimensions are symbolic, they are equal if their names are equal.
-// 2. if both dimensions are not symbolic, they are equal if their values are equal.
-// 3. if one dimension is symbolic and the other is not, they are not equal.
-void CheckShapeEquality(const ONNX_NAMESPACE::TensorShapeProto* shape1,
-                        const ONNX_NAMESPACE::TensorShapeProto* shape2);
-
-// Create OrtValue on CPU copying from provided inputs.
-template <typename T>
-OrtValue CreateInputOrtValueOnCPU(gsl::span<const int64_t> dims, gsl::span<const T> value,
-                                  AllocatorPtr alloc = nullptr) {
-  static CPUExecutionProviderInfo info;
-  static CPUExecutionProvider cpu_provider(info);
-  static AllocatorPtr cpu_allocator = cpu_provider.CreatePreferredAllocators()[0];
-
-  TensorShape shape(dims);
-  assert(shape.Size() == static_cast<int64_t>(value.size()));
-  auto element_type = DataTypeImpl::GetType<T>();
-  auto allocator = alloc ? alloc : cpu_allocator;
-  auto p_tensor = std::make_unique<Tensor>(element_type, shape, allocator);
-
-  if (value.size() > 0 && !alloc) {  // using CPU allocator
-    memcpy(p_tensor->MutableDataRaw(), value.data(), p_tensor->SizeInBytes());
-  }
-
-  OrtValue ort_value;
-  ort_value.Init(p_tensor.release(),
-                 DataTypeImpl::GetType<Tensor>(),
-                 DataTypeImpl::GetType<Tensor>()->GetDeleteFunc());
-  return ort_value;
-}
 
 // QNN-EP COPY START
 // Below are ONNX Attributes utilities copied from MS onnxruntime\core\graph\node_attr_utils.h directly.

--- a/onnxruntime/test/util/test_environment.cc
+++ b/onnxruntime/test/util/test_environment.cc
@@ -1,25 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "test/test_environment.h"
 #include "onnxruntime_cxx_api.h"
 #include <iostream>
 #include <memory>
-
-#include "gtest/gtest.h"
-#include "google/protobuf/stubs/common.h"
-
-#include "core/session/ort_env.h"
-#include "core/session/environment.h"
 
 extern std::unique_ptr<Ort::Env> ort_env;
 
 namespace onnxruntime {
 namespace test {
-
-const ::onnxruntime::Environment& GetEnvironment() {
-  return ((OrtEnv*)*ort_env.get())->GetEnvironment();
-}
 
 Ort::Env* GetOrtEnv() {
   return ort_env.get();

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -8,21 +8,12 @@
 #include <string>
 #include <vector>
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#endif
-#include <onnx/onnx_pb.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include "gmock/gmock.h"
 #include "onnxruntime_cxx_api.h"
 #include "onnxruntime_session_options_config_keys.h"
 
 #include "test/util/include/asserts.h"
 #include "test/util/include/test/test_environment.h"
-
-#include "gmock/gmock.h"
 
 namespace onnxruntime {
 namespace test {
@@ -294,26 +285,6 @@ void RunAndVerifyOutputsWithEP(ModelPathOrBytes model_path_or_bytes,
 
   if (params.graph_verifier) {
     (*params.graph_verifier)(ort_session);
-  }
-}
-
-void CheckShapeEquality(const ONNX_NAMESPACE::TensorShapeProto* shape1,
-                        const ONNX_NAMESPACE::TensorShapeProto* shape2) {
-  EXPECT_NE(shape1, nullptr);
-  EXPECT_NE(shape2, nullptr);
-  EXPECT_EQ(shape1->dim_size(), shape2->dim_size()) << "Shapes do not have same rank";
-  auto min_dims = std::min(shape1->dim_size(), shape2->dim_size());
-  for (int i = 0; i < min_dims; ++i) {
-    auto dim1 = shape1->dim(i);
-    auto dim2 = shape2->dim(i);
-    EXPECT_EQ(dim1.has_dim_value(), dim2.has_dim_value());
-    if (dim1.has_dim_value()) {
-      EXPECT_EQ(dim1.dim_value(), dim2.dim_value());
-    }
-    EXPECT_EQ(dim1.has_dim_param(), dim2.has_dim_param());
-    if (dim1.has_dim_param()) {
-      EXPECT_EQ(dim1.dim_param(), dim2.dim_param());
-    }
   }
 }
 

--- a/qcom/linters/check_private_ort_headers.py
+++ b/qcom/linters/check_private_ort_headers.py
@@ -4,7 +4,7 @@
 """Lintrunner adapter: flag includes of private ORT Core headers in QNN EP source,
 and flag unapproved include directories in the QNN EP cmake target.
 
-Two checks are performed depending on file type:
+Three checks are performed depending on file type:
 
 C++ (.h / .cc): Any #include whose path starts with core/ but not core/providers/qnn/
 is a private ORT Core header dependency. Public ORT headers (onnxruntime_c_api.h, etc.)
@@ -15,6 +15,10 @@ CMake (.cmake): Every path in target_include_directories(onnxruntime_providers_q
 target_include_directories(onnxruntime_provider_test ...) must be in APPROVED_CMAKE_INCLUDES.
 Any path not on that list triggers an error, forcing deliberate review before a new include
 directory is accepted.
+
+CMake (.cmake): ONNXRUNTIME_APPLICATION_INCLUDES may only be assigned via set() with
+paths from APPROVED_APP_INCLUDES. Any list(APPEND ONNXRUNTIME_APPLICATION_INCLUDES ...)
+call is always an error, as is any set() that introduces an unapproved path.
 """
 
 from __future__ import annotations
@@ -92,6 +96,38 @@ _TID_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ---------------------------------------------------------------------------
+# ONNXRUNTIME_APPLICATION_INCLUDES guard
+# ---------------------------------------------------------------------------
+
+_APP_INCLUDES_VAR = "ONNXRUNTIME_APPLICATION_INCLUDES"
+
+# Approved paths that may appear inside set(ONNXRUNTIME_APPLICATION_INCLUDES ...).
+# Mirrors the two branches in cmake/external/onnxruntime_prebuilt.cmake exactly.
+# Update only after careful review of that file.
+APPROVED_APP_INCLUDES: frozenset[str] = frozenset(
+    {
+        # onnxruntime_ORT_HOME (prebuilt) branch
+        '"${onnxruntime_ORT_HOME}/include"',
+        # build-from-source branch
+        '"${ORT_SOURCE_DIR}/include/onnxruntime/core/session"',
+        '"${ORT_SOURCE_DIR}/include/onnxruntime/core/providers/cpu"',
+        # Comment tokens (stripped before token scan, kept here for documentation only)
+    }
+)
+
+# Matches list(APPEND ONNXRUNTIME_APPLICATION_INCLUDES ...) — always forbidden.
+_APP_INCLUDES_APPEND_RE = re.compile(
+    r"\blist\s*\(\s*APPEND\s+" + re.escape(_APP_INCLUDES_VAR) + r"\b",
+    re.IGNORECASE,
+)
+
+# Matches set(ONNXRUNTIME_APPLICATION_INCLUDES ...) — allowed only with approved paths.
+_APP_INCLUDES_SET_RE = re.compile(
+    r"\bset\s*\(\s*" + re.escape(_APP_INCLUDES_VAR) + r"\b",
+    re.IGNORECASE,
+)
+
 
 def _strip_cmake_comments(text: str) -> str:
     return re.sub(r"#[^\n]*", "", text)
@@ -149,6 +185,81 @@ def check_cmake_file(path: str) -> list[dict]:
     return messages
 
 
+def check_app_includes(path: str) -> list[dict]:
+    """Flag any list(APPEND ONNXRUNTIME_APPLICATION_INCLUDES ...) and any
+    set(ONNXRUNTIME_APPLICATION_INCLUDES ...) that contains unapproved paths."""
+    messages = []
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            content = f.read()
+
+        # list(APPEND ...) is always forbidden.
+        for m in _APP_INCLUDES_APPEND_RE.finditer(content):
+            line = content[: m.start()].count("\n") + 1
+            messages.append(
+                {
+                    "path": path,
+                    "line": line,
+                    "char": None,
+                    "code": LINTER_CODE,
+                    "severity": "error",
+                    "name": "app-includes-extended",
+                    "original": None,
+                    "replacement": None,
+                    "description": (
+                        f"list(APPEND {_APP_INCLUDES_VAR} ...) is forbidden. "
+                        f"Update APPROVED_APP_INCLUDES in "
+                        "qcom/linters/check_private_ort_headers.py only after "
+                        "careful review of cmake/external/onnxruntime_prebuilt.cmake."
+                    ),
+                }
+            )
+
+        # set(...) is allowed only with approved path tokens.
+        for m in _APP_INCLUDES_SET_RE.finditer(content):
+            call_line = content[: m.start()].count("\n") + 1
+            open_pos = content.index("(", m.start())
+            depth, i = 1, open_pos + 1
+            while i < len(content) and depth:
+                if content[i] == "(":
+                    depth += 1
+                elif content[i] == ")":
+                    depth -= 1
+                i += 1
+            args_text = content[open_pos + 1 : i - 1]
+
+            # Re-tokenize preserving quoted strings so paths with spaces stay intact.
+            for tok_m in re.finditer(r'"[^"]*"|\S+', _strip_cmake_comments(args_text)):
+                token = tok_m.group()
+                if token == _APP_INCLUDES_VAR:
+                    continue
+                if token not in APPROVED_APP_INCLUDES:
+                    tok_pos = content.find(token, open_pos)
+                    tok_line = content[:tok_pos].count("\n") + 1 if tok_pos >= 0 else call_line
+                    messages.append(
+                        {
+                            "path": path,
+                            "line": tok_line,
+                            "char": None,
+                            "code": LINTER_CODE,
+                            "severity": "error",
+                            "name": "unapproved-app-include",
+                            "original": None,
+                            "replacement": None,
+                            "description": (
+                                f"Unapproved path {token!r} in "
+                                f"set({_APP_INCLUDES_VAR} ...). "
+                                "Update APPROVED_APP_INCLUDES in "
+                                "qcom/linters/check_private_ort_headers.py only after "
+                                "careful review of cmake/external/onnxruntime_prebuilt.cmake."
+                            ),
+                        }
+                    )
+    except OSError as exc:
+        messages.append(_io_error(path, exc))
+    return messages
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -178,7 +289,7 @@ def main() -> None:
     for path in args.filenames:
         ext = os.path.splitext(path)[1].lower()
         if ext == ".cmake" or os.path.basename(path) == "CMakeLists.txt":
-            msgs = check_cmake_file(path)
+            msgs = check_cmake_file(path) + check_app_includes(path)
         else:
             msgs = check_cc_file(path)
         for msg in msgs:

--- a/qcom/linters/check_private_ort_headers.py
+++ b/qcom/linters/check_private_ort_headers.py
@@ -11,9 +11,10 @@ is a private ORT Core header dependency. Public ORT headers (onnxruntime_c_api.h
 are always included by filename only, never via a core/ path, so this rule has no
 false positives for legitimate includes.
 
-CMake (.cmake): Every path in target_include_directories(onnxruntime_providers_qnn ...)
-must be in APPROVED_CMAKE_INCLUDES. Any path not on that list triggers an error,
-forcing deliberate review before a new include directory is accepted.
+CMake (.cmake): Every path in target_include_directories(onnxruntime_providers_qnn ...),
+target_include_directories(onnxruntime_provider_test ...) must be in APPROVED_CMAKE_INCLUDES.
+Any path not on that list triggers an error, forcing deliberate review before a new include
+directory is accepted.
 """
 
 from __future__ import annotations
@@ -65,23 +66,29 @@ def check_cc_file(path: str) -> list[dict]:
 # CMake check
 # ---------------------------------------------------------------------------
 
-# Exact set of include directories approved for onnxruntime_providers_qnn.
-# Any deviation (addition or removal) requires updating this list after careful review.
-APPROVED_CMAKE_INCLUDES: frozenset[str] = frozenset(
-    {
-        "${CMAKE_CURRENT_BINARY_DIR}",
-        "${ONNXRUNTIME_APPLICATION_INCLUDE_ROOT}/core/session",
-        "${onnxruntime_QNN_HOME}/include/QNN",
-        "${onnxruntime_QNN_HOME}/include",
-    }
-)
+# Approved include directories per cmake target.
+# Any deviation (addition or removal) requires updating this mapping after careful review.
+APPROVED_CMAKE_INCLUDES: dict[str, frozenset[str]] = {
+    "onnxruntime_providers_qnn": frozenset(
+        {
+            "${CMAKE_CURRENT_BINARY_DIR}",
+            "${onnxruntime_QNN_HOME}/include/QNN",
+            "${onnxruntime_QNN_HOME}/include",
+            "${ONNXRUNTIME_APPLICATION_INCLUDES}",
+        }
+    ),
+    "onnxruntime_provider_test": frozenset(
+        {
+            "${ONNXRUNTIME_APPLICATION_INCLUDES}",
+        }
+    ),
+}
 
-_CMAKE_TARGET = "onnxruntime_providers_qnn"
 _CMAKE_KEYWORDS = frozenset({"PRIVATE", "PUBLIC", "INTERFACE", "BEFORE", "SYSTEM"})
 
-# Matches the start of a target_include_directories call for our target.
+# Matches the start of a target_include_directories call for any watched target.
 _TID_RE = re.compile(
-    r"target_include_directories\s*\(\s*" + re.escape(_CMAKE_TARGET) + r"\b",
+    r"target_include_directories\s*\(\s*(" + "|".join(re.escape(t) for t in APPROVED_CMAKE_INCLUDES) + r")\b",
     re.IGNORECASE,
 )
 
@@ -97,6 +104,8 @@ def check_cmake_file(path: str) -> list[dict]:
             content = f.read()
 
         for call_m in _TID_RE.finditer(content):
+            cmake_target = call_m.group(1)
+            approved = APPROVED_CMAKE_INCLUDES[cmake_target]
             call_line = content[: call_m.start()].count("\n") + 1
 
             # Find the matching closing paren using a depth counter.
@@ -111,9 +120,9 @@ def check_cmake_file(path: str) -> list[dict]:
             args_text = content[open_pos + 1 : i - 1]
 
             for token in _strip_cmake_comments(args_text).split():
-                if token == _CMAKE_TARGET or token in _CMAKE_KEYWORDS:
+                if token == cmake_target or token in _CMAKE_KEYWORDS:
                     continue
-                if token not in APPROVED_CMAKE_INCLUDES:
+                if token not in approved:
                     # Find line number of this specific token within the call.
                     tok_pos = content.find(token, open_pos)
                     tok_line = content[:tok_pos].count("\n") + 1 if tok_pos >= 0 else call_line
@@ -129,7 +138,7 @@ def check_cmake_file(path: str) -> list[dict]:
                             "replacement": None,
                             "description": (
                                 f"Unapproved include directory {token!r} added to "
-                                f"{_CMAKE_TARGET}. Update APPROVED_CMAKE_INCLUDES in "
+                                f"{cmake_target}. Update APPROVED_CMAKE_INCLUDES in "
                                 "qcom/linters/check_private_ort_headers.py only after "
                                 "careful review."
                             ),


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- `test/providers/qnn/*`: Updates QNN-specific tests
    - (`gru_test.cc`, `lstm_test.cc`, `qnn_device_compatibility_test.cc`, `qnn_ep_context_test.cc`) to use the public API surface only.
- `cmake/onnxruntime_unittests.cmake`: Drops the remaining private header search path
- `core/providers/qnn/qnn_provider_factory.cc`: Enhances `ValidateCompiledModelCompatibilityInfo` to construct a temporary QnnEp when the factory has not yet created a persistent EP, rather than returning an early error.
- Extends `qcom/linters/check_private_ort_headers.py` and `.lintrunner.toml` to cover `onnxruntime_unittests.cmake` and `onnxruntime_prebuilt.cmake`.
    - Adds per-target approved include sets for `onnxruntime_providers_qnn` and `onnxruntime_provider_test`.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The PR aims to reduce the scope and overhead of https://github.com/onnxruntime/onnxruntime-qnn/pull/222

