### PR TITLE
[QNN EP] Add support to build Linux x86_64 wheels on manylinux_2_34 Docker

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -17,7 +17,7 @@ on:
       target_arch:
         description: |
           The architecture for which to build.
-          [Linux] aarch64_manylinux_2_34, aarch64_oe_gcc11_2, or x86_64.
+          [Linux] aarch64_manylinux_2_34, aarch64_oe_gcc11_2, x86_64, or x86_64_manylinux_2_34.
           [Windows] arm64, arm64ec, arm64x, or x86_64.
         default: arm64
         type: string

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -56,6 +56,24 @@ jobs:
       # version of cpython that's installed on our Linux build machines.
       target_py_vsn: "3.10"
 
+  build-and-test-linux-x86_64-manylinux-2-34:
+    if: ${{ inputs.do_all }}
+    needs: [archive-testdata]
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      target_os: linux
+      target_arch: x86_64_manylinux_2_34
+      testdata_archive_artifact_name: testdata-tarbz2
+      target_py_vsn: ${{ inputs.target_py_vsn }}
+      run_tests: true
+      test_wheel: false
+      upload_test_archive: true
+      upload_wheel: true
+      build_archive: true
+      upload_archive: true
+
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.do_all }}
     needs: [archive-testdata]

--- a/.github/workflows/qualcomm-internal-build-artifacts.yml
+++ b/.github/workflows/qualcomm-internal-build-artifacts.yml
@@ -38,8 +38,8 @@ on:
         description: "JSON list of Python versions to build for x86_64 Linux"
         type: string
         default: "['3.10','3.12']"
-      linux_aarch64_manylinux_2_34_target_py_vsns:
-        description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
+      linux_target_py_vsns:
+        description: "JSON list of Python versions to build for Linux targets (aarch64 manylinux_2_34 and x86_64 manylinux_2_34)"
         type: string
         default: "['3.11','3.12','3.13','3.14']"
       windows_target_archs:
@@ -92,11 +92,11 @@ jobs:
       target_arch: aarch64
 
   build-linux-aarch64-manylinux_2_34:
-    if: ${{ toJSON(fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)) != '[]' }}
+    if: ${{ toJSON(fromJSON(inputs.linux_target_py_vsns)) != '[]' }}
     needs: [archive-testdata]
     strategy:
       matrix:
-        target_py_vsn: ${{ fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns) }}
+        target_py_vsn: ${{ fromJSON(inputs.linux_target_py_vsns) }}
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
@@ -108,10 +108,10 @@ jobs:
       target_py_vsn: ${{ matrix.target_py_vsn }}
       run_tests: false
       # Upload the test archive with the first Python version we encounter
-      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
+      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
       # Build Tgz with the first Python version we encounter
-      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
-      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_aarch64_manylinux_2_34_target_py_vsns)[0] }}
+      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
+      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
 
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.build_linux_aarch64_oe_gcc11_2 }}
@@ -147,6 +147,28 @@ jobs:
       # Test archive is python-version independent; upload only with the first matrix entry
       upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_x86_64_target_py_vsns)[0] }}
       upload_wheel: true
+
+  build-and-test-linux-x86_64-manylinux-2-34:
+    if: ${{ toJSON(fromJSON(inputs.linux_target_py_vsns)) != '[]' }}
+    needs: [archive-testdata]
+    strategy:
+      matrix:
+        target_py_vsn: ${{ fromJSON(inputs.linux_target_py_vsns) }}
+    uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+    secrets: inherit
+    with:
+      nightly_build: ${{ inputs.nightly_build }}
+      version_suffix: ${{ inputs.version_suffix }}
+      target_os: linux
+      target_arch: x86_64_manylinux_2_34
+      testdata_archive_artifact_name: testdata-tarbz2
+      target_py_vsn: ${{ matrix.target_py_vsn }}
+      run_tests: false
+      test_wheel: false
+      upload_test_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
+      upload_wheel: true
+      build_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
+      upload_archive: ${{ matrix.target_py_vsn == fromJSON(inputs.linux_target_py_vsns)[0] }}
 
   build-windows:
     if: ${{ toJSON(fromJSON(inputs.windows_target_archs)) != '[]' && toJSON(fromJSON(inputs.windows_target_py_vsns)) != '[]' }}

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -44,7 +44,7 @@ jobs:
       build_linux_aarch64_oe_gcc11_2: true
       build_linux_x86_64: true
       linux_x86_64_target_py_vsns: "['3.10','3.12']"
