### PR TITLE
[QNN EP] Support for Linux x86_64 Ubuntu 22.04 Docker Wheel, Tgz and Test Archive Builds

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -17,7 +17,7 @@ on:
       target_arch:
         description: |
           The architecture for which to build.
-          [Linux] aarch64_manylinux_2_34, aarch64_oe_gcc11_2, or x86_64.
+          [Linux] aarch64_manylinux_2_34, aarch64_oe_gcc11_2, x86_64, or x86_64_ubuntu_22_04.
           [Windows] arm64, arm64ec, arm64x, or x86_64.
         default: arm64
         type: string

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -50,6 +50,22 @@ jobs:
       # version of cpython that's installed on our Linux build machines.
       target_py_vsn: "3.10"
 
+  build-and-test-linux-x86_64-ubuntu-22-04:
+    if: ${{ inputs.do_all }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      target_os: linux
+      target_arch: x86_64_ubuntu_22_04
+      target_py_vsn: ${{ inputs.target_py_vsn }}
+      run_tests: true
+      test_wheel: false
+      upload_test_archive: true
+      upload_wheel: true
+      build_archive: true
+      upload_archive: true
+
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.do_all }}
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -34,8 +34,8 @@ on:
         description: "If true, build for x86_64 Linux"
         type: boolean
         default: true
-      linux_aarch64_manylinux_2_34_target_py_vsns:
-        description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
+      linux_target_py_vsns:
+        description: "JSON list of Python versions to build for Linux targets (aarch64 manylinux_2_34 and x86_64 Ubuntu 22.04)"
         type: string
         default: "['3.11','3.12','3.13','3.14']"
       windows_target_archs:
@@ -82,10 +82,10 @@ jobs:
       target_arch: aarch64
 
   build-linux-aarch64-manylinux_2_34:
-    if: ${{ toJSON(fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)) != '[]' }}
+    if: ${{ toJSON(fromJSON(inputs.linux_target_py_vsns)) != '[]' }}
     strategy:
       matrix:
-        target_py_vsn: ${{ fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns) }}
+        target_py_vsn: ${{ fromJSON(inputs.linux_target_py_vsns) }}
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
@@ -96,10 +96,10 @@ jobs:
       target_py_vsn: ${{ matrix.target_py_vsn }}
       run_tests: false
       # Upload the test archive with the first Python version we encounter
-      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
+      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
       # Build Tgz with the first Python version we encounter
-      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
-      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
+      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
+      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
 
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
@@ -130,6 +130,26 @@ jobs:
       run_tests: false
       upload_test_archive: true
       upload_wheel: true
