### PR TITLE
[QNN EP] Add ReduceLogSumExp op support

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -434,6 +434,7 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:RandomUniformLike||
 |ai.onnx:Reciprocal||
 |ai.onnx:ReduceL2||
+|ai.onnx:ReduceLogSumExp|Decomposed into ReduceMax->Sub->Exp->ReduceSum->Log->Add. Quantized input not supported.|
 |ai.onnx:ReduceMax||
 |ai.onnx:ReduceMean||
 |ai.onnx:ReduceMin||

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -56,6 +56,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateRandomUniformLikeOpBuilder("RandomUniformLike", *this);
   CreateReciprocalOpBuilder("Reciprocal", *this);
   CreateReduceOpBuilder("ReduceL2", *this);
+  CreateReduceOpBuilder("ReduceLogSumExp", *this);
   CreateReduceOpBuilder("ReduceMax", *this);
   CreateReduceOpBuilder("ReduceMean", *this);
   CreateReduceOpBuilder("ReduceMin", *this);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -23,6 +23,7 @@ enum ReduceOpType {
   REDUCE_OP_TYPE_PROD,
   REDUCE_OP_TYPE_SUM,
   REDUCE_OP_TYPE_L2,
+  REDUCE_OP_TYPE_LOG_SUM_EXP,
 
   REDUCE_OP_TYPE_COUNT,
   REDUCE_OP_TYPE_UNKNOWN,
@@ -41,6 +42,8 @@ ReduceOpType GetReduceOpType(const std::string& op_type) {
     return REDUCE_OP_TYPE_SUM;
   } else if (op_type == "ReduceL2") {
     return REDUCE_OP_TYPE_L2;
+  } else if (op_type == "ReduceLogSumExp") {
+    return REDUCE_OP_TYPE_LOG_SUM_EXP;
   } else {
     return REDUCE_OP_TYPE_UNKNOWN;
   }
@@ -81,6 +84,7 @@ const std::array<int, REDUCE_OP_TYPE_COUNT> ReduceOpBuilder::opset_with_axes_as_
     18,  // ReduceProd
     13,  // ReduceSum
     18,  // ReduceL2
+    18,  // ReduceLogSumExp
 };
 
 Ort::Status ReduceOpBuilder::GetAxesSet(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
@@ -172,6 +176,16 @@ Ort::Status ReduceOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, c
   RETURN_IF(reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_L2 && node_unit.Inputs()[0].quant_param.has_value(),
             "QNN EP: ReduceL2 operator does not support quantized input for now.");
 
+  if (reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_LOG_SUM_EXP) {
+    RETURN_IF(node_unit.Inputs()[0].quant_param.has_value(),
+              "QNN EP: ReduceLogSumExp operator does not support quantized input.");
+    ONNXTensorElementDataType input_type = node_unit.Inputs()[0].type;
+    RETURN_IF(input_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT &&
+                  input_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 &&
+                  input_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16,
+              "QNN EP: ReduceLogSumExp operator only supports float input dtypes.");
+  }
+
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
 }
 
@@ -219,9 +233,11 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   //
   // Handle keepdims param.
   //
-  auto onnx_keepdims = node_attr_helper.Get("keepdims", (int32_t)1);
-  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), onnx_keepdims != 0,
-                                     QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, param_tensor_names));
+  const int32_t onnx_keepdims = node_attr_helper.Get("keepdims", (int32_t)1);
+  if (node_unit.OpType() != "ReduceLogSumExp") {
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), onnx_keepdims != 0,
+                                       QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, param_tensor_names));
+  }
 
   if (node_unit.OpType() == "ReduceL2") {
     // If ReduceL2, QNN doesn't have a single Op for it, we need to add a
@@ -291,6 +307,151 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                                   std::move(sqrt_param_names),
                                                   do_op_validation),
                   "CreateQnnNode failed");
