### PR TITLE
[QNN EP] Replace positional constructors in QnnQuantParamsWrapper with named factories

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -183,9 +183,9 @@ Ort::Status BaseOpBuilder::AddZeroBiasInput(QnnModelWrapper& qnn_model_wrapper,
   QnnQuantParamsWrapper bias_qparams;
 
   if (input1_qparams.IsPerChannel()) {
-    bias_qparams = QnnQuantParamsWrapper(bias_scales, bias_offsets, /*axis*/ 0, /*is_int4*/ false);
+    bias_qparams = QnnQuantParamsWrapper::PerChannel(bias_scales, bias_offsets, /*axis*/ 0);
   } else {
-    bias_qparams = QnnQuantParamsWrapper(bias_scales[0], bias_offsets[0]);
+    bias_qparams = QnnQuantParamsWrapper::PerTensor(bias_scales[0], bias_offsets[0]);
   }
 
   auto tensor_wrapper = QnnTensorWrapper(bias_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -405,7 +405,7 @@ class BatchNormalizationOpBuilder : public BaseOpBuilder {
                                             scale,
                                             zero_point,
                                             symmetric));
-      quant_param = QnnQuantParamsWrapper(scale, zero_point);
+      quant_param = QnnQuantParamsWrapper::PerTensor(scale, zero_point);
       for (size_t i = 0; i < double_tensor.size(); ++i) {
         int quant_value_int = 0;
         RETURN_IF_ERROR(utils::Quantize(double_tensor[i], scale, zero_point, info.qnn_data_type, quant_value_int));
@@ -675,7 +675,7 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
                                    bias_info.qnn_data_type,
                                    scale_rmin < 0.0);
     if (is_quantized_op && bias_is_float) {
-      bias_info.quant_param = QnnQuantParamsWrapper(1.0f, 0);  // Placeholder, computed in Postprocess
+      bias_info.quant_param = QnnQuantParamsWrapper::PerTensor(1.0f, 0);  // Placeholder, computed in Postprocess
     }
 
     // use_float_params stores the fused weight/bias as F32.

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -400,10 +400,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
         }
       }
 
-      QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
-                                            gsl::span<const float>(offsets_qnn),
-                                            bitwidth,
-                                            gsl::span<const uint32_t>(block_size_arr));
+      QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
+                                                                                  gsl::span<const float>(offsets_qnn),
+                                                                                  bitwidth,
+                                                                                  gsl::span<const uint32_t>(block_size_arr));
 
       // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
       QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
@@ -703,7 +703,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
 
               // Create new tensor wrapper with requantized data
               std::string bias_name = bias_input.name;
-              QnnQuantParamsWrapper new_quant_params(new_scales[0], new_offsets[0]);
+              QnnQuantParamsWrapper new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
               QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
                                                   std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
                                                   std::move(requantized_bias_data));
@@ -795,7 +795,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
 
                 // Create new tensor wrapper with requantized data
                 std::string bias_name = bias_input.name;
-                QnnQuantParamsWrapper new_quant_params(new_scales, new_offsets, quant_axis, false);
+                QnnQuantParamsWrapper new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, quant_axis);
                 QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
                                                     std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
                                                     std::move(requantized_bias_data));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
@@ -83,7 +83,7 @@ Ort::Status ExpandOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     float rmax = 1.0f;
     float rmin = 1.0f;
     RETURN_IF_ERROR(utils::GetQuantParams(rmin, rmax, qnn_data_type, scale, zero_point));
-    quantize_param = QnnQuantParamsWrapper(scale, zero_point);
+    quantize_param = QnnQuantParamsWrapper::PerTensor(scale, zero_point);
     int quant_value_int = 0;
     double ini_value = 1.0;
     RETURN_IF_ERROR(utils::Quantize(ini_value, scale, zero_point, qnn_data_type, quant_value_int));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -237,7 +237,7 @@ Ort::Status GatherOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                                     cast_output_name,
                                                     QNN_TENSOR_TYPE_NATIVE,
                                                     QNN_DATATYPE_UFIXED_POINT_8,
-                                                    QnnQuantParamsWrapper(1.0f, 0),
+                                                    QnnQuantParamsWrapper::PerTensor(1.0f, 0),
                                                     std::vector<uint32_t>(input0_info.shape),
                                                     do_op_validation));
     }
@@ -290,7 +290,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
 
     const std::string gather_output_name = utils::UniqueNameGenerator().New(output_name, "_u8_to_bool_in");
-    QnnQuantParamsWrapper gather_quant_params(1.0f, 0);
+    QnnQuantParamsWrapper gather_quant_params = QnnQuantParamsWrapper::PerTensor(1.0f, 0);
     QnnTensorWrapper gather_output_wrapper(gather_output_name,
                                            QNN_TENSOR_TYPE_NATIVE,
                                            QNN_DATATYPE_UFIXED_POINT_8,
@@ -430,7 +430,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   QnnQuantParamsWrapper gather_quant_params = quantize_param.Copy();
   if (cast_plan.needs_bool_cast) {
     gather_qnn_data_type = QNN_DATATYPE_UFIXED_POINT_8;
-    gather_quant_params = QnnQuantParamsWrapper(1.0f, 0);
+    gather_quant_params = QnnQuantParamsWrapper::PerTensor(1.0f, 0);
   }
 
   Qnn_TensorType_t tensor_type = (!reshape_required && is_graph_output && !cast_plan.needs_bool_cast && !cast_plan.needs_int64_cast)

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
@@ -256,10 +256,9 @@ Ort::Status GatherBlockQuantizedOpBuilder::ProcessInputs(
     RETURN_IF_NOT(static_cast<int64_t>(weight_shape[1]) * 2 ==
                       static_cast<int64_t>(scale_shape[1]) * block_size,
                   "GatherBlockQuantized: weight packed bytes mismatch with scales * block_size");
-    QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper(float_scale,
-                                                                 int32_offset,
-                                                                 block_sizes,
-                                                                 QNN_DATATYPE_SFIXED_POINT_4);
+    QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper::Block(float_scale,
+                                                                        int32_offset,
+                                                                        block_sizes);
     std::vector<uint32_t> weight_shape_ = {static_cast<uint32_t>(weight_shape[0]),
                                            static_cast<uint32_t>(scale_shape[1] * block_size)};
     QnnTensorWrapper weight_tensor_wrapper(weight_tensor_name,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -403,10 +403,10 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
     offsets_qnn = std::move(onnx_offsets);
   }
 
-  QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
-                                        gsl::span<const float>(offsets_qnn),
-                                        bitwidth,
-                                        gsl::span<const uint32_t>(block_size_arr));
+  QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
+                                                                              gsl::span<const float>(offsets_qnn),
+                                                                              bitwidth,
+                                                                              gsl::span<const uint32_t>(block_size_arr));
 
   // 2-D weight [N, K] with BW_FLOAT_BLOCK encoding.
   std::vector<uint32_t> weight_shape_2d = {static_cast<uint32_t>(N), static_cast<uint32_t>(K)};

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -385,7 +385,7 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     int32_t ln_offset = 0;
     RETURN_IF_ERROR(utils::GetQuantParams(-ln_abs_max, ln_abs_max, x_qnn_data_type,
                                           ln_scale, ln_offset, /*symmetric=*/false));
-    ln_intermediate_qp = QnnQuantParamsWrapper(ln_scale, ln_offset);
+    ln_intermediate_qp = QnnQuantParamsWrapper::PerTensor(ln_scale, ln_offset);
   } else {
     // FP path
     ln_intermediate_qp = final_output_info.quant_param.Copy();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -785,10 +785,10 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
     }
   }
 