+
+  build-linux-x86_64-ubuntu-22-04:
+    if: ${{ toJSON(fromJSON(inputs.linux_target_py_vsns)) != '[]' }}
+    strategy:
+      matrix:
+        target_py_vsn: ${{ fromJSON(inputs.linux_target_py_vsns) }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: linux
+      target_arch: x86_64_ubuntu_22_04
+      target_py_vsn: ${{ matrix.target_py_vsn }}
+      run_tests: false
+      test_wheel: false
+      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
+      upload_wheel: true
+      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
+      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
 
   build-windows:
     if: ${{ toJSON(fromJSON(inputs.windows_target_archs)) != '[]' && toJSON(fromJSON(inputs.windows_target_py_vsns)) != '[]' }}

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -43,7 +43,7 @@ jobs:
       build_android_aarch64_aar: true
       build_linux_aarch64_oe_gcc11_2: true
       build_linux_x86_64: true
-      linux_aarch64_manylinux_2_34_target_py_vsns: "['3.11','3.12','3.13','3.14']"
+      linux_target_py_vsns: "['3.11','3.12','3.13','3.14']"
       windows_target_archs: "['arm64', 'arm64ec', 'x86_64']"
       windows_target_py_vsns: "['3.11','3.12','3.13','3.14']"
       windows_arm64_build_archive: true
@@ -145,6 +145,26 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
 
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.11-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.12-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.13-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.14-wheels
+
       - name: Download arm64 Windows 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -229,6 +249,11 @@ jobs:
         with:
           name: linux-x86_64-py3.10-tests
 
+      - name: Download x86_64 Ubuntu 22.04 Linux Tests from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.11-tests
+
       - name: Download arm64 Windows Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -278,6 +303,11 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
+      - name: Download x86_64 Ubuntu 22.04 Linux TGZ Package from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.11-tgz
+
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -315,11 +345,11 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 1 linux x86_64 + 4 linux aarch64 manylinux_2_34 + 4 arm64 + 4 merged AMD = 13 wheels
+          # After merge: 1 linux x86_64 + 4 linux aarch64 manylinux_2_34 + 4 linux x86_64 ubuntu 22.04 + 4 arm64 + 4 merged AMD = 17 wheels
           # (arm64ec and x86_64 originals are deleted by the merge step above)
           count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
           echo "Found $count wheel(s)"
-          [ "$count" -eq 13 ] || { echo "ERROR: Expected 13 wheels, found $count"; exit 1; }
+          [ "$count" -eq 17 ] || { echo "ERROR: Expected 17 wheels, found $count"; exit 1; }
 
       - name: Verify NuGet artifact
         run: |
@@ -331,7 +361,7 @@ jobs:
         run: |
           count=$(find "${{ github.workspace }}/build" -name "*.tar.bz2" | wc -l)
           echo "Found $count .tar.bz2 archive(s)"
-          [ "$count" -eq 3 ] || { echo "ERROR: Expected 3 .tar.bz2 archives, found $count"; exit 1; }
+          [ "$count" -eq 4 ] || { echo "ERROR: Expected 4 .tar.bz2 archives, found $count"; exit 1; }
 
       - name: Verify Zip artifacts
         run: |
@@ -344,7 +374,7 @@ jobs:
         run: |
           count=$(find "${{ github.workspace }}/build" -name "*.tgz" | wc -l)
           echo "Found $count TGZ archive(s)"
-          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 TGZ archive, found $count"; exit 1; }
+          [ "$count" -eq 2 ] || { echo "ERROR: Expected 2 TGZ archives, found $count"; exit 1; }
 
       - name: Verify AAR artifact
         run: |

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -19,8 +19,8 @@ on:
         description: "Version suffix for released package. If set, the specified suffix will be appended to the version string."
         type: string
         default: ""
-      linux_aarch64_manylinux_2_34_target_py_vsns:
-        description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
+      linux_target_py_vsns:
+        description: "JSON list of Python versions to build for Linux targets (aarch64 manylinux_2_34 and x86_64 Ubuntu 22.04)"
         type: string
         default: "['3.11','3.12','3.13','3.14']"
       windows_target_archs:
@@ -50,7 +50,7 @@ jobs:
       build_android_aarch64_aar: true
       build_linux_aarch64_oe_gcc11_2: false
       build_linux_x86_64: false
-      linux_aarch64_manylinux_2_34_target_py_vsns: ${{ inputs.linux_aarch64_manylinux_2_34_target_py_vsns }}
+      linux_aarch64_manylinux_2_34_target_py_vsns: ${{ inputs.linux_target_py_vsns }}
       windows_target_archs: ${{ inputs.windows_target_archs }}
       windows_target_py_vsns: ${{ inputs.windows_target_py_vsns }}
       windows_arm64_build_archive: true
@@ -92,6 +92,26 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.11-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.12-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.13-wheels
+
+      - name: Download x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.14-wheels
 
       - name: Download Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
@@ -158,6 +178,7 @@ jobs:
           mkdir "${{ github.workspace }}/build/dist"
           cp "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
           cp "${{ github.workspace }}/build/linux-aarch64_manylinux_2_34/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
+          cp "${{ github.workspace }}/build/linux-x86_64_ubuntu_22_04/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
 
       - name: Consolidate Wheels
         run: |
@@ -189,10 +210,10 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 4 linux aarch64 manylinux_2_34 + 4 arm64 + 4 merged AMD wheels in build/dist/
+          # After merge: 4 linux aarch64 manylinux_2_34 + 4 linux x86_64 ubuntu 22.04 + 4 arm64 + 4 merged AMD wheels in build/dist/
           count=$(find "${{ github.workspace }}/build/dist" -name "*.whl" | wc -l)
           echo "Found $count wheel(s) in build/dist"
-          [ "$count" -eq 12 ] || { echo "ERROR: Expected 12 wheels in build/dist, found $count"; exit 1; }
+          [ "$count" -eq 16 ] || { echo "ERROR: Expected 16 wheels in build/dist, found $count"; exit 1; }
 
       - name: Check Wheels
         run: |
@@ -346,6 +367,11 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
+      - name: Download Linux x86_64 Ubuntu 22.04 TGZ from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.11-tgz
+
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -372,7 +398,7 @@ jobs:
         run: |
           count=$(find "${{ github.workspace }}/build" -name "*.tgz" | wc -l)
           echo "Found $count TGZ archive(s)"
-          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 TGZ archive, found $count"; exit 1; }
+          [ "$count" -eq 2 ] || { echo "ERROR: Expected 2 TGZ archives, found $count"; exit 1; }
 
       - name: Prepare Windows ARM64 Zip lib for signing
         run: |
@@ -430,6 +456,11 @@ jobs:
           # Upload Linux aarch64 manylinux_2_34 zip
           ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
             "${{ github.workspace }}/build/linux-aarch64_manylinux_2_34/Release/dist" \
+            "$NETRC_FILE"
+
+          # Upload Linux x86_64 ubuntu 22.04 zip
+          ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
+            "${{ github.workspace }}/build/linux-x86_64_ubuntu_22_04/Release/dist" \
             "$NETRC_FILE"
 
           # Upload Windows ARM64EC PDB archive

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -382,6 +382,23 @@ class TaskLibrary:
                 )
             )
 