-      linux_aarch64_manylinux_2_34_target_py_vsns: "['3.11','3.12','3.13','3.14']"
+      linux_target_py_vsns: "['3.11','3.12','3.13','3.14']"
       windows_target_archs: "['arm64', 'arm64ec', 'x86_64']"
       windows_target_py_vsns: "['3.11','3.12','3.13','3.14']"
       windows_arm64_build_archive: true
@@ -135,6 +135,26 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.12-wheels
+
+      - name: Download x86_64 manylinux_2_34 Linux 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.11-wheels
+
+      - name: Download x86_64 linux-x86_64_manylinux_2_34 Linux 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.12-wheels
+
+      - name: Download x86_64 linux-x86_64_manylinux_2_34 Linux 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.13-wheels
+
+      - name: Download x86_64 linux-x86_64_manylinux_2_34 Linux 3.14 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.14-wheels
 
       - name: Download aarch64 manylinux_2_34 Linux 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
@@ -240,6 +260,11 @@ jobs:
         with:
           name: linux-x86_64-py3.10-tests
 
+      - name: Download x86_64 manylinux_2_34 Linux Tests from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.11-tests
+
       - name: Download arm64 Windows Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -303,6 +328,11 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
+      - name: Download x86_64 manylinux_2_34 Linux TGZ Package from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.11-tgz
+
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -345,11 +375,11 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 2 linux x86_64 (py3.10, py3.12) + 4 linux aarch64 manylinux_2_34 + 4 arm64 + 4 merged AMD = 14 wheels
+          # After merge: 2 linux x86_64 (py3.10, py3.12) + 4 linux aarch64 manylinux_2_34 + 4 linux x86_64 manylinux_2_34 + 4 arm64 + 4 merged AMD = 18 wheels
           # (arm64ec and x86_64 originals are deleted by the merge step above)
           count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
           echo "Found $count wheel(s)"
-          [ "$count" -eq 14 ] || { echo "ERROR: Expected 14 wheels, found $count"; exit 1; }
+          [ "$count" -eq 18 ] || { echo "ERROR: Expected 18 wheels, found $count"; exit 1; }
 
       - name: Verify NuGet artifact
         run: |
