### PR TITLE
Run BN in FP precision

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -25,6 +25,12 @@ class BatchNormalizationOpBuilder : public BaseOpBuilder {
                             std::vector<std::string>& input_names,
                             bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
   Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                             const OrtNodeUnit& node_unit,
                             const Ort::Logger& logger) const override final ORT_MUST_USE_RESULT;
@@ -567,10 +573,10 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
   {
     const std::string& scale_name = inputs[1].name;
     const std::string& bias_name = inputs[2].name;
-    TensorInfo var_info = {};
-    TensorInfo mean_info = {};
     TensorInfo scale_info = {};
     TensorInfo bias_info = {};
+    TensorInfo mean_info = {};
+    TensorInfo var_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], scale_info));
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[3], mean_info));
@@ -588,17 +594,17 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
 
     std::vector<uint8_t> scale_unpacked_tensor;
     std::vector<uint8_t> bias_unpacked_tensor;
-    std::vector<uint8_t> var_unpacked_tensor;
     std::vector<uint8_t> mean_unpacked_tensor;
+    std::vector<uint8_t> var_unpacked_tensor;
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info.initializer_tensor, scale_unpacked_tensor));
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, bias_unpacked_tensor));
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(mean_info.initializer_tensor, mean_unpacked_tensor));
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(var_info.initializer_tensor, var_unpacked_tensor));
 
-    std::vector<double> mean_double_tensor;
-    std::vector<double> std_double_tensor;
     std::vector<double> scale_double_tensor;
     std::vector<double> bias_double_tensor;
+    std::vector<double> mean_double_tensor;
+    std::vector<double> std_double_tensor;
 
     OrtNodeAttrHelper node_helper(node_unit);
     const float epsilon = node_helper.Get("epsilon", 1e-05f);  // Default is 1e-05 according to ONNX spec.
@@ -643,15 +649,31 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
       bias_info.quant_param = QnnQuantParamsWrapper(1.0f, 0);  // Placeholder, computed in Postprocess
     }
 
