### PR TITLE
[QNN EP] ORT Version >= 1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coloredlogs
 flatbuffers
 numpy >= 1.21.6
-onnxruntime == 1.24.4
+onnxruntime >= 1.24.2
 packaging
 protobuf
 sympy


### PR DESCRIPTION
This PR cherry-picks #448 as part of `rel-2.1.1` which prevents pinning ORT Core to `1.24.4`