### PR TITLE
Add BUILD_ALWAYS ON to ort_core_target ExternalProject

### DIFF
--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -208,6 +208,7 @@ ExternalProject_Add(
     PATCH_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${ORT_BUILD_COMMAND}
+    BUILD_ALWAYS ON
     INSTALL_COMMAND ${ORT_INSTALL_COMMAND}
     BUILD_BYPRODUCTS ${ORT_BUILD_BYPRODUCTS}
     # Enable comprehensive logging for debugging


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Setting BUILD_ALWAYS ON ensures the `ExternalProject` build step runs unconditionally on every build invocation. The ORT Core `build.py` script already has its own incremental build logic (via CMake/Ninja internally), so re-running it when nothing has changed is essentially a no-op — it detects no work is needed and exits quickly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- When ORT Core is built from source via ExternalProject_Add, CMake's default behavior skips the build step if it determines nothing has changed (based on the stamp file). However, since the ORT Core build is driven by build.py with its own dependency tracking, CMake's staleness check can produce false negatives — skipping rebuilds when the ORT Core source tree has actually changed.
- This causes incremental builds to silently use stale ORT Core binaries, leading to
  hard-to-diagnose issues during development.