+    // Store fused weight/bias as F32 to avoid per-channel quantization overflow
+    // BN fused_weight = gamma/sqrt(var+eps) can have extreme dynamic range across channels,
+    // which overflows when requantized to a single per-tensor U8/S32 scale
+    // Only needed when scale input is per-channel (per-tensor doesn't have this issue)
+    const bool use_float_params = is_quantized_op &&
+                                  (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+                                   input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+                                  scale_info.quant_param.IsPerChannel();
+
     if (!qnn_model_wrapper.IsQnnTensorWrapperExist(scale_name)) {
       std::vector<uint8_t> scale_raw_tensor;
-      QnnQuantParamsWrapper scale_quant_param = scale_info.quant_param;
-      RETURN_IF_ERROR(Postprocess(scale_info,
-                                  scale_double_tensor,
-                                  scale_rmax,
-                                  scale_rmin,
-                                  scale_quant_param,
-                                  scale_raw_tensor));
+      QnnQuantParamsWrapper scale_quant_param;
+      if (use_float_params) {
+        RETURN_IF_ERROR(ConvertToRawOnQnnDataType(QNN_DATATYPE_FLOAT_32, scale_double_tensor, scale_raw_tensor));
+        scale_info.qnn_data_type = QNN_DATATYPE_FLOAT_32;
+      } else {
+        scale_quant_param = scale_info.quant_param;
+        RETURN_IF_ERROR(Postprocess(scale_info,
+                                    scale_double_tensor,
+                                    scale_rmax,
+                                    scale_rmin,
+                                    scale_quant_param,
+                                    scale_raw_tensor));
+      }
+
       Qnn_TensorType_t scale_tensor_type = qnn_model_wrapper.GetTensorType(scale_name);
       QnnTensorWrapper input_tensorwrapper(scale_name, scale_tensor_type, scale_info.qnn_data_type,
                                            std::move(scale_quant_param), std::move(scale_info.shape),
@@ -662,13 +684,19 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
 
     if (!qnn_model_wrapper.IsQnnTensorWrapperExist(bias_name)) {
       std::vector<uint8_t> bias_raw_tensor;
-      QnnQuantParamsWrapper bias_quant_param = bias_info.quant_param;
-      RETURN_IF_ERROR(Postprocess(bias_info,
-                                  bias_double_tensor,
-                                  bias_rmax,
-                                  bias_rmin,
-                                  bias_quant_param,
-                                  bias_raw_tensor));
+      QnnQuantParamsWrapper bias_quant_param;
+      if (use_float_params) {
+        RETURN_IF_ERROR(ConvertToRawOnQnnDataType(QNN_DATATYPE_FLOAT_32, bias_double_tensor, bias_raw_tensor));
+        bias_info.qnn_data_type = QNN_DATATYPE_FLOAT_32;
+      } else {
+        bias_quant_param = bias_info.quant_param;
+        RETURN_IF_ERROR(Postprocess(bias_info,
+                                    bias_double_tensor,
+                                    bias_rmax,
+                                    bias_rmin,
+                                    bias_quant_param,
+                                    bias_raw_tensor));
+      }
       Qnn_TensorType_t bias_tensor_type = qnn_model_wrapper.GetTensorType(bias_name);
       QnnTensorWrapper input_tensorwrapper(bias_name, bias_tensor_type, bias_info.qnn_data_type,
                                            std::move(bias_quant_param), std::move(bias_info.shape),
@@ -677,6 +705,80 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
     }
     input_names.push_back(bias_name);
   }
+
+  return Ort::Status();
+}
+
+Ort::Status BatchNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                                     const OrtNodeUnit& node_unit,
+                                                                     std::vector<std::string>&& input_names,
+                                                                     const Ort::Logger& logger,
+                                                                     bool do_op_validation) const {
+  if (input_names.size() < 1) {
+    return Ort::Status();
+  }
+
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
+  TensorInfo scale_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info));
+  const bool use_float_params = input_info.quant_param.IsQuantized() &&
+                                (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+                                 input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+                                scale_info.quant_param.IsPerChannel();
+
+  if (!use_float_params) {
+    RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), {},
+                                   logger, do_op_validation, GetQnnOpType(node_unit.OpType())));
+    return Ort::Status();
+  }
+
+  // Insert Dequantize (quantized -> Float_32) before BN
+  const std::string& orig_input_name = input_names[0];
+  const std::string convert_in_output = utils::UniqueNameGenerator().New(orig_input_name, "_to_f32");
+
+  std::vector<uint32_t> input_shape = input_info.shape;
+  QnnTensorWrapper convert_in_out_tensor(convert_in_output, QNN_TENSOR_TYPE_NATIVE,
+                                         QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
+                                         std::vector<uint32_t>(input_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(convert_in_out_tensor)), "Failed to add tensor");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_dequant_in"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                                                {orig_input_name}, {convert_in_output}, {},
+                                                do_op_validation),
+                "Failed to add dequantize node");
+
+  // BN node: all float32
+  const auto& outputs = node_unit.Outputs();
+  const std::string& orig_output_name = outputs[0].name;
+  const std::string bn_output_name = utils::UniqueNameGenerator().New(orig_output_name, "_bn_f32");
+
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
+  QnnTensorWrapper bn_out_tensor(bn_output_name, QNN_TENSOR_TYPE_NATIVE,
+                                 QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
+                                 std::vector<uint32_t>(output_info.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bn_out_tensor)), "Failed to add tensor");
+
+  std::vector<std::string> bn_inputs = {convert_in_output, input_names[1], input_names[2]};
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_bn"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_BATCHNORM,
+                                                std::move(bn_inputs), {bn_output_name}, {},
+                                                do_op_validation),
+                "Failed to add Batchnorm node");
+
+  // Insert Quantize (Float_32 -> quantized) after BN
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);
+  Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+  QnnTensorWrapper final_out_tensor(orig_output_name, out_tensor_type,
+                                    output_info.qnn_data_type, std::move(output_info.quant_param),
+                                    std::move(output_info.shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_out_tensor)), "Failed to add tensor");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_quant_out"),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                                                {bn_output_name}, {orig_output_name}, {},
+                                                do_op_validation),
+                "Failed to add quantize node");
 
   return Ort::Status();
 }

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -713,7 +713,8 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U16) {
   TestInputDef<float> bias_def({channels}, true, bias_data);
 
   RunBatchNormQDQTest<uint16_t, uint8_t>(input_def, scale_def, bias_def,
-                                         ExpectedEPNodeAssignment::All);
+                                         ExpectedEPNodeAssignment::All,
+                                         QDQTolerance(0.008f));
 }
 
 // Test BatchNorm with near-zero variance channels (U8 input). When gamma/sqrt(var+eps) produces

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -687,6 +687,104 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_U8S8F32) {
                        ExpectedEPNodeAssignment::All);
 }
 
