### PR TITLE
[QNN EP] Pass --nightly_build as explicit CLI argument to build.py

### DIFF
--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -334,8 +334,5 @@ class QdcTestsTask(RunExecutablesWithVenvTask):
 def ort_build_env_vars(old_env: Mapping[str, str] | None = None) -> dict[str, str]:
     env = os.environ.copy() if old_env is None else dict(old_env)
     if env.get("ORT_NIGHTLY_BUILD", "0") == "1":
-        env["NIGHTLY_BUILD"] = "1"
         env["Build_SourceVersion"] = git_head_sha()
-    elif env.get("ORT_NIGHTLY_BUILD", "0") == "0":
-        env["NIGHTLY_BUILD"] = "0"
     return env

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -301,7 +301,7 @@ else
       package_args+=(--version_suffix "${ORT_VERSION_SUFFIX}")
     fi
     if [[ "${ORT_NIGHTLY_BUILD:-}" == "1" ]]; then
-      package_args+=(--wheel_name_suffix "qcom_internal")
+      package_args+=(--wheel_name_suffix "qcom_internal" --nightly_build)
     fi
 
     if [ -n "${enable_coverage}" ]; then

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -223,7 +223,6 @@ if ($BuildWheel) {
     $BuildWheelArgs += "--build_wheel"
     if ($env:ORT_NIGHTLY_BUILD -eq "1") {
         $BuildWheelArgs += "--wheel_name_suffix=qcom_internal"
-        $env:NIGHTLY_BUILD = "1"
     }
 }
 

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -223,6 +223,7 @@ if ($BuildWheel) {
     $BuildWheelArgs += "--build_wheel"
     if ($env:ORT_NIGHTLY_BUILD -eq "1") {
         $BuildWheelArgs += "--wheel_name_suffix=qcom_internal"
+        $BuildWheelArgs += "--nightly_build"
     }
 }
 

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1065,7 +1065,7 @@ def main():
         # TODO: find asan DLL and copy it to onnxruntime/capi folder when args.enable_address_sanitizer is True and
         #  the target OS is Windows
         if args.build_wheel:
-            nightly_build = bool(os.getenv("NIGHTLY_BUILD") == "1")
+            nightly_build = args.nightly_build
             build_python_wheel(
                 source_dir,
                 build_dir,

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -443,6 +443,11 @@ def add_other_feature_args(parser: argparse.ArgumentParser) -> None:
         default="",
         help="Version suffix for Python Wheel, NuGet and Zip archive.",
     )
+    parser.add_argument(
+        "--nightly_build",
+        action="store_true",
+        help="Mark this as a nightly build, appending a date-based suffix to the wheel version.",
+    )
 
 
 def is_cross_compiling(args: argparse.Namespace) -> bool:


### PR DESCRIPTION
`tools/ci_build/build.py` previously read `NIGHTLY_BUILD` via env var while all other build flags are passed as explicit CLI arguments, requiring separate translation layers for Linux and Windows. This PR adds `--nightly_build` as a CLI argument and has both shell scripts pass it explicitly when `ORT_NIGHTLY_BUILD=1`. The redundant NIGHTLY_BUILD translation layers are removed.

Building on top review comment from #308 