### PR TITLE
[QNN EP] Minor fixes in building Linux x86 Wheels

### DIFF
--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -158,7 +158,7 @@ Environment variables
         "--target-py-version",
         choices=["3.10", "3.11", "3.12", "3.13", "3.14", "None"],
         default="3.10" if is_host_linux() else "3.12",
-        help="[Windows only] Build a wheel for this version of Python",
+        help="Build a wheel for this version of Python",
     )
     parser.add_argument(
         "--venv-path",

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ else:
     ]
     libs.extend(qnn_deps)
 
-if is_manylinux:
+if is_manylinux or platform.system() == "Linux":
     data = list(dl_libs)
 else:
     data = list(libs)


### PR DESCRIPTION
### Description

- Drops the `is_manylinux` gate in `setup.py` so the QAIRT runtime libs (`libQnnCpu.so`, `libQnnHtp.so`, …) are bundled into the wheel even when the build is not running inside a manylinux container. Without this, the linux x86_64 wheel only shipped `libonnxruntime_providers_qnn.so` and was unusable at runtime.
- Change the help definition of `qcom/build_and_test.py` which specified the wheel can only be built on Windows.