### PR TITLE
[QNN EP] Enable static MSVC runtime for x86_64

### DIFF
--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -136,9 +136,9 @@ $CommonArgs = `
     "--config", $Config, `
     "--parallel"
 
-# Use static MSVC runtime for ARM64 builds to eliminate MSVCP140.dll and
+# Use static MSVC runtime for builds to eliminate MSVCP140.dll and
 # VCRUNTIME140.dll dependencies from the shipping QNN EP DLL.
-if ($Arch -in @("aarch64", "arm64", "arm64ec")) {
+if ($Arch -in @("aarch64", "arm64", "arm64ec", "x86_64")) {
     $CommonArgs += "--enable_msvc_static_runtime"
 }
 


### PR DESCRIPTION
This PR adds support to enable static MSVC runtime for Windows x86_64 builds


