### PR TITLE
[DO NOT MERGE] Validate ASan CI catches PR #326 leak

### DIFF
--- a/.github/workflows/qualcomm-internal-asan.yml
+++ b/.github/workflows/qualcomm-internal-asan.yml
@@ -5,8 +5,6 @@ name: Qualcomm Internal ASan
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 on:
   workflow_call:
@@ -16,12 +14,6 @@ jobs:
   asan-linux-x86_64:
     name: "asan-linux-x86_64"
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
-    env:
-      # Hardcoded Debug because upstream tools/ci_build/build.py only wires
-      # -fsanitize=address into the Linux Debug branch; RelWithDebInfo +
-      # --enable_address_sanitizer would silently produce a non-instrumented
-      # binary. Switching configs requires patching upstream ORT first.
-      ASAN_BUILD_DIR: build/linux-x86_64/Debug
     steps:
       - uses: actions/checkout@v6
         with:
@@ -65,25 +57,3 @@ jobs:
           python3 qcom/build_and_test.py \
             --target-py-version None \
             asan_linux_x86_64
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
-        # Skipped on fork PRs: the action creates a check run, which the fork-PR GITHUB_TOKEN cannot do.
-        if: ${{ always() && steps.gate.outputs.run == 'true' && github.event.pull_request.head.repo.fork != true }}
-        with:
-          check_name: asan-linux-x86_64-test-results
-          group_reports: false
-          include_passed: true
-          detailed_summary: true
-          verbose_summary: false
-          report_paths: |
-            ${{ env.ASAN_BUILD_DIR }}/*.results.xml
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v7
-        if: ${{ always() && steps.gate.outputs.run == 'true' }}
-        with:
-          name: "asan-linux-x86_64-${{ github.sha }}-test-results"
-          retention-days: 7
-          path: |
-            ${{ env.ASAN_BUILD_DIR }}/*.results.xml

--- a/.github/workflows/qualcomm-internal-asan.yml
+++ b/.github/workflows/qualcomm-internal-asan.yml
@@ -1,0 +1,85 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+name: Qualcomm Internal ASan
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  asan-linux-x86_64:
+    name: "asan-linux-x86_64"
+    runs-on: ["self-hosted", "X64", "Linux", "Build"]
+    env:
+      ASAN_BUILD_DIR: build/linux-x86_64/Debug
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # submodules omitted here; initialized below only when ASan is needed.
+
+      - name: Check if ASan is needed
+        id: gate
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          base_ref="${{ github.base_ref }}"
+          if [ -z "${base_ref}" ]; then
+            echo "::error::github.base_ref is empty (event_name=${{ github.event_name }})"
+            exit 1
+          fi
+
+          if ! changed=$(git diff --name-only "origin/${base_ref}...HEAD"); then
+            echo "::error::git diff against origin/${base_ref}...HEAD failed"
+            exit 1
+          fi
+
+          if echo "${changed}" | grep -qE 'onnxruntime/(core|test)/providers/qnn/'; then
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Initialize submodules
+        if: steps.gate.outputs.run == 'true'
+        run: git submodule update --init --recursive
+
+      - name: Run ASan build and unit tests (Linux x86_64, Debug)
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          python3 qcom/build_and_test.py \
+            --target-py-version None \
+            asan_linux_x86_64
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v6
+        # Skipped on fork PRs: the action creates a check run, which the fork-PR GITHUB_TOKEN cannot do.
+        if: ${{ always() && steps.gate.outputs.run == 'true' && github.event.pull_request.head.repo.fork != true }}
+        with:
+          check_name: asan-linux-x86_64-test-results
+          group_reports: false
+          include_passed: true
+          detailed_summary: true
+          verbose_summary: false
+          report_paths: |
+            ${{ env.ASAN_BUILD_DIR }}/*.results.xml
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v7
+        if: ${{ always() && steps.gate.outputs.run == 'true' }}
+        with:
+          name: "asan-linux-x86_64-${{ github.sha }}-test-results"
+          retention-days: 7
+          path: |
+            ${{ env.ASAN_BUILD_DIR }}/*.results.xml

--- a/.github/workflows/qualcomm-internal-asan.yml
+++ b/.github/workflows/qualcomm-internal-asan.yml
@@ -17,6 +17,10 @@ jobs:
     name: "asan-linux-x86_64"
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     env:
+      # Hardcoded Debug because upstream tools/ci_build/build.py only wires
+      # -fsanitize=address into the Linux Debug branch; RelWithDebInfo +
+      # --enable_address_sanitizer would silently produce a non-instrumented
+      # binary. Switching configs requires patching upstream ORT first.
       ASAN_BUILD_DIR: build/linux-x86_64/Debug
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/qualcomm-internal-ci.yml
+++ b/.github/workflows/qualcomm-internal-ci.yml
@@ -37,3 +37,8 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/qualcomm-internal-coverage.yml
     secrets: inherit
+
+  asan:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/qualcomm-internal-asan.yml
+    secrets: inherit

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1083,8 +1083,6 @@ void QnnBackendManager::ProcessContextFromBinListAsync(Qnn_ContextHandle_t conte
   auto s = AddQnnContextHandle(context);
   if (!s.IsOK()) {
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING, ("Unable to add context " + context_ss.str()).c_str());
-  } else {
-    context_created_ = true;
   }
 }
 
@@ -1408,7 +1406,6 @@ Ort::Status QnnBackendManager::ReleaseContext() {
   // release QNN context handles
   contexts_.clear();
   context_map_.clear();
-  ep_context_handle_map_.clear();
 
   context_created_ = false;
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -428,17 +428,14 @@ Ort::Status QnnModel::ExecuteGraph(OrtKernelContext* context,
     size_t length;
     tensor_status = ort_api.GetTensorShapeElementCount(tensor_type_and_shape, &length);
     if (tensor_status != nullptr) {
-      ort_api.ReleaseTensorTypeAndShapeInfo(tensor_type_and_shape);
       return 0;  // Return 0 on error, will be handled by caller
     }
     ONNXTensorElementDataType element_type;
     tensor_status = ort_api.GetTensorElementType(tensor_type_and_shape, &element_type);
     if (tensor_status != nullptr) {
-      ort_api.ReleaseTensorTypeAndShapeInfo(tensor_type_and_shape);
       return 0;  // Return 0 on error, will be handled by caller
     }
     size_t element_size = GetElementSizeByType(element_type);
-    ort_api.ReleaseTensorTypeAndShapeInfo(tensor_type_and_shape);
     return element_size * length;
   };
 

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -440,6 +440,7 @@ class TaskLibrary:
                 ],
             )
         )
+
     if is_host_linux() and is_host_x86_64():
 
         @public_task("Build with AddressSanitizer and run unit tests under ASan (Linux x86_64, Debug)")

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -40,6 +40,7 @@ from ep_build.tasks.build import (
     GenerateCoverageTask,
     GenerateDiffCoverageTask,
     QdcTestsTask,
+    RunAsanTask,
 )
 from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, DockerBuildTask
 from ep_build.tasks.python import (
@@ -439,6 +440,37 @@ class TaskLibrary:
                 ],
             )
         )
+    if is_host_linux() and is_host_x86_64():
+
+        @public_task("Build with AddressSanitizer and run unit tests under ASan (Linux x86_64, Debug)")
+        @depends(["create_venv"])
+        def asan_linux_x86_64(self, plan: Plan) -> str:
+            build_dir = REPO_ROOT / "build" / "linux-x86_64"
+            return plan.add_step(
+                CompositeTask(
+                    "ASan build and test",
+                    [
+                        BuildEpLinuxTask(
+                            "Building ONNX Runtime for Linux (Debug + ASan)",
+                            self.__venv_path,
+                            "linux",
+                            "x86_64",
+                            "Debug",
+                            None,  # target_py_version: ASan task does not exercise the Python wheel
+                            self.__ort_prebuilt_root,
+                            self.__qairt_sdk_root,
+                            "build",
+                            extra_args=["--enable-asan"],
+                        ),
+                        RunAsanTask(
+                            "Running tests under ASan",
+                            self.__venv_path,
+                            build_dir,
+                            config="Debug",
+                        ),
+                    ],
+                )
+            )
 
     @public_task("Build ONNX Runtime for this host's native architecture")
     @depends(

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -179,6 +179,29 @@ class GenerateCoverageTask(BashScriptsWithVenvTask):
         super().__init__(group_name, venv, [cmd])
 
 
+class RunAsanTask(BashScriptsWithVenvTask):
+    """Run onnxruntime_provider_test under AddressSanitizer via run_asan.sh.
+
+    The script wraps the binary with asan_filter_leaks.sh so that only Direct
+    leaks (ORT/test-side) and ASan heap errors fail the run; Indirect leaks
+    rooted in stripped QAIRT backend libraries are treated as known noise.
+    """
+
+    def __init__(
+        self,
+        group_name: str | None,
+        venv: Path | None,
+        build_dir: Path,
+        config: str = "Debug",
+    ) -> None:
+        cmd = [
+            str(REPO_ROOT / "qcom" / "scripts" / "linux" / "run_asan.sh"),
+            f"--build-dir={build_dir}",
+            f"--config={config}",
+        ]
+        super().__init__(group_name, venv, [cmd])
+
+
 class GenerateDiffCoverageTask(CompositeTask):
     """Generate patch/diff coverage report using diff-cover.
 

--- a/qcom/scripts/linux/asan_filter_leaks.sh
+++ b/qcom/scripts/linux/asan_filter_leaks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Run a test binary under AddressSanitizer and classify the result:
+#
+#   - Any ASan heap error (overflow, UAF, double-free, ...)     → exit 1
+#   - Any gtest assertion failure ([  FAILED  ])                → exit 1
+#   - Any Direct leak (post-suppression)                        → exit 1
+#   - Only Indirect leaks remain (any source)                   → exit 0
+#   - Anything else (segfault before gtest XML, ...)            → exit 1
+#
+# Rationale: Indirect leaks frequently have <unknown module> stacks because
+# the QAIRT SDK backend libraries are shipped stripped, so they cannot be
+# reliably attributed to a root and cannot be matched by `leak:` suppression
+# patterns. Rather than chase that, we trust the Direct-leak signal and
+# the suppression list in tools/ci_build/lsan_suppressions.txt to cover
+# known stripped backend libs. ORT-side leaks would show as Direct.
+#
+# Usage:
+#   asan_filter_leaks.sh <test_binary> [args...]
+
+set -u  # NOTE: -e and pipefail are intentionally omitted.
+# The core pipeline below must be allowed to "fail" (non-zero binary exit)
+# so that PIPESTATUS[0] can be captured and the leak type classified.
+# Adding pipefail/errexit would abort the script before the classification
+# logic runs, defeating the purpose of this filter.
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <test_binary> [args...]" >&2
+    exit 2
+fi
+
+binary="$1"
+shift
+
+log_file=$(mktemp -t asan-filter.XXXXXX.log)
+trap 'rm -f "$log_file"' EXIT
+
+"$binary" "$@" 2>&1 | tee "$log_file"
+binary_rc=${PIPESTATUS[0]}
+
+# Clean run - no leaks, no ASan errors, all tests passed
+if [ "$binary_rc" -eq 0 ]; then
+    exit 0
+fi
+
+# Binary returned non-zero - classify the cause
+echo "" >&2
+echo "===== [asan-filter] binary exited ${binary_rc}, classifying =====" >&2
+
+# 1. Any non-leak ASan error wins
+if grep -q "ERROR: AddressSanitizer:" "$log_file"; then
+    echo "[asan-filter] ASan heap error detected -> FAIL" >&2
+    exit 1
+fi
+
+# 2. Any gtest assertion failure wins
+if grep -q "\[  FAILED  \]" "$log_file"; then
+    echo "[asan-filter] gtest assertion failed -> FAIL" >&2
+    exit 1
+fi
+
+# 3. Any Direct leak originates in our (or test) code
+if grep -q "^Direct leak" "$log_file"; then
+    direct_count=$(grep -c "^Direct leak" "$log_file")
+    echo "[asan-filter] ${direct_count} Direct leak(s) from ORT/test code -> FAIL" >&2
+    exit 1
+fi
+
+# 4. Only Indirect leaks left -> not policed, pass
+if grep -q "^Indirect leak" "$log_file"; then
+    indirect_count=$(grep -c "^Indirect leak" "$log_file")
+    summary=$(grep -E "SUMMARY: AddressSanitizer:.*leaked" "$log_file" | tail -1 || true)
+    echo "[asan-filter] Only ${indirect_count} Indirect leak(s) (${summary})" >&2
+    echo "[asan-filter] No Direct leaks; Indirect leaks are not policed -> PASS" >&2
+    exit 0
+fi
+
+# 5. Anything else (segfault, etc.) - fail
+echo "[asan-filter] Unrecognized failure mode (binary exit=${binary_rc}) -> FAIL" >&2
+echo "[asan-filter] Last 30 lines of binary output:" >&2
+tail -n 30 "$log_file" >&2
+exit 1

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -40,10 +40,15 @@ warnings_as_errors=1
 build_java=
 build_archive=
 enable_coverage=
+enable_asan=
 for i in "$@"; do
   case $i in
     --build-archive)
       build_archive=1
+      shift
+      ;;
+    --enable-asan)
+      enable_asan=1
       shift
       ;;
     --config=*)
@@ -306,6 +311,10 @@ else
 
     if [ -n "${enable_coverage}" ]; then
       common_args+=(--cmake_extra_defines "ENABLE_COVERAGE:BOOL=ON")
+    fi
+
+    if [ -n "${enable_asan}" ]; then
+      common_args+=(--enable_address_sanitizer)
     fi
 
     "${python_for_build}" ${REPO_ROOT}/tools/ci_build/build.py \

--- a/qcom/scripts/linux/run_asan.sh
+++ b/qcom/scripts/linux/run_asan.sh
@@ -18,7 +18,12 @@
 # Usage:
 #   bash run_asan.sh \
 #       --build-dir=/path/to/build/linux-x86_64 \
-#       [--config=Debug|RelWithDebInfo]
+#       [--config=Debug]
+#
+# Note: --config currently accepts Debug only. Upstream tools/ci_build/build.py
+# wires `-fsanitize=address` into the Linux build only on the Debug branch, so
+# RelWithDebInfo + --enable_address_sanitizer would silently produce a
+# non-instrumented binary. The script enforces this with a guard below.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
@@ -46,7 +51,9 @@ for arg in "$@"; do
 Usage: $(basename "${BASH_SOURCE[0]}") --build-dir=<path> [--config=<cfg>]
 
   --build-dir=<path>    Required. Build root (e.g. build/linux-x86_64).
-  --config=<cfg>        Optional. Build configuration subdirectory.  Default: Debug
+  --config=<cfg>        Optional. Build configuration subdirectory. Default: Debug.
+                        Currently Debug is the only supported value; see the
+                        header note for why RelWithDebInfo is not yet available.
 EOF
             exit 0
             ;;

--- a/qcom/scripts/linux/run_asan.sh
+++ b/qcom/scripts/linux/run_asan.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Run onnxruntime_provider_test under AddressSanitizer via asan_filter_leaks.sh.
+#
+# Owns the ASan test-time concerns (LD_LIBRARY_PATH, ASAN_OPTIONS,
+# LSAN_OPTIONS, suppressions file path) so that build.sh / run_tests.sh
+# stay ASan-unaware. ONNX model tests are intentionally not invoked here:
+# onnxruntime_plugin_ep_onnx_test dlopens an ASan-instrumented .so without
+# ASan in the host process's initial library list, which makes ASan refuse
+# to initialize.
+#
+# Prerequisites:
+#   - A build compiled with --enable-asan (i.e. -fsanitize=address).
+#     Use: python qcom/build_and_test.py asan_linux_x86_64
+#
+# Usage:
+#   bash run_asan.sh \
+#       --build-dir=/path/to/build/linux-x86_64 \
+#       [--config=Debug|RelWithDebInfo]
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source "${REPO_ROOT}/qcom/scripts/linux/common.sh"
+source "${REPO_ROOT}/qcom/scripts/linux/tools.sh"
+
+set_strict_mode
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+build_dir=""
+config="Debug"
+
+for arg in "$@"; do
+    case "${arg}" in
+        --build-dir=*)
+            build_dir="${arg#--build-dir=}"
+            ;;
+        --config=*)
+            config="${arg#--config=}"
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") --build-dir=<path> [--config=<cfg>]
+
+  --build-dir=<path>    Required. Build root (e.g. build/linux-x86_64).
+  --config=<cfg>        Optional. Build configuration subdirectory.  Default: Debug
+EOF
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: ${arg}"
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate arguments
+# ---------------------------------------------------------------------------
+if [ -z "${build_dir}" ]; then
+    die "--build-dir is required. Run with --help for usage."
+fi
+
+if [ "${config}" != "Debug" ]; then
+    die "ASan currently only supports --config=Debug (got: ${config})"
+fi
+
+build_dir="$(realpath "${build_dir}")"
+
+if [ ! -d "${build_dir}/${config}" ]; then
+    die "Build directory not found: ${build_dir}/${config}"
+fi
+
+cd "${build_dir}/${config}"
+
+log_info "=== QNN EP ASan Test Runner ==="
+log_info "build_dir : ${build_dir}"
+log_info "config    : ${config}"
+
+# ---------------------------------------------------------------------------
+# Set environment for the ASan run.
+#
+# The QNN backend libraries (libQnnCpu.so, libQnnHtp.so, ...) sit alongside
+# onnxruntime_provider_test in the build directory. ctest would normally
+# inject this via per-test ENVIRONMENT properties, but we run the binary
+# directly here to feed it through asan_filter_leaks.sh.
+# ---------------------------------------------------------------------------
+export LD_LIBRARY_PATH="${PWD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export ASAN_OPTIONS="halt_on_error=1:detect_leaks=1:print_stats=0"
+export LSAN_OPTIONS="exitcode=1:suppressions=${REPO_ROOT}/tools/ci_build/lsan_suppressions.txt:print_suppressions=0"
+
+# ---------------------------------------------------------------------------
+# Run the test binary through asan_filter_leaks.sh
+# ---------------------------------------------------------------------------
+log_info "--- Running onnxruntime_provider_test under ASan ---"
+"${REPO_ROOT}/qcom/scripts/linux/asan_filter_leaks.sh" \
+    "./onnxruntime_provider_test" \
+    "--gtest_output=xml:${PWD}/onnxruntime_provider_test.results.xml"

--- a/qcom/scripts/linux/run_asan.sh
+++ b/qcom/scripts/linux/run_asan.sh
@@ -103,5 +103,4 @@ export LSAN_OPTIONS="exitcode=1:suppressions=${REPO_ROOT}/tools/ci_build/lsan_su
 # ---------------------------------------------------------------------------
 log_info "--- Running onnxruntime_provider_test under ASan ---"
 "${REPO_ROOT}/qcom/scripts/linux/asan_filter_leaks.sh" \
-    "./onnxruntime_provider_test" \
-    "--gtest_output=xml:${PWD}/onnxruntime_provider_test.results.xml"
+    "./onnxruntime_provider_test"

--- a/tools/ci_build/lsan_suppressions.txt
+++ b/tools/ci_build/lsan_suppressions.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# LeakSanitizer suppressions for QNN EP CI ASan builds.
+#
+# Format: leak:<substring matched against any frame in the leak stack>
+# See: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions
+#
+# Policy: CI fails on any Direct leak; Indirect leaks are filtered out by
+# qcom/scripts/linux/asan_filter_leaks.sh. The suppressions below cover
+# Direct leaks rooted in stripped QAIRT SDK backend libraries which are
+# tracked separately with the QNN team.
+
+leak:libQnnHtp.so
+leak:libQnnCpu.so


### PR DESCRIPTION
## Purpose

End-to-end validation that the ASan CI introduced in #419 actually catches a real ORT-side memory leak. **Not for merge** — closes once #419 lands.

## What this branch does

Forked from #419's branch (`dev/chunghow/ci-linux-x86-enable-asan`) and adds a single revert commit on top: `git revert 7be29c678d` (PR #326 — \"Fix memory leak in OrtTensorTypeAndShapeInfo in ExecuteGraph\"). This re-introduces the original leak the QNN team fixed in March.

## Local result (also expected on CI)

\`\`\`
SUMMARY: AddressSanitizer: 738800 byte(s) leaked in 7267 allocation(s).
[asan-filter] 2 Direct leak(s) from ORT/test code -> FAIL
\`\`\`

The two Direct leak stacks point exactly at the lambda call sites in \`onnxruntime/core/providers/qnn/builder/qnn_model.cc\`:
- \`qnn_model.cc:453\` — input tensors loop
- \`qnn_model.cc:499\` — output tensors loop

asan_filter classifies as FAIL (Direct leak from ORT code, not the libQnn noise we already suppress) → ASan job exits 1 → PR check goes red.

## Once #419 merges

Close this branch + draft PR. No production impact.