@@ -362,6 +392,7 @@ jobs:
           # Expected .tar.bz2 artifacts. Append its glob here for a new one.
           expected=(
             "onnxruntime-tests-linux-aarch64_manylinux_2_34.tar.bz2"
+            onnxruntime-tests-linux-x86_64_manylinux_2_34.tar.bz2
             "onnxruntime-tests-linux-aarch64_oe_gcc11_2.tar.bz2"
             "onnxruntime-tests-linux-x86_64.tar.bz2"
             "onnxruntime-testdata.tar.bz2"
@@ -425,7 +456,7 @@ jobs:
         run: |
           count=$(find "${{ github.workspace }}/build" -name "*.tgz" | wc -l)
           echo "Found $count TGZ archive(s)"
-          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 TGZ archive, found $count"; exit 1; }
+          [ "$count" -eq 2 ] || { echo "ERROR: Expected 2 TGZ archive, found $count"; exit 1; }
 
       - name: Verify AAR artifact
         run: |

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -19,8 +19,8 @@ on:
         description: "Version suffix for released package. If set, the specified suffix will be appended to the version string."
         type: string
         default: ""
-      linux_aarch64_manylinux_2_34_target_py_vsns:
-        description: "JSON list of Python versions to build for aarch64 manylinux_2_34"
+      linux_target_py_vsns:
+        description: "JSON list of Python versions to build for Linux targets (aarch64 manylinux_2_34 and x86_64 manylinux_2_34)"
         type: string
         default: "['3.11','3.12','3.13','3.14']"
       windows_target_archs:
@@ -50,7 +50,7 @@ jobs:
       build_android_aarch64_aar: true
       build_linux_aarch64_oe_gcc11_2: false
       build_linux_x86_64: false
-      linux_aarch64_manylinux_2_34_target_py_vsns: ${{ inputs.linux_aarch64_manylinux_2_34_target_py_vsns }}
+      linux_target_py_vsns: ${{ inputs.linux_target_py_vsns }}
       windows_target_archs: ${{ inputs.windows_target_archs }}
       windows_target_py_vsns: ${{ inputs.windows_target_py_vsns }}
       windows_arm64_build_archive: true
@@ -92,6 +92,26 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
+
+      - name: Download x86_64 manylinux_2_34 Linux 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.11-wheels
+
+      - name: Download x86_64 manylinux_2_34 Linux 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.12-wheels
+
+      - name: Download x86_64 manylinux_2_34 Linux 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.13-wheels
+
+      - name: Download x86_64 manylinux_2_34 Linux 3.14 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.14-wheels
 
       - name: Download Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
@@ -158,6 +178,7 @@ jobs:
           mkdir "${{ github.workspace }}/build/dist"
           cp "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
           cp "${{ github.workspace }}/build/linux-aarch64_manylinux_2_34/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
+          cp "${{ github.workspace }}/build/linux-x86_64_manylinux_2_34/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
 
       - name: Consolidate Wheels
         run: |
@@ -189,10 +210,10 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 4 linux aarch64 manylinux_2_34 + 4 arm64 + 4 merged AMD wheels in build/dist/
+          # After merge: 4 linux aarch64 manylinux_2_34 + 4 linux x86_64 manylinux_2_34 + 4 arm64 + 4 merged AMD wheels in build/dist/
           count=$(find "${{ github.workspace }}/build/dist" -name "*.whl" | wc -l)
           echo "Found $count wheel(s) in build/dist"
-          [ "$count" -eq 12 ] || { echo "ERROR: Expected 12 wheels in build/dist, found $count"; exit 1; }
+          [ "$count" -eq 16 ] || { echo "ERROR: Expected 16 wheels in build/dist, found $count"; exit 1; }
 
       - name: Check Wheels
         run: |
@@ -346,6 +367,11 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
+      - name: Download Linux x86_64 manylinux_2_34 TGZ from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_manylinux_2_34-py3.11-tgz
+
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -401,7 +427,7 @@ jobs:
         run: |
           count=$(find "${{ github.workspace }}/build" -name "*.tgz" | wc -l)
           echo "Found $count TGZ archive(s)"
-          [ "$count" -eq 1 ] || { echo "ERROR: Expected 1 TGZ archive, found $count"; exit 1; }
+          [ "$count" -eq 2 ] || { echo "ERROR: Expected 2 TGZ archive, found $count"; exit 1; }
 
       - name: Prepare Windows ARM64 Zip lib for signing
         run: |
@@ -459,6 +485,10 @@ jobs:
           # Upload Linux aarch64 manylinux_2_34 zip
           ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
             "${{ github.workspace }}/build/linux-aarch64_manylinux_2_34/Release/dist" \
+            "$NETRC_FILE"
+
+          ./qcom/scripts/upleveling/upload_zip_to_artifactory.sh \
+            "${{ github.workspace }}/build/linux-x86_64_manylinux_2_34/Release/dist" \
             "$NETRC_FILE"
 
           # Upload Windows ARM64EC PDB archive

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -277,7 +277,7 @@ class TaskLibrary:
     @depends(["create_venv"])
     def _build_ort_linux_x86_64_manylinux_2_34(self, plan: Plan) -> str:
         """In-container build steps for x86_64-manylinux_2_34. Not to be used outside of Docker."""
-        extra_args = []
+        extra_args = ["--no-warnings-as-errors"]
 
         env = os.environ.copy()
         if self.__docker_ccache_root is not None:

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -41,7 +41,7 @@ from ep_build.tasks.build import (
     GenerateDiffCoverageTask,
     QdcTestsTask,
 )
-from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, DockerBuildTask
+from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, MANYLINUX_2_34_X86_64_TAG, DockerBuildTask
 from ep_build.tasks.python import (
     CreateOrtVenvTask,
     CreateQdcVenvTask,
@@ -273,6 +273,36 @@ class TaskLibrary:
             )
         )
 