+  } else if (node_unit.OpType() == "ReduceLogSumExp") {
+    // Decompose ReduceLogSumExp(x, axes, keepdims) numerically-stably as:
+    //   m       = ReduceMax(x, axes, keepdims=True)
+    //   result  = Add(Log(ReduceSum(Exp(Sub(x, m)), axes, keepdims=True)), m)
+    //   output  = result if user keepdims=True else Reshape(result, output_shape)
+    // Subtracting per-axis max keeps Exp in (0, 1] so the chain is numerically safe on FP16.
+    // All intermediate reduce outputs use keepdims=True so shapes line up without scalar tensors.
+    const auto& input = node_unit.Inputs()[0];
+    const auto& output = node_unit.Outputs()[0];
+    std::vector<uint32_t> input_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape), "Cannot get input shape.");
+    std::vector<uint32_t> output_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.shape, output_shape), "Cannot get output shape.");
+    RETURN_IF(input.quant_param.has_value(), "Input tensor must not be quantized.");
+    Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
+    RETURN_IF_ERROR(utils::GetQnnDataType(false, output.type, qnn_data_type));
+    const std::string input_name = input_names[0];
+
+    // kept_shape: input shape with reduced axes set to 1 (full input rank). All internal reduce/elementwise
+    // outputs share this shape, so broadcasting and the final Add work without rank mismatches.
+    std::set<AxesOnnxIntType> axes_set;
+    RETURN_IF_ERROR(GetAxesSet(qnn_model_wrapper, node_unit, axes_set));
+    std::vector<uint32_t> kept_shape = input_shape;
+    for (auto ax : axes_set) {
+      RETURN_IF_NOT(ax >= 0 && static_cast<size_t>(ax) < input_shape.size(),
+                    "QNN EP: ReduceLogSumExp axis out of range.");
+      kept_shape[static_cast<size_t>(ax)] = 1;
+    }
+
+    // Reuse the user's axes param (already in param_tensor_names[0]) for both inner ReduceMax and ReduceSum.
+    const std::string user_axes_param_name = param_tensor_names[0];
+
+    // Build a separate keep_dims=True param for the inner reduces.
+    std::vector<std::string> kd_true_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_inner",
+                                       true, QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, kd_true_param_names));
+    const std::string kd_true_param_name = kd_true_param_names[0];
+
+    const bool needs_reshape = (onnx_keepdims == 0);
+
+    // Step 1: m = ReduceMax(x, axes=user, keepdims=True).
+    const std::string max_output_name = utils::UniqueNameGenerator().New(input_name, "_max");
+    QnnTensorWrapper max_tensorwrapper(max_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(kept_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(max_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_REDUCE_MAX),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_REDUCE_MAX,
+                                                  {input_name},
+                                                  {max_output_name},
+                                                  {user_axes_param_name, kd_true_param_name},
+                                                  do_op_validation),
+                  "CreateQnnNode failed");
+
+    // Step 2: d = Sub(x, m).
+    const std::string sub_output_name = utils::UniqueNameGenerator().New(input_name, "_normalized");
+    QnnTensorWrapper sub_tensorwrapper(sub_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(input_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sub_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_SUBTRACT),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_SUBTRACT,
+                                                  {input_name, max_output_name},
+                                                  {sub_output_name},
+                                                  {},
+                                                  do_op_validation),
+                  "CreateQnnNode failed");
+
+    // Step 3: e = Exp(d).
+    const std::string exp_output_name = utils::UniqueNameGenerator().New(input_name, "_exp");
+    QnnTensorWrapper exp_tensorwrapper(exp_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(input_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(exp_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_EXP),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_EXP,
+                                                  {sub_output_name},
+                                                  {exp_output_name},
+                                                  {},
+                                                  do_op_validation),
+                  "CreateQnnNode failed");
+
+    // Step 4: s = ReduceSum(e, axes=user, keepdims=True).
+    const std::string reduce_sum_output_name = utils::UniqueNameGenerator().New(input_name, "_sum");
+    QnnTensorWrapper reduce_sum_tensorwrapper(reduce_sum_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type,
+                                              QnnQuantParamsWrapper(), std::vector<uint32_t>(kept_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reduce_sum_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_REDUCE_SUM),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_REDUCE_SUM,
+                                                  {exp_output_name},
+                                                  {reduce_sum_output_name},
+                                                  {user_axes_param_name, kd_true_param_name},
+                                                  do_op_validation),
+                  "CreateQnnNode failed");
+
+    // Step 5: l = Log(s).
+    const std::string log_output_name = utils::UniqueNameGenerator().New(input_name, "_log");
+    QnnTensorWrapper log_tensorwrapper(log_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(kept_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(log_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_LOG),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_LOG,
+                                                  {reduce_sum_output_name},
+                                                  {log_output_name},
+                                                  {},
+                                                  do_op_validation),
+                  "CreateQnnNode failed");
+
+    // Step 6: result_kept = Add(l, m). Both have kept_shape, no broadcast.
+    const std::string add_output_name = needs_reshape
+                                            ? utils::UniqueNameGenerator().New(input_name, "_kept")
+                                            : output.name;
+    Qnn_TensorType_t add_output_tensor_type =
+        (!needs_reshape && qnn_model_wrapper.IsGraphOutput(output.name)) ? QNN_TENSOR_TYPE_APP_READ
+                                                                         : QNN_TENSOR_TYPE_NATIVE;
+    QnnTensorWrapper add_tensorwrapper(add_output_name, add_output_tensor_type, qnn_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(kept_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_ADD),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_ADD,
+                                                  {log_output_name, max_output_name},
+                                                  {add_output_name},
+                                                  {},
+                                                  do_op_validation),
+                  "CreateQnnNode failed");
+
+    // Step 7 (only when user keepdims=False): squeeze the reduced axes via Reshape.
+    if (needs_reshape) {
+      Qnn_TensorType_t output_tensor_type =
+          qnn_model_wrapper.IsGraphOutput(output.name) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+      QnnTensorWrapper reshape_tensorwrapper(output.name, output_tensor_type, qnn_data_type, QnnQuantParamsWrapper(),
+                                             std::move(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reshape_tensorwrapper)), "AddTensorWrapper failed");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_RESHAPE),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                    QNN_OP_RESHAPE,
+                                                    {add_output_name},
+                                                    {output.name},
+                                                    {},
+                                                    do_op_validation),
+                    "CreateQnnNode failed");
+    }
   } else {
     RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names),
                                    std::move(param_tensor_names), logger, do_op_validation,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -327,8 +327,6 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
     // kept_shape: input shape with reduced axes set to 1 (full input rank). All internal reduce/elementwise
     // outputs share this shape, so broadcasting and the final Add work without rank mismatches.