+    @task
+    @depends(["build_ort_linux_x86_64_ubuntu_22_04"])
+    def archive_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
+        return plan.add_step(
+            BuildEpLinuxTask(
+                "Archiving ONNX Runtime for Linux x86_64 Ubuntu 22.04",
+                self.__venv_path,
+                "linux",
+                "x86_64",
+                self.__config,
+                self.__target_py_version,
+                self.__ort_prebuilt_root,
+                self.__qairt_sdk_root,
+                "archive",
+            )
+        )
+
     if is_host_windows():
 
         @task
@@ -796,6 +813,16 @@ class TaskLibrary:
         )
 
     @task
+    def extract_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
+        return plan.add_step(
+            ExtractArchiveTask(
+                "Extracting ONNX Runtime for Linux x86_64 Ubuntu 22.04",
+                REPO_ROOT / "build" / "onnxruntime-tests-linux-x86_64_ubuntu_22_04.tar.bz2",
+                REPO_ROOT,
+            )
+        )
+
+    @task
     def extract_ort_windows_arm64(self, plan: Plan) -> str:
         return plan.add_step(
             ExtractArchiveTask(
@@ -902,6 +929,25 @@ class TaskLibrary:
             return plan.add_step(
                 BuildEpLinuxTask(
                     "Testing ONNX Runtime for Linux",
+                    self.__venv_path,
+                    "linux",
+                    "x86_64",
+                    self.__config,
+                    self.__target_py_version,
+                    self.__ort_prebuilt_root,
+                    self.__qairt_sdk_root,
+                    "test",
+                )
+            )
+
+    if is_host_linux() and is_host_x86_64():
+
+        @task
+        @depends(["build_ort_linux_x86_64_ubuntu_22_04"])
+        def test_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
+            return plan.add_step(
+                BuildEpLinuxTask(
+                    "Testing ONNX Runtime for Linux x86_64 Ubuntu 22.04",
                     self.__venv_path,
                     "linux",
                     "x86_64",

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -507,24 +507,6 @@ class TaskLibrary:
             ),
         )
 
-    @task
-    @depends(["docker_build_ubuntu_22_04_x86_64"])
-    def build_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
-        return plan.add_step(
-            BuildEpDockerTask(
-                "Building ONNX Runtime for Linux x86_64 on Ubuntu 22.04",
-                "x86_64_ubuntu_22_04",
-                self.__config,
-                self.__target_py_version,
-                self.__qairt_sdk_root,
-                self.__docker_ccache_root,
-                self.__build_archive,
-                inner_task="_build_ort_linux_x86_64_ubuntu_22_04",
-                docker_tag=UBUNTU_22_04_X86_64_TAG,
-                platform="linux/amd64",
-            ),
-        )
-
     if (is_host_linux() and is_host_x86_64()) or is_host_mac():
 
         @task
@@ -576,6 +558,24 @@ class TaskLibrary:
                     build_archive=self.__build_archive,
                 )
             )
