### PR TITLE
[QNN EP] Don't set count_pad_for_edges for GlobalAveragePool

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -428,8 +428,8 @@ Ort::Status PoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                         qnn_output_shape));
   }
 
-  qnn_pool_params.count_pad_for_edges = is_avg_pool &&
-                                        (is_global_pool || node_helper.Get("count_include_pad", static_cast<int64_t>(0)) != 0);
+  qnn_pool_params.count_pad_for_edges =
+      is_avg_pool && node_helper.Get("count_include_pad", static_cast<int64_t>(0)) != 0;
 
   std::vector<std::string> param_tensor_names;
   RETURN_IF_ERROR(AddQnnPoolParamWrappers(node_unit,


### PR DESCRIPTION
### Description

For `GlobalAveragePool`, the QNN op builder was setting `count_pad_for_edges = true`. This change removes that, so the flag is driven only by the ONNX `count_include_pad` attribute on `AveragePool`.

### Motivation and Context

`GlobalAveragePool` has no padding and no `count_include_pad` attribute, so `count_pad_for_edges` should be `false`. The DLC emitted by QNN EP now matches the one produced by native for the same model.