-    std::set<AxesOnnxIntType> axes_set;
-    RETURN_IF_ERROR(GetAxesSet(qnn_model_wrapper, node_unit, axes_set));
     std::vector<uint32_t> kept_shape = input_shape;
     for (auto ax : axes_set) {
       RETURN_IF_NOT(ax >= 0 && static_cast<size_t>(ax) < input_shape.size(),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -320,7 +320,6 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape), "Cannot get input shape.");
     std::vector<uint32_t> output_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.shape, output_shape), "Cannot get output shape.");
-    RETURN_IF(input.quant_param.has_value(), "Input tensor must not be quantized.");
     Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
     RETURN_IF_ERROR(utils::GetQnnDataType(false, output.type, qnn_data_type));
     const std::string input_name = input_names[0];

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -339,7 +339,8 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
     // Build a separate keep_dims=True param for the inner reduces.
     std::vector<std::string> kd_true_param_names;
-    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_inner",
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(),
+                                       utils::UniqueNameGenerator().New(node_unit, "_inner"),
                                        true, QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, kd_true_param_names));
     const std::string kd_true_param_name = kd_true_param_names[0];
 

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1617,6 +1617,7 @@ void OrtSelectorManager::CreateSelectors() {
       {"LogSoftmax", {}},
       {"LpNormalization", {}},
       {"Neg", {}},
+      {"ReduceLogSumExp", {}},
       {"ReduceMax", {}},
       {"ReduceMean", {}},
       {"ReduceMin", {}},

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.cc
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.cc
@@ -832,6 +832,7 @@ bool ReduceOpHasAxesInput(const std::string& op_type, int opset_version) {
       {"ReduceProd", 18},
       {"ReduceSum", 13},
       {"ReduceL2", 18},
+      {"ReduceLogSumExp", 18},
   };
 
   const auto it = opset_with_axes_as_input.find(op_type);

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -335,6 +335,65 @@ TEST_F(QnnCPUBackendTests, ReduceL2Opset13) {
                        ExpectedEPNodeAssignment::All);
 }
 
