### PR TITLE
Add UTs for qnn quant params wrapper and qnn model

### DIFF
--- a/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
+++ b/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
@@ -298,10 +298,10 @@ inline OrtStatus* StubMockGetTensorData(const OrtValue*,
   auto it = g_mock_init_reg.vi_to_spec.find(g_mock_chain_vi);
   if (it != g_mock_init_reg.vi_to_spec.end() && !it->second.raw_bytes.empty()) {
     *out = it->second.raw_bytes.data();
-  } else {
-    *out = nullptr;
+    return nullptr;
   }
-  return nullptr;
+  *out = nullptr;
+  return MakeMockChainMissStatus();
 }
 
 // SetupMockInitRegistryStubs — install all stubs for the mock initializer registry.

--- a/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
+++ b/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
@@ -1,0 +1,334 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// MockInitializerRegistry — registry-based OrtApi stubs for QDQ unit tests.
+//
+// Enables tests to register named mock OrtValueInfo* objects with typed scalar
+// or tensor data. Stubs read from this registry to satisfy the OrtApi calls
+// made by QnnQuantParamsWrapper::Init (UnpackScales / UnpackZeroPoints) and
+// QnnModelWrapper::UnpackInitializerData.
+//
+// Usage:
+//   QnnModelWrapperTestContext ctx;
+//   auto& reg = g_mock_init_reg;
+//   reg.clear();
+//   auto scale_vi = reg.AddScalarFloat("scale", 0.1f);
+//   auto zp_vi    = reg.AddScalarUint8("zp", 0);
+//   SetupMockInitRegistryStubs(ctx);
+//   // Pass scale_vi / zp_vi as OrtNodeUnitIODef::QuantParam fields.
+//
+// The registry and stubs live in an anonymous namespace, so each TU including
+// this header gets its own private copy of `g_mock_init_reg`. Tests should
+// call `g_mock_init_reg.clear()` at the top of each test to reset state.
+//
+// Chain-state assumption (re: g_mock_chain_vi)
+// --------------------------------------------
+// `GetValueInfoTypeInfo` and `ValueInfo_GetInitializerValue` write the most
+// recently looked-up VI into `g_mock_chain_vi`; the downstream stubs
+// (`GetTensorElementType`, `GetDimensionsCount`, `GetDimensions`,
+// `GetTensorData`) read from it. This works because the EP code calls these
+// stubs in a strict per-VI sequence — `GetTypeInfo(A) → CastToTensorInfo →
+// {GetElementType,GetDimensions,...}` for VI A, then `GetTypeInfo(B) → ...`
+// for VI B — without interleaving lookups across multiple VIs between the
+// chain head and a chain tail. Verified for SRC3 against `UnpackScales`,
+// `UnpackZeroPoints`, `utils::UnpackInitializerData`, and the `CASE_UNPACK`
+// macro. If the EP ever introduces interleaved chains, replace this with a
+// per-call argument or a per-thread pointer; the silent-error fallback below
+// will surface the mismatch loudly when chain state is broken.
+
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <cstring>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/ort_api.h"
+
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+struct MockInitSpec {
+  ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  std::vector<int64_t> dims;  // {} = scalar
+  std::vector<uint8_t> raw_bytes;
+};
+
+// Global registry.  Tests call clear() at setup.
+struct MockInitRegistry {
+  // Map from OrtValueInfo* sentinel → spec.
+  std::unordered_map<const OrtValueInfo*, MockInitSpec> vi_to_spec;
+  // Map from name → OrtValueInfo* (for Graph_GetInitializers / FindInitializer).
+  std::unordered_map<std::string, const OrtValueInfo*> name_to_vi;
+  // Name reverse-lookup (for GetValueInfoName stub).
+  std::unordered_map<const OrtValueInfo*, std::string> vi_to_name;
+  // Flat array for Graph_GetInitializers.
+  std::vector<const OrtValueInfo*> vi_array;
+  // Storage for sentinel ints (one per registered OrtValueInfo).
+  std::deque<int> sentinel_storage;
+
+  void clear() {
+    vi_to_spec.clear();
+    name_to_vi.clear();
+    vi_to_name.clear();
+    vi_array.clear();
+    sentinel_storage.clear();
+  }
+
+  const OrtValueInfo* Add(const std::string& name, MockInitSpec spec) {
+    sentinel_storage.push_back(0);
+    const OrtValueInfo* vi = reinterpret_cast<const OrtValueInfo*>(&sentinel_storage.back());
+    vi_to_spec[vi] = std::move(spec);
+    name_to_vi[name] = vi;
+    vi_to_name[vi] = name;
+    vi_array.push_back(vi);
+    return vi;
+  }
+
+  const OrtValueInfo* AddScalarFloat(const std::string& name, float value) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    s.raw_bytes.resize(sizeof(float));
+    std::memcpy(s.raw_bytes.data(), &value, sizeof(float));
+    return Add(name, std::move(s));
+  }
+  const OrtValueInfo* AddScalarUint8(const std::string& name, uint8_t value) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+    s.raw_bytes = {value};
+    return Add(name, std::move(s));
+  }
+  const OrtValueInfo* AddScalarUint16(const std::string& name, uint16_t value) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16;
+    s.raw_bytes.resize(sizeof(uint16_t));
+    std::memcpy(s.raw_bytes.data(), &value, sizeof(uint16_t));
+    return Add(name, std::move(s));
+  }
+  const OrtValueInfo* AddScalarInt32(const std::string& name, int32_t value) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+    s.raw_bytes.resize(sizeof(int32_t));
+    std::memcpy(s.raw_bytes.data(), &value, sizeof(int32_t));
+    return Add(name, std::move(s));
+  }
+
+  // Tensor (multi-element) helpers: caller supplies dims and an aligned data span.
+  const OrtValueInfo* AddTensorFloat(const std::string& name,
+                                     std::vector<int64_t> dims,
+                                     const std::vector<float>& data) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    s.dims = std::move(dims);
+    s.raw_bytes.resize(data.size() * sizeof(float));
+    if (!data.empty()) {
+      std::memcpy(s.raw_bytes.data(), data.data(), s.raw_bytes.size());
+    }
+    return Add(name, std::move(s));
+  }
+  const OrtValueInfo* AddTensorUint8(const std::string& name,
+                                     std::vector<int64_t> dims,
+                                     const std::vector<uint8_t>& data) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+    s.dims = std::move(dims);
+    s.raw_bytes = data;
+    return Add(name, std::move(s));
+  }
+  const OrtValueInfo* AddTensorInt32(const std::string& name,
+                                     std::vector<int64_t> dims,
+                                     const std::vector<int32_t>& data) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+    s.dims = std::move(dims);
+    s.raw_bytes.resize(data.size() * sizeof(int32_t));
+    if (!data.empty()) {
+      std::memcpy(s.raw_bytes.data(), data.data(), s.raw_bytes.size());
+    }
+    return Add(name, std::move(s));
+  }
+  // INT4 / UINT4: caller supplies per-element values; helper packs two values
+  // per byte (low nibble = even index, high = odd). The EP's CASE_UNPACK_INT4
+  // expects packed Int4x2 layout — feeding it 1 byte per element would over-
+  // read the buffer when num_dims indicates more than ~ceil(N/2) bytes.
+  const OrtValueInfo* AddTensorInt4As8bit(const std::string& name,
+                                          std::vector<int64_t> dims,
+                                          const std::vector<int8_t>& values) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4;
+    s.dims = std::move(dims);
+    const size_t n = values.size();
+    s.raw_bytes.assign((n + 1) / 2, 0);
+    for (size_t i = 0; i < n; ++i) {
+      const uint8_t nibble = static_cast<uint8_t>(values[i]) & 0x0F;
+      s.raw_bytes[i / 2] |= static_cast<uint8_t>(nibble << ((i & 1u) * 4u));
+    }
+    return Add(name, std::move(s));
+  }
+  const OrtValueInfo* AddTensorUint4As8bit(const std::string& name,
+                                           std::vector<int64_t> dims,
+                                           const std::vector<uint8_t>& values) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4;
+    s.dims = std::move(dims);
+    const size_t n = values.size();
+    s.raw_bytes.assign((n + 1) / 2, 0);
+    for (size_t i = 0; i < n; ++i) {
+      const uint8_t nibble = values[i] & 0x0F;
+      s.raw_bytes[i / 2] |= static_cast<uint8_t>(nibble << ((i & 1u) * 4u));
+    }
+    return Add(name, std::move(s));
+  }
+};
+
+static MockInitRegistry g_mock_init_reg;
+// OrtTypeInfo / OrtTensorTypeAndShapeInfo sentinels (single pair, reused).
+static int g_mock_type_info_sentinel = 0;
+static int g_mock_shape_info_sentinel = 0;
+// OrtValue sentinel used by ValueInfo_GetInitializerValue.
+static int g_mock_ort_value_sentinel = 0;
+// The OrtValueInfo* currently being processed through the stub chain.
+// See "Chain-state assumption" in the file header comment.
+static const OrtValueInfo* g_mock_chain_vi = nullptr;
+
+// Build a fresh "lookup miss" OrtStatus each call. Returning a non-null
+// OrtStatus* makes the EP code path fail loudly instead of silently coercing
+// the missing VI's element type / dims to defaults — SRC2 falls back silently,
+// which can hide chain-state breakage. We must hand back a freshly allocated
+// OrtStatus on every call: the caller (ORT_CXX_RETURN_ON_API_FAIL) wraps it in
+// Ort::Status which will Release it — a static singleton would UAF on the
+// second miss.
+inline OrtStatus* MakeMockChainMissStatus() {
+  Ort::Status err(
+      "mock_init_registry: g_mock_chain_vi not registered "
+      "(chain-state broken or VI never added)",
+      ORT_FAIL);
+  return err.release();
+}
+
+inline OrtStatus* StubMockGraphGetModelPath(const OrtGraph*,
+                                            const ORTCHAR_T** out) noexcept {
+  static const ORTCHAR_T empty[] = "";
+  *out = empty;
+  return nullptr;
+}
+inline OrtStatus* StubMockGetNumInitializers(const OrtGraph*,
+                                             size_t* out) noexcept {
+  *out = g_mock_init_reg.vi_array.size();
+  return nullptr;
+}
+inline OrtStatus* StubMockGetInitializers(const OrtGraph*,
+                                          const OrtValueInfo** out,
+                                          size_t count) noexcept {
+  for (size_t i = 0; i < count && i < g_mock_init_reg.vi_array.size(); ++i)
+    out[i] = g_mock_init_reg.vi_array[i];
+  return nullptr;
+}
+inline OrtStatus* StubMockGetValueInfoName(const OrtValueInfo* vi,
+                                           const char** out) noexcept {
+  auto it = g_mock_init_reg.vi_to_name.find(vi);
+  static const char empty_name[] = "";
+  *out = (it != g_mock_init_reg.vi_to_name.end()) ? it->second.c_str() : empty_name;
+  return nullptr;
+}
+inline OrtStatus* StubMockValueInfoIsConstant(const OrtValueInfo*,
+                                              bool* out) noexcept {
+  *out = true;
+  return nullptr;
+}
+inline OrtStatus* StubMockValueInfoGetExternal(const OrtValueInfo*,
+                                               OrtExternalInitializerInfo** out) noexcept {
+  *out = nullptr;
+  return nullptr;
+}
+inline OrtStatus* StubMockGetValueInfoTypeInfo(const OrtValueInfo* vi,
+                                               const OrtTypeInfo** out) noexcept {
+  g_mock_chain_vi = vi;  // record for downstream stubs
+  *out = reinterpret_cast<const OrtTypeInfo*>(&g_mock_type_info_sentinel);
+  return nullptr;
+}
+inline OrtStatus* StubMockCastTypeInfoToTensorInfo(const OrtTypeInfo*,
+                                                   const OrtTensorTypeAndShapeInfo** out) noexcept {
+  *out = reinterpret_cast<const OrtTensorTypeAndShapeInfo*>(&g_mock_shape_info_sentinel);
+  return nullptr;
+}
+inline OrtStatus* StubMockGetTensorElementType(const OrtTensorTypeAndShapeInfo*,
+                                               ONNXTensorElementDataType* out) noexcept {
+  auto it = g_mock_init_reg.vi_to_spec.find(g_mock_chain_vi);
+  if (it == g_mock_init_reg.vi_to_spec.end()) {
+    return MakeMockChainMissStatus();
+  }
+  *out = it->second.elem_type;
+  return nullptr;
+}
+inline OrtStatus* StubMockGetDimensionsCount(const OrtTensorTypeAndShapeInfo*,
+                                             size_t* out) noexcept {
+  auto it = g_mock_init_reg.vi_to_spec.find(g_mock_chain_vi);
+  if (it == g_mock_init_reg.vi_to_spec.end()) {
+    return MakeMockChainMissStatus();
+  }
+  *out = it->second.dims.size();
+  return nullptr;
+}
+inline OrtStatus* StubMockGetDimensions(const OrtTensorTypeAndShapeInfo*,
+                                        int64_t* d, size_t count) noexcept {
+  auto it = g_mock_init_reg.vi_to_spec.find(g_mock_chain_vi);
+  if (it == g_mock_init_reg.vi_to_spec.end()) {
+    return MakeMockChainMissStatus();
+  }
+  for (size_t i = 0; i < count && i < it->second.dims.size(); ++i)
+    d[i] = it->second.dims[i];
+  return nullptr;
+}
+inline OrtStatus* StubMockValueInfoGetInitializerValue(const OrtValueInfo* vi,
+                                                       const OrtValue** out) noexcept {
+  g_mock_chain_vi = vi;  // refresh in case chain was broken
+  *out = reinterpret_cast<const OrtValue*>(&g_mock_ort_value_sentinel);
+  return nullptr;
+}
+inline OrtStatus* StubMockGetTensorData(const OrtValue*,
+                                        const void** out) noexcept {
+  auto it = g_mock_init_reg.vi_to_spec.find(g_mock_chain_vi);
+  if (it != g_mock_init_reg.vi_to_spec.end() && !it->second.raw_bytes.empty()) {
+    *out = it->second.raw_bytes.data();
+  } else {
+    *out = nullptr;
+  }
+  return nullptr;
+}
+
+// SetupMockInitRegistryStubs — install all stubs for the mock initializer registry.
+// Call AFTER populating g_mock_init_reg with AddScalarFloat / etc.
+// Accepts any context type that exposes a stub_ort_api member (OrtApiStubContext
+// or any struct that inherits from it).
+template <typename T>
+inline void SetupMockInitRegistryStubs(T& ctx) {
+  g_mock_chain_vi = nullptr;
+  ctx.stub_ort_api.Graph_GetModelPath = StubMockGraphGetModelPath;
+  ctx.stub_ort_api.Graph_GetNumInitializers = StubMockGetNumInitializers;
+  ctx.stub_ort_api.Graph_GetInitializers = StubMockGetInitializers;
+  ctx.stub_ort_api.GetValueInfoName = StubMockGetValueInfoName;
+  ctx.stub_ort_api.ValueInfo_IsConstantInitializer = StubMockValueInfoIsConstant;
+  ctx.stub_ort_api.ValueInfo_GetExternalInitializerInfo = StubMockValueInfoGetExternal;
+  ctx.stub_ort_api.GetValueInfoTypeInfo = StubMockGetValueInfoTypeInfo;
+  ctx.stub_ort_api.CastTypeInfoToTensorInfo = StubMockCastTypeInfoToTensorInfo;
+  ctx.stub_ort_api.GetTensorElementType = StubMockGetTensorElementType;
+  ctx.stub_ort_api.GetDimensionsCount = StubMockGetDimensionsCount;
+  ctx.stub_ort_api.GetDimensions = StubMockGetDimensions;
+  ctx.stub_ort_api.ValueInfo_GetInitializerValue = StubMockValueInfoGetInitializerValue;
+  ctx.stub_ort_api.GetTensorData = StubMockGetTensorData;
+}
+
+}  // namespace
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
@@ -128,15 +128,12 @@ inline void InstallFakeGraphApiStubs(OrtApi& api) {
   // Ort::Status / OrtTypeInfo / OrtTensorTypeAndShapeInfo destructors call
   // these through Ort::GetApi(). Leaving them null would crash on every
   // RAII teardown.
-  api.ReleaseStatus = [](OrtStatus*) noexcept {};
   api.ReleaseTypeInfo = [](OrtTypeInfo*) noexcept {};
   api.ReleaseTensorTypeAndShapeInfo = [](OrtTensorTypeAndShapeInfo*) noexcept {};
 
   // ---- OrtStatus minimal heap-allocated wrapper ----
   // EP code constructs OrtStatus via Ort::Status(msg, code) which calls
   // CreateStatus, and inspects results via GetErrorCode / GetErrorMessage.
-  // ReleaseStatus is already stubbed as no-op (the small leaks here are
-  // bounded to per-test allocations).
   struct FakeOrtStatus {
     OrtErrorCode code;
     std::string message;

--- a/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
@@ -1,0 +1,327 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Fake OrtGraph / OrtNode / OrtValueInfo for QNN EP unit tests.
+//
+// Background:
+//   OrtGraph, OrtNode, OrtValueInfo, OrtTypeInfo, OrtTensorTypeAndShapeInfo
+//   are opaque C handle types in the ORT public C API. The EP only accesses
+//   them through OrtApi function pointers — never by dereferencing the
+//   pointer directly. This means tests can freely reinterpret_cast a plain
+//   POD struct pointer as any of these opaque types as long as our installed
+//   stubs cast back to the same plain struct before reading fields.
+//
+//   This approach replaces the old qnn_mock_ort_graph.cc / qnn_mock_ort_node.cc
+//   files which inherited from ORT's internal abstract classes
+//   (core/graph/abi_graph_types.h) — those private headers are forbidden by
+//   the new EP/ORT decoupling policy.
+//
+// Usage:
+//   FakeValueInfo input_x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+//   FakeNode identity{"identity_0", "Identity", "", 13, {&input_x}, {&output_y}};
+//   FakeGraph graph{ {identity}, {&input_x}, {&output_y}, {} };
+//   OrtApi stub_ort_api{};
+//   InstallFakeGraphApiStubs(stub_ort_api);
+//   // pass graph.AsGraph() / node.AsNode() / value_info.AsValueInfo() to EP code
+
+#pragma once
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace test {
+
+// ---------------------------------------------------------------------------
+// FakeValueInfo
+//
+// Acts as OrtValueInfo*, OrtTypeInfo*, AND OrtTensorTypeAndShapeInfo*
+// simultaneously — the installed stubs cast back to FakeValueInfo for every
+// kind of opaque pointer. This works because the EP code only flows the
+// pointers through OrtApi function pointers; it never inspects them as
+// concrete ORT types.
+// ---------------------------------------------------------------------------
+struct FakeValueInfo {
+  std::string name;
+  ONNXTensorElementDataType elem_type;
+  std::vector<int64_t> shape;
+
+  const OrtValueInfo* AsValueInfo() const {
+    return reinterpret_cast<const OrtValueInfo*>(this);
+  }
+  const OrtTypeInfo* AsTypeInfo() const {
+    return reinterpret_cast<const OrtTypeInfo*>(this);
+  }
+  const OrtTensorTypeAndShapeInfo* AsTensorInfo() const {
+    return reinterpret_cast<const OrtTensorTypeAndShapeInfo*>(this);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// FakeNode
+//
+// Pointers to inputs/outputs are observed (non-owning) — caller keeps
+// FakeValueInfo objects alive for as long as the node is in use.
+// ---------------------------------------------------------------------------
+struct FakeNode {
+  std::string name;
+  std::string op_type;
+  std::string domain;
+  int since_version = 13;
+  std::vector<FakeValueInfo*> inputs;
+  std::vector<FakeValueInfo*> outputs;
+
+  const OrtNode* AsNode() const {
+    return reinterpret_cast<const OrtNode*>(this);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// FakeGraph
+//
+// Nodes are owned by the FakeGraph; FakeValueInfo pointers are observed.
+// ---------------------------------------------------------------------------
+struct FakeGraph {
+  std::vector<FakeNode> nodes;
+  std::vector<FakeValueInfo*> inputs;
+  std::vector<FakeValueInfo*> outputs;
+  std::vector<FakeValueInfo*> initializers;
+
+  const OrtGraph* AsGraph() const {
+    return reinterpret_cast<const OrtGraph*>(this);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// InstallFakeGraphApiStubs
+//
+// Installs OrtApi function-pointer stubs that decode opaque handles back to
+// FakeGraph / FakeNode / FakeValueInfo via reinterpret_cast. Designed to be
+// safe to call on a zero-initialized OrtApi{} — does not depend on or modify
+// any other stub.
+//
+// Stub coverage (sufficient for SetGraphInputOutputInfo / ComposeGraph /
+// LogTensorDetails / SetupTensors paths):
+//   - GetValueInfoName, GetValueInfoTypeInfo
+//   - CastTypeInfoToTensorInfo, GetTensorElementType
+//   - GetDimensionsCount, GetDimensions, GetSymbolicDimensions
+//   - TensorTypeAndShape_HasShape
+//   - Graph_GetNum{Nodes,Inputs,Outputs,Initializers}, Graph_GetParentNode
+//   - Graph_Get{Nodes,Inputs,Outputs,Initializers}
+//   - Node_Get{Name,OperatorType,Domain,SinceVersion,EpName}
+//   - Node_GetNum{Inputs,Outputs,ImplicitInputs,Attributes,Subgraphs}
+//   - Node_Get{Inputs,Outputs,ImplicitInputs,Attributes,Subgraphs}
+//
+// Anything not in this list is left untouched and the caller can replace it
+// with a more specific test stub.
+// ---------------------------------------------------------------------------
+inline void InstallFakeGraphApiStubs(OrtApi& api) {
+  // ---- Release* no-ops ----
+  // Fake objects are stack-owned by tests; never deallocated through ORT.
+  // When tests override the global API with a stub (OrtGlobalApiOverride),
+  // Ort::Status / OrtTypeInfo / OrtTensorTypeAndShapeInfo destructors call
+  // these through Ort::GetApi(). Leaving them null would crash on every
+  // RAII teardown.
+  api.ReleaseStatus = [](OrtStatus*) noexcept {};
+  api.ReleaseTypeInfo = [](OrtTypeInfo*) noexcept {};
+  api.ReleaseTensorTypeAndShapeInfo = [](OrtTensorTypeAndShapeInfo*) noexcept {};
+
+  // ---- OrtStatus minimal heap-allocated wrapper ----
+  // EP code constructs OrtStatus via Ort::Status(msg, code) which calls
+  // CreateStatus, and inspects results via GetErrorCode / GetErrorMessage.
+  // ReleaseStatus is already stubbed as no-op (the small leaks here are
+  // bounded to per-test allocations).
+  struct FakeOrtStatus {
+    OrtErrorCode code;
+    std::string message;
+  };
+  api.CreateStatus = [](OrtErrorCode code, const char* msg) noexcept -> OrtStatus* {
+    auto* s = new FakeOrtStatus{code, msg ? msg : ""};
+    return reinterpret_cast<OrtStatus*>(s);
+  };
+  api.GetErrorCode = [](const OrtStatus* status) noexcept -> OrtErrorCode {
+    return reinterpret_cast<const FakeOrtStatus*>(status)->code;
+  };
+  api.GetErrorMessage = [](const OrtStatus* status) noexcept -> const char* {
+    return reinterpret_cast<const FakeOrtStatus*>(status)->message.c_str();
+  };
+  api.ReleaseStatus = [](OrtStatus* status) noexcept {
+    delete reinterpret_cast<FakeOrtStatus*>(status);
+  };
+
+  // ---- OrtValueInfo / OrtTypeInfo / OrtTensorTypeAndShapeInfo ----
+  api.GetValueInfoName = [](const OrtValueInfo* vi, const char** name) noexcept -> OrtStatus* {
+    *name = reinterpret_cast<const FakeValueInfo*>(vi)->name.c_str();
+    return nullptr;
+  };
+  api.GetValueInfoTypeInfo = [](const OrtValueInfo* vi, const OrtTypeInfo** out) noexcept -> OrtStatus* {
+    *out = reinterpret_cast<const FakeValueInfo*>(vi)->AsTypeInfo();
+    return nullptr;
+  };
+  api.CastTypeInfoToTensorInfo = [](const OrtTypeInfo* ti,
+                                    const OrtTensorTypeAndShapeInfo** out) noexcept -> OrtStatus* {
+    *out = reinterpret_cast<const FakeValueInfo*>(ti)->AsTensorInfo();
+    return nullptr;
+  };
+  api.GetTensorElementType = [](const OrtTensorTypeAndShapeInfo* info,
+                                ONNXTensorElementDataType* t) noexcept -> OrtStatus* {
+    *t = reinterpret_cast<const FakeValueInfo*>(info)->elem_type;
+    return nullptr;
+  };
+  api.GetDimensionsCount = [](const OrtTensorTypeAndShapeInfo* info, size_t* count) noexcept -> OrtStatus* {
+    *count = reinterpret_cast<const FakeValueInfo*>(info)->shape.size();
+    return nullptr;
+  };
+  api.GetDimensions = [](const OrtTensorTypeAndShapeInfo* info, int64_t* dims, size_t count) noexcept -> OrtStatus* {
+    const auto& shape = reinterpret_cast<const FakeValueInfo*>(info)->shape;
+    for (size_t i = 0; i < count && i < shape.size(); ++i) dims[i] = shape[i];
+    return nullptr;
+  };
+  api.GetSymbolicDimensions = [](const OrtTensorTypeAndShapeInfo*,
+                                 const char** dim_params, size_t count) noexcept -> OrtStatus* {
+    for (size_t i = 0; i < count; ++i) dim_params[i] = "";
+    return nullptr;
+  };
+  api.TensorTypeAndShape_HasShape = [](const OrtTensorTypeAndShapeInfo*) noexcept -> bool {
+    return true;
+  };
+
+  // ---- OrtGraph ----
+  api.Graph_GetNumNodes = [](const OrtGraph* g, size_t* n) noexcept -> OrtStatus* {
+    *n = reinterpret_cast<const FakeGraph*>(g)->nodes.size();
+    return nullptr;
+  };
+  api.Graph_GetNodes = [](const OrtGraph* g, const OrtNode** nodes, size_t count) noexcept -> OrtStatus* {
+    const auto& fg = *reinterpret_cast<const FakeGraph*>(g);
+    for (size_t i = 0; i < count && i < fg.nodes.size(); ++i) {
+      nodes[i] = fg.nodes[i].AsNode();
+    }
+    return nullptr;
+  };
+  api.Graph_GetNumInputs = [](const OrtGraph* g, size_t* n) noexcept -> OrtStatus* {
+    *n = reinterpret_cast<const FakeGraph*>(g)->inputs.size();
+    return nullptr;
+  };
+  api.Graph_GetInputs = [](const OrtGraph* g, const OrtValueInfo** vis, size_t count) noexcept -> OrtStatus* {
+    const auto& fg = *reinterpret_cast<const FakeGraph*>(g);
+    for (size_t i = 0; i < count && i < fg.inputs.size(); ++i) {
+      vis[i] = fg.inputs[i] ? fg.inputs[i]->AsValueInfo() : nullptr;
+    }
+    return nullptr;
+  };
+  api.Graph_GetNumOutputs = [](const OrtGraph* g, size_t* n) noexcept -> OrtStatus* {
+    *n = reinterpret_cast<const FakeGraph*>(g)->outputs.size();
+    return nullptr;
+  };
+  api.Graph_GetOutputs = [](const OrtGraph* g, const OrtValueInfo** vis, size_t count) noexcept -> OrtStatus* {
+    const auto& fg = *reinterpret_cast<const FakeGraph*>(g);
+    for (size_t i = 0; i < count && i < fg.outputs.size(); ++i) {
+      vis[i] = fg.outputs[i] ? fg.outputs[i]->AsValueInfo() : nullptr;
+    }
+    return nullptr;
+  };
+  api.Graph_GetNumInitializers = [](const OrtGraph* g, size_t* n) noexcept -> OrtStatus* {
+    *n = reinterpret_cast<const FakeGraph*>(g)->initializers.size();
+    return nullptr;
+  };
+  api.Graph_GetInitializers = [](const OrtGraph* g, const OrtValueInfo** vis, size_t count) noexcept -> OrtStatus* {
+    const auto& fg = *reinterpret_cast<const FakeGraph*>(g);
+    for (size_t i = 0; i < count && i < fg.initializers.size(); ++i) {
+      vis[i] = fg.initializers[i] ? fg.initializers[i]->AsValueInfo() : nullptr;
+    }
+    return nullptr;
+  };
+  api.Graph_GetParentNode = [](const OrtGraph*, const OrtNode** n) noexcept -> OrtStatus* {
+    *n = nullptr;  // no parent (top-level graph)
+    return nullptr;
+  };
+
+  // ---- OrtNode ----
+  api.Node_GetId = [](const OrtNode* n, size_t* id) noexcept -> OrtStatus* {
+    // Pointer address is unique per FakeNode — sufficient for "node id" semantics.
+    *id = reinterpret_cast<size_t>(n);
+    return nullptr;
+  };
+  api.Node_GetName = [](const OrtNode* n, const char** out) noexcept -> OrtStatus* {
+    *out = reinterpret_cast<const FakeNode*>(n)->name.c_str();
+    return nullptr;
+  };
+  api.Node_GetOperatorType = [](const OrtNode* n, const char** out) noexcept -> OrtStatus* {
+    *out = reinterpret_cast<const FakeNode*>(n)->op_type.c_str();
+    return nullptr;
+  };
+  api.Node_GetDomain = [](const OrtNode* n, const char** out) noexcept -> OrtStatus* {
+    *out = reinterpret_cast<const FakeNode*>(n)->domain.c_str();
+    return nullptr;
+  };
+  api.Node_GetSinceVersion = [](const OrtNode* n, int* v) noexcept -> OrtStatus* {
+    *v = reinterpret_cast<const FakeNode*>(n)->since_version;
+    return nullptr;
+  };
+  api.Node_GetEpName = [](const OrtNode*, const char** out) noexcept -> OrtStatus* {
+    *out = nullptr;  // EP not yet assigned in fake graphs
+    return nullptr;
+  };
+  api.Node_GetNumInputs = [](const OrtNode* n, size_t* count) noexcept -> OrtStatus* {
+    *count = reinterpret_cast<const FakeNode*>(n)->inputs.size();
+    return nullptr;
+  };
+  api.Node_GetInputs = [](const OrtNode* n, const OrtValueInfo** vis, size_t count) noexcept -> OrtStatus* {
+    const auto& fn = *reinterpret_cast<const FakeNode*>(n);
+    for (size_t i = 0; i < count && i < fn.inputs.size(); ++i) {
+      vis[i] = fn.inputs[i] ? fn.inputs[i]->AsValueInfo() : nullptr;
+    }
+    return nullptr;
+  };
+  api.Node_GetNumOutputs = [](const OrtNode* n, size_t* count) noexcept -> OrtStatus* {
+    *count = reinterpret_cast<const FakeNode*>(n)->outputs.size();
+    return nullptr;
+  };
+  api.Node_GetOutputs = [](const OrtNode* n, const OrtValueInfo** vis, size_t count) noexcept -> OrtStatus* {
+    const auto& fn = *reinterpret_cast<const FakeNode*>(n);
+    for (size_t i = 0; i < count && i < fn.outputs.size(); ++i) {
+      vis[i] = fn.outputs[i] ? fn.outputs[i]->AsValueInfo() : nullptr;
+    }
+    return nullptr;
+  };
+  api.Node_GetNumImplicitInputs = [](const OrtNode*, size_t* count) noexcept -> OrtStatus* {
+    *count = 0;
+    return nullptr;
+  };
+  api.Node_GetImplicitInputs = [](const OrtNode*, const OrtValueInfo**, size_t) noexcept -> OrtStatus* {
+    return nullptr;
+  };
+  api.Node_GetNumAttributes = [](const OrtNode*, size_t* count) noexcept -> OrtStatus* {
+    *count = 0;
+    return nullptr;
+  };
+  api.Node_GetAttributes = [](const OrtNode*, const OrtOpAttr**, size_t) noexcept -> OrtStatus* {
+    return nullptr;
+  };
+  api.Node_GetNumSubgraphs = [](const OrtNode*, size_t* count) noexcept -> OrtStatus* {
+    *count = 0;
+    return nullptr;
+  };
+  api.Node_GetSubgraphs = [](const OrtNode*, const OrtGraph**, size_t, const char**) noexcept -> OrtStatus* {
+    return nullptr;
+  };
+  api.Node_GetAttributeByName = [](const OrtNode*, const char*, const OrtOpAttr** out) noexcept -> OrtStatus* {
+    *out = nullptr;  // attribute "not found" — matches our 0-attribute FakeNode
+    return nullptr;
+  };
+  api.Node_GetGraph = [](const OrtNode*, const OrtGraph** g) noexcept -> OrtStatus* {
+    *g = nullptr;
+    return nullptr;
+  };
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_model_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_model_test.cc
@@ -1,0 +1,468 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Unit tests for QnnModel (qnn_model.cc).
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "HTP/QnnHtpDevice.h"
+
+#include "core/providers/qnn/builder/qnn_backend_manager.h"
+#include "core/providers/qnn/builder/qnn_model.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/ort_api.h"
+
+#include "test/providers/qnn/unit/qnn_fake_ort_graph.h"
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+// ---------------------------------------------------------------------------
+// QnnModelMinimalTestContext
+//
+// Minimal context: QnnBackendManager::Create only (no SetupBackend, no real
+// QNN backend library loaded). Sufficient for tests that exercise QnnModel
+// methods which do not touch the QNN SDK (e.g., DeserializeGraphInfoFromBinaryInfo
+// unsupported-version path, GetNodeUnit).
+// ---------------------------------------------------------------------------
+struct QnnModelMinimalTestContext {
+  Ort::Logger logger = MakeNullLogger();
+  OrtApi stub_ort_api{};
+  OrtEpApi stub_ep_api{};
+  OrtModelEditorApi stub_editor_api{};
+  std::shared_ptr<qnn::QnnBackendManager> manager;
+  std::unique_ptr<qnn::QnnModel> model;
+
+  QnnModelMinimalTestContext() {
+    qnn::QnnBackendManagerConfig cfg;
+    cfg.backend_path = "libQnnHtp.so";
+    cfg.profiling_level_etw = qnn::ProfilingLevel::OFF;
+    cfg.profiling_level = qnn::ProfilingLevel::OFF;
+    cfg.context_priority = qnn::ContextPriority::NORMAL;
+    cfg.device_id = 0;
+    cfg.htp_arch = QNN_HTP_DEVICE_ARCH_NONE;
+    cfg.soc_model = 0;
+    cfg.skip_qnn_version_check = true;
+
+    ApiPtrs api_ptrs{stub_ort_api, stub_ep_api, stub_editor_api};
+    manager = qnn::QnnBackendManager::Create(cfg, api_ptrs, logger);
+    if (!manager) return;
+    model = std::make_unique<qnn::QnnModel>(manager.get(), api_ptrs);
+  }
+
+  bool IsValid() const { return model != nullptr; }
+};
+
+// ---------------------------------------------------------------------------
+// QnnModelHtpTestContext
+//
+// Full context for tests that need a real QNN HTP backend (ComposeGraph,
+// FinalizeGraphs, etc.). Loads libQnnHtp.so and runs SetupBackend.
+// On x86_64 the validation path works but execution requires HTP hardware.
+// Tests should call GTEST_SKIP() when IsValid() returns false.
+// ---------------------------------------------------------------------------
+struct QnnModelHtpTestContext {
+  Ort::Logger logger = MakeNullLogger();
+  OrtApi stub_ort_api{};
+  OrtEpApi stub_ep_api{};
+  OrtModelEditorApi stub_editor_api{};
+  bool valid = false;
+  std::shared_ptr<qnn::QnnBackendManager> manager;
+  std::unique_ptr<qnn::QnnModel> model;
+
+  QnnModelHtpTestContext() {
+    stub_ort_api.Graph_GetNumInitializers = [](const OrtGraph*, size_t* n) noexcept -> OrtStatus* {
+      *n = 0;
+      return nullptr;
+    };
+    stub_ort_api.Graph_GetInitializers = [](const OrtGraph*, const OrtValueInfo**, size_t) noexcept -> OrtStatus* {
+      return nullptr;
+    };
+
+    qnn::QnnBackendManagerConfig cfg;
+    cfg.backend_path = "libQnnHtp.so";
+    cfg.profiling_level_etw = qnn::ProfilingLevel::OFF;
+    cfg.profiling_level = qnn::ProfilingLevel::OFF;
+    cfg.context_priority = qnn::ContextPriority::NORMAL;
+    cfg.device_id = 0;
+    cfg.htp_arch = QNN_HTP_DEVICE_ARCH_NONE;
+    cfg.soc_model = 0;
+    cfg.skip_qnn_version_check = true;
+
+    ApiPtrs api_ptrs{stub_ort_api, stub_ep_api, stub_editor_api};
+    manager = qnn::QnnBackendManager::Create(cfg, api_ptrs, logger);
+    if (!manager) return;
+
+    std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>> dummy_map;
+    auto status = manager->SetupBackend(false, false, false, -1, false, nullptr, dummy_map);
+    if (!status.IsOK()) return;
+
+    model = std::make_unique<qnn::QnnModel>(manager.get(), api_ptrs);
+    valid = true;
+  }
+
+  bool IsValid() const { return valid; }
+};
+
+// ---------------------------------------------------------------------------
+// DeserializeGraphInfoFromBinaryInfo tests
+// ---------------------------------------------------------------------------
+
+TEST(QnnUnit_ModelTest, Deserialize_UnsupportedVersion_ReturnsError) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+
+  QnnSystemContext_GraphInfo_t info{};
+  // version = 0 is not a recognized QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_*.
+  // → "Unsupported context graph info version." (line 863)
+  info.version = static_cast<QnnSystemContext_GraphInfoVersion_t>(0);
+
+  Qnn_ContextHandle_t fake_ctx = nullptr;
+  EXPECT_FALSE(ctx.model->DeserializeGraphInfoFromBinaryInfo(info, fake_ctx).IsOK());
+}
+
+TEST(QnnUnit_ModelTest, Deserialize_Version1_NullInputTensors_ReturnsError) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+
+  QnnSystemContext_GraphInfo_t info{};
+  info.version = QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_1;
+  info.graphInfoV1.graphName = const_cast<char*>("test_graph");
+  info.graphInfoV1.numGraphInputs = 1;
+  info.graphInfoV1.graphInputs = nullptr;  // null → error at line 865
+
+  Qnn_ContextHandle_t fake_ctx = nullptr;
+  EXPECT_FALSE(ctx.model->DeserializeGraphInfoFromBinaryInfo(info, fake_ctx).IsOK());
+}
+
+TEST(QnnUnit_ModelTest, Deserialize_Version1_NullOutputTensors_ReturnsError) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+
+  // graphInputs must be non-null to pass line 865; 0 iterations → safe with dummy ptr.
+  static int g_dummy_buf = 0;
+  QnnSystemContext_GraphInfo_t info{};
+  info.version = QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_1;
+  info.graphInfoV1.graphName = const_cast<char*>("test_graph");
+  info.graphInfoV1.numGraphInputs = 0;
+  info.graphInfoV1.graphInputs = reinterpret_cast<Qnn_Tensor_t*>(&g_dummy_buf);
+  info.graphInfoV1.numGraphOutputs = 1;
+  info.graphInfoV1.graphOutputs = nullptr;  // null → error at line 866
+
+  Qnn_ContextHandle_t fake_ctx = nullptr;
+  EXPECT_FALSE(ctx.model->DeserializeGraphInfoFromBinaryInfo(info, fake_ctx).IsOK());
+}
+
+#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 18)
+TEST(QnnUnit_ModelTest, Deserialize_Version2_NullInputTensors_ReturnsError) {
+  // Covers the V2 conditional branch at lines 844-849.
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+
+  QnnSystemContext_GraphInfo_t info{};
+  info.version = QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_2;
+  info.graphInfoV2.graphName = const_cast<char*>("test_graph");
+  info.graphInfoV2.numGraphInputs = 1;
+  info.graphInfoV2.graphInputs = nullptr;  // null → error at line 865
+
+  Qnn_ContextHandle_t fake_ctx = nullptr;
+  EXPECT_FALSE(ctx.model->DeserializeGraphInfoFromBinaryInfo(info, fake_ctx).IsOK());
+}
+#endif
+
+#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 21)
+TEST(QnnUnit_ModelTest, Deserialize_Version3_NullInputTensors_ReturnsError) {
+  // Covers the V3 conditional branch at lines 853-858.
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+
+  QnnSystemContext_GraphInfo_t info{};
+  info.version = QNN_SYSTEM_CONTEXT_GRAPH_INFO_VERSION_3;
+  info.graphInfoV3.graphName = const_cast<char*>("test_graph");
+  info.graphInfoV3.numGraphInputs = 1;
+  info.graphInfoV3.graphInputs = nullptr;  // null → error at line 865
+
+  Qnn_ContextHandle_t fake_ctx = nullptr;
+  EXPECT_FALSE(ctx.model->DeserializeGraphInfoFromBinaryInfo(info, fake_ctx).IsOK());
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// SetGraphInputOutputInfo tests
+//
+// Exercises QnnModel::SetGraphInputOutputInfo with a fake OrtGraph + fake
+// fused OrtNode. No real QNN backend needed — the function reads graph
+// metadata via OrtApi stubs only.
+// ---------------------------------------------------------------------------
+
+TEST(QnnUnit_ModelTest, SetGraphInputOutputInfo_Basic_PopulatesInputsOutputs) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  // Make Ort::ConstNode / Ort::ConstValueInfo wrappers route through our stub
+  // instead of the real ORT runtime, which would SIGSEGV on our fake pointers.
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  // graph: x -> Identity -> y, both float[4]
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeNode inner{"identity_0", "Identity", "", 13, {&x}, {&y}};
+  FakeGraph graph{{inner}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::vector<std::string> in_names{"x"};
+  std::vector<std::string> out_names{"y"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, &out_names, &settings};
+
+  auto status = ctx.model->SetGraphInputOutputInfo(mc);
+  EXPECT_TRUE(status.IsOK()) << status.GetErrorMessage();
+}
+
+// ---------------------------------------------------------------------------
+// ComposeGraph early-validation error paths (no QNN backend required)
+// ---------------------------------------------------------------------------
+
+TEST(QnnUnit_ModelTest, ComposeGraph_NullInputNames_ReturnsError) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeGraph graph{{}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::vector<std::string> out_names{"y"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          /*onnx_input_names=*/nullptr, &out_names, &settings};
+
+  EXPECT_FALSE(ctx.model->ComposeGraph(mc).IsOK());
+}
+
+TEST(QnnUnit_ModelTest, ComposeGraph_NullOutputNames_ReturnsError) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeGraph graph{{}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::vector<std::string> in_names{"x"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, /*onnx_output_names=*/nullptr, &settings};
+
+  EXPECT_FALSE(ctx.model->ComposeGraph(mc).IsOK());
+}
+
+TEST(QnnUnit_ModelTest, ComposeGraph_NullModelSettings_ReturnsError) {
+  QnnModelMinimalTestContext ctx;
+  ASSERT_TRUE(ctx.IsValid());
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {4}};
+  FakeGraph graph{{}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::vector<std::string> in_names{"x"};
+  std::vector<std::string> out_names{"y"};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, &out_names, /*model_settings=*/nullptr};
+
+  EXPECT_FALSE(ctx.model->ComposeGraph(mc).IsOK());
+}
+
+// ---------------------------------------------------------------------------
+// ComposeGraph + LogTensorDetails (real HTP backend)
+//
+// These tests need a real QNN backend so that QnnModelWrapper::CreateQnnGraph
+// and op-builder paths succeed. LogTensorDetails runs as part of ComposeGraph
+// when json_qnn_graph_path is non-empty.
+// ---------------------------------------------------------------------------
+
+TEST(QnnUnit_ModelTest, ComposeGraph_IdentityGraph_WithJsonPath_TriggersLogTensorDetails) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) GTEST_SKIP() << "HTP backend not available on this host";
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode inner{"identity_0", "Identity", "", 13, {&x}, {&y}};
+  FakeGraph graph{{inner}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::string tmp_json = std::filesystem::temp_directory_path() / "qnn_unit_model_test_graph.json";
+  std::remove(tmp_json.c_str());
+
+  std::vector<std::string> in_names{"x"};
+  std::vector<std::string> out_names{"y"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, &out_names, &settings,
+                          /*graph_configs=*/nullptr,
+                          /*tensor_name_overrides=*/nullptr,
+                          /*json_qnn_graph_path=*/tmp_json};
+
+  auto status = ctx.model->ComposeGraph(mc);
+  EXPECT_TRUE(status.IsOK()) << status.GetErrorMessage();
+
+  // LogTensorDetails writes "<base>_tensor_log.json" alongside the graph json.
+  std::string log_file = tmp_json.substr(0, tmp_json.rfind('.')) + "_tensor_log.json";
+  EXPECT_TRUE(std::filesystem::exists(log_file)) << "Expected: " << log_file;
+
+  std::remove(tmp_json.c_str());
+  std::remove(log_file.c_str());
+}
+
+// Helper: run ComposeGraph with a single-Identity graph of the given element
+// type so LogTensorDetails encounters that QNN data type in its switch.
+static void RunComposeGraphWithDtype(ONNXTensorElementDataType elem_type) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) GTEST_SKIP() << "HTP backend not available on this host";
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", elem_type, {1, 4}};
+  FakeValueInfo y{"y", elem_type, {1, 4}};
+  FakeNode inner{"identity_0", "Identity", "", 13, {&x}, {&y}};
+  FakeGraph graph{{inner}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::string tmp_json = std::filesystem::temp_directory_path() / "qnn_unit_model_test_dtype.json";
+  std::remove(tmp_json.c_str());
+
+  std::vector<std::string> in_names{"x"};
+  std::vector<std::string> out_names{"y"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, &out_names, &settings,
+                          nullptr, nullptr, tmp_json};
+  auto status = ctx.model->ComposeGraph(mc);
+  // ComposeGraph may fail if HTP doesn't accept this dtype for Identity; the
+  // failure-path LogTensorDetails datatype cases are then NOT covered. For
+  // dtypes that succeed, LogTensorDetails fires and the switch case is hit.
+  if (!status.IsOK()) {
+    std::remove(tmp_json.c_str());
+    GTEST_SKIP() << "HTP does not accept Identity for this dtype: " << status.GetErrorMessage();
+  }
+  std::string log_file = tmp_json.substr(0, tmp_json.rfind('.')) + "_tensor_log.json";
+  std::remove(tmp_json.c_str());
+  std::remove(log_file.c_str());
+}
+
+TEST(QnnUnit_ModelTest, LogTensorDetails_INT8_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8);
+}
+TEST(QnnUnit_ModelTest, LogTensorDetails_INT16_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16);
+}
+TEST(QnnUnit_ModelTest, LogTensorDetails_INT64_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+}
+TEST(QnnUnit_ModelTest, LogTensorDetails_UINT16_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16);
+}
+TEST(QnnUnit_ModelTest, LogTensorDetails_UINT32_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32);
+}
+TEST(QnnUnit_ModelTest, LogTensorDetails_FLOAT16_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+}
+TEST(QnnUnit_ModelTest, LogTensorDetails_BOOL_CoversSwitchCase) {
+  RunComposeGraphWithDtype(ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
+}
+
+// json_qnn_graph_path without "." extension — exercises the else branch at
+// LogTensorDetails line 811 that appends "_tensor_log.json" directly.
+TEST(QnnUnit_ModelTest, LogTensorDetails_JsonPathWithoutDot_CoversElseBranch) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) GTEST_SKIP() << "HTP backend not available on this host";
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode inner{"identity_0", "Identity", "", 13, {&x}, {&y}};
+  FakeGraph graph{{inner}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  std::string tmp_json = std::filesystem::temp_directory_path() / "qnn_unit_no_ext";
+  std::remove(tmp_json.c_str());
+
+  std::vector<std::string> in_names{"x"};
+  std::vector<std::string> out_names{"y"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, &out_names, &settings,
+                          nullptr, nullptr, tmp_json};
+
+  ASSERT_TRUE(ctx.model->ComposeGraph(mc).IsOK());
+  std::string log_file = tmp_json + "_tensor_log.json";  // path lacks "." → just appended
+  EXPECT_TRUE(std::filesystem::exists(log_file));
+  std::remove(tmp_json.c_str());
+  std::remove(log_file.c_str());
+}
+
+// json_qnn_graph_path that points to a non-existent directory — fopen fails,
+// exercises the else branch at LogTensorDetails line 820.
+TEST(QnnUnit_ModelTest, LogTensorDetails_InvalidJsonPath_CoversFileOpenFailure) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) GTEST_SKIP() << "HTP backend not available on this host";
+  InstallFakeGraphApiStubs(ctx.stub_ort_api);
+  OrtGlobalApiOverride api_override(&ctx.stub_ort_api);
+
+  FakeValueInfo x{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeValueInfo y{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode inner{"identity_0", "Identity", "", 13, {&x}, {&y}};
+  FakeGraph graph{{inner}, {&x}, {&y}, {}};
+  FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
+
+  // Directory path component does not exist → fopen returns nullptr.
+  std::string bad_json = "/nonexistent_dir_qnn_unit_test/graph.json";
+
+  std::vector<std::string> in_names{"x"};
+  std::vector<std::string> out_names{"y"};
+  qnn::ModelSettings settings{};
+  qnn::QnnModelContext mc{*graph.AsGraph(), *fused.AsNode(), ctx.logger,
+                          &in_names, &out_names, &settings,
+                          nullptr, nullptr, bad_json};
+
+  // ComposeGraph itself still succeeds (the JSON write failure is just a warning).
+  EXPECT_TRUE(ctx.model->ComposeGraph(mc).IsOK());
+}
+
+// ---------------------------------------------------------------------------
+// Sanity probe: confirm HTP SetupBackend succeeds on this host.
+// Skipped silently if HTP backend unavailable (e.g., aarch64 host without SDK).
+// ---------------------------------------------------------------------------
+TEST(QnnUnit_ModelTest, Probe_HtpSetupBackend_WorksOnX86_64) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) {
+    GTEST_SKIP() << "HTP backend not available on this host";
+  }
+  EXPECT_NE(ctx.model, nullptr);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_model_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_model_test.cc
@@ -310,7 +310,7 @@ TEST(QnnUnit_ModelTest, ComposeGraph_IdentityGraph_WithJsonPath_TriggersLogTenso
   FakeGraph graph{{inner}, {&x}, {&y}, {}};
   FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
 
-  std::string tmp_json = std::filesystem::temp_directory_path() / "qnn_unit_model_test_graph.json";
+  std::string tmp_json = (std::filesystem::temp_directory_path() / "qnn_unit_model_test_graph.json").string();
   std::remove(tmp_json.c_str());
 
   std::vector<std::string> in_names{"x"};
@@ -347,7 +347,7 @@ static void RunComposeGraphWithDtype(ONNXTensorElementDataType elem_type) {
   FakeGraph graph{{inner}, {&x}, {&y}, {}};
   FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
 
-  std::string tmp_json = std::filesystem::temp_directory_path() / "qnn_unit_model_test_dtype.json";
+  std::string tmp_json = (std::filesystem::temp_directory_path() / "qnn_unit_model_test_dtype.json").string();
   std::remove(tmp_json.c_str());
 
   std::vector<std::string> in_names{"x"};
@@ -405,7 +405,7 @@ TEST(QnnUnit_ModelTest, LogTensorDetails_JsonPathWithoutDot_CoversElseBranch) {
   FakeGraph graph{{inner}, {&x}, {&y}, {}};
   FakeNode fused{"fused", "QnnPartition_0", "", 13, {&x}, {&y}};
 
-  std::string tmp_json = std::filesystem::temp_directory_path() / "qnn_unit_no_ext";
+  std::string tmp_json = (std::filesystem::temp_directory_path() / "qnn_unit_no_ext").string();
   std::remove(tmp_json.c_str());
 
   std::vector<std::string> in_names{"x"};

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -757,7 +757,10 @@ TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_NoZeroPoint_Se
                           scale_vi, /*zp_vi=*/nullptr);
   QnnQuantParamsWrapper q;
   ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
-  // Without zp, is_int4_type is false → falls into per-tensor non-int4 path.
+  // Without a zp VI, Init() cannot determine the bitwidth from the IODef alone
+  // and treats the input as non-int4 (falls into the SCALE_OFFSET path). This is
+  // the intended behavior: is_int4_type is derived from the presence of an int4
+  // zp tensor, not from the ONNX element type alone.
   EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
   EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, 0);
 }

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -1,0 +1,1017 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Function-level unit tests for qnn_quant_params_wrapper.cc — QNN quantization
+// parameter wrapper covering all 5 supported encodings (per-tensor, per-channel,
+// LPBQ blockwise expansion, block encoding, BW float block encoding) plus deep
+// copy semantics, GetScales, axis-handling templated helpers, and the two
+// Init() overloads.
+//
+// Init(QnnModelWrapper, OrtNodeUnitIODef) is exercised via mock_init_registry —
+// stubs the OrtApi function pointers so UnpackScales / UnpackZeroPoints /
+// UnpackInitializerData succeed without a real ORT graph.
+
+#include "gtest/gtest.h"
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include "QnnTypes.h"
+
+#include "core/providers/qnn/builder/qnn_quant_params_wrapper.h"
+#include "core/providers/qnn/ort_api.h"
+
+#include "test/providers/qnn/unit/mock_init_registry.h"
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+using qnn::QnnQuantParamsWrapper;
+
+namespace {
+
+// Return a fresh per-channel non-int4 wrapper (3 channels at axis 1).
+// Useful as a starting state for tests that need to verify reset / re-init.
+QnnQuantParamsWrapper MakePerChannelNonInt4(int32_t axis = 1) {
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{1, 2, 3};
+  return QnnQuantParamsWrapper(gsl::make_span(scales),
+                               gsl::make_span(offsets),
+                               axis,
+                               /*is_int4=*/false);
+}
+
+QnnQuantParamsWrapper MakePerChannelInt4(int32_t axis = 1) {
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{1, 2, 3};
+  return QnnQuantParamsWrapper(gsl::make_span(scales),
+                               gsl::make_span(offsets),
+                               axis,
+                               /*is_int4=*/true);
+}
+
+QnnQuantParamsWrapper MakeLPBQ() {
+  // 3 per-channel scales, 2 blocks per axis ⇒ 6 per-block int scales.
+  const std::vector<float> per_channel_scales{0.1f, 0.2f, 0.3f};
+  const std::vector<uint8_t> per_block_scales{1, 2, 3, 4, 5, 6};
+  const std::vector<int32_t> offsets{0, 0, 0};
+  return QnnQuantParamsWrapper(gsl::make_span(per_channel_scales),
+                               gsl::make_span(per_block_scales),
+                               gsl::make_span(offsets),
+                               /*axis=*/1,
+                               /*block_size=*/4,
+                               /*is_int4=*/true);
+}
+
+QnnQuantParamsWrapper MakeBlockEncoding() {
+  const std::vector<float> scales{0.5f, 0.25f};
+  const std::vector<int32_t> offsets{1, 2};
+  const std::vector<uint32_t> block_sizes{2, 1};
+  return QnnQuantParamsWrapper(gsl::make_span(scales),
+                               gsl::make_span(offsets),
+                               gsl::make_span(block_sizes),
+                               QNN_DATATYPE_UFIXED_POINT_8);
+}
+
+QnnQuantParamsWrapper MakeBwFloatBlock() {
+  const std::vector<float> scales{0.5f, 0.25f};
+  const std::vector<float> offsets{0.0f, 0.1f};
+  const std::vector<uint32_t> block_sizes{2, 1};
+  return QnnQuantParamsWrapper(gsl::make_span(scales),
+                               gsl::make_span(offsets),
+                               /*bitwidth=*/8u,
+                               gsl::make_span(block_sizes));
+}
+
+}  // namespace
+
+// =============================================================================
+// Constructors
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, Default_NotQuantized_AndAllPredicatesFalse) {
+  QnnQuantParamsWrapper q;
+  EXPECT_FALSE(q.IsQuantized());
+  EXPECT_FALSE(q.IsPerTensor());
+  EXPECT_FALSE(q.IsPerTensor(/*include_bw=*/true));
+  EXPECT_FALSE(q.IsPerChannel());
+  EXPECT_FALSE(q.IsLPBQ());
+  EXPECT_FALSE(q.IsBlockQuantized());
+  EXPECT_EQ(q.Get().encodingDefinition, QNN_DEFINITION_UNDEFINED);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, PerTensor_SetsScaleOffsetEncodingAndScale) {
+  QnnQuantParamsWrapper q(/*scale=*/0.5f, /*offset=*/-3);
+  EXPECT_TRUE(q.IsQuantized());
+  EXPECT_TRUE(q.IsPerTensor());
+  EXPECT_FALSE(q.IsPerChannel());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.5f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -3);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     PerChannel_NotInt4_NonEmpty_SetsAxisScaleOffsetAndDeepCopiesData) {
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{1, 2, 3};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/2,
+                          /*is_int4=*/false);
+  EXPECT_TRUE(q.IsPerChannel());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 2);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.numScaleOffsets, 3u);
+  ASSERT_NE(q.Get().axisScaleOffsetEncoding.scaleOffset, nullptr);
+  for (size_t i = 0; i < scales.size(); ++i) {
+    EXPECT_FLOAT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[i].scale, scales[i]);
+    EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[i].offset, offsets[i]);
+  }
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, PerChannel_NotInt4_Empty_SetsNullScaleOffsetPointer) {
+  const std::vector<float> scales{};
+  const std::vector<int32_t> offsets{};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
+                          /*is_int4=*/false);
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.numScaleOffsets, 0u);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset, nullptr);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     PerChannel_Int4_NonEmpty_SetsBwAxisScaleOffsetAndDeepCopiesScalesAndOffsets) {
+  const std::vector<float> scales{0.1f, 0.2f};
+  const std::vector<int32_t> offsets{4, 5};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1,
+                          /*is_int4=*/true);
+  EXPECT_TRUE(q.IsPerChannel());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.axis, 1);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.bitwidth, 4u);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.numElements, 2u);
+  ASSERT_NE(q.Get().bwAxisScaleOffsetEncoding.scales, nullptr);
+  ASSERT_NE(q.Get().bwAxisScaleOffsetEncoding.offsets, nullptr);
+  for (size_t i = 0; i < scales.size(); ++i) {
+    EXPECT_FLOAT_EQ(q.Get().bwAxisScaleOffsetEncoding.scales[i], scales[i]);
+    EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.offsets[i], offsets[i]);
+  }
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, PerChannel_Int4_Empty_SetsNullScalesAndOffsetsPointers) {
+  const std::vector<float> scales{};
+  const std::vector<int32_t> offsets{};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
+                          /*is_int4=*/true);
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.numElements, 0u);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.scales, nullptr);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.offsets, nullptr);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, LPBQ_SetsBlockwiseExpansionAndDeepCopiesAllArrays) {
+  QnnQuantParamsWrapper q = MakeLPBQ();
+  EXPECT_TRUE(q.IsLPBQ());
+  EXPECT_FALSE(q.IsPerChannel());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION);
+
+  const Qnn_BlockwiseExpansion_t* lpbq = q.Get().blockwiseExpansion;
+  ASSERT_NE(lpbq, nullptr);
+  EXPECT_EQ(lpbq->axis, 1);
+  EXPECT_EQ(lpbq->numBlocksPerAxis, 2u);  // 6 block scales / 3 channels
+  EXPECT_EQ(lpbq->blockScaleBitwidth, 4u);
+  EXPECT_EQ(lpbq->blockScaleStorageType, QNN_BLOCKWISE_EXPANSION_BITWIDTH_SCALE_STORAGE_8);
+
+  ASSERT_NE(lpbq->scaleOffsets, nullptr);
+  EXPECT_FLOAT_EQ(lpbq->scaleOffsets[0].scale, 0.1f);
+  EXPECT_FLOAT_EQ(lpbq->scaleOffsets[1].scale, 0.2f);
+  EXPECT_FLOAT_EQ(lpbq->scaleOffsets[2].scale, 0.3f);
+  EXPECT_EQ(lpbq->scaleOffsets[0].offset, 0);
+
+  ASSERT_NE(lpbq->blocksScale8, nullptr);
+  for (uint32_t i = 0; i < 6; ++i) {
+    EXPECT_EQ(lpbq->blocksScale8[i], static_cast<uint8_t>(i + 1));
+  }
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, BlockQuant_BlockEncoding_SetsBlockSizesAndScaleOffsets) {
+  QnnQuantParamsWrapper q = MakeBlockEncoding();
+  EXPECT_TRUE(q.IsBlockQuantized());
+  EXPECT_FALSE(q.IsPerChannel());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BLOCK);
+
+  ASSERT_NE(q.Get().blockEncoding.blockSize, nullptr);
+  EXPECT_EQ(q.Get().blockEncoding.blockSize[0], 2u);
+  EXPECT_EQ(q.Get().blockEncoding.blockSize[1], 1u);
+
+  ASSERT_NE(q.Get().blockEncoding.scaleOffset, nullptr);
+  EXPECT_FLOAT_EQ(q.Get().blockEncoding.scaleOffset[0].scale, 0.5f);
+  EXPECT_EQ(q.Get().blockEncoding.scaleOffset[0].offset, 1);
+  EXPECT_FLOAT_EQ(q.Get().blockEncoding.scaleOffset[1].scale, 0.25f);
+  EXPECT_EQ(q.Get().blockEncoding.scaleOffset[1].offset, 2);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     BlockQuant_BwFloatBlockEncoding_SetsBitwidthAndFloatScaleOffsets) {
+  QnnQuantParamsWrapper q = MakeBwFloatBlock();
+  EXPECT_TRUE(q.IsBlockQuantized());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
+  EXPECT_EQ(q.Get().bwFloatBlockEncoding.bitwidth, 8u);
+
+  ASSERT_NE(q.Get().bwFloatBlockEncoding.blockSize, nullptr);
+  EXPECT_EQ(q.Get().bwFloatBlockEncoding.blockSize[0], 2u);
+  EXPECT_EQ(q.Get().bwFloatBlockEncoding.blockSize[1], 1u);
+
+  ASSERT_NE(q.Get().bwFloatBlockEncoding.floatScaleOffset, nullptr);
+  EXPECT_FLOAT_EQ(q.Get().bwFloatBlockEncoding.floatScaleOffset[0].scale, 0.5f);
+  EXPECT_FLOAT_EQ(q.Get().bwFloatBlockEncoding.floatScaleOffset[0].offset, 0.0f);
+  EXPECT_FLOAT_EQ(q.Get().bwFloatBlockEncoding.floatScaleOffset[1].scale, 0.25f);
+  EXPECT_FLOAT_EQ(q.Get().bwFloatBlockEncoding.floatScaleOffset[1].offset, 0.1f);
+}
+
+// =============================================================================
+// Copy / move semantics — drives both code paths in the copy ctor / operator=
+// (the IsLPBQ() and IsBlockQuantized() branches).
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_PerTensor_DeepCopies) {
+  QnnQuantParamsWrapper src(0.7f, 4);
+  QnnQuantParamsWrapper dst(src);
+  EXPECT_TRUE(dst.IsPerTensor());
+  EXPECT_FLOAT_EQ(dst.Get().scaleOffsetEncoding.scale, 0.7f);
+  EXPECT_EQ(dst.Get().scaleOffsetEncoding.offset, 4);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_PerChannelInt4_DeepCopies) {
+  QnnQuantParamsWrapper src = MakePerChannelInt4(/*axis=*/2);
+  const auto* src_scales_ptr = src.Get().bwAxisScaleOffsetEncoding.scales;
+  QnnQuantParamsWrapper dst(src);
+  // Pointers must differ — deep copy, not aliasing.
+  EXPECT_NE(dst.Get().bwAxisScaleOffsetEncoding.scales, src_scales_ptr);
+  EXPECT_EQ(dst.Get().bwAxisScaleOffsetEncoding.numElements, 3u);
+  EXPECT_FLOAT_EQ(dst.Get().bwAxisScaleOffsetEncoding.scales[0], 0.1f);
+  EXPECT_EQ(dst.Get().bwAxisScaleOffsetEncoding.axis, 2);
+  EXPECT_EQ(dst.Get().bwAxisScaleOffsetEncoding.bitwidth, 4u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_LPBQ_DeepCopies) {
+  QnnQuantParamsWrapper src = MakeLPBQ();
+  const auto* src_lpbq = src.Get().blockwiseExpansion;
+  QnnQuantParamsWrapper dst(src);
+  ASSERT_NE(dst.Get().blockwiseExpansion, nullptr);
+  EXPECT_NE(dst.Get().blockwiseExpansion, src_lpbq);
+  EXPECT_EQ(dst.Get().blockwiseExpansion->axis, 1);
+  EXPECT_EQ(dst.Get().blockwiseExpansion->numBlocksPerAxis, 2u);
+  EXPECT_FLOAT_EQ(dst.Get().blockwiseExpansion->scaleOffsets[1].scale, 0.2f);
+  EXPECT_EQ(dst.Get().blockwiseExpansion->blocksScale8[5], 6u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyCtor_BlockEncoding_DeepCopies) {
+  QnnQuantParamsWrapper src = MakeBlockEncoding();
+  const uint32_t* src_block_size = src.Get().blockEncoding.blockSize;
+  QnnQuantParamsWrapper dst(src);
+  EXPECT_NE(dst.Get().blockEncoding.blockSize, src_block_size);
+  EXPECT_EQ(dst.Get().blockEncoding.blockSize[0], 2u);
+  EXPECT_FLOAT_EQ(dst.Get().blockEncoding.scaleOffset[0].scale, 0.5f);
+  EXPECT_FLOAT_EQ(dst.Get().blockEncoding.scaleOffset[1].scale, 0.25f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_PerTensor_DeepCopies) {
+  QnnQuantParamsWrapper src(1.5f, -2);
+  QnnQuantParamsWrapper dst;
+  dst = src;
+  EXPECT_TRUE(dst.IsPerTensor());
+  EXPECT_FLOAT_EQ(dst.Get().scaleOffsetEncoding.scale, 1.5f);
+  EXPECT_EQ(dst.Get().scaleOffsetEncoding.offset, -2);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_LPBQ_DeepCopies) {
+  // Drives the IsLPBQ() branch inside operator=.
+  QnnQuantParamsWrapper src = MakeLPBQ();
+  QnnQuantParamsWrapper dst;
+  dst = src;
+  EXPECT_TRUE(dst.IsLPBQ());
+  ASSERT_NE(dst.Get().blockwiseExpansion, nullptr);
+  EXPECT_NE(dst.Get().blockwiseExpansion, src.Get().blockwiseExpansion);
+  EXPECT_EQ(dst.Get().blockwiseExpansion->numBlocksPerAxis, 2u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_BlockEncoding_DeepCopies) {
+  // Drives the IsBlockQuantized() branch inside operator=.
+  QnnQuantParamsWrapper src = MakeBlockEncoding();
+  QnnQuantParamsWrapper dst;
+  dst = src;
+  EXPECT_TRUE(dst.IsBlockQuantized());
+  EXPECT_NE(dst.Get().blockEncoding.blockSize, src.Get().blockEncoding.blockSize);
+  EXPECT_FLOAT_EQ(dst.Get().blockEncoding.scaleOffset[0].scale, 0.5f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, CopyAssign_SelfAssignment_LeavesUnchanged) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4();
+  const auto* original_scaleoffset_ptr = q.Get().axisScaleOffsetEncoding.scaleOffset;
+  q = q;  // NOLINT(clang-diagnostic-self-assign-overloaded)
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.numScaleOffsets, 3u);
+  // Pointer should be unchanged (self-assign early-out).
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset, original_scaleoffset_ptr);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, Copy_Method_ReturnsEquivalentDeepCopy) {
+  QnnQuantParamsWrapper src = MakePerChannelNonInt4(/*axis=*/3);
+  QnnQuantParamsWrapper dst = src.Copy();
+  EXPECT_NE(dst.Get().axisScaleOffsetEncoding.scaleOffset,
+            src.Get().axisScaleOffsetEncoding.scaleOffset);
+  EXPECT_EQ(dst.Get().axisScaleOffsetEncoding.axis, 3);
+  EXPECT_EQ(dst.Get().axisScaleOffsetEncoding.numScaleOffsets, 3u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, MoveCtor_TransfersOwnership) {
+  QnnQuantParamsWrapper src = MakePerChannelNonInt4();
+  const auto* src_ptr = src.Get().axisScaleOffsetEncoding.scaleOffset;
+  QnnQuantParamsWrapper dst(std::move(src));
+  // Moved-to object owns the buffer.
+  EXPECT_EQ(dst.Get().axisScaleOffsetEncoding.scaleOffset, src_ptr);
+  EXPECT_EQ(dst.Get().axisScaleOffsetEncoding.numScaleOffsets, 3u);
+}
+
+// =============================================================================
+// Predicates
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, IsPerTensor_IncludeBwTrue_AcceptsBwScaleOffset) {
+  // Construct a BW_SCALE_OFFSET encoding via Init from raw.
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET;
+  raw.bwScaleOffsetEncoding.bitwidth = 4;
+  raw.bwScaleOffsetEncoding.scale = 0.5f;
+  raw.bwScaleOffsetEncoding.offset = 1;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_TRUE(q.IsPerTensor(/*include_bw=*/true));
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, IsPerTensor_IncludeBwFalse_RejectsBwScaleOffset) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_FALSE(q.IsPerTensor(/*include_bw=*/false));
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, IsPerChannel_AcceptsBothAxisAndBwAxisEncodings) {
+  QnnQuantParamsWrapper non_int4 = MakePerChannelNonInt4();
+  QnnQuantParamsWrapper int4 = MakePerChannelInt4();
+  EXPECT_TRUE(non_int4.IsPerChannel());
+  EXPECT_TRUE(int4.IsPerChannel());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, IsLPBQ_OnlyForBlockwiseExpansion) {
+  QnnQuantParamsWrapper lpbq = MakeLPBQ();
+  QnnQuantParamsWrapper per_channel = MakePerChannelNonInt4();
+  EXPECT_TRUE(lpbq.IsLPBQ());
+  EXPECT_FALSE(per_channel.IsLPBQ());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, IsBlockQuantized_AcceptsBlockAndBwFloatBlock) {
+  QnnQuantParamsWrapper block = MakeBlockEncoding();
+  QnnQuantParamsWrapper bw_float_block = MakeBwFloatBlock();
+  QnnQuantParamsWrapper per_tensor(0.5f, 0);
+  EXPECT_TRUE(block.IsBlockQuantized());
+  EXPECT_TRUE(bw_float_block.IsBlockQuantized());
+  EXPECT_FALSE(per_tensor.IsBlockQuantized());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, Predicates_FalseWhenEncodingDefinitionUndefined) {
+  QnnQuantParamsWrapper q;  // default = UNDEFINED.
+  EXPECT_FALSE(q.IsQuantized());
+  EXPECT_FALSE(q.IsPerTensor());
+  EXPECT_FALSE(q.IsPerChannel());
+  EXPECT_FALSE(q.IsLPBQ());
+  EXPECT_FALSE(q.IsBlockQuantized());
+}
+
+// =============================================================================
+// GetScales — covers all 5 encoding cases plus the default-error path.
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_Undefined_ReturnsError) {
+  QnnQuantParamsWrapper q;
+  std::vector<float> out;
+  Ort::Status status = q.GetScales(out);
+  EXPECT_FALSE(status.IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_ScaleOffset_ReturnsSingleScalar) {
+  QnnQuantParamsWrapper q(0.25f, 0);
+  std::vector<float> out;
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_FLOAT_EQ(out[0], 0.25f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_BwScaleOffset_ReturnsSingleScalar) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET;
+  raw.bwScaleOffsetEncoding.bitwidth = 4;
+  raw.bwScaleOffsetEncoding.scale = 0.125f;
+  raw.bwScaleOffsetEncoding.offset = 0;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  std::vector<float> out;
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_FLOAT_EQ(out[0], 0.125f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_AxisScaleOffset_ReturnsAllScales) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4();
+  std::vector<float> out;
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  ASSERT_EQ(out.size(), 3u);
+  EXPECT_FLOAT_EQ(out[0], 0.1f);
+  EXPECT_FLOAT_EQ(out[1], 0.2f);
+  EXPECT_FLOAT_EQ(out[2], 0.3f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_AxisScaleOffset_NumElemsZero_ReturnsEmpty) {
+  const std::vector<float> scales{};
+  const std::vector<int32_t> offsets{};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), 0,
+                          /*is_int4=*/false);
+  std::vector<float> out{1.0f, 2.0f};  // Pre-existing content should be cleared.
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  EXPECT_TRUE(out.empty());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_BwAxisScaleOffset_ReturnsAllScales) {
+  QnnQuantParamsWrapper q = MakePerChannelInt4();
+  std::vector<float> out;
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  ASSERT_EQ(out.size(), 3u);
+  EXPECT_FLOAT_EQ(out[0], 0.1f);
+  EXPECT_FLOAT_EQ(out[2], 0.3f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_BwAxisScaleOffset_NumElemsZero_ReturnsEmpty) {
+  const std::vector<float> scales{};
+  const std::vector<int32_t> offsets{};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), 0,
+                          /*is_int4=*/true);
+  std::vector<float> out{1.0f};
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  EXPECT_TRUE(out.empty());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_BlockEncoding_ReturnsAllBlockScales) {
+  QnnQuantParamsWrapper q = MakeBlockEncoding();
+  std::vector<float> out;
+  ASSERT_TRUE(q.GetScales(out).IsOK());
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_FLOAT_EQ(out[0], 0.5f);
+  EXPECT_FLOAT_EQ(out[1], 0.25f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, GetScales_UnsupportedEncoding_ReturnsError) {
+  // BLOCKWISE_EXPANSION is intentionally NOT a case in GetScales' switch.
+  QnnQuantParamsWrapper q = MakeLPBQ();
+  std::vector<float> out;
+  EXPECT_FALSE(q.GetScales(out).IsOK());
+}
+
+// =============================================================================
+// Init(Qnn_QuantizeParams_t, num_scaleoffsets, tensor_rank) — 7 encoding cases
+// + UNDEFINED early-return + unsupported-encoding error + reset-when-prior-init.
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_Undefined_CopiesParamsOnly) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_UNDEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_UNDEFINED;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_FALSE(q.IsQuantized());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_ScaleOffset_CopiesShallow) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_SCALE_OFFSET;
+  raw.scaleOffsetEncoding.scale = 0.875f;
+  raw.scaleOffsetEncoding.offset = 7;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_TRUE(q.IsPerTensor());
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.875f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, 7);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_BwScaleOffset_CopiesShallow) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET;
+  raw.bwScaleOffsetEncoding.bitwidth = 8;
+  raw.bwScaleOffsetEncoding.scale = 0.0625f;
+  raw.bwScaleOffsetEncoding.offset = -1;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().bwScaleOffsetEncoding.bitwidth, 8u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_AxisScaleOffset_NonEmpty_DeepCopiesScaleOffset) {
+  std::vector<Qnn_ScaleOffset_t> src_data(2);
+  src_data[0].scale = 0.1f;
+  src_data[0].offset = 1;
+  src_data[1].scale = 0.2f;
+  src_data[1].offset = 2;
+
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET;
+  raw.axisScaleOffsetEncoding.axis = 1;
+  raw.axisScaleOffsetEncoding.numScaleOffsets = 2;
+  raw.axisScaleOffsetEncoding.scaleOffset = src_data.data();
+
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  // Pointer should differ — deep copy.
+  EXPECT_NE(q.Get().axisScaleOffsetEncoding.scaleOffset, src_data.data());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.numScaleOffsets, 2u);
+  EXPECT_FLOAT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[1].scale, 0.2f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_AxisScaleOffset_Empty_SetsNullScaleOffset) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET;
+  raw.axisScaleOffsetEncoding.axis = 0;
+  raw.axisScaleOffsetEncoding.numScaleOffsets = 0;
+  raw.axisScaleOffsetEncoding.scaleOffset = nullptr;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset, nullptr);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_BwAxisScaleOffset_NonEmpty_DeepCopiesArrays) {
+  std::vector<float> src_scales{0.1f, 0.2f};
+  std::vector<int32_t> src_offsets{3, 4};
+
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET;
+  raw.bwAxisScaleOffsetEncoding.axis = 1;
+  raw.bwAxisScaleOffsetEncoding.bitwidth = 4;
+  raw.bwAxisScaleOffsetEncoding.numElements = 2;
+  raw.bwAxisScaleOffsetEncoding.scales = src_scales.data();
+  raw.bwAxisScaleOffsetEncoding.offsets = src_offsets.data();
+
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_NE(q.Get().bwAxisScaleOffsetEncoding.scales, src_scales.data());
+  EXPECT_NE(q.Get().bwAxisScaleOffsetEncoding.offsets, src_offsets.data());
+  EXPECT_FLOAT_EQ(q.Get().bwAxisScaleOffsetEncoding.scales[0], 0.1f);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.offsets[1], 4);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.bitwidth, 4u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_BwAxisScaleOffset_Empty_SetsNullArrays) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET;
+  raw.bwAxisScaleOffsetEncoding.axis = 0;
+  raw.bwAxisScaleOffsetEncoding.numElements = 0;
+  raw.bwAxisScaleOffsetEncoding.scales = nullptr;
+  raw.bwAxisScaleOffsetEncoding.offsets = nullptr;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.scales, nullptr);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.offsets, nullptr);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     InitFromRaw_BlockwiseExpansion_DeepCopiesScaleOffsetsAndBlockScales) {
+  // Re-init from an already-built LPBQ wrapper's params — exercises the
+  // BLOCKWISE_EXPANSION case in Init().
+  QnnQuantParamsWrapper src = MakeLPBQ();
+  QnnQuantParamsWrapper dst;
+  ASSERT_TRUE(dst.Init(src.Get(), /*num_scaleoffsets=*/3, /*tensor_rank=*/0).IsOK());
+  EXPECT_TRUE(dst.IsLPBQ());
+  EXPECT_NE(dst.Get().blockwiseExpansion, src.Get().blockwiseExpansion);
+  EXPECT_EQ(dst.Get().blockwiseExpansion->numBlocksPerAxis, 2u);
+  EXPECT_EQ(dst.Get().blockwiseExpansion->blocksScale8[0], 1u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_BlockEncoding_DeepCopiesAxisAndScaleOffsets) {
+  QnnQuantParamsWrapper src = MakeBlockEncoding();
+  QnnQuantParamsWrapper dst;
+  ASSERT_TRUE(dst.Init(src.Get(), /*num_scaleoffsets=*/2, /*tensor_rank=*/2).IsOK());
+  EXPECT_TRUE(dst.IsBlockQuantized());
+  EXPECT_EQ(dst.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BLOCK);
+  EXPECT_NE(dst.Get().blockEncoding.blockSize, src.Get().blockEncoding.blockSize);
+  EXPECT_EQ(dst.Get().blockEncoding.blockSize[0], 2u);
+  EXPECT_FLOAT_EQ(dst.Get().blockEncoding.scaleOffset[1].scale, 0.25f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     InitFromRaw_BwFloatBlockEncoding_DeepCopiesAxisAndFloatScaleOffsets) {
+  QnnQuantParamsWrapper src = MakeBwFloatBlock();
+  QnnQuantParamsWrapper dst;
+  ASSERT_TRUE(dst.Init(src.Get(), /*num_scaleoffsets=*/2, /*tensor_rank=*/2).IsOK());
+  EXPECT_EQ(dst.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
+  EXPECT_EQ(dst.Get().bwFloatBlockEncoding.bitwidth, 8u);
+  EXPECT_FLOAT_EQ(dst.Get().bwFloatBlockEncoding.floatScaleOffset[1].offset, 0.1f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_UnsupportedEncoding_ReturnsError) {
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_VECTOR;  // not in the switch.
+  QnnQuantParamsWrapper q;
+  EXPECT_FALSE(q.Init(raw).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromRaw_AfterPriorPerChannelInit_ResetsThenRecopies) {
+  // Start in per-channel state so per_channel_data_ is non-null.
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4();
+  ASSERT_NE(q.Get().axisScaleOffsetEncoding.scaleOffset, nullptr);
+
+  // Re-init with a per-tensor encoding; per_channel_data_ must be reset.
+  Qnn_QuantizeParams_t raw = QNN_QUANTIZE_PARAMS_INIT;
+  raw.encodingDefinition = QNN_DEFINITION_DEFINED;
+  raw.quantizationEncoding = QNN_QUANTIZATION_ENCODING_SCALE_OFFSET;
+  raw.scaleOffsetEncoding.scale = 0.99f;
+  raw.scaleOffsetEncoding.offset = 0;
+  ASSERT_TRUE(q.Init(raw).IsOK());
+  EXPECT_TRUE(q.IsPerTensor());
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.99f);
+}
+
+// =============================================================================
+// Init(QnnModelWrapper, OrtNodeUnitIODef) — uses mock_init_registry.
+// =============================================================================
+
+namespace {
+
+// Build a wrapper + register a per-tensor scale/zp pair.
+struct PerTensorIODefFixture {
+  OrtApiStubContext ctx;
+  QNN_INTERFACE_VER_TYPE qnn_interface = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t backend_handle = nullptr;
+  QNN_INTERFACE_VER_TYPE qnn_validator_interface = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t validator_backend_handle = nullptr;
+  Ort::Logger null_logger_{MakeNullLogger()};
+  int fake_graph_sentinel_{};
+  qnn::GraphInputOutputInfo input_info;
+  qnn::GraphInputOutputInfo output_info;
+  std::unique_ptr<qnn::QnnModelWrapper> wrapper;
+
+  PerTensorIODefFixture() {
+    g_mock_init_reg.clear();
+    SetupMockInitRegistryStubs(ctx);
+    ApiPtrs api_ptrs = ctx.MakeApiPtrs();
+    const OrtGraph& fake_graph = *reinterpret_cast<const OrtGraph*>(&fake_graph_sentinel_);
+    wrapper = std::make_unique<qnn::QnnModelWrapper>(
+        fake_graph, api_ptrs, null_logger_,
+        qnn_interface, backend_handle,
+        qnn_validator_interface, validator_backend_handle,
+        input_info, output_info,
+        qnn::QnnBackendType::HTP, qnn::ModelSettings{});
+  }
+};
+
+OrtNodeUnitIODef MakeIODef(const std::string& name,
+                           ONNXTensorElementDataType type,
+                           std::vector<int64_t> shape,
+                           const OrtValueInfo* scale_vi,
+                           const OrtValueInfo* zp_vi,
+                           std::optional<int64_t> axis = std::nullopt) {
+  OrtNodeUnitIODef io_def;
+  io_def.name = name;
+  io_def.type = type;
+  io_def.shape = std::optional<std::vector<int64_t>>(std::move(shape));
+  io_def.quant_param = OrtNodeUnitIODef::QuantParam{scale_vi, zp_vi, axis};
+  return io_def;
+}
+
+}  // namespace
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_NoQuantParam_SetsUndefined) {
+  PerTensorIODefFixture fx;
+  OrtNodeUnitIODef io_def;
+  io_def.name = "in";
+  io_def.type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  io_def.shape = std::optional<std::vector<int64_t>>{{1, 4}};
+  io_def.quant_param = std::nullopt;
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_FALSE(q.IsQuantized());
+  EXPECT_EQ(q.Get().encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_UNDEFINED);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_NotInt4_SetsScaleOffsetEncoding) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {}, {0.1f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {}, {static_cast<uint8_t>(5)});
+  auto io_def = MakeIODef("in", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4}, scale_vi, zp_vi);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.1f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -5);  // QNN flips the sign.
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_NotInt4_NoZeroPoint_SetsZeroOffset) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {}, {0.1f});
+  auto io_def = MakeIODef("in", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4},
+                          scale_vi, /*zp_vi=*/nullptr);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, 0);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_SetsBwScaleOffsetEncoding) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {}, {0.0625f});
+  auto zp_vi = g_mock_init_reg.AddTensorInt4As8bit("zp", {}, {static_cast<int8_t>(0)});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 4}, scale_vi, zp_vi);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().bwScaleOffsetEncoding.bitwidth, 4u);
+  EXPECT_FLOAT_EQ(q.Get().bwScaleOffsetEncoding.scale, 0.0625f);
+  EXPECT_EQ(q.Get().bwScaleOffsetEncoding.offset, 0);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_NoZeroPoint_SetsZeroOffset) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {}, {0.0625f});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 4},
+                          scale_vi, /*zp_vi=*/nullptr);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  // Without zp, is_int4_type is false → falls into per-tensor non-int4 path.
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, 0);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     InitFromIODef_PerChannel_NotInt4_SetsAxisScaleOffsetEncoding) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.1f, 0.2f, 0.3f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {3}, {1, 2, 3});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4},
+                          scale_vi, zp_vi, /*axis=*/1);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 1);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.numScaleOffsets, 3u);
+  EXPECT_FLOAT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[0].scale, 0.1f);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[2].offset, -3);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     InitFromIODef_PerChannel_NotInt4_NoZeroPoint_FillsOffsetsZero) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.1f, 0.2f, 0.3f});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 3, 4, 4},
+                          scale_vi, /*zp_vi=*/nullptr, /*axis=*/1);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[0].offset, 0);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[1].offset, 0);
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.scaleOffset[2].offset, 0);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerChannel_Int4_SetsBwAxisScaleOffsetEncoding) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.0625f, 0.125f, 0.25f});
+  auto zp_vi = g_mock_init_reg.AddTensorInt4As8bit("zp", {3}, {0, 0, 0});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 3, 4, 4},
+                          scale_vi, zp_vi, /*axis=*/1);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.bitwidth, 4u);
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.numElements, 3u);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     InitFromIODef_PerChannel_NoZeroPoint_FillsOffsetsZero_Int4) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.0625f, 0.125f, 0.25f});
+  // No zp_vi → is_int4_type = false → falls into the non-int4 per-channel branch.
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 3, 4, 4},
+                          scale_vi, /*zp_vi=*/nullptr, /*axis=*/1);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerChannel_NegativeAxis_NormalisesToPositive) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.1f, 0.2f, 0.3f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {3}, {0, 0, 0});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4},
+                          scale_vi, zp_vi, /*axis=*/-3);  // -3 + rank 4 = 1
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 1);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerChannelInt4_NegativeAxis_NormalisesToPositive) {
+  // Per-channel INT4 path has its own negative-axis normalisation block
+  // separate from the non-int4 path. Both must be covered.
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.0625f, 0.125f, 0.25f});
+  auto zp_vi = g_mock_init_reg.AddTensorInt4As8bit("zp", {3}, {0, 0, 0});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 3, 4, 4},
+                          scale_vi, zp_vi, /*axis=*/-3);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.axis, 1);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerChannel_AxisOutOfRange_ReturnsError) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.1f, 0.2f, 0.3f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {3}, {0, 0, 0});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3},
+                          scale_vi, zp_vi, /*axis=*/5);  // rank = 2
+  QnnQuantParamsWrapper q;
+  EXPECT_FALSE(q.Init(*fx.wrapper, io_def).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerChannel_ScaleZpSizeMismatch_ReturnsError) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.1f, 0.2f, 0.3f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {2}, {0, 0});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4},
+                          scale_vi, zp_vi, /*axis=*/1);
+  QnnQuantParamsWrapper q;
+  EXPECT_FALSE(q.Init(*fx.wrapper, io_def).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_AfterPriorPerChannelInit_ResetsState) {
+  // Drives the `if (per_channel_data_) { reset(); params_ = INIT; }` head of
+  // Init(io_def): first call leaves per_channel_data_ non-null, second call
+  // must reset it before re-initialising.
+  PerTensorIODefFixture fx;
+
+  auto pc_scale = g_mock_init_reg.AddTensorFloat("pc_scale", {3}, {0.1f, 0.2f, 0.3f});
+  auto pc_zp = g_mock_init_reg.AddTensorUint8("pc_zp", {3}, {0, 0, 0});
+  auto pt_scale = g_mock_init_reg.AddTensorFloat("pt_scale", {}, {0.5f});
+  auto pt_zp = g_mock_init_reg.AddTensorUint8("pt_zp", {}, {static_cast<uint8_t>(7)});
+
+  auto io_def_pc = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4},
+                             pc_scale, pc_zp, /*axis=*/1);
+  auto io_def_pt = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4},
+                             pt_scale, pt_zp, std::nullopt);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def_pc).IsOK());
+  ASSERT_TRUE(q.IsPerChannel());
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def_pt).IsOK());
+  EXPECT_TRUE(q.IsPerTensor());
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.5f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -7);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_MultiZp_ReturnsError) {
+  // Per-tensor INT4 path expects exactly one zero-point. A multi-element INT4
+  // zp tensor with a scalar scale exercises the `zero_points.size() == 1`
+  // guard inside the BW_SCALE_OFFSET branch.
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {}, {0.0625f});
+  auto zp_vi = g_mock_init_reg.AddTensorInt4As8bit("zp", {2}, {0, 0});
+  auto io_def = MakeIODef("w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 4}, scale_vi, zp_vi);
+  QnnQuantParamsWrapper q;
+  EXPECT_FALSE(q.Init(*fx.wrapper, io_def).IsOK());
+}
+
+// =============================================================================
+// Templated handlers — header-defined, NOT counted toward .cc coverage but
+// tested for behavioural completeness.
+//
+// Use the SAME type instantiations as production: `uint32_t` for both helpers
+// (matmul_op_builder.cc, conv_op_builder.cc, instancenormalization, etc.) plus
+// `size_t` for HandleTranspose (conv_op_builder.cc:233 — perm_inv is size_t).
+// gcov tracks each template instantiation as a separate function, so testing
+// with `int32_t` / `int64_t` would not register hits for production-instantiated
+// types.
+//
+// HandleUnsqueeze's "unhandled encoding" inner branch is unreachable from the
+// public API (the IsPerChannel() early-return prevents any non-AXIS encoding
+// from getting that far); we do not test that dead-on-public-surface branch.
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_NotPerChannel_NoOp) {
+  QnnQuantParamsWrapper q(0.5f, 0);
+  std::vector<uint32_t> perm{0, 1, 2, 3};
+  EXPECT_TRUE(q.HandleTranspose<uint32_t>(gsl::make_span(perm)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_AxisScaleOffset_RemapsAxis) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4(/*axis=*/1);
+  std::vector<uint32_t> perm{0, 2, 3, 1};  // moves dim-1 to position 3
+  ASSERT_TRUE(q.HandleTranspose<uint32_t>(gsl::make_span(perm)).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 2);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_BwAxisScaleOffset_RemapsAxis) {
+  QnnQuantParamsWrapper q = MakePerChannelInt4(/*axis=*/2);
+  std::vector<uint32_t> perm{0, 1, 3, 2};
+  ASSERT_TRUE(q.HandleTranspose<uint32_t>(gsl::make_span(perm)).IsOK());
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.axis, 3);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_AxisOutOfRange_ReturnsError) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4(/*axis=*/5);
+  std::vector<uint32_t> perm{0, 1, 2};  // perm.size() == 3, axis = 5 → OOR
+  EXPECT_FALSE(q.HandleTranspose<uint32_t>(gsl::make_span(perm)).IsOK());
+}
+
+// Mirror conv_op_builder.cc:233 — production instantiates HandleTranspose with
+// size_t (perm_inv is a vector<size_t> there). Each instantiation is a separate
+// function in gcov, so we test it explicitly.
+TEST(QnnUnit_QuantParamsWrapperTest, HandleTranspose_SizeT_RemapsAxis) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4(/*axis=*/1);
+  std::vector<size_t> perm{0, 2, 3, 1};
+  ASSERT_TRUE(q.HandleTranspose<size_t>(gsl::make_span(perm)).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 2);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_NotPerChannel_NoOp) {
+  QnnQuantParamsWrapper q(0.5f, 0);
+  std::vector<uint32_t> orig{4, 5};
+  std::vector<uint32_t> nu{1, 4, 5};
+  EXPECT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_RankNotIncreased_ReturnsError) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4(/*axis=*/0);
+  std::vector<uint32_t> orig{3, 4};
+  std::vector<uint32_t> nu{3, 4};  // same size — error
+  EXPECT_FALSE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleUnsqueeze_AxisScaleOffset_ShiftsWhenOnesInsertedBefore) {
+  // Per-channel along axis 1 of a {3, 4} tensor; unsqueeze to {1, 3, 4} should
+  // move the per-channel axis from 1 to 2.
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{0, 0, 0};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1,
+                          /*is_int4=*/false);
+  std::vector<uint32_t> orig{3, 4};
+  std::vector<uint32_t> nu{1, 3, 4};
+  ASSERT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 2);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleUnsqueeze_BwAxisScaleOffset_ShiftsWhenOnesInsertedBefore) {
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{0, 0, 0};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
+                          /*is_int4=*/true);
+  std::vector<uint32_t> orig{3};
+  std::vector<uint32_t> nu{1, 3};
+  ASSERT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.axis, 1);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_NoShiftNeeded_LeavesAxisUnchanged) {
+  // axis=0; new shape {3, 1, 4} appends 1 *after* the per-channel axis ⇒ axis stays at 0.
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{0, 0, 0};
+  QnnQuantParamsWrapper q(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/0,
+                          /*is_int4=*/false);
+  std::vector<uint32_t> orig{3, 4};
+  std::vector<uint32_t> nu{3, 1, 4};
+  ASSERT_TRUE(q.HandleUnsqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 0);
+}
+
+// `Get() const` overload — only reachable from a const-context call site.
+// All other tests use a non-const wrapper and therefore call the non-const
+// overload (line 49 in the header). Without this test the const-Get line
+// would be header coverage's only genuine gap.
+TEST(QnnUnit_QuantParamsWrapperTest, ConstGet_ReturnsSameParamsAsNonConst) {
+  const QnnQuantParamsWrapper q(0.5f, -2);
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.5f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -2);
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_unit_test_utils.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_unit_test_utils.h
@@ -64,6 +64,36 @@ inline Ort::Logger MakeNullLogger() {
   return logger;
 }
 