+
+    @task
+    @depends(["docker_build_ubuntu_22_04_x86_64"])
+    def build_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
+        return plan.add_step(
+            BuildEpDockerTask(
+                "Building ONNX Runtime for Linux x86_64 on Ubuntu 22.04",
+                "x86_64_ubuntu_22_04",
+                self.__config,
+                self.__target_py_version,
+                self.__qairt_sdk_root,
+                self.__docker_ccache_root,
+                self.__build_archive,
+                inner_task="_build_ort_linux_x86_64_ubuntu_22_04",
+                docker_tag=UBUNTU_22_04_X86_64_TAG,
+                platform="linux/amd64",
+            ),
+        )
 
     if is_host_linux() and is_host_x86_64():
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -40,7 +40,7 @@ from ep_build.tasks.build import (
     GenerateDiffCoverageTask,
     QdcTestsTask,
 )
-from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, DockerBuildTask
+from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, UBUNTU_22_04_X86_64_TAG, DockerBuildTask
 from ep_build.tasks.python import (
     CreateOrtVenvTask,
     CreateQdcVenvTask,
@@ -272,6 +272,36 @@ class TaskLibrary:
             )
         )
 
+    @implementation_detail
+    @depends(["create_venv"])
+    def _build_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
+        """In-container build steps for x86_64-ubuntu_22_04. Not to be used outside of Docker."""
+        extra_args = []
+
+        env = os.environ.copy()
+        if self.__docker_ccache_root is not None:
+            ccache_dir = self.__docker_ccache_root / "linux-x86_64-ubuntu_22_04"
+            env["CCACHE_DIR"] = str(ccache_dir)
+        else:
+            extra_args.append("--no-use-cache")
+
+        return plan.add_step(
+            BuildEpLinuxTask(
+                None,
+                self.__venv_path,
+                "linux",
+                "x86_64",
+                self.__config,
+                self.__target_py_version,
+                self.__ort_prebuilt_root,
+                self.__qairt_sdk_root,
+                "build",
+                extra_args=extra_args if extra_args else None,
+                env=env,
+                build_archive=self.__build_archive,
+            )
+        )
+
     if is_host_linux() or is_host_mac():
 
         @task
@@ -474,6 +504,24 @@ class TaskLibrary:
                 self.__qairt_sdk_root,
                 self.__docker_ccache_root,
                 self.__build_archive,
+            ),
+        )
+
+    @task
+    @depends(["docker_build_ubuntu_22_04_x86_64"])
+    def build_ort_linux_x86_64_ubuntu_22_04(self, plan: Plan) -> str:
+        return plan.add_step(
+            BuildEpDockerTask(
+                "Building ONNX Runtime for Linux x86_64 on Ubuntu 22.04",
+                "x86_64_ubuntu_22_04",
+                self.__config,
+                self.__target_py_version,
+                self.__qairt_sdk_root,
+                self.__docker_ccache_root,
+                self.__build_archive,
+                inner_task="_build_ort_linux_x86_64_ubuntu_22_04",
+                docker_tag=UBUNTU_22_04_X86_64_TAG,
+                platform="linux/amd64",
             ),
         )
 