+//
+// ReduceLogSumExp
+//
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset18) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 2}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset18_NoKeepDims) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 3, 4}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{1, 2},
+                       false,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset18_NegativeAxes) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 3, 4}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{-1},
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset13) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 2}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{0, 1},
+                       true,  // keepdims
+                       13,
+                       ExpectedEPNodeAssignment::All);
+}
+
+// Empty axes input -> reduce over all axes (ONNX default when noop_with_empty_axes=0).
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset18_DefaultAllAxes) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 3, 4}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{},  // empty -> reduce all
+                       true,                    // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All);
+}
+
+// Rank-1 input covers the degenerate kept_shape path.
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset18_Rank1) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({5}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{0},
+                       false,  // keepdims=False exercises the trailing Reshape
+                       18,
+                       ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 // Test creates a graph with a ReduceSum node, and checks that all nodes are supported by the QNN EP
@@ -733,6 +792,86 @@ TEST_F(QnnHTPBackendTests, ReduceMeanS8Opset18) {
                              18,            // opset
                              ExpectedEPNodeAssignment::All);
 }
+
+//
+// ReduceLogSumExp on HTP
+//
+
+// Disabled: ReduceLogSumExp is not in the QDQ unary selector (qnn_ep_utils.cc), so the QDQ
+// pattern is not collapsed into a single NodeUnit. The Reduce's input never carries quant_param,
+// the IsOpSupported quant-param guard cannot fire, and the standalone Q/DQ nodes are claimed
+// individually -> num_ep_nodes = 5, not 0. Re-enable if/when ReduceLogSumExp is added to the
+// QDQ unary selector list.
+TEST_F(QnnHTPBackendTests, DISABLED_ReduceLogSumExpU8Opset18_Rejected) {
+  RunReduceOpQDQTest<uint8_t>("ReduceLogSumExp",
+                              TestInputDef<float>({2, 2}, false, GetFloatDataInRange(-5.0f, 5.0f, 4)),
+                              {0, 1},  // axes
+                              true,    // keepdims
+                              18,
+                              ExpectedEPNodeAssignment::None);
+}
+
+// FP16 basic test.
+TEST_F(QnnHTPBackendTests, ReduceLogSumExpOpset18_FP16) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 3, 4}, false, -5.0f, 5.0f),
+                       {1, 2},  // axes
+                       true,    // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All,
+                       3e-2f,
+                       true);  // enable_fp16
+}
+
+// FP16 stability regression: input magnitudes around 30 would overflow naive log(sum(exp(x))) on FP16
+// (FP16 max exp arg ~= 11). The decomposition uses x - max(x) before exp, so values stay in (0, 1].
+TEST_F(QnnHTPBackendTests, ReduceLogSumExpOpset18_FP16_LargeInput) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 4}, false, 20.0f, 30.0f),
+                       {1},   // axes
+                       true,  // keepdims
+                       18,
+                       ExpectedEPNodeAssignment::All,
+                       1e-1f,
+                       true);  // enable_fp16
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+static void RunReduceLogSumExpHTPBF16Test(const TestInputDef<float>& input_def,
+                                          const std::vector<int64_t>& axes,
+                                          bool keepdims,
+                                          int opset,
+                                          ExpectedEPNodeAssignment expected_ep_assignment,
+                                          float tolerance = 0.01f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["htp_bf16_enable"] = "1";
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildReduceOpTestCase<float>("ReduceLogSumExp",
+                                               input_def,
+                                               ReduceOpHasAxesInput("ReduceLogSumExp", opset),
+                                               axes,
+                                               keepdims,
+                                               false),  // noop_with_empty_axes
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  tolerance);
+}
+
+TEST_F(QnnHTPBackendTests, ReduceLogSumExp_HTP_BF16_KeepDims) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V79);
+  RunReduceLogSumExpHTPBF16Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-5.0f, 5.0f, 6)),
+                                {1, 2},  // axes
+                                true,    // keepdims
+                                18,
+                                ExpectedEPNodeAssignment::All);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -797,12 +797,7 @@ TEST_F(QnnHTPBackendTests, ReduceMeanS8Opset18) {
 // ReduceLogSumExp on HTP
 //
 
-// Disabled: ReduceLogSumExp is not in the QDQ unary selector (qnn_ep_utils.cc), so the QDQ
-// pattern is not collapsed into a single NodeUnit. The Reduce's input never carries quant_param,
-// the IsOpSupported quant-param guard cannot fire, and the standalone Q/DQ nodes are claimed
-// individually -> num_ep_nodes = 5, not 0. Re-enable if/when ReduceLogSumExp is added to the
-// QDQ unary selector list.
-TEST_F(QnnHTPBackendTests, DISABLED_ReduceLogSumExpU8Opset18_Rejected) {
+TEST_F(QnnHTPBackendTests, ReduceLogSumExpU8Opset18_Rejected) {
   RunReduceOpQDQTest<uint8_t>("ReduceLogSumExp",
                               TestInputDef<float>({2, 2}, false, GetFloatDataInRange(-5.0f, 5.0f, 4)),
                               {0, 1},  // axes

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -374,6 +374,15 @@ TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset13) {
                        ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset13_NoKeepDims) {
+  RunReduceTest<float>("ReduceLogSumExp",
+                       TestInputDef<float>({2, 3, 4}, false, -5.0f, 5.0f),
+                       std::vector<int64_t>{1},
+                       false,  // keepdims=False exercises the trailing Reshape on the opset-13 path
+                       13,
+                       ExpectedEPNodeAssignment::All);
+}
+
 // Empty axes input -> reduce over all axes (ONNX default when noop_with_empty_axes=0).
 TEST_F(QnnCPUBackendTests, ReduceLogSumExpOpset18_DefaultAllAxes) {
   RunReduceTest<float>("ReduceLogSumExp",


### PR DESCRIPTION
  ### Description

Adds `ReduceLogSumExp` to QNN EP. 

### Decomposition

Before
 Y = ReduceLogSumExp(X, axes, keepdims)

After
  m = ReduceMax(X, axes, keepdims=True)
  Y = log( ReduceSum( exp(X − m), axes, keepdims ) ) + m

  Subtracting `m` keeps `exp(...)` in `(0, 1]` so the chain is FP16-safe.

  ### Motivation & Context

  Without this, every `ReduceLogSumExp` node falls back to CPU and partitions the graph.

  ONNX spec: https://onnx.ai/onnx/operators/onnx__ReduceLogSumExp.html
  
  ### Opset support

  | Opset    | `axes` location      | `noop_with_empty_axes` | Status     | Tested at |
  |----------|----------------------|------------------------|------------|-----------|
  | 1 – 12   | attribute            | n/a                    | supported  | —         |
  | 13 – 17  | attribute            | n/a                    | supported  | opset 13  |
  | 18+      | optional input       | supported (`0` only)   | supported  | opset 18  |

  ### Tests

  | Backend | dtypes | Cases |
  |---|---|---|
  | CPU | FP32 | opset 13 / 18, keepdims on/off, negative axes, default-all-axes, rank-1 |
  | HTP | FP16 | basic + FP16-overflow regression (input magnitudes ~30) |
  | HTP | BF16 (V81+ ARM64) | keepdims |