### PR TITLE
Add Qualcomm copyright to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 Copyright (c) Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
### Description
* Adds QCOM copyright alongside existing MSFT copyright in LICENSE file