@@ -705,6 +753,23 @@ class TaskLibrary:
                     "ORT_NIGHTLY_BUILD": os.environ.get("ORT_NIGHTLY_BUILD", "0"),
                     "ORT_VERSION_SUFFIX": os.environ.get("ORT_VERSION_SUFFIX", ""),
                 },
+            )
+        )
+
+    @task
+    def docker_build_ubuntu_22_04_x86_64(self, plan: Plan) -> str:
+        return plan.add_step(
+            DockerBuildTask(
+                "Building Ubuntu 22.04 x86_64 Docker image",
+                REPO_ROOT / "qcom" / "scripts" / "linux" / "ubuntu_22_04" / "Dockerfile",
+                UBUNTU_22_04_X86_64_TAG,
+                build_args={
+                    "BUILD_UID": str(os.getuid()),
+                    "BUILD_GID": str(os.getgid()),
+                    "ORT_NIGHTLY_BUILD": os.environ.get("ORT_NIGHTLY_BUILD", "0"),
+                    "ORT_VERSION_SUFFIX": os.environ.get("ORT_VERSION_SUFFIX", ""),
+                },
+                platform="linux/amd64",
             )
         )
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -20,7 +20,7 @@ from ..task import (
 )
 from ..typing import BuildConfigT, TargetArchLinuxT, TargetArchWindowsT, TargetPyVersionT
 from ..util import BASH_EXECUTABLE, REPO_ROOT, git_head_sha
-from .docker import DOCKER_REPO_ROOT, MANYLINUX_2_34_AARCH64_TAG, UBUNTU_22_04_X86_64_TAG, DockerBuildAndTestTask
+from .docker import DOCKER_REPO_ROOT, MANYLINUX_2_34_AARCH64_TAG, DockerBuildAndTestTask
 from .windows import RunPowershellScriptsTask
 
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -20,7 +20,7 @@ from ..task import (
 )
 from ..typing import BuildConfigT, TargetArchLinuxT, TargetArchWindowsT, TargetPyVersionT
 from ..util import BASH_EXECUTABLE, REPO_ROOT, git_head_sha
-from .docker import DOCKER_REPO_ROOT, MANYLINUX_2_34_AARCH64_TAG, DockerBuildAndTestTask
+from .docker import DOCKER_REPO_ROOT, MANYLINUX_2_34_AARCH64_TAG, UBUNTU_22_04_X86_64_TAG, DockerBuildAndTestTask
 from .windows import RunPowershellScriptsTask
 
 
@@ -40,6 +40,9 @@ class BuildEpDockerTask(CompositeTask):
         qairt_sdk_root: Path | None,
         ccache_root: Path | None,
         build_archive: bool = False,
+        inner_task: str = "_build_ort_linux_aarch64_manylinux_2_34",
+        docker_tag: str = MANYLINUX_2_34_AARCH64_TAG,
+        platform: str = "linux/aarch64",
     ) -> None:
         dist_rel_dir = Path("build") / f"linux-{target_arch}" / config / "dist"
 
@@ -52,14 +55,15 @@ class BuildEpDockerTask(CompositeTask):
                 ),
                 DockerBuildAndTestTask(
                     "Building ONNX Runtime inside a container",
-                    ["_build_ort_linux_aarch64_manylinux_2_34"],
+                    [inner_task],
                     target_py_version,
-                    MANYLINUX_2_34_AARCH64_TAG,
+                    docker_tag,
                     volumes={REPO_ROOT: DOCKER_REPO_ROOT},
                     venv_path=DOCKER_REPO_ROOT / "build" / "venv.build",
                     qairt_sdk_root=qairt_sdk_root,
                     ccache_root=ccache_root,
                     build_archive=build_archive,
+                    platform=platform,
                 ),
             ],
         )

