### PR TITLE
[QNN EP] Set ORT Core Version to >=1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coloredlogs
 flatbuffers
 numpy >= 1.21.6
-onnxruntime == 1.26.0
+onnxruntime >= 1.24.2
 packaging
 protobuf
 sympy


### PR DESCRIPTION
This PR sets the floor of `onnxruntime` in `requirements.txt` to `>= 1.24.2`. This prevents pinning `ORT Core` to `1.24.4`

