### PR TITLE
ci: pin twine<6.2.0 to keep --skip-existing working

### DIFF
--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -94,7 +94,10 @@ jobs:
       - name: Install Dependencies
         run: |
           python3 -m venv venv
-          source venv/bin/activate && pip3 install twine
+          # Pin twine <6.2.0: 6.2.0 dropped --skip-existing for non-Warehouse
+          # indexes (the internal pypiserver at ort-ep-win-01), causing
+          # `UnsupportedConfiguration` on upload.
+          source venv/bin/activate && pip3 install 'twine<6.2.0'
 
       - name: Check wheel
         run: |


### PR DESCRIPTION
## Summary

- Nightly publish job fails on `twine upload --skip-existing ... -r local` with:
  ```
  ERROR  UnsupportedConfiguration: The configured repository
         'http://ort-ep-win-01.na.qualcomm.com:8080' does not have support for
         the following features: --skip-existing and is an unsupported
         configuration
  ```
- Root cause: twine **6.2.0** removed the workarounds that let `--skip-existing` function against non-Warehouse indexes (i.e. anything that isn't PyPI/TestPyPI). Our internal pypiserver at `ort-ep-win-01.na.qualcomm.com:8080` is not Warehouse, so the flag is now rejected. The workflow runs an unpinned `pip3 install twine`, so the job started pulling 6.2.0 and failing.
- Fix: pin `twine<6.2.0` in the `Install Dependencies` step of `.github/workflows/qualcomm-internal-release.yml`. Minimal hold-the-line fix; a follow-up should drop `--skip-existing` (and tolerate 409 on re-upload) or move to a Warehouse-compatible index so we can pick up future twine versions.

Failing run: https://github.com/onnxruntime/onnxruntime-qnn/actions/runs/26505731138/job/78146586110