--- a/qcom/ep_build/tasks/docker.py
+++ b/qcom/ep_build/tasks/docker.py
@@ -14,6 +14,7 @@ from ..util import DEFAULT_PYTHON_LINUX
 DOCKER_BUILD_USER = "ortqnnep"
 DOCKER_REPO_ROOT = Path("/ort")
 MANYLINUX_2_34_AARCH64_TAG = "ort-manylinux_2_34_aarch64"
+UBUNTU_22_04_X86_64_TAG = "ort-ubuntu_22_04_x86_64"
 
 
 def _argify(arg: str, sep: str, args: Mapping[Any, Any]) -> list[str]:
@@ -27,6 +28,7 @@ class DockerBuildTask(RunExecutablesTask):
         dockerfile: Path,
         image_name: str,
         build_args: Mapping[str, str] | None = None,
+        platform: str = "linux/aarch64",
     ) -> None:
         build_args_list: list[str] = ["--build-arg", f"BUILD_USER={DOCKER_BUILD_USER}"]
         if build_args is not None:
@@ -36,7 +38,7 @@ class DockerBuildTask(RunExecutablesTask):
             group_name,
             [
                 [
-                    "docker", "build", "--platform", "linux/aarch64",
+                    "docker", "build", "--platform", platform,
                     "--file", str(dockerfile), "--tag", image_name,
                     *build_args_list,
                     str(dockerfile.parent),
@@ -56,9 +58,10 @@ class DockerRunTask(RunExecutablesTask):
         volumes: Mapping[Path, Path] | None = None,
         env: Mapping[str, str] | None = None,
         remove: bool = True,
+        platform: str = "linux/aarch64",
     ) -> None:
         def make_cmd() -> list[list[str]]:
-            cmd = ["docker", "run", "--platform", "linux/aarch64", "--user", DOCKER_BUILD_USER]
+            cmd = ["docker", "run", "--platform", platform, "--user", DOCKER_BUILD_USER]
             if working_dir is not None:
                 cmd.extend(["--workdir", str(working_dir)])
             if volumes is not None:
@@ -89,6 +92,7 @@ class DockerBuildAndTestTask(DockerRunTask):
         qairt_sdk_root: Path | None = None,
         ccache_root: Path | None = None,
         build_archive: bool = False,
+        platform: str = "linux/aarch64",
     ) -> None:
         # deferred to avoid circular import
         from ..tools import get_package_dir, get_tools_dir  # noqa:PLC0415
@@ -130,4 +134,5 @@ class DockerBuildAndTestTask(DockerRunTask):
             volumes_with_caches,
             env,
             remove,
+            platform,
         )

--- a/qcom/ep_build/typing.py
+++ b/qcom/ep_build/typing.py
@@ -4,7 +4,7 @@
 from typing import Literal
 
 BuildConfigT = Literal["Debug", "Release", "RelWithDebInfo"]