-  QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
-                                        gsl::span<const float>(offsets_qnn),
-                                        bitwidth,
-                                        gsl::span<const uint32_t>(block_size_arr));
+  QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
+                                                                              gsl::span<const float>(offsets_qnn),
+                                                                              bitwidth,
+                                                                              gsl::span<const uint32_t>(block_size_arr));
 
   // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
   // Weight is reshaped to 4-D [1, 1, K, N] to satisfy the QNN HTP BQ MatMul requirement.

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -394,10 +394,9 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
 
         // 2.5 Create QNN wrappers.
         const std::vector<uint32_t> block_sizes = {1, gsl::narrow_cast<uint32_t>(block_size)};
-        QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper(per_block_float_scale,
-                                                                     per_block_int32_offset,
-                                                                     block_sizes,
-                                                                     QNN_DATATYPE_SFIXED_POINT_4);
+        QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper::Block(per_block_float_scale,
+                                                                            per_block_int32_offset,
+                                                                            block_sizes);
 
         std::vector<uint32_t> weight_shape = {gsl::narrow_cast<uint32_t>(N), gsl::narrow_cast<uint32_t>(K)};
         QnnTensorWrapper weight_tensor_wrapper(weight_tensor_name,
@@ -448,10 +447,10 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
         // 2.5 Create QNN wrappers.
         // Note that unlike weights requiring transpose, scales/offsets are expected in original ONNX shape.
         const std::vector<uint32_t> block_sizes = {1, 1, gsl::narrow_cast<uint32_t>(block_size), 1};
-        QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper(per_block_float_scale,
-                                                                     per_block_float_zp,
-                                                                     gsl::narrow_cast<uint32_t>(bits),
-                                                                     block_sizes);
+        QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper::BwFloatBlock(per_block_float_scale,
+                                                                                   per_block_float_zp,
+                                                                                   gsl::narrow_cast<uint32_t>(bits),
+                                                                                   block_sizes);
 
         // Shape is for Conv2d, expecting in HWIO.
         std::vector<uint32_t> weight_shape = {1, 1, gsl::narrow_cast<uint32_t>(K), gsl::narrow_cast<uint32_t>(N)};

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qlinear_matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qlinear_matmul_op_builder.cc
@@ -182,7 +182,7 @@ Ort::Status QLinearMatMulOpBuilder::BuildQuantParam(const QnnModelWrapper& qnn_m
   RETURN_IF_ERROR(ReadZeroPointAsInt32(qnn_model_wrapper, zp_tensor, zero_point));
 
   // UnpackZeroPoints already returns -zp (QNN offset convention); pass through directly.
-  out_quant_param = QnnQuantParamsWrapper(scale, zero_point);
+  out_quant_param = QnnQuantParamsWrapper::PerTensor(scale, zero_point);
   return Ort::Status();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/randomnormallike_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/randomnormallike_op_builder.cc
@@ -152,7 +152,7 @@ Ort::Status RandomNormalLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapp
     float quant_scale = 0.0f;
     int32_t zero_point = 0;
     RETURN_IF_ERROR(utils::GetQuantParams(quant_min, quant_max, QNN_DATATYPE_UFIXED_POINT_8, quant_scale, zero_point));
-    QnnQuantParamsWrapper quantize_param(quant_scale, zero_point);
+    QnnQuantParamsWrapper quantize_param = QnnQuantParamsWrapper::PerTensor(quant_scale, zero_point);
 
     QnnTensorWrapper intermediate_output_wrapper(intermediate_output_name,
                                                  QNN_TENSOR_TYPE_NATIVE,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/randomuniformlike_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/randomuniformlike_op_builder.cc
@@ -147,7 +147,7 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrap
     float scale = 0.0f;
     int32_t zero_point = 0;
     RETURN_IF_ERROR(utils::GetQuantParams(low, high, QNN_DATATYPE_UFIXED_POINT_8, scale, zero_point));
-    quantize_param = QnnQuantParamsWrapper(scale, zero_point);
+    quantize_param = QnnQuantParamsWrapper::PerTensor(scale, zero_point);
     QnnTensorWrapper intermediate_output_wrapper(intermediate_output_name,
                                                  QNN_TENSOR_TYPE_NATIVE,
                                                  QNN_DATATYPE_UFIXED_POINT_8,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -107,7 +107,7 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
     if (scale_info.quant_param.IsQuantized()) {
       float quant_scale = 1.0f;
       int32_t zero_point = 0;
-      beta_quant_param = QnnQuantParamsWrapper(quant_scale, zero_point);
+      beta_quant_param = QnnQuantParamsWrapper::PerTensor(quant_scale, zero_point);
     }
 
     const size_t beta_size_in_bytes = utils::GetQnnTensorDataSizeInBytes(beta_shape, beta_data_type);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -219,7 +219,7 @@ Ort::Status ProcessAlphaAttributeAsInput(QnnModelWrapper& qnn_model_wrapper,
 
     unpacked_data.resize(1);
     RETURN_IF_ERROR(qnn::utils::QuantizeData(float_data, shape, scales, offsets, unpacked_data, qnn_data_type));
-    quantize_param = QnnQuantParamsWrapper(scales[0], static_cast<int32_t>(offsets[0]));
+    quantize_param = QnnQuantParamsWrapper::PerTensor(scales[0], static_cast<int32_t>(offsets[0]));
   } else {
     const auto& inputs = node_unit.Inputs();
     TensorInfo input_info = {};

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -83,7 +83,7 @@ static bool NeedsBoundedOutputSplit(const std::string& op_type, const TensorInfo
 static QnnQuantParamsWrapper BuildUnitRangeQuantParams(Qnn_DataType_t qnn_data_type) {
   const size_t bitwidth = utils::GetElementSizeByType(qnn_data_type) * 8;
   const float scale = 1.0f / static_cast<float>(uint64_t{1} << bitwidth);
-  return QnnQuantParamsWrapper(scale, /*offset*/ 0);
+  return QnnQuantParamsWrapper::PerTensor(scale, /*offset*/ 0);
 }
 
 // Creates the QNN Softmax node and wires its output to `output_name`

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.cc
@@ -170,7 +170,7 @@ Ort::Status BuildWeightQuantParams(const QnnModelWrapper& qmw,
 
   if (scales.size() == 1) {
     const int32_t offset = offsets.empty() ? 0 : offsets[0];
-    out_params = QnnQuantParamsWrapper(scales[0], offset);
+    out_params = QnnQuantParamsWrapper::PerTensor(scales[0], offset);
     return Ort::Status();
   }
 
@@ -186,10 +186,9 @@ Ort::Status BuildWeightQuantParams(const QnnModelWrapper& qmw,
                   "B_zp length must equal B_scale length for per-channel");
   }
 
-  out_params = QnnQuantParamsWrapper(gsl::span<const float>(scales),
-                                     gsl::span<const int32_t>(offsets),
-                                     per_channel_axis,
-                                     /*is_int4=*/false);
+  out_params = QnnQuantParamsWrapper::PerChannel(gsl::span<const float>(scales),
+                                                 gsl::span<const int32_t>(offsets),
+                                                 per_channel_axis);
   return Ort::Status();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.cc
@@ -283,7 +283,9 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   auto block_size = helper.Get("block_size", static_cast<int64_t>(0));
 
   size_t output_channel_axis = 0;  // Current LowPowerBlockQuantize() support output_channel_axis at index=0;
-  weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
+  weight_qparams = QnnQuantParamsWrapper::LowPowerBlockwise(per_channel_float_scale, per_block_int_scale,
+                                                            weight_offset, output_channel_axis,
+                                                            /*block_scale_bitwidth*/ is_int4_type ? 4 : 8);
 
   Qnn_DataType_t weight_data_type = is_int4_type ? QNN_DATATYPE_SFIXED_POINT_4 : QNN_DATATYPE_SFIXED_POINT_8;
   QnnTensorWrapper weight_tensor;
@@ -365,7 +367,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
     std::vector<uint8_t> bias_quant_data(bias_elements * qnn::utils::GetElementSizeByType(bias_data_type));
 
     RETURN_IF_ERROR(qnn::utils::QuantizeData(bias_float_data, bias_shape, bias_scales, bias_offsets, bias_quant_data, bias_data_type, /*axis*/ 0));
-    QnnQuantParamsWrapper bias_qparams(bias_scales, bias_offsets, /*axis*/ 0, /*is_int4*/ 0);
+    QnnQuantParamsWrapper bias_qparams = QnnQuantParamsWrapper::PerChannel(bias_scales, bias_offsets, /*axis*/ 0);
 
     bias_tensor = QnnTensorWrapper(bias_tensor_name, bias_tensor_type, bias_data_type,
                                    std::move(bias_qparams), std::move(bias_shape),

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.cc
@@ -347,7 +347,9 @@ Ort::Status ProcessLPBQWeight(QnnModelWrapper& qnn_model_wrapper,
 
     // Construct Quant params for Weight
     QnnQuantParamsWrapper weight_qparams;
-    weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
+    weight_qparams = QnnQuantParamsWrapper::LowPowerBlockwise(per_channel_float_scale, per_block_int_scale,
+                                                              weight_offset, output_channel_axis,
+                                                              /*block_scale_bitwidth*/ is_int4_type ? 4 : 8);
 
     // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
     Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
@@ -385,7 +387,6 @@ Ort::Status ProcessLPBQWeight(QnnModelWrapper& qnn_model_wrapper,
     if (input_channel_axis < 0) {
       input_channel_axis = weight_shape.size() + input_channel_axis;  // QNN requires positive axis value
     }
-    auto block_size = helper.Get("block_size", static_cast<int64_t>(0));
 
     // Check if the weight is a constant initializer
     RETURN_IF_NOT(qnn_model_wrapper.IsConstantInput(weight_tensor_name), "Weight must be a constant initializer");
@@ -406,7 +407,9 @@ Ort::Status ProcessLPBQWeight(QnnModelWrapper& qnn_model_wrapper,
 
     // Construct Quant params for Weight
     QnnQuantParamsWrapper weight_qparams;
-    weight_qparams = QnnQuantParamsWrapper(per_channel_float_scale, per_block_int_scale, weight_offset, output_channel_axis, block_size, is_int4_type);
+    weight_qparams = QnnQuantParamsWrapper::LowPowerBlockwise(per_channel_float_scale, per_block_int_scale,
+                                                              weight_offset, output_channel_axis,
+                                                              /*block_scale_bitwidth*/ is_int4_type ? 4 : 8);
 
     // Get weight tensor type from input of w_dql_tensor or output_dql_tensor
     Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -48,98 +48,125 @@ QnnQuantParamsWrapper& QnnQuantParamsWrapper::operator=(const QnnQuantParamsWrap
   return *this;
 }
 
-// Construct per-tensor quantization params.
-QnnQuantParamsWrapper::QnnQuantParamsWrapper(float scale, int32_t offset) {
-  params_.encodingDefinition = QNN_DEFINITION_DEFINED;
-  params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_SCALE_OFFSET;
-  params_.scaleOffsetEncoding.scale = scale;
-  params_.scaleOffsetEncoding.offset = offset;
+// Per-tensor quantization (SCALE_OFFSET).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::PerTensor(float scale, int32_t offset) {
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_SCALE_OFFSET;
+  qp.params_.scaleOffsetEncoding.scale = scale;
+  qp.params_.scaleOffsetEncoding.offset = offset;
+  return qp;
 }
 
-// Construct a per-channel quantization param.
-QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> scales, gsl::span<const int32_t> offsets,
-                                             int32_t axis, bool is_int4) {
-  assert(scales.size() == offsets.size());  // Logic error if sizes don't match.
+// Per-tensor quantization with explicit bitwidth (BW_SCALE_OFFSET).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::PerTensorBw(float scale, int32_t offset, uint32_t bitwidth) {
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET;
+  qp.params_.bwScaleOffsetEncoding.bitwidth = bitwidth;
+  qp.params_.bwScaleOffsetEncoding.scale = scale;
+  qp.params_.bwScaleOffsetEncoding.offset = offset;
+  return qp;
+}
+
+// Per-channel quantization (AXIS_SCALE_OFFSET).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::PerChannel(gsl::span<const float> scales,
+                                                        gsl::span<const int32_t> offsets,
+                                                        int32_t axis) {
+  assert(scales.size() == offsets.size());
   const uint32_t num_elems = static_cast<uint32_t>(scales.size());
-  params_.encodingDefinition = QNN_DEFINITION_DEFINED;
 
-  if (is_int4) {
-    params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET;
-    params_.bwAxisScaleOffsetEncoding.numElements = num_elems;
-    params_.bwAxisScaleOffsetEncoding.axis = axis;
-    params_.bwAxisScaleOffsetEncoding.bitwidth = 4;
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET;
+  qp.params_.axisScaleOffsetEncoding.numScaleOffsets = num_elems;
+  qp.params_.axisScaleOffsetEncoding.axis = axis;
 
-    // Deep copy to the scales[] and offsets[] arrays
-    if (num_elems > 0) {
-      per_channel_scales_size_ = num_elems;
-      const size_t num_scale_bytes = num_elems * sizeof(float);
-      const size_t num_zp_bytes = num_elems * sizeof(int32_t);
-      const size_t num_bytes = num_scale_bytes + num_zp_bytes;
-      constexpr std::uintptr_t align = alignof(float);
-      static_assert(alignof(float) == alignof(int32_t));
+  if (num_elems > 0) {
+    const size_t num_bytes = num_elems * sizeof(Qnn_ScaleOffset_t);
+    constexpr std::uintptr_t align = alignof(Qnn_ScaleOffset_t);
+    qp.per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
+    Qnn_ScaleOffset_t* aligned_dst = ALIGN_PTR_UP(qp.per_channel_data_.get(), align, Qnn_ScaleOffset_t*);
 
-      per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
-      char* scales_begin = ALIGN_PTR_UP(per_channel_data_.get(), align, char*);
-      char* zps_begin = scales_begin + num_scale_bytes;
-
-      std::memcpy(scales_begin, scales.data(), num_scale_bytes);
-      std::memcpy(zps_begin, offsets.data(), num_zp_bytes);
-      params_.bwAxisScaleOffsetEncoding.scales = reinterpret_cast<float*>(scales_begin);
-      params_.bwAxisScaleOffsetEncoding.offsets = reinterpret_cast<int32_t*>(zps_begin);
-    } else {
-      params_.bwAxisScaleOffsetEncoding.scales = nullptr;
-      params_.bwAxisScaleOffsetEncoding.offsets = nullptr;
+    for (size_t i = 0; i < static_cast<uint32_t>(num_elems); i++) {
+      aligned_dst[i].offset = offsets[i];
+      aligned_dst[i].scale = scales[i];
     }
+
+    qp.params_.axisScaleOffsetEncoding.scaleOffset = aligned_dst;
   } else {
-    params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET;
-    params_.axisScaleOffsetEncoding.numScaleOffsets = num_elems;
-    params_.axisScaleOffsetEncoding.axis = axis;
-
-    // Deep copy to the scaleOffset data.
-    if (num_elems > 0) {
-      const size_t num_bytes = num_elems * sizeof(Qnn_ScaleOffset_t);
-      constexpr std::uintptr_t align = alignof(Qnn_ScaleOffset_t);
-      per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
-      Qnn_ScaleOffset_t* aligned_dst = ALIGN_PTR_UP(per_channel_data_.get(), align, Qnn_ScaleOffset_t*);
-
-      for (size_t i = 0; i < static_cast<uint32_t>(num_elems); i++) {
-        aligned_dst[i].offset = offsets[i];
-        aligned_dst[i].scale = scales[i];
-      }
-
-      params_.axisScaleOffsetEncoding.scaleOffset = aligned_dst;
-    } else {
-      params_.axisScaleOffsetEncoding.scaleOffset = nullptr;
-    }
+    qp.params_.axisScaleOffsetEncoding.scaleOffset = nullptr;
   }
+  return qp;
 }
 
-// Construct a LPBQ quantization param.
-QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> per_channel_float_scales, gsl::span<const uint8_t> per_block_int_scales,
-                                             gsl::span<const int32_t> offsets, int64_t axis, int64_t block_size, bool is_int4) {
-  ORT_UNUSED_PARAMETER(block_size);
-  assert(per_channel_float_scales.size() == offsets.size());  // Logic error if sizes don't match.
+// Per-channel quantization with explicit bitwidth (BW_AXIS_SCALE_OFFSET).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::PerChannelBw(gsl::span<const float> scales,
+                                                          gsl::span<const int32_t> offsets,
+                                                          int32_t axis,
+                                                          uint32_t bitwidth) {
+  assert(scales.size() == offsets.size());
+  const uint32_t num_elems = static_cast<uint32_t>(scales.size());
+
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET;
+  qp.params_.bwAxisScaleOffsetEncoding.numElements = num_elems;
+  qp.params_.bwAxisScaleOffsetEncoding.axis = axis;
+  qp.params_.bwAxisScaleOffsetEncoding.bitwidth = bitwidth;
+
+  if (num_elems > 0) {
+    qp.per_channel_scales_size_ = num_elems;
+    const size_t num_scale_bytes = num_elems * sizeof(float);
+    const size_t num_zp_bytes = num_elems * sizeof(int32_t);
+    const size_t num_bytes = num_scale_bytes + num_zp_bytes;
+    constexpr std::uintptr_t align = alignof(float);
+    static_assert(alignof(float) == alignof(int32_t));
+
+    qp.per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
+    char* scales_begin = ALIGN_PTR_UP(qp.per_channel_data_.get(), align, char*);
+    char* zps_begin = scales_begin + num_scale_bytes;
+
+    std::memcpy(scales_begin, scales.data(), num_scale_bytes);
+    std::memcpy(zps_begin, offsets.data(), num_zp_bytes);
+    qp.params_.bwAxisScaleOffsetEncoding.scales = reinterpret_cast<float*>(scales_begin);
+    qp.params_.bwAxisScaleOffsetEncoding.offsets = reinterpret_cast<int32_t*>(zps_begin);
+  } else {
+    qp.params_.bwAxisScaleOffsetEncoding.scales = nullptr;
+    qp.params_.bwAxisScaleOffsetEncoding.offsets = nullptr;
+  }
+  return qp;
+}
+
+// Low-power blockwise (LPBQ) quantization (BLOCKWISE_EXPANSION).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::LowPowerBlockwise(gsl::span<const float> per_channel_float_scales,
+                                                               gsl::span<const uint8_t> per_block_int_scales,
+                                                               gsl::span<const int32_t> offsets,
+                                                               int64_t axis,
+                                                               uint32_t block_scale_bitwidth) {
+  assert(per_channel_float_scales.size() == offsets.size());
   const uint32_t num_elems = static_cast<uint32_t>(per_channel_float_scales.size());
-  params_.encodingDefinition = QNN_DEFINITION_DEFINED;
 
-  params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION;
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION;
 
-  // create the blockwiseExpansion object
+  // Allocate the blockwiseExpansion object.
   const size_t bwe_num_bytes = sizeof(Qnn_BlockwiseExpansion_t);
   constexpr std::uintptr_t bwe_align = alignof(Qnn_BlockwiseExpansion_t);
-  blockwise_expansion_data_ = std::make_unique<char[]>(bwe_num_bytes + bwe_align);
-  Qnn_BlockwiseExpansion_t* lpbqPtr = ALIGN_PTR_UP(blockwise_expansion_data_.get(), bwe_align, Qnn_BlockwiseExpansion_t*);
+  qp.blockwise_expansion_data_ = std::make_unique<char[]>(bwe_num_bytes + bwe_align);
+  Qnn_BlockwiseExpansion_t* lpbqPtr = ALIGN_PTR_UP(qp.blockwise_expansion_data_.get(), bwe_align,
+                                                   Qnn_BlockwiseExpansion_t*);
   Qnn_BlockwiseExpansion_t& lpbq = *lpbqPtr;
 
   lpbq.axis = static_cast<int32_t>(axis);
 
-  // Deep copy the scaleOffset data.
   if (num_elems > 0) {
-    per_channel_scales_size_ = num_elems;
+    qp.per_channel_scales_size_ = num_elems;
     const size_t num_bytes = num_elems * sizeof(Qnn_ScaleOffset_t);
     constexpr std::uintptr_t align = alignof(Qnn_ScaleOffset_t);
-    per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
-    Qnn_ScaleOffset_t* aligned_dst = ALIGN_PTR_UP(per_channel_data_.get(), align, Qnn_ScaleOffset_t*);
+    qp.per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
+    Qnn_ScaleOffset_t* aligned_dst = ALIGN_PTR_UP(qp.per_channel_data_.get(), align, Qnn_ScaleOffset_t*);
 
     for (size_t i = 0; i < static_cast<uint32_t>(num_elems); i++) {
       aligned_dst[i].offset = offsets[i];
@@ -150,82 +177,84 @@ QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> per_channel_
   }
 
   lpbq.numBlocksPerAxis = static_cast<uint32_t>(per_block_int_scales.size()) / num_elems;
-  lpbq.blockScaleBitwidth = is_int4 ? 4 : 8;
+  lpbq.blockScaleBitwidth = block_scale_bitwidth;
   lpbq.blockScaleStorageType = QNN_BLOCKWISE_EXPANSION_BITWIDTH_SCALE_STORAGE_8;
 
-  // Deep copy the block int scales
+  // Deep copy the per-block int scales.
   const size_t num_bytes = per_block_int_scales.size() * sizeof(uint8_t);
   constexpr std::uintptr_t align = alignof(uint8_t);
-  block_scales_data_ = std::make_unique<uint8_t[]>(num_bytes + align);
-  uint8_t* aligned_dst = ALIGN_PTR_UP(block_scales_data_.get(), align, uint8_t*);
+  qp.block_scales_data_ = std::make_unique<uint8_t[]>(num_bytes + align);
+  uint8_t* aligned_dst = ALIGN_PTR_UP(qp.block_scales_data_.get(), align, uint8_t*);
   for (size_t i = 0; i < static_cast<uint32_t>(per_block_int_scales.size()); i++) {
     aligned_dst[i] = per_block_int_scales[i];
   }
   lpbq.blocksScale8 = aligned_dst;
 
-  params_.blockwiseExpansion = lpbqPtr;
+  qp.params_.blockwiseExpansion = lpbqPtr;
+  return qp;
 }
 
-// Construct a BlockEncoding BQ quantization param.
-QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> scales,
-                                             gsl::span<const int32_t> offsets,
-                                             gsl::span<const uint32_t> block_sizes,
-                                             Qnn_DataType_t tensor_data_type) {
-  ORT_UNUSED_PARAMETER(tensor_data_type);
+// Block-encoded quantization (BLOCK).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::Block(gsl::span<const float> scales,
+                                                   gsl::span<const int32_t> offsets,
+                                                   gsl::span<const uint32_t> block_sizes) {
   assert(block_sizes.size() > 0);
   assert(scales.size() > 0);
-  assert(scales.size() == offsets.size());  // Logic error if sizes don't match.
+  assert(scales.size() == offsets.size());
 
-  num_blocks_ = static_cast<uint32_t>(scales.size());
-  params_.encodingDefinition = QNN_DEFINITION_DEFINED;
-  params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BLOCK;
+  QnnQuantParamsWrapper qp;
+  qp.num_blocks_ = static_cast<uint32_t>(scales.size());
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BLOCK;
 
-  block_encoding_tensor_rank_ = static_cast<uint32_t>(block_sizes.size());
-  block_encoding_axis_data_ = std::make_unique<uint32_t[]>(block_encoding_tensor_rank_);
-  std::memcpy(block_encoding_axis_data_.get(),
+  qp.block_encoding_tensor_rank_ = static_cast<uint32_t>(block_sizes.size());
+  qp.block_encoding_axis_data_ = std::make_unique<uint32_t[]>(qp.block_encoding_tensor_rank_);
+  std::memcpy(qp.block_encoding_axis_data_.get(),
               block_sizes.data(),
-              static_cast<size_t>(block_encoding_tensor_rank_) * sizeof(uint32_t));
-  params_.blockEncoding.blockSize = block_encoding_axis_data_.get();
+              static_cast<size_t>(qp.block_encoding_tensor_rank_) * sizeof(uint32_t));
+  qp.params_.blockEncoding.blockSize = qp.block_encoding_axis_data_.get();
 
-  // Deep copy the scale offsets
-  if (num_blocks_ > 0) {
-    block_encoding_scale_offsets_data_ = std::make_unique<Qnn_ScaleOffset_t[]>(num_blocks_);
-    for (size_t i = 0; i < num_blocks_; ++i) {
-      block_encoding_scale_offsets_data_[i].offset = offsets[i];
-      block_encoding_scale_offsets_data_[i].scale = scales[i];
+  if (qp.num_blocks_ > 0) {
+    qp.block_encoding_scale_offsets_data_ = std::make_unique<Qnn_ScaleOffset_t[]>(qp.num_blocks_);
+    for (size_t i = 0; i < qp.num_blocks_; ++i) {
+      qp.block_encoding_scale_offsets_data_[i].offset = offsets[i];
+      qp.block_encoding_scale_offsets_data_[i].scale = scales[i];
     }
-    params_.blockEncoding.scaleOffset = block_encoding_scale_offsets_data_.get();
+    qp.params_.blockEncoding.scaleOffset = qp.block_encoding_scale_offsets_data_.get();
   }
+  return qp;
 }
 
-// Construct a BlockEncoding BQ quantization param.
-QnnQuantParamsWrapper::QnnQuantParamsWrapper(gsl::span<const float> scales,
-                                             gsl::span<const float> offsets,
-                                             const uint32_t bitwidth,
-                                             gsl::span<const uint32_t> block_sizes) {
+// Block-encoded quantization with explicit bitwidth and float offsets (BW_FLOAT_BLOCK).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float> scales,
+                                                          gsl::span<const float> offsets,
+                                                          uint32_t bitwidth,
+                                                          gsl::span<const uint32_t> block_sizes) {
   assert(scales.size() > 0);
   assert(scales.size() == offsets.size());
   assert(bitwidth > 0);
   assert(block_sizes.size() > 0);
 
-  params_.encodingDefinition = QNN_DEFINITION_DEFINED;
-  params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK;
-  params_.bwFloatBlockEncoding.bitwidth = bitwidth;
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK;
+  qp.params_.bwFloatBlockEncoding.bitwidth = bitwidth;
 
-  block_encoding_tensor_rank_ = static_cast<uint32_t>(block_sizes.size());
-  block_encoding_axis_data_ = std::make_unique<uint32_t[]>(block_encoding_tensor_rank_);
-  std::memcpy(block_encoding_axis_data_.get(),
+  qp.block_encoding_tensor_rank_ = static_cast<uint32_t>(block_sizes.size());
+  qp.block_encoding_axis_data_ = std::make_unique<uint32_t[]>(qp.block_encoding_tensor_rank_);
+  std::memcpy(qp.block_encoding_axis_data_.get(),
               block_sizes.data(),
-              static_cast<size_t>(block_encoding_tensor_rank_) * sizeof(uint32_t));
-  params_.bwFloatBlockEncoding.blockSize = block_encoding_axis_data_.get();
+              static_cast<size_t>(qp.block_encoding_tensor_rank_) * sizeof(uint32_t));
+  qp.params_.bwFloatBlockEncoding.blockSize = qp.block_encoding_axis_data_.get();
 
-  num_blocks_ = static_cast<uint32_t>(scales.size());
-  bw_float_block_encoding_scale_offsets_data_ = std::make_unique<Qnn_FloatScaleOffset_t[]>(num_blocks_);
-  for (size_t idx = 0; idx < num_blocks_; ++idx) {
-    bw_float_block_encoding_scale_offsets_data_[idx].offset = offsets[idx];
-    bw_float_block_encoding_scale_offsets_data_[idx].scale = scales[idx];
+  qp.num_blocks_ = static_cast<uint32_t>(scales.size());
+  qp.bw_float_block_encoding_scale_offsets_data_ = std::make_unique<Qnn_FloatScaleOffset_t[]>(qp.num_blocks_);
+  for (size_t idx = 0; idx < qp.num_blocks_; ++idx) {
+    qp.bw_float_block_encoding_scale_offsets_data_[idx].offset = offsets[idx];
+    qp.bw_float_block_encoding_scale_offsets_data_[idx].scale = scales[idx];
   }
-  params_.bwFloatBlockEncoding.floatScaleOffset = bw_float_block_encoding_scale_offsets_data_.get();
+  qp.params_.bwFloatBlockEncoding.floatScaleOffset = qp.bw_float_block_encoding_scale_offsets_data_.get();
+  return qp;
 }
 
 // Get a copy of scales. Works for both per-tensor and per-channel.
@@ -677,8 +706,8 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
     // For ONNX axis=0 (block axis=0): QNN axis=1; for axis=1: QNN axis=0.
     const int64_t qnn_axis = 1 - axis;
 
-    *this = QnnQuantParamsWrapper(per_channel_scales, per_block_int_scales, lpbq_offsets,
-                                  qnn_axis, ort_quant_params->block_size.value(), is_int4_type);
+    *this = QnnQuantParamsWrapper::LowPowerBlockwise(per_channel_scales, per_block_int_scales, lpbq_offsets,
+                                                     qnn_axis, /*block_scale_bitwidth=*/is_int4_type ? 4 : 8);
   } else {
     return MAKE_EP_FAIL("Unexpected tensor kind for QuantParamsWrapper::Init()");
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -26,25 +26,43 @@ class QnnQuantParamsWrapper {
   QnnQuantParamsWrapper(QnnQuantParamsWrapper&& other) = default;
   QnnQuantParamsWrapper& operator=(QnnQuantParamsWrapper&& other) = default;
 
-  // Construct a per-tensor quantization param (SCALE_OFFSET)
-  QnnQuantParamsWrapper(float scale, int32_t offset);
+  // Named factories. Each maps 1:1 to a Qnn_QuantizationEncoding_t value so the
+  // intended encoding is visible at the call site.
 
-  // Construct a per-channel quantization param.
-  QnnQuantParamsWrapper(gsl::span<const float> scales, gsl::span<const int32_t> offsets, int32_t axis, bool is_int4);
+  // QNN_QUANTIZATION_ENCODING_SCALE_OFFSET
+  static QnnQuantParamsWrapper PerTensor(float scale, int32_t offset);
 
-  // Construct a LPBQ quantization param.
-  QnnQuantParamsWrapper(gsl::span<const float> per_channel_float_scales, gsl::span<const uint8_t> per_block_int_scales,
-                        gsl::span<const int32_t> offsets, int64_t axis, int64_t block_size, bool is_int4);
+  // QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET
+  static QnnQuantParamsWrapper PerTensorBw(float scale, int32_t offset, uint32_t bitwidth);
 
-  // Construct a BQ quantization param.
-  QnnQuantParamsWrapper(gsl::span<const float> scales, gsl::span<const int32_t> offsets,
-                        gsl::span<const uint32_t> block_size, Qnn_DataType_t tensor_data_type);
+  // QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET
+  static QnnQuantParamsWrapper PerChannel(gsl::span<const float> scales,
+                                          gsl::span<const int32_t> offsets,
+                                          int32_t axis);
 
-  // Construct a BQ quantization param with specified bitwidth and float offsets.
-  QnnQuantParamsWrapper(gsl::span<const float> scales,
-                        gsl::span<const float> offsets,
-                        const uint32_t bitwidth,
-                        gsl::span<const uint32_t> block_size);
+  // QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET
+  static QnnQuantParamsWrapper PerChannelBw(gsl::span<const float> scales,
+                                            gsl::span<const int32_t> offsets,
+                                            int32_t axis,
+                                            uint32_t bitwidth);
+
+  // QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION (LPBQ)
+  static QnnQuantParamsWrapper LowPowerBlockwise(gsl::span<const float> per_channel_float_scales,
+                                                 gsl::span<const uint8_t> per_block_int_scales,
+                                                 gsl::span<const int32_t> offsets,
+                                                 int64_t axis,
+                                                 uint32_t block_scale_bitwidth);
+
+  // QNN_QUANTIZATION_ENCODING_BLOCK
+  static QnnQuantParamsWrapper Block(gsl::span<const float> scales,
+                                     gsl::span<const int32_t> offsets,
+                                     gsl::span<const uint32_t> block_sizes);
+
+  // QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK
+  static QnnQuantParamsWrapper BwFloatBlock(gsl::span<const float> scales,
+                                            gsl::span<const float> offsets,
+                                            uint32_t bitwidth,
+                                            gsl::span<const uint32_t> block_sizes);
 
   Qnn_QuantizeParams_t& Get() { return params_; }
   const Qnn_QuantizeParams_t& Get() const { return params_; }

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1699,7 +1699,7 @@ Ort::Status InsertConvertOp(QnnModelWrapper& qnn_model_wrapper,
   QnnTensorWrapper convert_output_tensorwrapper(convert_output_name,
                                                 QNN_TENSOR_TYPE_NATIVE,
                                                 output_qnn_data_type,
-                                                QnnQuantParamsWrapper(scale, offset),
+                                                QnnQuantParamsWrapper::PerTensor(scale, offset),
                                                 std::move(output_shape_copy));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(convert_output_tensorwrapper)), "Failed to add tensor.");
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(UniqueNameGenerator().New(convert_output_name, QNN_OP_CONVERT),

--- a/onnxruntime/test/providers/qnn/unit/qnn_model_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_model_wrapper_test.cc
@@ -336,10 +336,10 @@ TEST(QnnUnit_ModelWrapperTest, AddReshapeNode_PerChannelQuant_ReturnsError) {
 
   std::vector<float> scales{1.0f, 2.0f};
   std::vector<int32_t> offsets{0, 0};
-  qnn::QnnQuantParamsWrapper per_channel_quant(
+  qnn::QnnQuantParamsWrapper per_channel_quant = qnn::QnnQuantParamsWrapper::PerChannel(
       gsl::make_span(scales.data(), scales.size()),
       gsl::make_span(offsets.data(), offsets.size()),
-      /*axis=*/0, /*is_int4=*/false);
+      /*axis=*/0);
 
   Ort::Status status = wrapper->AddReshapeNode(
       "in", "out", {2u}, {2u},
@@ -400,10 +400,10 @@ TEST(QnnUnit_ModelWrapperTest, AddTransposeNode_PerChannelQuant_ReturnsError) {
 
   std::vector<float> scales{1.0f, 2.0f};
   std::vector<int32_t> offsets{0, 0};
-  qnn::QnnQuantParamsWrapper per_channel_quant(
+  qnn::QnnQuantParamsWrapper per_channel_quant = qnn::QnnQuantParamsWrapper::PerChannel(
       gsl::make_span(scales.data(), scales.size()),
       gsl::make_span(offsets.data(), offsets.size()),
-      /*axis=*/0, /*is_int4=*/false);
+      /*axis=*/0);
 
   Ort::Status status = wrapper->AddTransposeNode(
       0, "t_in", "t_out",
@@ -1409,7 +1409,7 @@ TEST(QnnUnit_ModelWrapperTest, ValidateQnnNode_HtpBackend_Relu_Succeeds) {
   auto wrapper = ctx.CreateWrapper(settings, qnn::QnnBackendType::HTP);
 
   // HTP validator requires quantized tensors for Relu — float32 is rejected at validation.
-  qnn::QnnQuantParamsWrapper quant(/*scale=*/1.0f / 255.0f, /*offset=*/0);
+  qnn::QnnQuantParamsWrapper quant = qnn::QnnQuantParamsWrapper::PerTensor(/*scale=*/1.0f / 255.0f, /*offset=*/0);
   qnn::QnnTensorWrapper input_tw("relu_in", QNN_TENSOR_TYPE_APP_WRITE, QNN_DATATYPE_UFIXED_POINT_8,
                                  quant.Copy(), std::vector<uint32_t>{1, 4});
   qnn::QnnTensorWrapper output_tw("relu_out", QNN_TENSOR_TYPE_APP_READ, QNN_DATATYPE_UFIXED_POINT_8,
@@ -1439,7 +1439,7 @@ TEST(QnnUnit_ModelWrapperTest, ValidateQnnNode_HtpBackend_InvalidOpType_Fails) {
   qnn::ModelSettings settings{};
   auto wrapper = ctx.CreateWrapper(settings, qnn::QnnBackendType::HTP);
 
-  qnn::QnnQuantParamsWrapper quant(/*scale=*/1.0f / 255.0f, /*offset=*/0);
+  qnn::QnnQuantParamsWrapper quant = qnn::QnnQuantParamsWrapper::PerTensor(/*scale=*/1.0f / 255.0f, /*offset=*/0);
   qnn::QnnTensorWrapper input_tw("in", QNN_TENSOR_TYPE_APP_WRITE, QNN_DATATYPE_UFIXED_POINT_8,
                                  quant.Copy(), std::vector<uint32_t>{1, 4});
   qnn::QnnTensorWrapper output_tw("out", QNN_TENSOR_TYPE_APP_READ, QNN_DATATYPE_UFIXED_POINT_8,

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -39,19 +39,13 @@ namespace {
 QnnQuantParamsWrapper MakePerChannelNonInt4(int32_t axis = 1) {
   const std::vector<float> scales{0.1f, 0.2f, 0.3f};
   const std::vector<int32_t> offsets{1, 2, 3};
-  return QnnQuantParamsWrapper(gsl::make_span(scales),
-                               gsl::make_span(offsets),
-                               axis,
-                               /*is_int4=*/false);
+  return QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), axis);
 }
 
 QnnQuantParamsWrapper MakePerChannelInt4(int32_t axis = 1) {
   const std::vector<float> scales{0.1f, 0.2f, 0.3f};
   const std::vector<int32_t> offsets{1, 2, 3};
-  return QnnQuantParamsWrapper(gsl::make_span(scales),
-                               gsl::make_span(offsets),
-                               axis,
-                               /*is_int4=*/true);
+  return QnnQuantParamsWrapper::PerChannelBw(gsl::make_span(scales), gsl::make_span(offsets), axis, /*bitwidth=*/4);
 }
 
 QnnQuantParamsWrapper MakeLPBQ() {
@@ -59,32 +53,30 @@ QnnQuantParamsWrapper MakeLPBQ() {
   const std::vector<float> per_channel_scales{0.1f, 0.2f, 0.3f};
   const std::vector<uint8_t> per_block_scales{1, 2, 3, 4, 5, 6};
   const std::vector<int32_t> offsets{0, 0, 0};
-  return QnnQuantParamsWrapper(gsl::make_span(per_channel_scales),
-                               gsl::make_span(per_block_scales),
-                               gsl::make_span(offsets),
-                               /*axis=*/1,
-                               /*block_size=*/4,
-                               /*is_int4=*/true);
+  return QnnQuantParamsWrapper::LowPowerBlockwise(gsl::make_span(per_channel_scales),
+                                                  gsl::make_span(per_block_scales),
+                                                  gsl::make_span(offsets),
+                                                  /*axis=*/1,
+                                                  /*block_scale_bitwidth=*/4);
 }
 
 QnnQuantParamsWrapper MakeBlockEncoding() {
   const std::vector<float> scales{0.5f, 0.25f};
   const std::vector<int32_t> offsets{1, 2};
   const std::vector<uint32_t> block_sizes{2, 1};
-  return QnnQuantParamsWrapper(gsl::make_span(scales),
-                               gsl::make_span(offsets),
-                               gsl::make_span(block_sizes),
-                               QNN_DATATYPE_UFIXED_POINT_8);
+  return QnnQuantParamsWrapper::Block(gsl::make_span(scales),
+                                      gsl::make_span(offsets),
+                                      gsl::make_span(block_sizes));
 }
 
 QnnQuantParamsWrapper MakeBwFloatBlock() {
   const std::vector<float> scales{0.5f, 0.25f};
   const std::vector<float> offsets{0.0f, 0.1f};
   const std::vector<uint32_t> block_sizes{2, 1};
-  return QnnQuantParamsWrapper(gsl::make_span(scales),
-                               gsl::make_span(offsets),
-                               /*bitwidth=*/8u,
-                               gsl::make_span(block_sizes));
+  return QnnQuantParamsWrapper::BwFloatBlock(gsl::make_span(scales),
+                                             gsl::make_span(offsets),
+                                             /*bitwidth=*/8u,
+                                             gsl::make_span(block_sizes));
 }
 
 }  // namespace
@@ -105,7 +97,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, Default_NotQuantized_AndAllPredicatesFalse)
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, PerTensor_SetsScaleOffsetEncodingAndScale) {
-  QnnQuantParamsWrapper q(/*scale=*/0.5f, /*offset=*/-3);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensor(/*scale=*/0.5f, /*offset=*/-3);
   EXPECT_TRUE(q.IsQuantized());
   EXPECT_TRUE(q.IsPerTensor());
   EXPECT_FALSE(q.IsPerChannel());
@@ -114,12 +106,23 @@ TEST(QnnUnit_QuantParamsWrapperTest, PerTensor_SetsScaleOffsetEncodingAndScale) 
   EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -3);
 }
 
+TEST(QnnUnit_QuantParamsWrapperTest, PerTensorBw_SetsBwScaleOffsetEncodingAndBitwidth) {
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensorBw(/*scale=*/0.25f, /*offset=*/7, /*bitwidth=*/4);
+  EXPECT_TRUE(q.IsQuantized());
+  EXPECT_TRUE(q.IsPerTensor(/*include_bw=*/true));
+  EXPECT_FALSE(q.IsPerTensor(/*include_bw=*/false));
+  EXPECT_FALSE(q.IsPerChannel());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().bwScaleOffsetEncoding.bitwidth, 4u);
+  EXPECT_FLOAT_EQ(q.Get().bwScaleOffsetEncoding.scale, 0.25f);
+  EXPECT_EQ(q.Get().bwScaleOffsetEncoding.offset, 7);
+}
+
 TEST(QnnUnit_QuantParamsWrapperTest,
      PerChannel_NotInt4_NonEmpty_SetsAxisScaleOffsetAndDeepCopiesData) {
   const std::vector<float> scales{0.1f, 0.2f, 0.3f};
   const std::vector<int32_t> offsets{1, 2, 3};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/2,
-                          /*is_int4=*/false);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/2);
   EXPECT_TRUE(q.IsPerChannel());
   EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
   EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 2);
@@ -134,8 +137,7 @@ TEST(QnnUnit_QuantParamsWrapperTest,
 TEST(QnnUnit_QuantParamsWrapperTest, PerChannel_NotInt4_Empty_SetsNullScaleOffsetPointer) {
   const std::vector<float> scales{};
   const std::vector<int32_t> offsets{};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
-                          /*is_int4=*/false);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0);
   EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
   EXPECT_EQ(q.Get().axisScaleOffsetEncoding.numScaleOffsets, 0u);
   EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset, nullptr);
@@ -145,8 +147,7 @@ TEST(QnnUnit_QuantParamsWrapperTest,
      PerChannel_Int4_NonEmpty_SetsBwAxisScaleOffsetAndDeepCopiesScalesAndOffsets) {
   const std::vector<float> scales{0.1f, 0.2f};
   const std::vector<int32_t> offsets{4, 5};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1,
-                          /*is_int4=*/true);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannelBw(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1, /*bitwidth=*/4);
   EXPECT_TRUE(q.IsPerChannel());
   EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
   EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.axis, 1);
@@ -163,8 +164,7 @@ TEST(QnnUnit_QuantParamsWrapperTest,
 TEST(QnnUnit_QuantParamsWrapperTest, PerChannel_Int4_Empty_SetsNullScalesAndOffsetsPointers) {
   const std::vector<float> scales{};
   const std::vector<int32_t> offsets{};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
-                          /*is_int4=*/true);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannelBw(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0, /*bitwidth=*/4);
   EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
   EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.numElements, 0u);
   EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.scales, nullptr);
@@ -237,11 +237,21 @@ TEST(QnnUnit_QuantParamsWrapperTest,
 // =============================================================================
 
 TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_PerTensor_DeepCopies) {
-  QnnQuantParamsWrapper src(0.7f, 4);
+  QnnQuantParamsWrapper src = QnnQuantParamsWrapper::PerTensor(0.7f, 4);
   QnnQuantParamsWrapper dst(src);
   EXPECT_TRUE(dst.IsPerTensor());
   EXPECT_FLOAT_EQ(dst.Get().scaleOffsetEncoding.scale, 0.7f);
   EXPECT_EQ(dst.Get().scaleOffsetEncoding.offset, 4);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_PerTensorBw_CopiesAllFields) {
+  QnnQuantParamsWrapper src = QnnQuantParamsWrapper::PerTensorBw(0.125f, -5, /*bitwidth=*/4);
+  QnnQuantParamsWrapper dst(src);
+  EXPECT_TRUE(dst.IsPerTensor(/*include_bw=*/true));
+  EXPECT_EQ(dst.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET);
+  EXPECT_EQ(dst.Get().bwScaleOffsetEncoding.bitwidth, 4u);
+  EXPECT_FLOAT_EQ(dst.Get().bwScaleOffsetEncoding.scale, 0.125f);
+  EXPECT_EQ(dst.Get().bwScaleOffsetEncoding.offset, -5);
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_PerChannelInt4_DeepCopies) {
@@ -279,12 +289,23 @@ TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_BlockEncoding_DeepCopies) {
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_PerTensor_DeepCopies) {
-  QnnQuantParamsWrapper src(1.5f, -2);
+  QnnQuantParamsWrapper src = QnnQuantParamsWrapper::PerTensor(1.5f, -2);
   QnnQuantParamsWrapper dst;
   dst = src;
   EXPECT_TRUE(dst.IsPerTensor());
   EXPECT_FLOAT_EQ(dst.Get().scaleOffsetEncoding.scale, 1.5f);
   EXPECT_EQ(dst.Get().scaleOffsetEncoding.offset, -2);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_PerTensorBw_CopiesAllFields) {
+  QnnQuantParamsWrapper src = QnnQuantParamsWrapper::PerTensorBw(0.0625f, 3, /*bitwidth=*/4);
+  QnnQuantParamsWrapper dst;
+  dst = src;
+  EXPECT_TRUE(dst.IsPerTensor(/*include_bw=*/true));
+  EXPECT_EQ(dst.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET);
+  EXPECT_EQ(dst.Get().bwScaleOffsetEncoding.bitwidth, 4u);
+  EXPECT_FLOAT_EQ(dst.Get().bwScaleOffsetEncoding.scale, 0.0625f);
+  EXPECT_EQ(dst.Get().bwScaleOffsetEncoding.offset, 3);
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_LPBQ_DeepCopies) {
@@ -306,6 +327,28 @@ TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_BlockEncoding_DeepCopies) {
   EXPECT_TRUE(dst.IsBlockQuantized());
   EXPECT_NE(dst.Get().blockEncoding.blockSize, src.Get().blockEncoding.blockSize);
   EXPECT_FLOAT_EQ(dst.Get().blockEncoding.scaleOffset[0].scale, 0.5f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_BwFloatBlock_DeepCopies) {
+  QnnQuantParamsWrapper src = MakeBwFloatBlock();
+  const auto* src_ptr = src.Get().bwFloatBlockEncoding.floatScaleOffset;
+  QnnQuantParamsWrapper dst(src);
+  EXPECT_TRUE(dst.IsBlockQuantized());
+  EXPECT_EQ(dst.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
+  EXPECT_NE(dst.Get().bwFloatBlockEncoding.floatScaleOffset, src_ptr);
+  EXPECT_EQ(dst.Get().bwFloatBlockEncoding.bitwidth, 8u);
+  EXPECT_FLOAT_EQ(dst.Get().bwFloatBlockEncoding.floatScaleOffset[0].scale, 0.5f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_BwFloatBlock_DeepCopies) {
+  QnnQuantParamsWrapper src = MakeBwFloatBlock();
+  QnnQuantParamsWrapper dst;
+  dst = src;
+  EXPECT_TRUE(dst.IsBlockQuantized());
+  EXPECT_EQ(dst.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
+  EXPECT_NE(dst.Get().bwFloatBlockEncoding.floatScaleOffset, src.Get().bwFloatBlockEncoding.floatScaleOffset);
+  EXPECT_EQ(dst.Get().bwFloatBlockEncoding.bitwidth, 8u);
+  EXPECT_FLOAT_EQ(dst.Get().bwFloatBlockEncoding.floatScaleOffset[1].offset, 0.1f);
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_SelfAssignment_LeavesUnchanged) {
@@ -379,7 +422,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, IsLPBQ_OnlyForBlockwiseExpansion) {
 TEST(QnnUnit_QuantParamsWrapperTest, IsBlockQuantized_AcceptsBlockAndBwFloatBlock) {
   QnnQuantParamsWrapper block = MakeBlockEncoding();
   QnnQuantParamsWrapper bw_float_block = MakeBwFloatBlock();
-  QnnQuantParamsWrapper per_tensor(0.5f, 0);
+  QnnQuantParamsWrapper per_tensor = QnnQuantParamsWrapper::PerTensor(0.5f, 0);
   EXPECT_TRUE(block.IsBlockQuantized());
   EXPECT_TRUE(bw_float_block.IsBlockQuantized());
   EXPECT_FALSE(per_tensor.IsBlockQuantized());
@@ -406,7 +449,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, GetScales_Undefined_ReturnsError) {
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, GetScales_ScaleOffset_ReturnsSingleScalar) {
-  QnnQuantParamsWrapper q(0.25f, 0);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensor(0.25f, 0);
   std::vector<float> out;
   ASSERT_TRUE(q.GetScales(out).IsOK());
   ASSERT_EQ(out.size(), 1u);
@@ -441,8 +484,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, GetScales_AxisScaleOffset_ReturnsAllScales)
 TEST(QnnUnit_QuantParamsWrapperTest, GetScales_AxisScaleOffset_NumElemsZero_ReturnsEmpty) {
   const std::vector<float> scales{};
   const std::vector<int32_t> offsets{};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), 0,
-                          /*is_int4=*/false);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), 0);
   std::vector<float> out{1.0f, 2.0f};  // Pre-existing content should be cleared.
   ASSERT_TRUE(q.GetScales(out).IsOK());
   EXPECT_TRUE(out.empty());
@@ -460,8 +502,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, GetScales_BwAxisScaleOffset_ReturnsAllScale
 TEST(QnnUnit_QuantParamsWrapperTest, GetScales_BwAxisScaleOffset_NumElemsZero_ReturnsEmpty) {
   const std::vector<float> scales{};
   const std::vector<int32_t> offsets{};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), 0,
-                          /*is_int4=*/true);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannelBw(gsl::make_span(scales), gsl::make_span(offsets), 0, /*bitwidth=*/4);
   std::vector<float> out{1.0f};
   ASSERT_TRUE(q.GetScales(out).IsOK());
   EXPECT_TRUE(out.empty());
@@ -917,7 +958,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_MultiZp_Return
 // =============================================================================
 
 TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_NotPerChannel_NoOp) {
-  QnnQuantParamsWrapper q(0.5f, 0);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensor(0.5f, 0);
   std::vector<uint32_t> perm{0, 1, 2, 3};
   EXPECT_TRUE(q.HandleTranspose<uint32_t>(gsl::make_span(perm)).IsOK());
 }
@@ -953,7 +994,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_SizeT_RemapsAxis) {
 }
 
 TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_NotPerChannel_NoOp) {
-  QnnQuantParamsWrapper q(0.5f, 0);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensor(0.5f, 0);
   std::vector<uint32_t> orig{4, 5};
   std::vector<uint32_t> nu{1, 4, 5};
   EXPECT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
@@ -972,8 +1013,7 @@ TEST(QnnUnit_QuantParamsWrapperTest,
   // move the per-channel axis from 1 to 2.
   const std::vector<float> scales{0.1f, 0.2f, 0.3f};
   const std::vector<int32_t> offsets{0, 0, 0};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1,
-                          /*is_int4=*/false);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1);
   std::vector<uint32_t> orig{3, 4};
   std::vector<uint32_t> nu{1, 3, 4};
   ASSERT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
@@ -984,8 +1024,7 @@ TEST(QnnUnit_QuantParamsWrapperTest,
      HandleUnsqueeze_BwAxisScaleOffset_ShiftsWhenOnesInsertedBefore) {
   const std::vector<float> scales{0.1f, 0.2f, 0.3f};
   const std::vector<int32_t> offsets{0, 0, 0};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
-                          /*is_int4=*/true);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannelBw(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0, /*bitwidth=*/4);
   std::vector<uint32_t> orig{3};
   std::vector<uint32_t> nu{1, 3};
   ASSERT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
@@ -996,8 +1035,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_NoShiftNeeded_LeavesAxisUnc
   // axis=0; new shape {3, 1, 4} appends 1 *after* the per-channel axis ⇒ axis stays at 0.
   const std::vector<float> scales{0.1f, 0.2f, 0.3f};
   const std::vector<int32_t> offsets{0, 0, 0};
-  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
-                          /*is_int4=*/false);
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0);
   std::vector<uint32_t> orig{3, 4};
   std::vector<uint32_t> nu{3, 1, 4};
   ASSERT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
@@ -1009,7 +1047,7 @@ TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_NoShiftNeeded_LeavesAxisUnc
 // overload (line 49 in the header). Without this test the const-Get line
 // would be header coverage's only genuine gap.
 TEST(QnnUnit_QuantParamsWrapperTest, ConstGet_ReturnsSameParamsAsNonConst) {
-  const QnnQuantParamsWrapper q(0.5f, -2);
+  const QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensor(0.5f, -2);
   EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.5f);
   EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -2);
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Callers now call QnnQuantParamsWrapper::PerTensor(), ::PerChannel(), ::PerChannelBw(), ::LowPowerBlockwise(), ::Block(), and ::BwFloatBlock() instead of selecting between six overloaded constructors by argument count and element type. Each factory name maps 1:1 to a Qnn_QuantizationEncoding_t enum value, making the intended encoding visible at the call site.
- Removes the is_int4 boolean (replaced by an explicit bitwidth parameter), the unused tensor_data_type argument from the Block constructor, and the unused block_size argument from the LPBQ constructor. Also exposes BW_SCALE_OFFSET as PerTensorBw() which previously had no constructor.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- QnnQuantParamsWrapper use positional constructors for different encodings, which is quite hard to read and maintain.