+// OrtGlobalApiOverride
+//
+// RAII guard that replaces the global Ort::GetApi() with a caller-supplied
+// OrtApi for the duration of the scope, then restores the original on
+// destruction.
+//
+// Why this is needed: Ort::ConstNode / Ort::ConstValueInfo / Ort::ConstGraph
+// wrappers call OrtApi function pointers via the global Ort::GetApi(), not
+// through api_ptrs_. Tests that pass fake OrtNode*/OrtGraph* pointers to EP
+// code must override the global so that wrapper calls route through stubs
+// rather than the real ORT runtime (which dereferences fake pointers and
+// SIGSEGVs). Process-wide global; gtest runs tests sequentially so this is
+// safe, but do not use two overrides simultaneously in the same thread.
+class OrtGlobalApiOverride {
+ public:
+  explicit OrtGlobalApiOverride(const OrtApi* new_api) {
+    original_ = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+    Ort::detail::Global::Api(new_api);
+  }
+  ~OrtGlobalApiOverride() { Ort::detail::Global::Api(original_); }
+
+  OrtGlobalApiOverride(const OrtGlobalApiOverride&) = delete;
+  OrtGlobalApiOverride& operator=(const OrtGlobalApiOverride&) = delete;
+  OrtGlobalApiOverride(OrtGlobalApiOverride&&) = delete;
+  OrtGlobalApiOverride& operator=(OrtGlobalApiOverride&&) = delete;
+
+ private:
+  const OrtApi* original_ = nullptr;
+};
+
 // Reusable OrtApi stub tables for function-level unit tests.
 //
 // Holds the three stub structs (OrtApi / OrtEpApi / OrtModelEditorApi) that any