-TargetArchLinuxT = Literal["aarch64", "aarch64_manylinux_2_34", "aarch64_oe_gcc11_2", "x86_64"]
+TargetArchLinuxT = Literal["aarch64", "aarch64_manylinux_2_34", "aarch64_oe_gcc11_2", "x86_64", "x86_64_ubuntu_22_04"]
 TargetArchWindowsT = Literal["arm64", "arm64ec", "arm64x", "x86_64"]
 TargetArchT = TargetArchLinuxT | TargetArchWindowsT
 TargetPyVersionT = Literal["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/qcom/scripts/linux/ubuntu_22_04/Dockerfile
+++ b/qcom/scripts/linux/ubuntu_22_04/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+ARG BUILD_USER
+ARG BUILD_UID
+ARG BUILD_GID
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    wget \
+    curl \
+    pkg-config \
+    ca-certificates \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y \
+       python3.11 python3.11-dev python3.11-venv \
+       python3.12 python3.12-dev python3.12-venv \
+       python3.13 python3.13-dev python3.13-venv \
+       python3.14 python3.14-dev python3.14-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g $BUILD_GID $BUILD_USER && useradd -u $BUILD_UID -g $BUILD_USER $BUILD_USER
+
+ARG ORT_NIGHTLY_BUILD=0
+ENV ORT_NIGHTLY_BUILD=$ORT_NIGHTLY_BUILD
+
+ARG ORT_VERSION_SUFFIX=
+ENV ORT_VERSION_SUFFIX=$ORT_VERSION_SUFFIX


### PR DESCRIPTION
### Motivation

The existing Linux x86_64 build runs natively on self-hosted runners, producing `linux_x86_64` wheels tied to whatever distro happens to be on the runner. This PR adds a parallel Docker-based pipeline that builds inside an `Ubuntu 22.04` container, giving us a reproducible environment and a multi-Python-version wheel matrix (3.11–3.14) to match what we already ship for `aarch64_manylinux_2_34`.

---

### Changes

#### New Docker image (`qcom/scripts/linux/ubuntu_22_04/Dockerfile`)
`Ubuntu 22.04` base image with build tools (`cmake`, `ninja`, `build-essential`, etc.) and `Python 3.11–3.14` installed via the deadsnakes PPA. Follows the same user/group ARG pattern as the existing `aarch64 manylinux Dockerfile`.

#### Generalized Docker task infrastructure (`qcom/ep_build/tasks/docker.py`, `build.py`)
- Added `UBUNTU_22_04_X86_64_TAG` constant.
- Added a `platform` parameter to `DockerBuildTask`, `DockerRunTask`, and `DockerBuildAndTestTask` (defaults to `linux/aarch64` for backward compatibility).
- Added `inner_task`, `docker_tag`, and `platform` parameters to `BuildEpDockerTask` so it can be reused for any Linux Docker target without subclassing.

#### New build tasks (`qcom/build_and_test.py`, `qcom/ep_build/typing.py`)
Three new tasks following the same pattern as the aarch64 manylinux equivalents:
- `docker_build_ubuntu_22_04_x86_64`: Builds the Docker image.
- `build_ort_linux_x86_64_ubuntu_22_04`: Depends on the Docker image build.
- `_build_ort_linux_x86_64_ubuntu_22_04`: Implementation detail that runs inside the container; calls `build.sh --target-arch=x86_64` with no `--qnn-arch-abi` (same as the native x86_64 build, since x86_64 is not cross-compiled).

`x86_64_ubuntu_22_04` is added to `TargetArchLinuxT`.

#### CI workflows
- **`qualcomm-internal-build-artifacts.yml`**: Merged `linux_aarch64_manylinux_2_34_target_py_vsns` and the new `linux_x86_64_ubuntu_22_04_target_py_vsns` into a single `linux_target_py_vsns` input (default `['3.11','3.12','3.13','3.14']`). Added `build-linux-x86_64-ubuntu-22-04` matrix job.
- **`qualcomm-internal-build-and-test.yml`**: Added `build-and-test-linux-x86_64-ubuntu-22-04` job with wheels, test archive, and TGZ upload enabled.
- **`qualcomm-internal-build-and-test-single-os.yml`**: Updated `target_arch` description to list `x86_64_ubuntu_22_04`.
- **`qualcomm-internal-upload-artifactory-from-github.yml`**: Renamed input to `linux_target_py_vsns`; added download, consolidation, and publish steps for Ubuntu 22.04 wheels and TGZ. Wheel count updated 12 → 16, TGZ count 1 → 2.
- **`qualcomm-internal-release.yml`**: Added download steps for Ubuntu 22.04 wheels (3.11–3.14), test archive, and TGZ. Updated artifact counts: wheels 13 → 17, `.tar.bz2` 3 → 4, TGZ 1 → 2.

---

### What is NOT changed
- The existing native `build_ort_linux_x86_64` task and its CI job are untouched.
- All aarch64 Docker paths are fully backward-compatible.
