### PR TITLE
[QNN EP] Support for Release Testing Workflow

### DIFF
--- a/.github/workflows/qualcomm-internal-release-testing.yml
+++ b/.github/workflows/qualcomm-internal-release-testing.yml
@@ -1,0 +1,361 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+name: Perform ONNX Runtime Execution Provider wheel, nuget, archive Release Testing
+
+permissions:
+  checks: write
+  contents: read
+  id-token: write
+
+on:
+  workflow_call:
+    inputs: &common_inputs
+      artifact_format:
+        description: "The format of artifacts to test. Choose one of [wheel, nuget, zip, tgz, all]."
+        type: string
+        required: true
+      artifact_version:
+        description: |
+          Source version of artifact.
+          For python wheel, the format should be <version>.<version>.<version><.><suffix>.
+            And the suffix should be <letters><numbers>.
+          For nuget package, the format should be <version>.<version>.<version>-<suffix>.
+            Please note that underscore (_) is not allowed in the version format.
+        type: string
+        required: true
+      test_package_version:
+        description: |
+          Version folder of the test package archive.
+          Required when artifact_format is zip, tgz, or all.
+        type: string
+        default: "2.5.0rc3"
+  workflow_dispatch:
+    inputs: *common_inputs
+
+env:
+  ARTIFACT_VERSION:     ${{ inputs.artifact_version }}
+  TEST_PACKAGE_VERSION: ${{ inputs.test_package_version }}
+  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+
+jobs:
+
+  # ===========================================================================
+  # ARTIFACT COUNT CHECK (runs first — gates all other jobs)
+  # ===========================================================================
+
+  verify-artifact-counts:
+    name: "Verify Artifact Counts"
+    runs-on: [Linux, self-hosted, X64]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify Artifact Counts
+        shell: bash
+        run: |
+          bash "${GITHUB_WORKSPACE}/qcom/scripts/release_testing/run_release_testing.sh" \
+            --artifact-type all \
+            --artifact-version "${ARTIFACT_VERSION}" \
+            --source-directory "${GITHUB_WORKSPACE}/release_testing" \
+            --only-count-check
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  # ===========================================================================
+  # WHEEL JOBS
+  # ===========================================================================
+
+  verify-windows-wheel-metadata:
+    name: "Verify Windows Wheel Metadata"
+    runs-on: [Windows, self-hosted, Build]
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'wheel' || inputs.artifact_format == 'all'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify Windows Wheel Metadata
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type wheel `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --download-from-artifactory `
+            --only-metadata
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  test-wheel-on-windows:
+    name: "Test Wheel - ${{ matrix.platform.name }} - Py${{ matrix.python-version }}"
+    runs-on: ${{ matrix.platform.os }}
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'wheel' || inputs.artifact_format == 'all'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: "Windows ARM64"
+            os: [Windows, self-hosted, ARM64]
+          - name: "Windows x86_64"
+            os: [Windows, self-hosted, X64]
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test Wheel
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type wheel `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --download-from-artifactory `
+            --python-versions "${{ matrix.python-version }}"
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  test-wheel-on-linux:
+    name: "Test Wheel - ${{ matrix.platform.name }} - Py${{ matrix.python-version }}"
+    runs-on: ${{ matrix.platform.os }}
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'wheel' || inputs.artifact_format == 'all'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: "Linux ARM64"
+            os: [Linux, self-hosted, ARM64]
+          - name: "Linux x86_64"
+            os: [Linux, self-hosted, X64]
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '${{ matrix.python-version }}'
+
+      - name: Test Wheel
+        shell: bash
+        run: |
+          bash "${GITHUB_WORKSPACE}/qcom/scripts/release_testing/run_release_testing.sh" \
+            --artifact-type wheel \
+            --artifact-version "${ARTIFACT_VERSION}" \
+            --source-directory "${GITHUB_WORKSPACE}/release_testing" \
+            --download-from-artifactory \
+            --python-versions "${{ matrix.python-version }}"
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  verify-backward-compatibility:
+    name: "Verify Backward Compatibility (Windows ARM64, Python 3.12)"
+    runs-on: [Windows, self-hosted, ARM64]
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'wheel' || inputs.artifact_format == 'all'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Backward Compatibility Test
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type wheel `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --download-from-artifactory `
+            --only-backward-compat
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  # ===========================================================================
+  # ZIP JOBS
+  # ===========================================================================
+
+  verify-windows-zip-metadata:
+    name: "Verify Windows Zip Metadata"
+    runs-on: [Windows, self-hosted, Build]
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'zip' || inputs.artifact_format == 'all'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify Windows Zip Metadata
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type zip `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --test-package-version "$env:TEST_PACKAGE_VERSION" `
+            --download-from-artifactory `
+            --only-metadata
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  smoke-test-zip-on-windows:
+    name: "Smoke Test Zip - ${{ matrix.platform.name }}"
+    runs-on: ${{ matrix.platform.os }}
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'zip' || inputs.artifact_format == 'all'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: "Windows ARM64"
+            os: [Windows, self-hosted, ARM64]
+          - name: "Windows x86_64"
+            os: [Windows, self-hosted, X64]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Smoke Test Zip
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type zip `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --test-package-version "$env:TEST_PACKAGE_VERSION" `
+            --download-from-artifactory
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  # ===========================================================================
+  # TGZ JOBS
+  # ===========================================================================
+
+  smoke-test-tgz-on-linux:
+    name: "Smoke Test TGZ - ${{ matrix.platform.name }}"
+    runs-on: ${{ matrix.platform.os }}
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'tgz' || inputs.artifact_format == 'all'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: "Linux ARM64"
+            os: [Linux, self-hosted, ARM64]
+          - name: "Linux x86_64"
+            os: [Linux, self-hosted, X64]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Smoke Test TGZ
+        shell: bash
+        run: |
+          bash "${GITHUB_WORKSPACE}/qcom/scripts/release_testing/run_release_testing.sh" \
+            --artifact-type tgz \
+            --artifact-version "${ARTIFACT_VERSION}" \
+            --source-directory "${GITHUB_WORKSPACE}/release_testing" \
+            --test-package-version "${TEST_PACKAGE_VERSION}" \
+            --download-from-artifactory
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  # ===========================================================================
+  # NUGET JOBS
+  # ===========================================================================
+
+  verify-windows-nuget-metadata:
+    name: "Verify Windows NuGet Metadata"
+    runs-on: [Windows, self-hosted, Build]
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'nuget' || inputs.artifact_format == 'all'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify NuGet Metadata
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type nuget `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --download-from-artifactory `
+            --only-metadata
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"
+
+  test-nuget-on-windows:
+    name: "Test NuGet - ${{ matrix.platform.name }}"
+    runs-on: ${{ matrix.platform.os }}
+    needs: verify-artifact-counts
+    if: inputs.artifact_format == 'nuget' || inputs.artifact_format == 'all'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: "Windows ARM64"
+            os: [Windows, self-hosted, ARM64]
+          - name: "Windows x86_64"
+            os: [Windows, self-hosted, X64]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test NuGet Package
+        shell: powershell
+        run: |
+          & "${{ github.workspace }}/qcom/scripts/release_testing/run_release_testing.ps1" `
+            --artifact-type nuget `
+            --artifact-version "$env:ARTIFACT_VERSION" `
+            --source-directory "${{ github.workspace }}/release_testing" `
+            --download-from-artifactory
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          echo "Job result: ${{ job.status }}"

--- a/.github/workflows/qualcomm-internal-release-testing.yml
+++ b/.github/workflows/qualcomm-internal-release-testing.yml
@@ -114,6 +114,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Test Wheel
         shell: powershell
@@ -149,6 +151,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -179,6 +183,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Backward Compatibility Test
         shell: powershell
@@ -243,6 +249,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Smoke Test Zip
         shell: powershell
@@ -281,6 +289,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Smoke Test TGZ
         shell: bash
@@ -344,6 +354,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Test NuGet Package
         shell: powershell

--- a/qcom/scripts/release_testing/install_and_test_wheel.ps1
+++ b/qcom/scripts/release_testing/install_and_test_wheel.ps1
@@ -1,0 +1,91 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$PythonVersion,
+    [Parameter(Mandatory=$true)]
+    [string]$WheelArch,
+    [Parameter(Mandatory=$true)]
+    [string]$WheelDirectory,
+    [Parameter(Mandatory=$true)]
+    [string]$ExpectedVersion,
+    [Parameter(Mandatory=$true)]
+    [string]$SamplePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Force UTF-8 for native-process I/O so ONNX Runtime's wide-char log output
+# isn't misrendered with spaces between every character.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+
+# Suppress ANSI color escape codes ([0;93m...[m) in ORT's log output —
+# they render as literal text in the GitHub Actions log viewer.
+$env:NO_COLOR = "1"
+
+$pyNoDot = $PythonVersion.Replace(".", "")
+$envName = "py${pyNoDot}_release_testing_env"
+
+# Find the wheel that matches both the Python version and the platform
+$wheel = Get-ChildItem -Path $WheelDirectory `
+  -Filter "*cp${pyNoDot}-cp${pyNoDot}-${WheelArch}.whl" |
+  Select-Object -First 1
+
+if (-not $wheel) {
+    Write-Host "No wheel found matching cp${pyNoDot}-${WheelArch} in $WheelDirectory" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Found wheel: $($wheel.FullName)" -ForegroundColor Cyan
+
+# Create venv named py{XYZ}_release_testing_env using the py launcher
+# to pick the requested Python version (no actions/setup-python needed).
+$pyTag = if ($WheelArch -eq "win_arm64") { "$PythonVersion-arm64" } else { "$PythonVersion" }
+if (Test-Path $envName) { Remove-Item -Path $envName -Recurse -Force }
+py -$pyTag -m venv $envName
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Failed to create venv (exit $LASTEXITCODE)" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+try {
+    # Activate venv (dot-source so the PATH update persists in this script's scope)
+    . "$envName/Scripts/Activate.ps1"
+
+    # Upgrade pip and install the local wheel
+    python -m pip install --upgrade pip
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "pip upgrade FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    python -m pip install $wheel.FullName
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Wheel install FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    # Verify the package reports the expected version
+    $reported = (python -c "import onnxruntime_qnn as qnn_ep; print(qnn_ep.__version__)").Trim()
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Version query FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    Write-Host "onnxruntime_qnn.__version__ = $reported"
+    if ($reported -ne $ExpectedVersion) {
+        Write-Host "Version mismatch: expected '$ExpectedVersion', got '$reported'" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Version check PASS" -ForegroundColor Green
+
+    # Run the sample test
+    python $SamplePath
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Sample test FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    Write-Host "Sample test PASS" -ForegroundColor Green
+} finally {
+    Remove-Item -Path $envName -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/qcom/scripts/release_testing/install_and_test_wheel.sh
+++ b/qcom/scripts/release_testing/install_and_test_wheel.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python-version)    python_version="$2";    shift 2 ;;
+    --wheel-arch)        wheel_arch="$2";        shift 2 ;;
+    --wheel-directory)   wheel_directory="$2";   shift 2 ;;
+    --expected-version)  expected_version="$2";  shift 2 ;;
+    --sample-path)       sample_path="$2";       shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+: "${python_version:?--python-version is required}"
+: "${wheel_arch:?--wheel-arch is required}"
+: "${wheel_directory:?--wheel-directory is required}"
+: "${expected_version:?--expected-version is required}"
+: "${sample_path:?--sample-path is required}"
+
+py_no_dot=$(echo "$python_version" | tr -d '.')
+env_name="py${py_no_dot}_release_testing_env"
+
+# Locate the requested Python interpreter on the host.
+# Try the version-suffixed binary first (python3.12), then the manylinux
+# container layout (/opt/python/cp{ver}-cp{ver}/bin/python) as a fallback
+# so this script works both natively and inside a manylinux container.
+python_bin=""
+if command -v "python${python_version}" >/dev/null 2>&1; then
+  python_bin=$(command -v "python${python_version}")
+elif [ -x "/opt/python/cp${py_no_dot}-cp${py_no_dot}/bin/python" ]; then
+  python_bin="/opt/python/cp${py_no_dot}-cp${py_no_dot}/bin/python"
+fi
+
+if [ -z "$python_bin" ] || [ ! -x "$python_bin" ]; then
+  echo "ERROR: Python ${python_version} interpreter not found."
+  echo "  Tried: python${python_version} on PATH"
+  echo "         /opt/python/cp${py_no_dot}-cp${py_no_dot}/bin/python"
+  exit 1
+fi
+echo "Using Python: $python_bin"
+
+# Find the wheel that matches both the Python version and the platform
+wheel=$(find "$wheel_directory" -maxdepth 1 \
+  -name "*cp${py_no_dot}-cp${py_no_dot}-${wheel_arch}.whl" | head -n 1)
+
+if [ -z "$wheel" ]; then
+  echo "ERROR: No wheel found matching cp${py_no_dot}-${wheel_arch} in $wheel_directory"
+  exit 1
+fi
+echo "Found wheel: $wheel"
+
+# Create venv named py{XYZ}_release_testing_env
+"$python_bin" -m venv "$env_name"
+
+# Activate venv
+source "$env_name/bin/activate"
+
+# Upgrade pip and install the local wheel
+python -m pip install --upgrade pip
+python -m pip install "$wheel"
+
+# Verify the package reports the expected version
+reported=$(python -c "import onnxruntime_qnn as qnn_ep; print(qnn_ep.__version__)")
+echo "onnxruntime_qnn.__version__ = $reported"
+if [ "$reported" != "$expected_version" ]; then
+  printf '\033[0;31mVersion mismatch: expected %s, got %s\033[0m\n' "$expected_version" "$reported" >&2
+  exit 1
+fi
+echo "Version check PASS"
+
+# Run the sample test
+python "$sample_path"

