### PR TITLE
ci: Build and publish Linux x86_64 py3.12 wheels in nightly

### DIFF
--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -34,6 +34,10 @@ on:
         description: "If true, build for x86_64 Linux"
         type: boolean
         default: true
+      linux_x86_64_target_py_vsns:
+        description: "JSON list of Python versions to build for x86_64 Linux"
+        type: string
+        default: "['3.10','3.12']"
       linux_aarch64_manylinux_2_34_target_py_vsns:
         description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
         type: string
@@ -125,8 +129,11 @@ jobs:
       upload_wheel: false
 
   build-linux-x86_64:
-    if: ${{ inputs.build_linux_x86_64 }}
+    if: ${{ inputs.build_linux_x86_64 && toJSON(fromJSON(inputs.linux_x86_64_target_py_vsns)) != '[]' }}
     needs: [archive-testdata]
+    strategy:
+      matrix:
+        target_py_vsn: ${{ fromJSON(inputs.linux_x86_64_target_py_vsns) }}
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
@@ -135,12 +142,10 @@ jobs:
       target_os: linux
       target_arch: x86_64
       testdata_archive_artifact_name: testdata-tarbz2
-      # Specifying a python version here doesn't actually do anything at this point since we don't know what the Linux
-      # wheel distribution story is yet. For now, this is just so that all of the job and artifact names reflect the
-      # version of cpython that's installed on our Linux build machines.
-      target_py_vsn: "3.10"
+      target_py_vsn: ${{ matrix.target_py_vsn }}
       run_tests: false
-      upload_test_archive: true
+      # Test archive is python-version independent; upload only with the first matrix entry
+      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_x86_64_target_py_vsns)[0] }}
       upload_wheel: true
 
   build-windows:

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -43,6 +43,7 @@ jobs:
       build_android_aarch64_aar: true
       build_linux_aarch64_oe_gcc11_2: true
       build_linux_x86_64: true
+      linux_x86_64_target_py_vsns: "['3.10','3.12']"
       linux_aarch64_manylinux_2_34_target_py_vsns: "['3.11','3.12','3.13','3.14']"
       windows_target_archs: "['arm64', 'arm64ec', 'x86_64']"
       windows_target_py_vsns: "['3.11','3.12','3.13','3.14']"
@@ -66,10 +67,15 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       # We only publish this for AI Hub to use and they only want x86_64 Linux
-      - name: Download Wheel from Artifactory
+      - name: Download x86_64 Linux 3.10 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.10-wheels
+
+      - name: Download x86_64 Linux 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64-py3.12-wheels
 
       - name: Consolidate Wheels
         run: |
@@ -97,7 +103,7 @@ jobs:
       - name: Publish
         if: ${{ !inputs.skip_publish_wheel }}
         run: |
-          source venv/bin/activate && twine upload --config-file=build/pypirc -r local ${{ github.workspace }}/build/dist/*
+          source venv/bin/activate && twine upload --skip-existing --config-file=build/pypirc -r local ${{ github.workspace }}/build/dist/*
 
   publish-qa-artifacts:
     name: "Publish QA artifacts to Artifactory"
@@ -124,6 +130,11 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.10-wheels
+
+      - name: Download x86_64 Linux 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64-py3.12-wheels
 
       - name: Download aarch64 manylinux_2_34 Linux 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
@@ -334,11 +345,11 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 1 linux x86_64 + 4 linux aarch64 manylinux_2_34 + 4 arm64 + 4 merged AMD = 13 wheels
+          # After merge: 2 linux x86_64 (py3.10, py3.12) + 4 linux aarch64 manylinux_2_34 + 4 arm64 + 4 merged AMD = 14 wheels
           # (arm64ec and x86_64 originals are deleted by the merge step above)
           count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
           echo "Found $count wheel(s)"
-          [ "$count" -eq 13 ] || { echo "ERROR: Expected 13 wheels, found $count"; exit 1; }
+          [ "$count" -eq 14 ] || { echo "ERROR: Expected 14 wheels, found $count"; exit 1; }
 
       - name: Verify NuGet artifact
         run: |

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -138,7 +138,22 @@ if [ -n "${target_py_version}" ]; then
   build_venv="${build_dir}/venv-${target_py_version}"
   if [ ! -d "${build_venv}" ]; then
     log_debug "Creating venv for build in ${build_venv}"
-    "python${target_py_version}" -m venv "${build_venv}"
+    if command -v "python${target_py_version}" >/dev/null 2>&1; then
+      "python${target_py_version}" -m venv "${build_venv}"
+    elif command -v uv >/dev/null 2>&1; then
+      log_info "python${target_py_version} not found; using uv to provision interpreter."
+      uv venv --seed --python "${target_py_version}" "${build_venv}"
+    else
+      log_info "Neither python${target_py_version} nor uv found; bootstrapping uv into ${build_dir}/_uv_bootstrap."
+      uv_bootstrap_dir="${build_dir}/_uv_bootstrap"
+      python3 -m pip install --quiet --target="${uv_bootstrap_dir}" uv
+      # Prefer the console-script binary; fall back to module form if the wheel didn't ship one.
+      if [ -x "${uv_bootstrap_dir}/bin/uv" ]; then
+        "${uv_bootstrap_dir}/bin/uv" venv --seed --python "${target_py_version}" "${build_venv}"
+      else
+        PYTHONPATH="${uv_bootstrap_dir}" python3 -m uv venv --seed --python "${target_py_version}" "${build_venv}"
+      fi
+    fi
   fi
 
   bash -c ". ${build_venv}/bin/activate && pip install uv"


### PR DESCRIPTION
Convert the Linux x86_64 build to a Python-version matrix (py3.10 + py3.12) so the nightly action publishes both wheels going forward.

Step required for qai-hub Python 3.10 deprecation. 