+// Test BatchNorm with low variance channels (U16 input). Channels with small variance produce
+// large fused weights that overflow per-tensor uint8 quantization. Float-promotion path fixes this issue
+TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U16) {
+#if defined(__linux__) && !defined(__aarch64__)
+  GTEST_SKIP() << "Skipped on x86_64 simulator due to flaky behavior";
+#endif
+  constexpr int64_t batch = 1;
+  constexpr int64_t channels = 4;
+  constexpr int64_t H = 2;
+  constexpr int64_t W = 2;
+  // Channels 0,1: normal variance. Channels 2,3: low variance (but not zero)
+  std::vector<float> input_data = {
+      -4.0f, -2.0f, 2.0f, 4.0f,   // ch0: var ~= 10
+      -3.0f, -1.0f, 1.0f, 3.0f,   // ch1: var ~= 5
+      5.0f, 5.1f, 4.9f, 5.0f,     // ch2: var ~= 0.005
+      -2.0f, -1.9f, -2.1f, -2.0f  // ch3: var ~= 0.005
+  };
+
+  std::vector<float> scale_data = {1.0f, 1.5f, 2.0f, 3.0f};
+  std::vector<float> bias_data = {0.0f, 0.5f, 1.0f, -1.0f};
+
+  TestInputDef<float> input_def({batch, channels, H, W}, false, input_data);
+  TestInputDef<float> scale_def({channels}, true, scale_data);
+  TestInputDef<float> bias_def({channels}, true, bias_data);
+
+  RunBatchNormQDQTest<uint16_t, uint8_t>(input_def, scale_def, bias_def,
+                                         ExpectedEPNodeAssignment::All);
+}
+
+// Test BatchNorm with near-zero variance channels (U8 input). When gamma/sqrt(var+eps) produces
+// outlier values, per-tensor uint8 quantization of fused weight overflows. The float-promotion path
+// (Convert U8->F32, BN in F32, Convert F32->U8) avoids this accuracy loss.
+TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U8) {
+  constexpr int64_t batch = 1;
+  constexpr int64_t channels = 4;
+  constexpr int64_t H = 2;
+  constexpr int64_t W = 2;
+  // Channels 0,1: normal variance. Channels 2,3: near-zero variance (constant-ish values).
+  std::vector<float> input_data = {
+      -4.0f, -2.0f, 2.0f, 4.0f,   // ch0: var ~= 10
+      -3.0f, -1.0f, 1.0f, 3.0f,   // ch1: var ~= 5
+      5.0f, 5.0f, 5.0f, 5.0f,     // ch2: var ~= 0 (near-zero)
+      -2.0f, -2.0f, -2.0f, -2.0f  // ch3: var ~= 0 (near-zero)
+  };
+
+  std::vector<float> scale_data = {1.0f, 1.5f, 2.0f, 3.0f};
+  std::vector<float> bias_data = {0.0f, 0.5f, 1.0f, -1.0f};
+
+  TestInputDef<float> input_def({batch, channels, H, W}, false, input_data);
+  TestInputDef<float> scale_def({channels}, true, scale_data);
+  TestInputDef<float> bias_def({channels}, true, bias_data);
+
+  // Need this custom method to test the float promotion logic to fp32. This lambda creates the op's inputs to be in per-channel mode
+  GetTestQDQModelFn<uint8_t> qdq_model_fn = [input_def, scale_def, bias_def](ModelTestBuilder& builder,
+                                                                             std::vector<QuantParams<uint8_t>>& output_qparams) {
+    const auto& input_shape = input_def.GetShape();
+    const auto& input_data_ref = input_def.GetRawData();
+    const int64_t num_channels = input_shape[1];
+
+    MakeTestInput(builder, "X", input_def);
+    QuantParams<uint8_t> input_qparams = GetTestInputQuantParams<uint8_t>(input_def);
+    std::string x_dq_name = AddQDQNodePair<uint8_t>(builder, "qdq1", "X", input_qparams.scale, input_qparams.zero_point);
+
+    // Per-channel QDQ for scale (axis=0)
+    MakeTestInput(builder, "scale", scale_def);
+    std::vector<float> scale_scales;
+    std::vector<uint8_t> scale_zps;
+    GetTestInputQuantParamsPerChannel<uint8_t>(scale_def, scale_scales, scale_zps, 0);
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attr = {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))};
+    std::string scale_dq_name = AddQDQNodePair<uint8_t>(builder, "qdq2", "scale", scale_scales, scale_zps, axis_attr, axis_attr);
+
+    std::string bias_dq_name = MakeTestQDQBiasInput(builder, "bias", bias_def, input_qparams.scale * scale_scales[0], true);
+
+    std::vector<float> mean_vals(num_channels);
+    std::vector<float> var_vals(num_channels);
+    ComputeChannelMeanAndVar(input_data_ref, input_shape, mean_vals, var_vals);
+
+    builder.MakeInitializer<float>("mean", {num_channels}, mean_vals);
+    builder.MakeInitializer<float>("var", {num_channels}, var_vals);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 1e-5f));
+    attributes.push_back(builder.MakeScalarAttribute("momentum", 0.9f));
+    builder.AddNode("bn", "BatchNormalization",
+                    {x_dq_name.c_str(), scale_dq_name.c_str(), bias_dq_name.c_str(), "mean", "var"},
+                    {"Y"}, "", attributes);
+
+    AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, "qdq_out", "Y",
+                                                   output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
+                       qdq_model_fn, provider_options, 21, ExpectedEPNodeAssignment::All);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test


### PR DESCRIPTION
### Description
Updates BN to be run in floating point precision when input is u8/u16


### Motivation and Context
Sinet in w8a8 precision drops accuracy to 18.5 (expected 92.9). Upon investigation, I found out BN OpBuilder is incorrectly changing per-channel inputs to per-tensor. Upon fixing the bug, I found out HTP does not actually support BN in per-channel mode even though docs claim otherwise. This PR hence updates BN to be run in FP instead. With this change, Sinet model in w8a8 precision shows an on-target accuracy of 92.9 which is in-line with simulated accuracy. 