--- a/qcom/scripts/release_testing/release_testing.py
+++ b/qcom/scripts/release_testing/release_testing.py
@@ -1,0 +1,719 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+"""
+Release testing orchestrator for onnxruntime-qnn artifacts.
+
+Runs validation tests for wheel, zip, tgz, and nuget artifacts either from
+a local directory or by downloading from Artifactory first. Designed to be
+invocable both from CI (GitHub Actions) and from a local dev/host machine.
+
+Usage:
+    # Local mode — artifacts already downloaded
+    python qcom/scripts/release_testing/release_testing.py --artifact-type wheel --artifact-version 2.6.0 \\
+        --source-directory ./release_testing
+
+    # Download mode — fetch from Artifactory first
+    python qcom/scripts/release_testing/release_testing.py --artifact-type wheel --artifact-version 2.6.0 \\
+        --source-directory ./release_testing --download-from-artifactory
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import platform
+import re
+import subprocess
+import sys
+from configparser import ConfigParser
+from pathlib import Path
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent.parent
+RELEASE_SCRIPTS_DIR = SCRIPT_DIR
+
+# Upleveling infrastructure paths (reused for certs and config)
+UPLEVELING_DIR = SCRIPT_DIR.parent / "upleveling"
+INI_FILE = UPLEVELING_DIR / "config.ini"
+ARTIFACTORY_CERTS_FILE = UPLEVELING_DIR / "certs" / "artifactory-ca.pem"
+
+# Hardcoded defaults
+PRODUCT_NAME = "onnxruntime-qnn"
+SAMPLE_PATH = REPO_ROOT / "qcom" / "samples" / "test_wheel.py"
+MODEL_PATH = (
+    REPO_ROOT
+    / "cmake"
+    / "external"
+    / "onnx"
+    / "onnx"
+    / "backend"
+    / "test"
+    / "data"
+    / "node"
+    / "test_abs"
+    / "model.onnx"
+)
+BACKWARD_COMPAT_ORT_VERSION = "1.24.2"
+
+# Storage index servers per artifact type (config.ini sections with direct storage URLs)
+ARTIFACT_STORAGE_INDEXES = {
+    "wheel": "artifactory-pypi-public-storage",
+    "nuget": "artifactory-nuget-public-storage",
+    "zip": "artifactory-zip-public-storage",
+    "tgz": "artifactory-zip-public-storage",
+    "test_package": "artifactory-zip-testproj-storage",
+}
+
+ARTIFACT_SUFFIXES = {
+    "wheel": ".whl",
+    "nuget": ".nupkg",
+    "zip": ".zip",
+    "tgz": ".tgz",
+}
+
+log = logging.getLogger("release_test")
+
+
+# =============================================================================
+# Platform detection
+# =============================================================================
+
+
+def is_host_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def is_host_linux() -> bool:
+    return platform.system() == "Linux"
+
+
+def is_host_arm64() -> bool:
+    # On Windows ARM64 with x64-emulated Python, platform.machine()
+    # returns "AMD64"; check PROCESSOR_ARCHITEW6432 for the true arch.
+    arch_w6432 = os.environ.get("PROCESSOR_ARCHITEW6432", "").upper()
+    if arch_w6432 == "ARM64":
+        return True
+    return platform.machine().lower() in ("aarch64", "arm64")
+
+
+def is_host_x86_64() -> bool:
+    return platform.machine().lower() in ("x86_64", "amd64")
+
+
+# =============================================================================
+# Artifactory download (follows qnn_ep_uplevel.py pattern)
+# =============================================================================
+
+
+def _get_artifactory_credentials() -> tuple[str, str]:
+    user = os.environ.get("ARTIFACTORY_USERNAME", "")
+    password = os.environ.get("ARTIFACTORY_PASSWORD", "")
+    missing = []
+    if not user:
+        missing.append("ARTIFACTORY_USERNAME")
+    if not password:
+        missing.append("ARTIFACTORY_PASSWORD")
+    if missing:
+        log.error(f"Missing env var(s) required for downloads: {', '.join(missing)}")
+        sys.exit(1)
+    return user, password
+
+
+def _get_repository_url(artifact_type: str, version: str) -> str:
+    config = ConfigParser()
+    config.read([str(INI_FILE)])
+    index = ARTIFACT_STORAGE_INDEXES[artifact_type]
+    base_url = config.get(index, "repository")
+    return f"{base_url}/{PRODUCT_NAME}/{version}"
+
+
+def download_artifacts(
+    artifact_type: str,
+    version: str,
+    suffix: str,
+    dest_dir: Path,
+    filename_filter: str | None = None,
+) -> list[str]:
+    """Download artifacts from Artifactory using HTTP (no JFrog CLI needed)."""
+    url = _get_repository_url(artifact_type, version)
+    user, password = _get_artifactory_credentials()
+    auth = HTTPBasicAuth(user, password)
+    verify = str(ARTIFACTORY_CERTS_FILE) if ARTIFACTORY_CERTS_FILE.exists() else True
+
+    log.info(f"Fetching artifact list from: {url}")
+    response = requests.get(url, auth=auth, verify=verify)
+    if response.status_code != 200:
+        log.error(f"Failed to fetch artifact list from {url} (HTTP {response.status_code})")
+        sys.exit(1)
+
+    # Parse Artifactory HTML directory listing (same regex as qnn_ep_uplevel.py)
+    artifact_list = [
+        m.group(1)
+        for m in (
+            re.search(r'href=["\']([^"\']*' + re.escape(suffix) + r')["\']', line)
+            for line in response.text.splitlines()
+            if suffix in line
+        )
+        if m
+    ]
+
+    if filename_filter:
+        artifact_list = [f for f in artifact_list if re.search(filename_filter, f)]
+
+    if not artifact_list:
+        log.error(f"No artifacts with suffix '{suffix}' found at {url}")
+        sys.exit(1)
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    for artifact_file in artifact_list:
+        artifact_url = f"{url}/{artifact_file}"
+        download_path = dest_dir / artifact_file
+        log.info(f"Downloading {artifact_file}")
+        r = requests.get(artifact_url, auth=auth, verify=verify)
+        if r.status_code != 200:
+            log.error(f"Failed to download {artifact_file} (HTTP {r.status_code})")
+            sys.exit(1)
+        download_path.write_bytes(r.content)
+        log.info(f"Saved {download_path}")
+
+    return artifact_list
+
+
+def list_artifacts(
+    artifact_type: str,
+    version: str,
+    suffix: str,
+    filename_filter: str | None = None,
+) -> list[str]:
+    """List artifact filenames on Artifactory without downloading them."""
+    url = _get_repository_url(artifact_type, version)
+    user, password = _get_artifactory_credentials()
+    auth = HTTPBasicAuth(user, password)
+    verify = str(ARTIFACTORY_CERTS_FILE) if ARTIFACTORY_CERTS_FILE.exists() else True
+
+    log.info(f"Listing artifacts at: {url}")
+    response = requests.get(url, auth=auth, verify=verify)
+    if response.status_code != 200:
+        log.error(f"Failed to fetch artifact list from {url} (HTTP {response.status_code})")
+        sys.exit(1)
+
+    artifact_list = [
+        m.group(1)
+        for m in (
+            re.search(r'href=["\']([^"\']*' + re.escape(suffix) + r')["\']', line)
+            for line in response.text.splitlines()
+            if suffix in line
+        )
+        if m
+    ]
+
+    if filename_filter:
+        artifact_list = [f for f in artifact_list if re.search(filename_filter, f)]
+
+    return artifact_list
+
+
+# =============================================================================
+# Artifact count verification
+# =============================================================================
+
+_WHEEL_ARCHES = ("win_arm64", "win_amd64", "manylinux_2_34_aarch64", "manylinux_2_35_x86_64")
+_EXPECTED_ZIP_SUFFIXES = ("win-arm64.zip", "win-arm64x.zip", "win-x64.zip")
+_EXPECTED_TGZ_SUFFIXES = ("linux-aarch64.tgz", "linux-x64.tgz")
+_ZIP_SKIP_PATTERN = r"(-pdb\.zip|-win-arm64ec\.zip)$"
+
+
+def verify_artifact_counts(args: argparse.Namespace) -> None:
+    """Verify all expected artifacts are present on Artifactory before running tests."""
+    python_versions = args.python_versions.split(",")
+    failed = False
+
+    # --- Wheels: 4 Python versions x 4 arches = 16 ---
+    wheels = list_artifacts("wheel", args.artifact_version, ".whl")
+    expected_wheels = [
+        f"cp{v.replace('.', '')}-cp{v.replace('.', '')}-{arch}.whl"
+        for v in python_versions
+        for arch in _WHEEL_ARCHES
+    ]
+    missing_wheels = [e for e in expected_wheels if not any(e in f for f in wheels)]
+    if missing_wheels:
+        log.error("Wheels: FAIL — %d missing:\n%s", len(missing_wheels), "\n".join(f"  {m}" for m in missing_wheels))
+        failed = True
+    else:
+        log.info(f"Wheels: PASS — {len(wheels)}/{len(expected_wheels)}")
+
+    # --- NuGet: 1 expected ---
+    nupkgs = list_artifacts("nuget", args.artifact_version, ".nupkg")
+    if len(nupkgs) != 1:
+        log.error(f"NuGet: FAIL — expected 1, found {len(nupkgs)}: {nupkgs}")
+        failed = True
+    else:
+        log.info("NuGet: PASS — 1/1")
+
+    # --- Zip: 3 expected, excluding -pdb.zip and -win-arm64ec.zip ---
+    all_zips = list_artifacts("zip", args.artifact_version, ".zip")
+    zips = [f for f in all_zips if not re.search(_ZIP_SKIP_PATTERN, f)]
+    missing_zips = [s for s in _EXPECTED_ZIP_SUFFIXES if not any(f.endswith(s) for f in zips)]
+    if missing_zips:
+        log.error(f"Zip: FAIL — missing: {missing_zips}")
+        failed = True
+    else:
+        log.info(f"Zip: PASS — {len(zips)}/3")
+
+    # --- TGZ: 2 expected ---
+    tgzs = list_artifacts("tgz", args.artifact_version, ".tgz")
+    missing_tgzs = [s for s in _EXPECTED_TGZ_SUFFIXES if not any(f.endswith(s) for f in tgzs)]
+    if missing_tgzs:
+        log.error(f"TGZ: FAIL — missing: {missing_tgzs}")
+        failed = True
+    else:
+        log.info(f"TGZ: PASS — {len(tgzs)}/2")
+
+    if failed:
+        sys.exit(1)
+    log.info("Artifact count check PASS: all expected artifacts are present")
+
+
+def run_script(script_name: str, args: list[str]) -> None:
+    """Run a release testing script (.ps1 or .sh)."""
+    script = RELEASE_SCRIPTS_DIR / script_name
+    if not script.exists():
+        log.error(f"Script not found: {script}")
+        sys.exit(1)
+
+    if script.suffix == ".ps1":
+        cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(script), *args]
+    elif script.suffix == ".sh":
+        cmd = ["bash", str(script), *args]
+    else:
+        log.error(f"Unknown script type: {script.suffix}")
+        sys.exit(1)
+
+    log.info(f"Running: {script.name} {' '.join(args)}")
+    result = subprocess.run(cmd, check=False)
+    if result.returncode != 0:
+        log.error(f"{script.name} failed with exit code {result.returncode}")
+        sys.exit(result.returncode)
+
+
+# =============================================================================
+# Per-artifact-type test runners
+# =============================================================================
+
+
+def _wheel_download_filter(args: argparse.Namespace) -> str | None:
+    """Return a filename regex that limits wheel downloads to what this job actually needs."""
+    if args.only_metadata:
+        # Metadata job verifies Authenticode on all Windows wheels (arm64 + amd64).
+        return r"(win_arm64|win_amd64)\.whl$"
+
+    if args.only_backward_compat:
+        # Backward compat always uses the win_arm64 cp312 wheel.
+        return r"cp312-cp312-win_arm64\.whl$"
+
+    # Install+test: filter by host platform and the requested Python version(s).
+    if is_host_windows():
+        arch_tag = "win_arm64" if is_host_arm64() else "win_amd64"
+    elif is_host_linux():
+        arch_tag = "manylinux_2_34_aarch64" if is_host_arm64() else "manylinux_2_35_x86_64"
+    else:
+        return r"\.whl$"  # unknown platform — download everything
+
+    py_alts = "|".join(f"cp{v.replace('.', '')}" for v in args.python_versions.split(","))
+    return rf"(?:{py_alts})-{arch_tag}\.whl$"
+
+
+def test_wheel(args: argparse.Namespace) -> None:
+    wheel_dir = Path(args.source_directory) / "wheel"
+
+    if args.download_from_artifactory:
+        downloaded = download_artifacts(
+            "wheel",
+            args.artifact_version,
+            ARTIFACT_SUFFIXES["wheel"],
+            wheel_dir,
+            filename_filter=_wheel_download_filter(args),
+        )
+
+        if args.only_metadata:
+            log.info(f"Downloaded {len(downloaded)} Windows wheel(s) for metadata verification")
+
+    if args.only_metadata:
+        if is_host_windows():
+            run_script(
+                "verify_windows_metadata.ps1",
+                [
+                    "-ArtifactType",
+                    "wheel",
+                    "-SourceDirectory",
+                    str(wheel_dir),
+                    "-ExpectedVersion",
+                    args.artifact_version,
+                ],
+            )
+        else:
+            log.info("Metadata verification is Windows-only, skipping")
+        return
+
+    if args.only_backward_compat:
+        if is_host_windows() and is_host_arm64():
+            run_script(
+                "verify_backward_compatibility.ps1",
+                [
+                    "-PythonVersion",
+                    "3.12",
+                    "-WheelArch",
+                    "win_arm64",
+                    "-WheelDirectory",
+                    str(wheel_dir),
+                    "-OnnxruntimeVersion",
+                    BACKWARD_COMPAT_ORT_VERSION,
+                    "-SamplePath",
+                    str(SAMPLE_PATH),
+                ],
+            )
+        else:
+            log.info("Backward compatibility test only runs on Windows ARM64, skipping")
+        return
+
+    # Default: install + test only
+    python_versions = args.python_versions.split(",")
+
+    if is_host_windows():
+        wheel_arch = "win_arm64" if is_host_arm64() else "win_amd64"
+        for pyver in python_versions:
+            run_script(
+                "install_and_test_wheel.ps1",
+                [
+                    "-PythonVersion",
+                    pyver,
+                    "-WheelArch",
+                    wheel_arch,
+                    "-WheelDirectory",
+                    str(wheel_dir),
+                    "-ExpectedVersion",
+                    args.artifact_version,
+                    "-SamplePath",
+                    str(SAMPLE_PATH),
+                ],
+            )
+
+    elif is_host_linux():
+        wheel_arch = "manylinux_2_34_aarch64" if is_host_arm64() else "manylinux_2_35_x86_64"
+        for pyver in python_versions:
+            run_script(
+                "install_and_test_wheel.sh",
+                [
+                    "--python-version",
+                    pyver,
+                    "--wheel-arch",
+                    wheel_arch,
+                    "--wheel-directory",
+                    str(wheel_dir),
+                    "--expected-version",
+                    args.artifact_version,
+                    "--sample-path",
+                    str(SAMPLE_PATH),
+                ],
+            )
+
+
+def test_zip(args: argparse.Namespace) -> None:
+    if not is_host_windows():
+        log.info("Zip testing is Windows-only, skipping on this platform")
+        return
+
+    archive_dir = Path(args.source_directory) / "archive"
+
+    if args.download_from_artifactory:
+        if not args.test_package_version:
+            log.error("--test-package-version is required for zip testing")
+            sys.exit(1)
+        download_artifacts(
+            "zip",
+            args.artifact_version,
+            ARTIFACT_SUFFIXES["zip"],
+            archive_dir,
+        )
+        if not args.only_metadata:
+            # Download test package (only needed for smoke tests)
+            test_pkg_files = download_artifacts(
+                "test_package",
+                args.test_package_version,
+                ".zip",
+                archive_dir,
+                filename_filter=r"test_package\.zip$",
+            )
+            for f in test_pkg_files:
+                src = archive_dir / f
+                dst = archive_dir / "test_package.zip"
+                if src != dst:
+                    src.rename(dst)
+
+    if args.only_metadata:
+        run_script(
+            "verify_windows_metadata.ps1",
+            [
+                "-ArtifactType",
+                "zip",
+                "-SourceDirectory",
+                str(archive_dir),
+                "-ExpectedVersion",
+                args.artifact_version,
+            ],
+        )
+        return
+
+    # Smoke test — determine platform-specific args
+    if is_host_arm64():
+        configs = [
+            ("win-arm64", "windows-arm64", "QnnHtp.dll"),
+            ("win-arm64x", "windows-arm64", "QnnHtp.dll"),
+            ("win-arm64x", "windows-x86_64", "QnnHtp.dll"),  # ARM64EC path
+        ]
+    elif is_host_x86_64():
+        configs = [
+            ("win-x64", "windows-x86_64", "QnnCpu.dll"),
+        ]
+    else:
+        log.warning(f"Unknown Windows architecture: {platform.machine()}")
+        return
+
+    test_package_zip = archive_dir / "test_package.zip"
+    for zip_arch, test_bin_arch, backend_dll in configs:
+        run_script(
+            "smoke_test_zip.ps1",
+            [
+                "-ZipDirectory",
+                str(archive_dir),
+                "-TestPackageZip",
+                str(test_package_zip),
+                "-ModelPath",
+                str(MODEL_PATH),
+                "-ZipArch",
+                zip_arch,
+                "-TestBinArch",
+                test_bin_arch,
+                "-BackendDll",
+                backend_dll,
+            ],
+        )
+
+
+def test_tgz(args: argparse.Namespace) -> None:
+    if not is_host_linux():
+        log.info("TGZ testing is Linux-only, skipping on this platform")
+        return
+
+    archive_dir = Path(args.source_directory) / "archive"
+
+    if args.download_from_artifactory:
+        if not args.test_package_version:
+            log.error("--test-package-version is required for tgz testing")
+            sys.exit(1)
+        download_artifacts(
+            "tgz",
+            args.artifact_version,
+            ARTIFACT_SUFFIXES["tgz"],
+            archive_dir,
+        )
+        # Download test package
+        test_pkg_files = download_artifacts(
+            "test_package",
+            args.test_package_version,
+            ".zip",
+            archive_dir,
+            filename_filter=r"test_package\.zip$",
+        )
+        for f in test_pkg_files:
+            src = archive_dir / f
+            dst = archive_dir / "test_package.zip"
+            if src != dst:
+                src.rename(dst)
+
+    # Smoke test — determine platform-specific args
+    if is_host_arm64():
+        tgz_arch, test_bin_arch, backend_lib = "linux-aarch64", "linux-arm64", "libQnnHtp.so"
+    elif is_host_x86_64():
+        tgz_arch, test_bin_arch, backend_lib = "linux-x64", "linux-x86_64", "libQnnCpu.so"
+    else:
+        log.warning(f"Unknown Linux architecture: {platform.machine()}")
+        return
+
+    test_package_zip = archive_dir / "test_package.zip"
+    run_script(
+        "smoke_test_tgz.sh",
+        [
+            "--tgz-directory",
+            str(archive_dir),
+            "--test-package-zip",
+            str(test_package_zip),
+            "--model-path",
+            str(MODEL_PATH),
+            "--tgz-arch",
+            tgz_arch,
+            "--test-bin-arch",
+            test_bin_arch,
+            "--backend-lib",
+            backend_lib,
+        ],
+    )
+
+
+def test_nuget(args: argparse.Namespace) -> None:
+    if not is_host_windows():
+        log.info("NuGet testing is Windows-only, skipping on this platform")
+        return
+
+    nuget_dir = Path(args.source_directory) / "nuget"
+
+    if args.download_from_artifactory:
+        download_artifacts(
+            "nuget",
+            args.artifact_version,
+            ARTIFACT_SUFFIXES["nuget"],
+            nuget_dir,
+        )
+
+    if args.only_metadata:
+        run_script(
+            "verify_windows_metadata.ps1",
+            [
+                "-ArtifactType",
+                "nuget",
+                "-SourceDirectory",
+                str(nuget_dir),
+                "-ExpectedVersion",
+                args.artifact_version,
+            ],
+        )
+        return
+
+    # Determine host-appropriate RID and backend
+    if is_host_arm64():
+        runtime_id, backend_dll = "win-arm64", "QnnHtp.dll"
+    elif is_host_x86_64():
+        runtime_id, backend_dll = "win-x64", "QnnCpu.dll"
+    else:
+        log.warning(f"Unknown Windows architecture: {platform.machine()}")
+        return
+
+    run_script(
+        "test_nuget_package.ps1",
+        [
+            "-NuGetDirectory",
+            str(nuget_dir),
+            "-ExpectedVersion",
+            args.artifact_version,
+            "-RuntimeIdentifiers",
+            runtime_id,
+            "-ModelPath",
+            str(MODEL_PATH),
+            "-BackendDll",
+            backend_dll,
+        ],
+    )
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Release testing orchestrator for onnxruntime-qnn artifacts",
+    )
+    parser.add_argument(
+        "--artifact-type",
+        required=True,
+        choices=["wheel", "zip", "tgz", "nuget", "all"],
+        help="Type of artifact to test",
+    )
+    parser.add_argument(
+        "--artifact-version",
+        required=True,
+        help="Version of the artifact to test (e.g. 2.6.0, 2.5.0rc3)",
+    )
+    parser.add_argument(
+        "--source-directory",
+        required=True,
+        help="Base directory for artifacts. Sub-directories (wheel/, archive/, nuget/) are created per type.",
+    )
+    parser.add_argument(
+        "--test-package-version",
+        default=None,
+        help="Version of the test package archive. Required for zip/tgz testing.",
+    )
+    parser.add_argument(
+        "--download-from-artifactory",
+        action="store_true",
+        help=(
+            "Download artifacts from Artifactory before testing. "
+            "Requires ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD env vars."
+        ),
+    )
+    parser.add_argument(
+        "--python-versions",
+        default="3.11,3.12,3.13,3.14",
+        help="Comma-separated Python versions for wheel testing (default: 3.11,3.12,3.13,3.14)",
+    )
+    parser.add_argument(
+        "--only-count-check",
+        action="store_true",
+        help="Only verify that all expected artifacts are present on Artifactory.",
+    )
+    parser.add_argument(
+        "--only-backward-compat",
+        action="store_true",
+        help="Only run the backward compatibility test (wheels only).",
+    )
+    parser.add_argument(
+        "--only-metadata",
+        action="store_true",
+        help="Only run metadata verification (Authenticode + version checks).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] [release_test] [%(levelname)s] %(message)s",
+    )
+
+    args = parse_args()
+
+    log.info(f"Platform: {platform.system()} {platform.machine()}")
+    log.info(f"Artifact type: {args.artifact_type}")
+    log.info(f"Artifact version: {args.artifact_version}")
+
+    if args.only_count_check:
+        verify_artifact_counts(args)
+        return
+
+    runners = {
+        "wheel": test_wheel,
+        "zip": test_zip,
+        "tgz": test_tgz,
+        "nuget": test_nuget,
+    }
+
+    if args.artifact_type == "all":
+        for name, runner in runners.items():
+            log.info(f"=== Testing {name} artifacts ===")
+            runner(args)
+    else:
+        runners[args.artifact_type](args)
+
+    log.info("All tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/qcom/scripts/release_testing/release_testing.py
+++ b/qcom/scripts/release_testing/release_testing.py
@@ -236,11 +236,8 @@ def verify_artifact_counts(args: argparse.Namespace) -> None:
 
     # --- Wheels: 4 Python versions x 4 arches = 16 ---
     wheels = list_artifacts("wheel", args.artifact_version, ".whl")
-    expected_wheels = [
-        f"cp{v.replace('.', '')}-cp{v.replace('.', '')}-{arch}.whl"
-        for v in python_versions
-        for arch in _WHEEL_ARCHES
-    ]
+    py_tags = [f"cp{v.replace('.', '')}" for v in python_versions]
+    expected_wheels = [f"{t}-{t}-{arch}.whl" for t in py_tags for arch in _WHEEL_ARCHES]
     missing_wheels = [e for e in expected_wheels if not any(e in f for f in wheels)]
     if missing_wheels:
         log.error("Wheels: FAIL — %d missing:\n%s", len(missing_wheels), "\n".join(f"  {m}" for m in missing_wheels))

--- a/qcom/scripts/release_testing/run_release_testing.ps1
+++ b/qcom/scripts/release_testing/run_release_testing.ps1
@@ -1,0 +1,36 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+# Bootstrap script for release testing on Windows.
+# Creates a venv, installs dependencies, and runs release_testing.py with all
+# forwarded arguments. Designed for both CI and local use.
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = git rev-parse --show-toplevel
+$VenvName = "release_testing_venv"
+
+# Clean stale venv
+if (Test-Path $VenvName) { Remove-Item -Path $VenvName -Recurse -Force }
+
+# Create and activate venv.
+# This venv only runs the Python orchestrator (release_testing.py); its
+# architecture does not affect which wheels are tested.  Wheel testing
+# creates its own arch-specific venv via install_and_test_wheel.ps1 using
+# the py launcher (e.g. py -3.12-arm64).
+python -m venv $VenvName
+. "$VenvName/Scripts/Activate.ps1"
+
+# Install dependencies (--system-certs for corporate proxy environments)
+pip install uv
+uv pip install --system-certs -r "$RepoRoot/qcom/requirements.txt"
+
+# Run release testing, forwarding all arguments
+python "$RepoRoot/qcom/scripts/release_testing/release_testing.py" @args
+$exitCode = $LASTEXITCODE
+
+# Cleanup
+deactivate
+Remove-Item -Path $VenvName -Recurse -Force -ErrorAction SilentlyContinue
+
+exit $exitCode

--- a/qcom/scripts/release_testing/run_release_testing.sh
+++ b/qcom/scripts/release_testing/run_release_testing.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+# Bootstrap script for release testing on Linux.
+# Creates a venv, installs dependencies, and runs release_testing.py with all
+# forwarded arguments. Designed for both CI and local use.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+VENV_NAME="release_testing_venv"
+
+# Clean stale venv
+rm -rf "${VENV_NAME}"
+
+# Create and activate venv
+python3 -m venv "${VENV_NAME}"
+source "${VENV_NAME}/bin/activate"
+
+# Install dependencies
+pip install uv
+uv pip install --system-certs -r "${REPO_ROOT}/qcom/requirements.txt"
+
+# Run release testing, forwarding all arguments
+python "${REPO_ROOT}/qcom/scripts/release_testing/release_testing.py" "$@"
+EXIT_CODE=$?
+
+# Cleanup
+deactivate
+rm -rf "${VENV_NAME}"
+
+exit ${EXIT_CODE}

--- a/qcom/scripts/release_testing/smoke_test_tgz.sh
+++ b/qcom/scripts/release_testing/smoke_test_tgz.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tgz-directory)    tgz_directory="$2";    shift 2 ;;
+    --test-package-zip) test_package_zip="$2"; shift 2 ;;
+    --model-path)       model_path="$2";       shift 2 ;;
+    --tgz-arch)         tgz_arch="$2";         shift 2 ;;
+    --test-bin-arch)    test_bin_arch="$2";    shift 2 ;;
+    --backend-lib)      backend_lib="$2";      shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+: "${tgz_directory:?--tgz-directory is required}"
+: "${test_package_zip:?--test-package-zip is required}"
+: "${model_path:?--model-path is required}"
+: "${tgz_arch:?--tgz-arch is required}"
+: "${test_bin_arch:?--test-bin-arch is required}"
+backend_lib="${backend_lib:-libQnnHtp.so}"
+
+# --- Extract the release tgz ---
+release_tgz=$(find "$tgz_directory" -maxdepth 1 -name "*${tgz_arch}.tgz" | head -n 1)
+if [ -z "$release_tgz" ]; then
+    echo ""
+    echo "ERROR: No ${tgz_arch} tgz found in $tgz_directory"
+    exit 1
+fi
+release_tgz_name=$(basename "$release_tgz")
+release_extract_dir="${tgz_directory}/${release_tgz_name%.tgz}_extracted"
+echo ""
+echo "Extracting release tgz: $release_tgz_name"
+mkdir -p "$release_extract_dir"
+tar -xf "$release_tgz" -C "$release_extract_dir"
+
+# --- Extract test_package.zip ---
+test_pkgs_dir="$(dirname "$test_package_zip")/test_package"
+echo "Extracting test_package.zip"
+mkdir -p "$test_pkgs_dir"
+python3 -c "import zipfile; zipfile.ZipFile('${test_package_zip}').extractall('${test_pkgs_dir}')"
+
+# --- Locate the test binaries folder in test_package ---
+test_bin_dir="${test_pkgs_dir}/${test_bin_arch}"
+if [ ! -d "$test_bin_dir" ]; then
+    echo "ERROR: ${test_bin_arch} folder not found in $test_pkgs_dir"
+    echo "Contents of $test_pkgs_dir:"
+    ls -1 "$test_pkgs_dir"
+    exit 1
+fi
+
+# --- Find onnxruntime_perf_test in the test binaries ---
+perf_test=$(find "$test_bin_dir" -name "onnxruntime_perf_test" -not -name "*.exe" | head -n 1)
+if [ -z "$perf_test" ]; then
+    echo "ERROR: onnxruntime_perf_test not found in $test_bin_dir"
+    exit 1
+fi
+
+# --- Copy onnxruntime_perf_test to the extracted release folder ---
+cp "$perf_test" "$release_extract_dir/"
+chmod +x "$release_extract_dir/onnxruntime_perf_test"
+echo ""
+echo "Copied onnxruntime_perf_test to release test directory"
+
+# --- Copy libonnxruntime.so and libonnxruntime_providers_shared.so from test_package ---
+cp "$test_bin_dir/libonnxruntime.so"                  "$release_extract_dir/"
+cp "$test_bin_dir/libonnxruntime_providers_shared.so" "$release_extract_dir/"
+echo "Copied libonnxruntime.so and libonnxruntime_providers_shared.so to release test directory"
+
+# --- Run the perf test smoke test ---
+echo "Running smoke test"
+echo ""
+
+cd "$release_extract_dir"
+ln -sf libonnxruntime.so libonnxruntime.so.1
+export LD_LIBRARY_PATH="$PWD"
+export ADSP_LIBRARY_PATH="$PWD"
+./onnxruntime_perf_test \
+    -I \
+    --plugin_ep_libs "QNNExecutionProvider|libonnxruntime_providers_qnn.so" \
+    --plugin_eps QNNExecutionProvider \
+    -m times \
+    -r 1 \
+    -p burst \
+    -i "backend_path|${backend_lib}" \
+    "$model_path"
+
+echo ""
+echo "Smoke test PASSED"

--- a/qcom/scripts/release_testing/smoke_test_zip.ps1
+++ b/qcom/scripts/release_testing/smoke_test_zip.ps1
@@ -1,0 +1,99 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ZipDirectory,
+    [Parameter(Mandatory=$true)]
+    [string]$TestPackageZip,
+    [Parameter(Mandatory=$true)]
+    [string]$ModelPath,
+    [Parameter(Mandatory=$true)]
+    [string]$ZipArch,
+    [Parameter(Mandatory=$true)]
+    [string]$TestBinArch,
+    [Parameter(Mandatory=$false)]
+    [string]$BackendDll = "QnnHtp.dll"
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+$env:NO_COLOR             = "1"
+
+# --- Extract the release zip ---
+$releaseZip = Get-ChildItem -Path $ZipDirectory -Filter "*${ZipArch}.zip" | Select-Object -First 1
+if (-not $releaseZip) {
+    Write-Host ""
+    Write-Host "ERROR: No ${ZipArch} zip found in $ZipDirectory" -ForegroundColor Red
+    exit 1
+}
+$releaseExtractDir = Join-Path $ZipDirectory "$($releaseZip.BaseName)_extracted"
+Write-Host ""
+Write-Host "Extracting release zip: $($releaseZip.Name)" -ForegroundColor Yellow
+Expand-Archive -Path $releaseZip.FullName -DestinationPath $releaseExtractDir -Force
+Get-ChildItem -Path $releaseExtractDir -Recurse | Unblock-File
+
+# --- Extract test_package.zip ---
+$testPkgsDir = Join-Path (Split-Path $TestPackageZip) "test_package"
+Write-Host "Extracting test_package.zip" -ForegroundColor Yellow
+Expand-Archive -Path $TestPackageZip -DestinationPath $testPkgsDir -Force
+
+# --- Locate the test binaries folder in test_package ---
+$testBinDir = Get-ChildItem -Path $testPkgsDir -Directory |
+    Where-Object { $_.Name -eq $TestBinArch } |
+    Select-Object -First 1
+
+if (-not $testBinDir) {
+    Write-Host "ERROR: No ${TestBinArch} folder found in $testPkgsDir" -ForegroundColor Red
+    Write-Host "Contents of ${testPkgsDir}:"
+    Get-ChildItem -Path $testPkgsDir | ForEach-Object { Write-Host "  $($_.Name)" }
+    exit 1
+}
+
+# --- Find onnxruntime_perf_test.exe in the test binaries ---
+$perfTest = Get-ChildItem -Path $testBinDir.FullName -Recurse -Filter "onnxruntime_perf_test.exe" |
+    Select-Object -First 1
+
+if (-not $perfTest) {
+    Write-Host "ERROR: onnxruntime_perf_test.exe not found in $($testBinDir.FullName)" -ForegroundColor Red
+    exit 1
+}
+
+# --- Copy onnxruntime_perf_test.exe to the extracted release folder ---
+Copy-Item -Path $perfTest.FullName -Destination $releaseExtractDir -Force
+$copiedExe = Join-Path $releaseExtractDir "onnxruntime_perf_test.exe"
+Unblock-File -Path $copiedExe
+Write-Host "Copied onnxruntime_perf_test.exe to release test directory" -ForegroundColor Cyan
+
+# --- Copy onnxruntime.dll and onnxruntime_providers_shared.dll from test_package ---
+foreach ($dll in @("onnxruntime.dll", "onnxruntime_providers_shared.dll")) {
+    $src = Join-Path $testBinDir.FullName $dll
+    Copy-Item -Path $src -Destination $releaseExtractDir -Force
+    Unblock-File -Path (Join-Path $releaseExtractDir $dll)
+    Write-Host "Copied $dll to release test directory" -ForegroundColor Cyan
+}
+
+# --- Run the perf test smoke test ---
+Write-Host "Running smoke test" -ForegroundColor Cyan
+Write-Host ""
+
+Push-Location $releaseExtractDir
+try {
+    & ".\onnxruntime_perf_test.exe" `
+        -I `
+        --plugin_ep_libs "QNNExecutionProvider|onnxruntime_providers_qnn.dll" `
+        --plugin_eps QNNExecutionProvider `
+        -m times `
+        -r 1 `
+        -p burst `
+        -i "backend_path|${BackendDll}" `
+        "$ModelPath"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Smoke test FAILED with exit code $LASTEXITCODE" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+} finally {
+    Pop-Location
+}
+Write-Host "Smoke test PASSED" -ForegroundColor Green

--- a/qcom/scripts/release_testing/test_nuget_package.ps1
+++ b/qcom/scripts/release_testing/test_nuget_package.ps1
@@ -1,0 +1,200 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$NuGetDirectory,
+    [Parameter(Mandatory=$true)]
+    [string]$ExpectedVersion,
+    [Parameter(Mandatory=$true)]
+    [string[]]$RuntimeIdentifiers,
+    [Parameter(Mandatory=$true)]
+    [string]$ModelPath,
+    [Parameter(Mandatory=$true)]
+    [string]$BackendDll
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+$env:NO_COLOR             = "1"
+
+# =============================================================================
+# Step 1: Verify dotnet CLI is installed
+# =============================================================================
+
+Write-Host ""
+Write-Host "Step 1: Checking required tools..." -ForegroundColor Cyan
+
+# --- dotnet CLI ---
+$dotnetCmd = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnetCmd) {
+    Write-Host "  ERROR: dotnet CLI not found in PATH." -ForegroundColor Red
+    Write-Host "         Install the .NET SDK from https://dotnet.microsoft.com/download and ensure it is on PATH." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Step 1 FAILED: dotnet CLI is missing. Cannot proceed." -ForegroundColor Red
+    exit 1
+}
+
+$dotnetVersion = (& dotnet --version 2>&1).ToString().Trim()
+Write-Host "  dotnet : $($dotnetCmd.Source)" -ForegroundColor Green
+Write-Host "           version $dotnetVersion" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "Step 1 PASSED" -ForegroundColor Green
+
+# =============================================================================
+# Step 2: Create a temporary .NET console project
+# =============================================================================
+
+Write-Host ""
+Write-Host "Step 2: Creating temporary .NET console project..." -ForegroundColor Cyan
+
+$projectDir = Join-Path ([System.IO.Path]::GetTempPath()) "QnnEpNuGetTest_$(Get-Random)"
+Write-Host "  Project directory: $projectDir"
+
+try {
+    & dotnet new console -n QnnEpNuGetTest -o $projectDir -f net8.0 --no-restore
+    Write-Host ""
+    Write-Host "Step 2 PASSED" -ForegroundColor Green
+
+    # =============================================================================
+    # Step 3: Add NuGet sources
+    # =============================================================================
+
+    Write-Host ""
+    Write-Host "Step 3: Adding NuGet sources..." -ForegroundColor Cyan
+
+    Push-Location $projectDir
+
+    # Add local .nupkg folder as a source
+    & dotnet nuget add source $NuGetDirectory --name QnnLocalSource
+    Write-Host "  Added local source : $NuGetDirectory" -ForegroundColor Green
+
+    # Add nuget.org as a source
+    & dotnet nuget add source "https://api.nuget.org/v3/index.json" --name nuget
+    Write-Host "  Added nuget.org source" -ForegroundColor Green
+
+    Write-Host ""
+    Write-Host "Step 3 PASSED" -ForegroundColor Green
+
+    # =============================================================================
+    # Step 4: Install packages
+    # =============================================================================
+
+    Write-Host ""
+    Write-Host "Step 4: Installing packages..." -ForegroundColor Cyan
+
+    & dotnet add package System.Numerics.Tensors --version 9.0.0
+    Write-Host "  Installed System.Numerics.Tensors 9.0.0" -ForegroundColor Green
+
+    # Pin Microsoft.ML.OnnxRuntime to the version used to compile onnxruntime-qnn.
+    # Parse the ort_core tag from cmake/deps.txt so the pin stays in sync automatically.
+    $depsFile = Join-Path $PSScriptRoot "../../../cmake/deps.txt"
+    $ortLine  = Get-Content $depsFile | Where-Object { $_ -match '^ort_core;' }
+    if ($ortLine -match '/tags/v([^/]+)\.zip') {
+        $ortVersion = $Matches[1]
+    } else {
+        Write-Host "  ERROR: Could not parse ort_core version from cmake/deps.txt" -ForegroundColor Red
+        exit 1
+    }
+    & dotnet add package Microsoft.ML.OnnxRuntime --version $ortVersion
+    Write-Host "  Installed Microsoft.ML.OnnxRuntime $ortVersion" -ForegroundColor Green
+
+    & dotnet add package Qualcomm.ML.OnnxRuntime.QNN `
+        --source $NuGetDirectory `
+        --version $ExpectedVersion
+    Write-Host "  Installed Qualcomm.ML.OnnxRuntime.QNN $ExpectedVersion" -ForegroundColor Green
+
+    Write-Host ""
+    Write-Host "Step 4 PASSED" -ForegroundColor Green
+
+    # =============================================================================
+    # Step 5: Build for each Runtime Identifier and verify native DLL output
+    # =============================================================================
+
+    Write-Host ""
+    Write-Host "Step 5: Building and verifying for Runtime Identifiers: $($RuntimeIdentifiers -join ', ')..." -ForegroundColor Cyan
+
+    $buildFailures = 0
+
+    foreach ($rid in $RuntimeIdentifiers) {
+        Write-Host ""
+        Write-Host "  --- RID: $rid ---" -ForegroundColor Yellow
+
+        # Restore for this specific RID using -p:RuntimeIdentifier to bypass SDK RID graph
+        # validation (allows non-standard RIDs like win-arm64ec that the CLI -r flag rejects)
+        & dotnet restore -p:RuntimeIdentifier=$rid
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  BUILD FAIL: dotnet restore exited with code $LASTEXITCODE for RID $rid" -ForegroundColor Red
+            $buildFailures++
+            continue
+        }
+
+        # Build targeting this RID
+        & dotnet build -p:RuntimeIdentifier=$rid --no-restore
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  BUILD FAIL: dotnet build exited with code $LASTEXITCODE for RID $rid" -ForegroundColor Red
+            $buildFailures++
+            continue
+        }
+
+        # Verify onnxruntime_providers_qnn.dll landed in the build output
+        $outputDir = Join-Path $projectDir "bin/Debug/net8.0/$rid"
+        $dll = Get-ChildItem -Path $outputDir -Filter "onnxruntime_providers_qnn.dll" -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+
+        if (-not $dll) {
+            Write-Host "  DLL FAIL: onnxruntime_providers_qnn.dll not found in $outputDir" -ForegroundColor Red
+            $buildFailures++
+            continue
+        }
+        Write-Host "  BUILD PASS: onnxruntime_providers_qnn.dll found at $($dll.FullName)" -ForegroundColor Green
+
+        # --- Step 6: Write a minimal C# smoke test and run inference ---
+        $programCs = Join-Path $projectDir "Program.cs"
+        Set-Content -Path $programCs -Encoding UTF8 -Value @"
+using Microsoft.ML.OnnxRuntime;
+
+var modelPath  = args[0];
+var backendDll = args[1];
+
+var options = new SessionOptions();
+options.AppendExecutionProvider("QNN", new Dictionary<string, string>
+{
+    ["backend_path"] = backendDll
+});
+
+using var session = new InferenceSession(modelPath, options);
+Console.WriteLine(`$"QNN EP smoke test PASSED — session created with backend: {backendDll}");
+"@
+
+        & dotnet run -p:RuntimeIdentifier=$rid --no-build -- "$ModelPath" "$BackendDll"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  SMOKE FAIL: inference exited with code $LASTEXITCODE for RID $rid" -ForegroundColor Red
+            $buildFailures++
+        } else {
+            Write-Host "  SMOKE PASS: QNN EP loaded and session created for RID $rid" -ForegroundColor Green
+        }
+    }
+
+    if ($buildFailures -gt 0) {
+        Write-Host ""
+        Write-Host "Step 5 FAILED: $buildFailures RID(s) did not produce the expected output." -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "Step 5 PASSED" -ForegroundColor Green
+
+} finally {
+    Pop-Location -ErrorAction SilentlyContinue
+    if (Test-Path $projectDir) {
+        Remove-Item -Path $projectDir -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Host ""
+        Write-Host "Cleaned up temporary project directory." -ForegroundColor DarkGray
+    }
+}
+
+Write-Host ""
+Write-Host "All steps PASSED" -ForegroundColor Green

--- a/qcom/scripts/release_testing/verify_backward_compatibility.ps1
+++ b/qcom/scripts/release_testing/verify_backward_compatibility.ps1
@@ -1,0 +1,91 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$PythonVersion,
+    [Parameter(Mandatory=$true)]
+    [string]$WheelArch,
+    [Parameter(Mandatory=$true)]
+    [string]$WheelDirectory,
+    [Parameter(Mandatory=$true)]
+    [string]$OnnxruntimeVersion,
+    [Parameter(Mandatory=$true)]
+    [string]$SamplePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Force UTF-8 for native-process I/O so ONNX Runtime's wide-char log output
+# isn't misrendered with spaces between every character.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+
+# Suppress ANSI color escape codes ([0;93m...[m) in ORT's log output —
+# they render as literal text in the GitHub Actions log viewer.
+$env:NO_COLOR = "1"
+
+$pyNoDot = $PythonVersion.Replace(".", "")
+$envName = "py${pyNoDot}_release_backward_compatibility_env"
+
+# Find the wheel that matches both the Python version and the platform
+$wheel = Get-ChildItem -Path $WheelDirectory `
+  -Filter "*cp${pyNoDot}-cp${pyNoDot}-${WheelArch}.whl" |
+  Select-Object -First 1
+
+if (-not $wheel) {
+    Write-Host "No wheel found matching cp${pyNoDot}-${WheelArch} in $WheelDirectory" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Found wheel: $($wheel.FullName)" -ForegroundColor Cyan
+
+# Create venv using the py launcher to pick the requested Python version
+$pyTag = if ($WheelArch -eq "win_arm64") { "$PythonVersion-arm64" } else { "$PythonVersion" }
+if (Test-Path $envName) { Remove-Item -Path $envName -Recurse -Force }
+py -$pyTag -m venv $envName
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Failed to create venv (exit $LASTEXITCODE)" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+try {
+    # Activate venv (dot-source so the PATH update persists in this script's scope)
+    . "$envName/Scripts/Activate.ps1"
+
+    # Upgrade pip
+    python -m pip install --upgrade pip
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "pip upgrade FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    # Install onnxruntime-qnn from the local wheel (pulls onnxruntime as a dependency)
+    python -m pip install $wheel.FullName
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Wheel install FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    # Replace the bundled onnxruntime with the older version to verify backward compatibility
+    python -m pip uninstall -y onnxruntime
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "onnxruntime uninstall FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    python -m pip install "onnxruntime==$OnnxruntimeVersion"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "onnxruntime==$OnnxruntimeVersion install FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+
+    # Run the sample test against the older onnxruntime
+    python $SamplePath
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Backward Compatibility test FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    Write-Host "Backward Compatibility test PASSED" -ForegroundColor Green
+} finally {
+    Remove-Item -Path $envName -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/qcom/scripts/release_testing/verify_windows_metadata.ps1
+++ b/qcom/scripts/release_testing/verify_windows_metadata.ps1
@@ -1,0 +1,337 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("wheel", "zip", "nuget")]
+    [string]$ArtifactType,
+    [Parameter(Mandatory=$true)]
+    [string]$SourceDirectory,
+    [Parameter(Mandatory=$true)]
+    [string]$ExpectedVersion
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Force UTF-8 so any native tool output renders correctly in the GHA log viewer.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding           = [System.Text.Encoding]::UTF8
+
+# =============================================================================
+# Shared helpers
+# =============================================================================
+
+function Normalize-Version([string]$Version) {
+    # Reduce to major.minor.patch — handles four-part FileVersion ("2.5.0.0"),
+    # pre-release suffixes ("2.5.0.rc3"), and plain three-part ("2.5.0").
+    $parts = $Version.Split('.')
+    return "$($parts[0]).$($parts[1]).$($parts[2])"
+}
+
+function Test-QnnDll {
+    param(
+        [Parameter(Mandatory=$true)] [string]$DllPath,
+        [Parameter(Mandatory=$true)] [string]$Label,
+        [Parameter(Mandatory=$true)] [string]$ExpectedVersion
+    )
+
+    $result = [pscustomobject]@{ CertPass = $false; VersionPass = $false }
+
+    if (-not (Test-Path $DllPath)) {
+        Write-Host "  [$Label] CERTIFICATE FAIL: DLL not found" -ForegroundColor Red
+        Write-Host "  [$Label] VERSION FAIL: DLL not found" -ForegroundColor Red
+        return $result
+    }
+
+    # Certificate check
+    $signature = Get-AuthenticodeSignature -FilePath $DllPath
+    if ($signature.Status -ne 'Valid') {
+        Write-Host "  [$Label] CERTIFICATE FAIL: Invalid signature ($($signature.Status))" -ForegroundColor Red
+    } elseif ($signature.SignerCertificate.Subject -like "*QUALCOMM INCORPORATED*") {
+        Write-Host "  [$Label] CERTIFICATE PASS" -ForegroundColor Green
+        $result.CertPass = $true
+    } else {
+        Write-Host "  [$Label] CERTIFICATE FAIL: Not signed by QUALCOMM INCORPORATED (Subject: $($signature.SignerCertificate.Subject))" -ForegroundColor Red
+    }
+
+    # Version check — normalise to major.minor.patch to handle both
+    # "2.5.0" (native DLLs) and "2.5.0.0" (managed DLL) against the
+    # same ExpectedVersion string (e.g. "2.5.0" or "2.5.0.rc3").
+    $rawVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($DllPath).FileVersion
+    $normFile   = Normalize-Version $rawVersion
+    $normExp    = Normalize-Version $ExpectedVersion
+
+    if ($normFile -eq $normExp) {
+        Write-Host "  [$Label] VERSION PASS: $rawVersion" -ForegroundColor Green
+        $result.VersionPass = $true
+    } else {
+        Write-Host "  [$Label] VERSION FAIL: Expected $ExpectedVersion, got $rawVersion" -ForegroundColor Red
+    }
+
+    return $result
+}
+
+function Expand-Artifact([string]$ArtifactPath, [string]$ExtractDir) {
+    # .whl and .nupkg are zip archives — copy to .zip first so Expand-Archive works.
+    $ext = [System.IO.Path]::GetExtension($ArtifactPath).ToLower()
+    if ($ext -eq '.zip') {
+        Expand-Archive -Path $ArtifactPath -DestinationPath $ExtractDir -Force
+    } else {
+        $zipPath = Join-Path ([System.IO.Path]::GetDirectoryName($ArtifactPath)) `
+                             "$([System.IO.Path]::GetFileNameWithoutExtension($ArtifactPath)).zip"
+        Copy-Item -Path $ArtifactPath -Destination $zipPath -Force
+        try {
+            Expand-Archive -Path $zipPath -DestinationPath $ExtractDir -Force
+        } finally {
+            Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# =============================================================================
+# Verify source directory
+# =============================================================================
+
+if (-not (Test-Path $SourceDirectory -PathType Container)) {
+    Write-Host ""
+    Write-Error "Directory not found: $SourceDirectory"
+    exit 1
+}
+
+# =============================================================================
+# Per-artifact-type verification
+# =============================================================================
+
+$certPassCount    = 0
+$certFailCount    = 0
+$versionPassCount = 0
+$versionFailCount = 0
+$nuspecPass        = $null   # only set for nuget
+
+switch ($ArtifactType) {
+
+    "wheel" {
+        $arm64Wheels = @(Get-ChildItem -Path $SourceDirectory -Recurse -Filter "*.whl" |
+            Where-Object { $_.Name -match "win_arm64\.whl$" })
+        $amdWheels   = @(Get-ChildItem -Path $SourceDirectory -Recurse -Filter "*.whl" |
+            Where-Object { $_.Name -match "win_amd64\.whl$" })
+
+        if (($arm64Wheels.Count + $amdWheels.Count) -eq 0) {
+            Write-Host ""
+            Write-Error "No wheels found matching win_amd64.whl or win_arm64.whl"
+            exit 1
+        }
+
+        Write-Host ""
+        Write-Host "Found $($arm64Wheels.Count) ARM64 wheel(s) and $($amdWheels.Count) AMD wheel(s)" -ForegroundColor Cyan
+
+        # --- ARM64 wheels: 1 DLL per wheel ---
+        foreach ($wheel in $arm64Wheels) {
+            Write-Host ""
+            Write-Host "Processing: $($wheel.Name)" -ForegroundColor Yellow
+
+            $extractDir = Join-Path $wheel.DirectoryName "$($wheel.BaseName)_extracted"
+            try {
+                Expand-Artifact $wheel.FullName $extractDir
+
+                $dll = Get-ChildItem -Path $extractDir -Recurse -Filter "onnxruntime_providers_qnn.dll" |
+                    Select-Object -First 1
+                $dllPath = if ($dll) { $dll.FullName } else { "" }
+
+                $r = Test-QnnDll -DllPath $dllPath -Label "arm64" -ExpectedVersion $ExpectedVersion
+                if ($r.CertPass)    { $certPassCount++ }    else { $certFailCount++ }
+                if ($r.VersionPass) { $versionPassCount++ } else { $versionFailCount++ }
+            }
+            catch {
+                Write-Host "  [arm64] ERROR: $($_.Exception.Message)" -ForegroundColor Red
+                $certFailCount++
+                $versionFailCount++
+            }
+            finally {
+                Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        # --- AMD64 wheels: 2 DLLs per wheel (amd64 + arm64ec), AND aggregation ---
+        foreach ($wheel in $amdWheels) {
+            Write-Host ""
+            Write-Host "Processing: $($wheel.Name)" -ForegroundColor Yellow
+
+            $extractDir = Join-Path $wheel.DirectoryName "$($wheel.BaseName)_extracted"
+
+            $amd64CertPass      = $false
+            $amd64VersionPass   = $false
+            $arm64ecCertPass    = $false
+            $arm64ecVersionPass = $false
+
+            try {
+                Expand-Artifact $wheel.FullName $extractDir
+
+                $allDlls    = Get-ChildItem -Path $extractDir -Recurse -Filter "onnxruntime_providers_qnn.dll"
+                $amd64Dll   = $allDlls | Where-Object { $_.FullName -match "[\\/]libs[\\/]amd64[\\/]"   } | Select-Object -First 1
+                $arm64ecDll = $allDlls | Where-Object { $_.FullName -match "[\\/]libs[\\/]arm64ec[\\/]" } | Select-Object -First 1
+
+                # libs/amd64/onnxruntime_providers_qnn.dll
+                $amd64Path = if ($amd64Dll) { $amd64Dll.FullName } else { "" }
+                $r = Test-QnnDll -DllPath $amd64Path -Label "amd64  " -ExpectedVersion $ExpectedVersion
+                $amd64CertPass    = $r.CertPass
+                $amd64VersionPass = $r.VersionPass
+
+                # libs/arm64ec/onnxruntime_providers_qnn.dll
+                $arm64ecPath = if ($arm64ecDll) { $arm64ecDll.FullName } else { "" }
+                $r = Test-QnnDll -DllPath $arm64ecPath -Label "arm64ec" -ExpectedVersion $ExpectedVersion
+                $arm64ecCertPass    = $r.CertPass
+                $arm64ecVersionPass = $r.VersionPass
+            }
+            catch {
+                Write-Host "  ERROR: $($_.Exception.Message)" -ForegroundColor Red
+            }
+            finally {
+                Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+
+            # Wheel-level verdict: both DLLs must pass for the wheel to pass
+            if ($amd64CertPass -and $arm64ecCertPass) {
+                $certPassCount++
+            } else {
+                $certFailCount++
+            }
+
+            if ($amd64VersionPass -and $arm64ecVersionPass) {
+                $versionPassCount++
+            } else {
+                $versionFailCount++
+            }
+        }
+    }
+
+    "zip" {
+        $zipArchs = @("win-arm64", "win-arm64x", "win-x64")
+
+        foreach ($arch in $zipArchs) {
+            $zips = @(Get-ChildItem -Path $SourceDirectory -Filter "*.zip" |
+                Where-Object { $_.Name -match "${arch}\.zip$" })
+
+            if ($zips.Count -ne 1) {
+                Write-Host ""
+                Write-Host "Expected 1 ${arch} zip in $SourceDirectory, found $($zips.Count)" -ForegroundColor Red
+                $certFailCount++
+                $versionFailCount++
+                continue
+            }
+
+            $zip = $zips[0]
+            Write-Host ""
+            Write-Host "Processing [$arch]: $($zip.Name)" -ForegroundColor Yellow
+
+            $extractDir = Join-Path $zip.DirectoryName "$($zip.BaseName)_extracted"
+
+            try {
+                Expand-Archive -Path $zip.FullName -DestinationPath $extractDir -Force
+
+                $dll = Get-ChildItem -Path $extractDir -Recurse -Filter "onnxruntime_providers_qnn.dll" |
+                    Select-Object -First 1
+                $dllPath = if ($dll) { $dll.FullName } else { "" }
+
+                $r = Test-QnnDll -DllPath $dllPath -Label $arch -ExpectedVersion $ExpectedVersion
+                if ($r.CertPass)    { $certPassCount++ }    else { $certFailCount++ }
+                if ($r.VersionPass) { $versionPassCount++ } else { $versionFailCount++ }
+            }
+            catch {
+                Write-Host "  [$arch] ERROR: $($_.Exception.Message)" -ForegroundColor Red
+                $certFailCount++
+                $versionFailCount++
+            }
+            finally {
+                Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    "nuget" {
+        $nupkg = Get-ChildItem -Path $SourceDirectory -Filter "*.nupkg" | Select-Object -First 1
+        if (-not $nupkg) {
+            Write-Host ""
+            Write-Host "ERROR: No .nupkg found in $SourceDirectory" -ForegroundColor Red
+            exit 1
+        }
+
+        Write-Host ""
+        Write-Host "Processing: $($nupkg.Name)" -ForegroundColor Yellow
+
+        $extractDir = Join-Path $nupkg.DirectoryName "$($nupkg.BaseName)_extracted"
+        $nuspecPass = $false
+
+        try {
+            Expand-Artifact $nupkg.FullName $extractDir
+
+            # --- Nuspec version check ---
+            Write-Host ""
+            Write-Host "--- nuspec ---" -ForegroundColor Cyan
+            $nuspecFile = Get-ChildItem -Path $extractDir -Filter "*.nuspec" | Select-Object -First 1
+            if (-not $nuspecFile) {
+                Write-Host "  NUSPEC FAIL: .nuspec not found in package" -ForegroundColor Red
+            } else {
+                [xml]$nuspec = Get-Content $nuspecFile.FullName -Encoding UTF8
+                $nuspecVersion = $nuspec.package.metadata.version
+                if ($nuspecVersion -eq $ExpectedVersion) {
+                    Write-Host "  NUSPEC VERSION PASS: $nuspecVersion" -ForegroundColor Green
+                    $nuspecPass = $true
+                } else {
+                    Write-Host "  NUSPEC VERSION FAIL: Expected $ExpectedVersion, got $nuspecVersion" -ForegroundColor Red
+                }
+            }
+
+            # --- DLL checks ---
+            $dllsToCheck = @(
+                @{ Label = "managed (netstandard2.0)"; RelPath = "lib\netstandard2.0\Qualcomm.ML.OnnxRuntime.QNN.dll" },
+                @{ Label = "native win-arm64";         RelPath = "runtimes\win-arm64\native\onnxruntime_providers_qnn.dll" },
+                @{ Label = "native win-x64";           RelPath = "runtimes\win-x64\native\onnxruntime_providers_qnn.dll" }
+            )
+
+            foreach ($entry in $dllsToCheck) {
+                Write-Host ""
+                Write-Host "--- $($entry.Label) ---" -ForegroundColor Cyan
+
+                $dllPath = Join-Path $extractDir $entry.RelPath
+                $r = Test-QnnDll -DllPath $dllPath -Label $entry.Label -ExpectedVersion $ExpectedVersion
+                if ($r.CertPass)    { $certPassCount++ }    else { $certFailCount++ }
+                if ($r.VersionPass) { $versionPassCount++ } else { $versionFailCount++ }
+            }
+        }
+        catch {
+            Write-Host ""
+            Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+        }
+        finally {
+            Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+Write-Host ""
+if ($null -ne $nuspecPass) {
+    Write-Host "=== Nuspec Summary ===" -ForegroundColor Cyan
+    if ($nuspecPass) {
+        Write-Host "Nuspec version: PASS" -ForegroundColor Green
+    } else {
+        Write-Host "Nuspec version: FAIL" -ForegroundColor Red
+    }
+}
+Write-Host "=== Certificate Summary ===" -ForegroundColor Cyan
+Write-Host "Total:  $($certPassCount + $certFailCount)"
+Write-Host "Passed: $certPassCount" -ForegroundColor Green
+Write-Host "Failed: $certFailCount" -ForegroundColor Red
+Write-Host "=== Version Summary ===" -ForegroundColor Cyan
+Write-Host "Total:  $($versionPassCount + $versionFailCount)"
+Write-Host "Passed: $versionPassCount" -ForegroundColor Green
+Write-Host "Failed: $versionFailCount" -ForegroundColor Red
+Write-Host "=== End of Summary ===" -ForegroundColor Cyan
+
+$failed = $certFailCount -gt 0 -or $versionFailCount -gt 0
+if ($null -ne $nuspecPass -and -not $nuspecPass) { $failed = $true }
+if ($failed) { exit 1 }

--- a/qcom/scripts/release_testing/verify_windows_metadata.ps1
+++ b/qcom/scripts/release_testing/verify_windows_metadata.ps1
@@ -23,9 +23,11 @@ $OutputEncoding           = [System.Text.Encoding]::UTF8
 
 function Normalize-Version([string]$Version) {
     # Reduce to major.minor.patch — handles four-part FileVersion ("2.5.0.0"),
-    # pre-release suffixes ("2.5.0.rc3"), and plain three-part ("2.5.0").
+    # pre-release suffixes ("2.5.0.rc3", "2.5.0rc3", "2.5.0rc"), and plain
+    # three-part ("2.5.0"). Strip any non-numeric suffix from the patch segment.
     $parts = $Version.Split('.')
-    return "$($parts[0]).$($parts[1]).$($parts[2])"
+    $patch = $parts[2] -replace '[^0-9].*', ''
+    return "$($parts[0]).$($parts[1]).$patch"
 }
 
 function Test-QnnDll {

--- a/qcom/scripts/upleveling/config.ini
+++ b/qcom/scripts/upleveling/config.ini
@@ -54,3 +54,19 @@ repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-maven-v
 
 [maven-central]
 repository: https://central.sonatype.com/api/v1/publisher/upload
+
+[artifactory-pypi-public-storage]
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-public-pypi-virtual
+cert: certs/artifactory-ca.pem
+
+[artifactory-nuget-public-storage]
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-public-nuget-virtual
+cert: certs/artifactory-ca.pem
+
+[artifactory-zip-public-storage]
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-public-generic-virtual
+cert: certs/artifactory-ca.pem
+
+[artifactory-zip-testproj-storage]
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual
+cert: certs/artifactory-ca.pem

--- a/qcom/scripts/upleveling/config.ini
+++ b/qcom/scripts/upleveling/config.ini
@@ -57,16 +57,12 @@ repository: https://central.sonatype.com/api/v1/publisher/upload
 
 [artifactory-pypi-public-storage]
 repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-public-pypi-virtual
-cert: certs/artifactory-ca.pem
 
 [artifactory-nuget-public-storage]
 repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-public-nuget-virtual
-cert: certs/artifactory-ca.pem
 
 [artifactory-zip-public-storage]
 repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-public-generic-virtual
-cert: certs/artifactory-ca.pem
 
 [artifactory-zip-testproj-storage]
 repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual
-cert: certs/artifactory-ca.pem


### PR DESCRIPTION
## Description

Adds end-to-end release validation infrastructure for `onnxruntime-qnn` artifacts. This includes a GitHub Actions workflow, a Python orchestrator (`release_testing.py`), platform-specific bootstrap scripts, and test/verification scripts for all supported artifact formats (wheel, zip, tgz, nuget).

---

## Motivation & Context

Before this PR, there was no automated validation gate between publishing artifacts to Artifactory and declaring a release good. Build CI only verified that artifacts could be built — not that the published packages were correctly signed, versioned, and functional on real hardware. This PR closes that gap by adding the first end-to-end release validation pipeline.

The workflow is invoked manually (`workflow_dispatch`) or called from a parent release orchestration workflow (`workflow_call`). There is no push trigger — it is a deliberate, gated action.

### Design decisions

**Python orchestrator (`release_testing.py`) as the single entry point** — All test orchestration lives in Python, not in the workflow YAML. The workflow is a thin wrapper that calls `run_release_testing.ps1` (Windows) or `run_release_testing.sh` (Linux), which bootstraps a venv, installs dependencies, and invokes `release_testing.py`. This means the same tests can run locally on a dev machine, on a host device, or on any CI system — not just GitHub Actions.

**HTTP-based Artifactory downloads (no JFrog CLI)** — Artifacts are downloaded via `requests` using HTTP basic auth against Artifactory storage URLs (configured in `config.ini`). This eliminates the JFrog CLI dependency and makes the scripts portable. Authentication uses `ARTIFACTORY_USERNAME` / `ARTIFACTORY_PASSWORD` environment variables, matching the existing `qnn_ep_uplevel.py` pattern.

**Consolidated metadata verification** — Three separate metadata verification scripts (wheel, zip, nuget) were consolidated into a single `verify_windows_metadata.ps1` with an `-ArtifactType` parameter. Shared logic (Authenticode signature check, FileVersion normalization to `major.minor.patch`) is factored into helper functions.

**Exit code propagation for external executables** — All PowerShell scripts check `$LASTEXITCODE` after every `python`, `pip`, and native executable call. `$ErrorActionPreference = 'Stop'` does not propagate non-zero exit codes from external executables in PowerShell.

**Per-job targeted downloads** — Each job downloads only the artifacts it needs. The metadata job downloads all Windows wheels; install/test jobs download only the single wheel for their platform and Python version. This avoids redundant multi-GB downloads across parallel matrix jobs.

**`test_package_version` is separate from `artifact_version`** — The test package archive (`onnxruntime-qnn-<ver>-test_package.zip`) is built and published on a different cadence than the release artifacts. Using the same version string would silently download the wrong package; callers must provide both explicitly.

**ARM64 host detection on Windows** — `is_host_arm64()` checks `PROCESSOR_ARCHITEW6432` before `platform.machine()`. On a WoS device running an x64-emulated Python interpreter, `platform.machine()` returns `AMD64`; `PROCESSOR_ARCHITEW6432` correctly identifies the true host architecture.

---

## Architecture

```
Workflow YAML
  └── run_release_testing.ps1 / .sh  (bootstrap: venv + deps)
        └── release_testing.py        (orchestrator: download + dispatch)
              ├── verify_windows_metadata.ps1  (Authenticode + version)
              ├── install_and_test_wheel.ps1 / .sh  (venv + install + sample)
              ├── verify_backward_compatibility.ps1  (downgrade ORT + sample)
              ├── smoke_test_zip.ps1  (extract + perf_test)
              ├── smoke_test_tgz.sh   (extract + perf_test)
              └── test_nuget_package.ps1  (dotnet build + inference)
```

The orchestrator supports three modes of operation:

| Flag | Behavior |
|---|---|
| `--only-count-check` | Query Artifactory and verify all expected artifacts are present (16 wheels, 1 NuGet, 3 zips, 2 tgz). Runs before all other jobs. |
| `--only-metadata` | Run metadata verification only (Authenticode + FileVersion). |
| `--only-backward-compat` | Run backward compatibility test only (wheel, Windows ARM64). |
| *(default)* | Run install/smoke tests only (no metadata, no backward compat). |

---

## Workflow Inputs

| Input | Required | Description |
|---|---|---|
| `artifact_format` | Yes | One of `wheel`, `nuget`, `zip`, `tgz`, `all`. |
| `artifact_version` | Yes | Version of the artifact to test. Locates `onnxruntime-qnn/<version>/` in Artifactory. |
| `test_package_version` | No (required for zip/tgz) | Version of `test_packages.zip` in `aisw-zip-testproj-generic-virtual`. May differ from `artifact_version`. |

---

## Jobs

All jobs depend on `verify-artifact-counts`, which runs first and fails fast if any expected artifacts are absent on Artifactory.

### Artifact count job (always runs)

| Job | Runner | What it does |
|---|---|---|
| `verify-artifact-counts` | Linux x86_64 | Queries Artifactory and verifies: 16 wheels (4 Python versions x 4 arches), 1 NuGet package, 3 Windows zips (excluding `-pdb.zip` and `-win-arm64ec.zip`), 2 Linux tgz archives. Fails with a detailed list of missing artifacts before any testing begins. |

### Wheel jobs (`artifact_format == wheel`)

| Job | Runner | What it does |
|---|---|---|
| `verify-windows-wheel-metadata` | Windows Build | Downloads all Windows wheels. Runs `verify_windows_metadata.ps1 -ArtifactType wheel`: checks Authenticode signature (signed by `QUALCOMM INCORPORATED`) and `FileVersion` for each DLL. AMD64 wheels carry two DLLs (`libs/amd64/` + `libs/arm64ec/`); both must pass for the wheel-level verdict. Version comparison normalizes to `major.minor.patch` to handle pre-release suffixes and four-part FileVersions. |
| `test-wheel-on-windows` | Windows ARM64 + x86_64 (8 matrix jobs) | Downloads only the wheel for this platform and Python version. Creates a venv via `py` launcher, installs wheel, asserts `onnxruntime_qnn.__version__ == artifact_version`, runs `qcom/samples/test_wheel.py`. Checks `$LASTEXITCODE` after every `python`/`pip` call. Cleans up venv in `finally` block. |
| `test-wheel-on-linux` | Linux ARM64 + x86_64 (8 matrix jobs) | Same as Windows, running natively on the self-hosted runner. Uses `actions/setup-python` to ensure the correct Python version is available. |
| `verify-backward-compatibility` | Windows ARM64 | Downloads the `cp312 win_arm64` wheel. Installs it, downgrades `onnxruntime` to `1.24.2`, then re-runs the sample to confirm the QNN EP plugin still loads against an older ORT runtime. |

### Zip jobs (`artifact_format == zip`)

| Job | Runner | What it does |
|---|---|---|
| `verify-windows-zip-metadata` | Windows Build | Downloads all 3 Windows zips (`win-arm64`, `win-arm64x`, `win-x64`). Runs `verify_windows_metadata.ps1 -ArtifactType zip`: extracts each zip, checks `onnxruntime_providers_qnn.dll` for Authenticode signature and `FileVersion`. |
| `smoke-test-zip-on-windows` | Windows ARM64 + x86_64 (2 matrix jobs) | Downloads the specific zip + `test_package.zip`. Extracts release zip, copies `onnxruntime_perf_test.exe`, `onnxruntime.dll`, and `onnxruntime_providers_shared.dll` from test_package. Runs 1 inference via plugin EP against `cmake/external/onnx/.../test_abs/model.onnx`. Platform auto-detected by the orchestrator. |

### TGZ jobs (`artifact_format == tgz`)

| Job | Runner | What it does |
|---|---|---|
| `smoke-test-tgz-on-linux` | Linux ARM64 + x86_64 (2 matrix jobs) | Downloads the specific tgz + `test_package.zip`. Extracts release tgz, copies `onnxruntime_perf_test`, `libonnxruntime.so`, and `libonnxruntime_providers_shared.so` from test_package. Creates `libonnxruntime.so.1` symlink, sets `LD_LIBRARY_PATH` and `ADSP_LIBRARY_PATH`. Runs 1 inference. Linux ARM64 uses `libQnnHtp.so`; x86_64 uses `libQnnCpu.so`. |

### NuGet jobs (`artifact_format == nuget`)

| Job | Runner | What it does |
|---|---|---|
| `verify-windows-nuget-metadata` | Windows Build | Downloads the `.nupkg`. Extracts it, checks `<version>` in `.nuspec` matches `artifact_version`. Checks Authenticode + `FileVersion` for all three DLLs: managed (`lib/netstandard2.0/`), native win-arm64, native win-x64. Managed DLL `FileVersion` in `x.y.z.0` format is normalized to `x.y.z` before comparison. |
| `test-nuget-on-windows` | Windows ARM64 + x86_64 | Downloads the `.nupkg`. Creates a temp `net8.0` console project, adds the local `.nupkg` as a NuGet source, installs `System.Numerics.Tensors`, `Microsoft.ML.OnnxRuntime` (pinned to the version from `cmake/deps.txt`), and `Qualcomm.ML.OnnxRuntime.QNN`. Builds for the host RID, writes a C# smoke test, runs QNN EP inference. |

---

## Files Changed

| File | Purpose |
|---|---|
| `.github/workflows/qualcomm-internal-release-testing.yml` | Workflow — 10 jobs covering all 4 artifact formats |
| `qcom/scripts/release_testing/release_testing.py` | Python orchestrator — CLI entry point for all release testing |
| `qcom/scripts/release_testing/run_release_testing.ps1` | Bootstrap script (Windows) — creates venv, installs deps, runs orchestrator |
| `qcom/scripts/release_testing/run_release_testing.sh` | Bootstrap script (Linux) — same as above |
| `qcom/scripts/release_testing/verify_windows_metadata.ps1` | Consolidated metadata verification for wheel, zip, and nuget artifacts |
| `qcom/scripts/release_testing/install_and_test_wheel.ps1` | Create venv, install wheel, version check, run sample (Windows) |
| `qcom/scripts/release_testing/install_and_test_wheel.sh` | Same for Linux; detects Python via `python{ver}` or manylinux `/opt/python/` path |
| `qcom/scripts/release_testing/verify_backward_compatibility.ps1` | Install wheel, downgrade ORT to 1.24.2, re-run sample |
| `qcom/scripts/release_testing/smoke_test_zip.ps1` | Extract zip + test_package, copy ORT DLLs, run perf_test (Windows) |
| `qcom/scripts/release_testing/smoke_test_tgz.sh` | Extract tgz + test_package, copy ORT libs, set env vars, run perf_test (Linux) |
| `qcom/scripts/release_testing/test_nuget_package.ps1` | dotnet restore + build per RID, write C# smoke test, run QNN EP inference |
| `qcom/scripts/upleveling/config.ini` | Added storage URL sections for Artifactory download |