+    @implementation_detail
+    @depends(["create_venv"])
+    def _build_ort_linux_x86_64_manylinux_2_34(self, plan: Plan) -> str:
+        """In-container build steps for x86_64-manylinux_2_34. Not to be used outside of Docker."""
+        extra_args = []
+
+        env = os.environ.copy()
+        if self.__docker_ccache_root is not None:
+            ccache_dir = self.__docker_ccache_root / "linux-x86_64-manylinux_2_34"
+            env["CCACHE_DIR"] = str(ccache_dir)
+        else:
+            extra_args.append("--no-use-cache")
+
+        return plan.add_step(
+            BuildEpLinuxTask(
+                None,
+                self.__venv_path,
+                "linux",
+                "x86_64",
+                self.__config,
+                self.__target_py_version,
+                self.__ort_prebuilt_root,
+                self.__qairt_sdk_root,
+                "build",
+                extra_args=extra_args if extra_args else None,
+                env=env,
+                build_archive=self.__build_archive,
+            )
+        )
+
     if is_host_linux() or is_host_mac():
 
         @task
@@ -342,6 +372,23 @@ class TaskLibrary:
             return plan.add_step(
                 BuildEpLinuxTask(
                     "Archiving ONNX Runtime for Linux",
+                    self.__venv_path,
+                    "linux",
+                    "x86_64",
+                    self.__config,
+                    self.__target_py_version,
+                    self.__ort_prebuilt_root,
+                    self.__qairt_sdk_root,
+                    "archive",
+                )
+            )
+
+        @task
+        @depends(["build_ort_linux_x86_64_manylinux_2_34"])
+        def archive_ort_linux_x86_64_manylinux_2_34(self, plan: Plan) -> str:
+            return plan.add_step(
+                BuildEpLinuxTask(
+                    "Archiving ONNX Runtime for Linux x86_64 manylinux 2_34",
                     self.__venv_path,
                     "linux",
                     "x86_64",
@@ -544,6 +591,24 @@ class TaskLibrary:
                 )
             )
 
+    @task
+    @depends(["docker_build_manylinux_2_34_x86_64"])
+    def build_ort_linux_x86_64_manylinux_2_34(self, plan: Plan) -> str:
+        return plan.add_step(
+            BuildEpDockerTask(
+                "Building ONNX Runtime for Linux x86_64 on manylinux_2_34",
+                "x86_64_manylinux_2_34",
+                self.__config,
+                self.__target_py_version,
+                self.__qairt_sdk_root,
+                self.__docker_ccache_root,
+                self.__build_archive,
+                inner_task="_build_ort_linux_x86_64_manylinux_2_34",
+                docker_tag=MANYLINUX_2_34_X86_64_TAG,
+                platform="linux/amd64",
+            ),
+        )
+
     if is_host_linux() and is_host_x86_64():
 
         @public_task("Build with code coverage and generate HTML report (Linux x86_64, RelWithDebInfo)")
@@ -723,6 +788,24 @@ class TaskLibrary:
             )
         )
 