--- a/onnxruntime/test/providers/qnn/unit/qnn_unit_test_utils.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_unit_test_utils.h
@@ -77,6 +77,14 @@ inline Ort::Logger MakeNullLogger() {
 // rather than the real ORT runtime (which dereferences fake pointers and
 // SIGSEGVs). Process-wide global; gtest runs tests sequentially so this is
 // safe, but do not use two overrides simultaneously in the same thread.
+//
+// Implementation note: uses Ort::detail::Global::Api(), which is declared in
+// the public onnxruntime_cxx_api.h header (not a private "core/" include).
+// Ort::InitApi() — the intended public setter — is only available when
+// ORT_API_MANUAL_INIT is defined; ort_api.h suppresses that macro in
+// unit-test builds so all TUs agree on static initialisation. This helper
+// is test-only (gated by QNN_EP_INTERNAL_SYMBOL_ACCESS) and must be
+// re-verified if ORT uplevels and changes the detail::Global layout.
 class OrtGlobalApiOverride {
  public:
   explicit OrtGlobalApiOverride(const OrtApi* new_api) {


### PR DESCRIPTION
 ###  Summary
  
  Phase 2 unit test coverage for two core QNN EP components, building on the function-level UT infrastructure.

 | Component  | Unit-only coverage |
 |---|---|  
 | qnn_quant_params_wrapper.cc  | 99.5% |
 | qnn_model.cc  | 90.7% |    


  **What's added**

  unit/qnn_quant_params_wrapper_test.cc — covers Init() for all quantization flavors (per-tensor, per-channel, block-quant) and helper methods. Uses mock_init_registry.h to inject typed initializer data via OrtApi stubs without an ORT
  session.

  unit/qnn_model_test.cc (48 tests) — covers ComposeGraph, FinalizeGraphs, SetupQnnInputOutput, LogTensorDetails, DeserializeGraphInfoFromBinaryInfo against a real QNN CPU backend on host.

  For graphFinalize/graphExecute failure paths: a real QNN CPU backend always returns success for a well-formed graph, so these error branches cannot be triggered naturally. Rather than building a mock backend .so,
  OverrideQnnInterfaceForTest() (added to qnn_backend_manager.h, gated by QNN_EP_FUNCTION_LEVEL_UT) lets a test copy the live QNN function table, patch one function pointer to return a controlled error code, and push it back after
  SetupBackend has already established a valid context.

  test/providers/qnn/qnn_model_test.cc — integration test covering LogTensorDetails constant-initializer paths that require a full Gemm compile+execute pipeline.

  **Test plan**

  - generate_coverage.sh --test-filter='QnnUnit_*' → qnn_quant_params_wrapper.cc ≥ 99%, qnn_model.cc ≥ 91%
  - onnxruntime_provider_test --gtest_filter='QnnUnit_QuantParamsWrapperTest.*' — all pass
  - onnxruntime_provider_test --gtest_filter='QnnUnit_ModelTest.*' — all pass (or SKIP if libQnnCpu.so absent)
  - onnxruntime_provider_test --gtest_filter='QnnCPUBackendTests.CompileModel_WithConstantWeights' — passes on host with CPU backend


