### PR TITLE
[Coverage] Parameterize Python version and extend path gate to qcom/

### DIFF
--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -10,7 +10,17 @@ permissions:
 
 on:
   workflow_call:
+    inputs:
+      target_py_vsn:
+        description: "Python version for the coverage build wheel (does not affect C++ coverage results)"
+        type: string
+        default: '3.10'
   workflow_dispatch:
+    inputs:
+      target_py_vsn:
+        description: "Python version for the coverage build wheel (does not affect C++ coverage results)"
+        type: string
+        default: '3.10'
 
 jobs:
   coverage-linux-x86_64:
@@ -45,7 +55,7 @@ jobs:
             exit 1
           fi
 
-          if echo "${changed}" | grep -qE 'onnxruntime/(core|test)/providers/qnn/'; then
+          if echo "${changed}" | grep -qE 'onnxruntime/(core|test)/providers/qnn/|^qcom/'; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
           else
             echo "run=false" >> "${GITHUB_OUTPUT}"
@@ -59,9 +69,9 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: |
           # Python version does not affect C++ code coverage results.
-          # 3.10 matches DEFAULT_PYTHON_LINUX in qcom/ep_build/util.py.
+          # Defaults to 3.10 to match DEFAULT_PYTHON_LINUX in qcom/ep_build/util.py.
           python3 qcom/build_and_test.py \
-            --target-py-version 3.10 \
+            --target-py-version ${{ inputs.target_py_vsn }} \
             diff_coverage_linux_x86_64
 
       - name: Upload Coverage Report


### PR DESCRIPTION
  ## Summary

  Prepares the coverage pipeline for Python 3.10/3.12 co-existence (motivated by PR #431)
  and closes a gap where `qcom/` edits could silently break coverage without CI catching it.

  ### Changes
  
  **Parameterize Python version (`target_py_vsn`)**
  
  `--target-py-version 3.10` was hardcoded in the workflow body. This PR exposes it as
  a `workflow_call` / `workflow_dispatch` input (default: `'3.10'`, preserving current
  CI behavior). When runners eventually transition to Python 3.12, callers only need to
  add `target_py_vsn: '3.12'` at the call site in `qualcomm-internal-ci.yml` — no
  workflow body changes required.

  Note: Python version does not affect C++ coverage results; it only determines which
  Python wheel is built as a side-effect of the coverage build. 

  **Extend path gate to `qcom/`**
  
  Previously, coverage only ran when `onnxruntime/(core|test)/providers/qnn/` files
  changed. Changes to `qcom/` (build scripts, coverage scripts, task definitions) could
  break the coverage pipeline without being caught by CI. The gate now also triggers on
  any `qcom/` change.