+    @task
+    def docker_build_manylinux_2_34_x86_64(self, plan: Plan) -> str:
+        return plan.add_step(
+            DockerBuildTask(
+                "Building manylinux_2_34 x86_64 Docker image",
+                REPO_ROOT / "qcom" / "scripts" / "linux" / "manylinux_2_34" / "Dockerfile",
+                MANYLINUX_2_34_X86_64_TAG,
+                build_args={
+                    "BASE_IMAGE": "quay.io/pypa/manylinux_2_34_x86_64",
+                    "BUILD_UID": str(os.getuid()),
+                    "BUILD_GID": str(os.getgid()),
+                    "ORT_NIGHTLY_BUILD": os.environ.get("ORT_NIGHTLY_BUILD", "0"),
+                    "ORT_VERSION_SUFFIX": os.environ.get("ORT_VERSION_SUFFIX", ""),
+                },
+                platform="linux/amd64",
+            )
+        )
+
     if is_host_linux() and is_host_arm64():
 
         @task
@@ -772,6 +855,34 @@ class TaskLibrary:
                                 str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
                                 "--target-platform",
                                 "linux-x86_64",
+                                "--archive",
+                                str(REPO_ROOT / "build" / "onnxruntime-testdata.tar.bz2"),
+                            ]
+                        ],
+                    ),
+                ],
+            )
+        )
+
+    @task
+    def extract_ort_linux_x86_64_manylinux_2_34(self, plan: Plan) -> str:
+        return plan.add_step(
+            CompositeTask(
+                None,
+                [
+                    ExtractArchiveTask(
+                        "Extracting per-arch ONNX Runtime archive",
+                        REPO_ROOT / "build" / "onnxruntime-tests-linux-x86_64_manylinux_2_34.tar.bz2",
+                        REPO_ROOT,
+                    ),
+                    RunExecutablesTask(
+                        "Extracting global testdata archive",
+                        [
+                            [
+                                str(self.__python_executable),
+                                str(REPO_ROOT / "qcom" / "scripts" / "all" / "extract_testdata.py"),
+                                "--target-platform",
+                                "linux-x86_64_manylinux_2_34",
                                 "--archive",
                                 str(REPO_ROOT / "build" / "onnxruntime-testdata.tar.bz2"),
                             ]
@@ -924,6 +1035,25 @@ class TaskLibrary:
             return plan.add_step(
                 BuildEpLinuxTask(
                     "Testing ONNX Runtime for Linux",
+                    self.__venv_path,
+                    "linux",
+                    "x86_64",
+                    self.__config,
+                    self.__target_py_version,
+                    self.__ort_prebuilt_root,
+                    self.__qairt_sdk_root,
+                    "test",
+                )
+            )
+
+    if is_host_linux() and is_host_x86_64():
+
+        @task
+        @depends(["build_ort_linux_x86_64_manylinux_2_34"])
+        def test_ort_linux_x86_64_manylinux_2_34(self, plan: Plan) -> str:
+            return plan.add_step(
+                BuildEpLinuxTask(
+                    "Testing ONNX Runtime for Linux x86_64 manylinux_2_34",
                     self.__venv_path,
                     "linux",
                     "x86_64",

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -40,6 +40,9 @@ class BuildEpDockerTask(CompositeTask):
         qairt_sdk_root: Path | None,
         ccache_root: Path | None,
         build_archive: bool = False,
+        inner_task: str = "_build_ort_linux_aarch64_manylinux_2_34",
+        docker_tag: str = MANYLINUX_2_34_AARCH64_TAG,
+        platform: str = "linux/aarch64",
     ) -> None:
         dist_rel_dir = Path("build") / f"linux-{target_arch}" / config / "dist"
 
@@ -52,14 +55,15 @@ class BuildEpDockerTask(CompositeTask):
                 ),
                 DockerBuildAndTestTask(
                     "Building ONNX Runtime inside a container",
-                    ["_build_ort_linux_aarch64_manylinux_2_34"],
+                    [inner_task],
                     target_py_version,
-                    MANYLINUX_2_34_AARCH64_TAG,
+                    docker_tag,
                     volumes={REPO_ROOT: DOCKER_REPO_ROOT},
                     venv_path=DOCKER_REPO_ROOT / "build" / "venv.build",
                     qairt_sdk_root=qairt_sdk_root,
                     ccache_root=ccache_root,
                     build_archive=build_archive,
+                    platform=platform,
                 ),
             ],
         )

--- a/qcom/ep_build/tasks/docker.py
+++ b/qcom/ep_build/tasks/docker.py
@@ -14,6 +14,7 @@ from ..util import DEFAULT_PYTHON_LINUX
 DOCKER_BUILD_USER = "ortqnnep"
 DOCKER_REPO_ROOT = Path("/ort")
 MANYLINUX_2_34_AARCH64_TAG = "ort-manylinux_2_34_aarch64"
+MANYLINUX_2_34_X86_64_TAG = "ort-manylinux_2_34_x86_64"
 
 
 def _argify(arg: str, sep: str, args: Mapping[Any, Any]) -> list[str]:
@@ -27,6 +28,7 @@ class DockerBuildTask(RunExecutablesTask):
         dockerfile: Path,
         image_name: str,
         build_args: Mapping[str, str] | None = None,
+        platform: str = "linux/aarch64",
     ) -> None:
         build_args_list: list[str] = ["--build-arg", f"BUILD_USER={DOCKER_BUILD_USER}"]
         if build_args is not None:
@@ -36,7 +38,7 @@ class DockerBuildTask(RunExecutablesTask):
             group_name,
             [
                 [
-                    "docker", "build", "--platform", "linux/aarch64",
+                    "docker", "build", "--platform", platform,
                     "--file", str(dockerfile), "--tag", image_name,
                     *build_args_list,
                     str(dockerfile.parent),
@@ -56,9 +58,10 @@ class DockerRunTask(RunExecutablesTask):
         volumes: Mapping[Path, Path] | None = None,
         env: Mapping[str, str] | None = None,
         remove: bool = True,
+        platform: str = "linux/aarch64",
     ) -> None:
         def make_cmd() -> list[list[str]]:
-            cmd = ["docker", "run", "--platform", "linux/aarch64", "--user", DOCKER_BUILD_USER]
+            cmd = ["docker", "run", "--platform", platform, "--user", DOCKER_BUILD_USER]
             if working_dir is not None:
                 cmd.extend(["--workdir", str(working_dir)])
             if volumes is not None:
@@ -89,6 +92,7 @@ class DockerBuildAndTestTask(DockerRunTask):
         qairt_sdk_root: Path | None = None,
         ccache_root: Path | None = None,
         build_archive: bool = False,
+        platform: str = "linux/aarch64",
     ) -> None:
         # deferred to avoid circular import
         from ..tools import get_package_dir, get_tools_dir  # noqa:PLC0415
@@ -122,12 +126,4 @@ class DockerBuildAndTestTask(DockerRunTask):
             volumes_with_caches[ccache_root] = Path("/ort_caches/ccache")
             cmd.append("--docker-ccache-root=/ort_caches/ccache")
 
-        super().__init__(
-            group_name,
-            image_name,
-            cmd,
-            DOCKER_REPO_ROOT,
-            volumes_with_caches,
-            env,
-            remove,
-        )
+        super().__init__(group_name, image_name, cmd, DOCKER_REPO_ROOT, volumes_with_caches, env, remove, platform)

--- a/qcom/ep_build/typing.py
+++ b/qcom/ep_build/typing.py
@@ -4,7 +4,7 @@
 from typing import Literal
 
 BuildConfigT = Literal["Debug", "Release", "RelWithDebInfo"]
-TargetArchLinuxT = Literal["aarch64", "aarch64_manylinux_2_34", "aarch64_oe_gcc11_2", "x86_64"]
+TargetArchLinuxT = Literal["aarch64", "aarch64_manylinux_2_34", "aarch64_oe_gcc11_2", "x86_64", "x86_64_manylinux_2_34"]
 TargetArchWindowsT = Literal["arm64", "arm64ec", "arm64x", "x86_64"]
 TargetArchT = TargetArchLinuxT | TargetArchWindowsT
 TargetPyVersionT = Literal["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/qcom/scripts/linux/manylinux_2_34/Dockerfile
+++ b/qcom/scripts/linux/manylinux_2_34/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/pypa/manylinux_2_34_aarch64
+ARG BASE_IMAGE=quay.io/pypa/manylinux_2_34_aarch64
+FROM ${BASE_IMAGE}
 
 ARG BUILD_USER
 ARG BUILD_UID


### PR DESCRIPTION
### Motivation

The existing `Linux x86_64` build runs natively on self-hosted runners, producing `linux_x86_64` wheels tied to whatever distro happens to be on the runner. This PR adds a parallel Docker-based pipeline that builds inside a `manylinux_2_34` container, giving us a reproducible environment and a multi-Python-version wheel matrix (3.11–3.14) to match what we already ship for `aarch64_manylinux_2_34`.

---

### Changes

#### Generalized manylinux Dockerfile (`qcom/scripts/linux/manylinux_2_34/Dockerfile`)
Parameterized the base image with `ARG BASE_IMAGE` (defaulting to `quay.io/pypa/manylinux_2_34_aarch64` for backward compatibility) so the same Dockerfile can build either an aarch64 or an x86_64 image. The aarch64 task continues to use the default; the new x86_64 task overrides it with `quay.io/pypa/manylinux_2_34_x86_64`.

#### Docker task infrastructure (`qcom/ep_build/tasks/docker.py`)
Added `MANYLINUX_2_34_X86_64_TAG` constant. The existing `platform`, `inner_task`, and `docker_tag` parameters on `BuildEpDockerTask` / `DockerBuildTask` / `DockerBuildAndTestTask` are reused — no new parameters needed.

#### New build tasks (`qcom/build_and_test.py`, `qcom/ep_build/typing.py`)
Five new tasks following the same pattern as the aarch64 manylinux equivalents:
- `docker_build_manylinux_2_34_x86_64`: Builds the x86_64 Docker image (passes `BASE_IMAGE=quay.io/pypa/manylinux_2_34_x86_64` as a build-arg, `platform=linux/amd64`).
- `build_ort_linux_x86_64_manylinux_2_34`: Depends on the Docker image build.
- `_build_ort_linux_x86_64_manylinux_2_34`: Implementation detail that runs inside the container; calls `build.sh --target-arch=x86_64` with no `--qnn-arch-abi` (same as the native x86_64 build, since x86_64 is not cross-compiled).
- `archive_ort_linux_x86_64_manylinux_2_34`: Archives the build output.
- `extract_ort_linux_x86_64_manylinux_2_34`: Extracts the test archive.
- `test_ort_linux_x86_64_manylinux_2_34`: Runs C++ tests natively on the x86_64 host (guarded with `is_host_linux() and is_host_x86_64()`).
- `x86_64_manylinux_2_34` is added to `TargetArchLinuxT`.

#### CI workflows
- **`qualcomm-internal-build-artifacts.yml`**: Merged `linux_aarch64_manylinux_2_34_target_py_vsns` and the new `linux_x86_64_manylinux_2_34_target_py_vsns` into a single `linux_target_py_vsns` input (default `['3.11','3.12','3.13','3.14']`). Added `build-linux-x86_64-manylinux-2-34` matrix job.
- **`qualcomm-internal-build-and-test.yml`**: Added `build-and-test-linux-x86_64-manylinux-2-34` job with wheels, test archive, and TGZ upload enabled.
- **`qualcomm-internal-build-and-test-single-os.yml`**: Updated `target_arch` description to list `x86_64_manylinux_2_34`.
- **`qualcomm-internal-upload-artifactory-from-github.yml`**: Renamed input to `linux_target_py_vsns`; added download, consolidation, and publish steps for x86_64 manylinux_2_34 wheels and TGZ. Wheel count updated 12 → 16, TGZ count 1 → 2.
- **`qualcomm-internal-release.yml`**: Added download steps for x86_64 manylinux_2_34 wheels (3.11–3.14), test archive, and TGZ. Updated artifact counts: wheels 14 → 18, `.tar.bz2` 4 → 5, TGZ 1 → 2.