### PR TITLE
add transpose-gather-transpose node group

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -5,6 +5,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
@@ -67,40 +68,6 @@ Ort::Status GatherOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   return BaseOpBuilder::IsOpSupported(qnn_model_wrapper, node_unit, logger);
 }
 
-// Makes negative indices positive and converts int64 indices to another integer type (typically int32 or uint32).
-// The input and output are both represented as byte arrays.
-template <typename SrcType, typename DstType>
-static bool MakeStaticIndicesPositiveAndValidate(const std::vector<uint8_t>& onnx_bytes,
-                                                 int64_t input0_axis_dim,
-                                                 /*out*/ std::vector<uint8_t>& qnn_bytes,
-                                                 /*out*/ bool* has_negative_indices) {
-  const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
-  gsl::span<const SrcType> onnx_indices{reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
-
-  qnn_bytes.resize(num_elems * sizeof(DstType));
-  gsl::span<DstType> qnn_indices{reinterpret_cast<DstType*>(qnn_bytes.data()), num_elems};
-
-  for (size_t i = 0; i < num_elems; i++) {
-    SrcType onnx_index = onnx_indices[i];
-
-    // Try to make a negative index positive by adding rank.
-    if (onnx_index < 0) {
-      if (has_negative_indices != nullptr) {
-        *has_negative_indices = true;
-      }
-      onnx_index += static_cast<SrcType>(input0_axis_dim);
-    }
-
-    if (onnx_index < 0 || static_cast<int64_t>(onnx_index) >= input0_axis_dim) {
-      return false;  // QNN does not support out-of-bounds indices.
-    }
-
-    qnn_indices[i] = static_cast<DstType>(onnx_index);
-  }
-
-  return true;
-}
-
 // Gets the size of input0 on the axis dimension.
 static Ort::Status GetInput0AxisDimValue(const QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
@@ -154,15 +121,15 @@ static Ort::Status ProcessIndicesInput(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(indices_info.initializer_tensor, onnx_indices_bytes));
 
     if (indices_info.qnn_data_type == QNN_DATATYPE_INT_64) {
-      RETURN_IF_NOT((MakeStaticIndicesPositiveAndValidate<int64_t, int32_t>(onnx_indices_bytes, input0_axis_dim,
-                                                                            qnn_indices_bytes,
-                                                                            &has_negative_indices)),
+      RETURN_IF_NOT((utils::MakeStaticIndicesPositiveAndValidate<int64_t, int32_t>(onnx_indices_bytes, input0_axis_dim,
+                                                                                   qnn_indices_bytes,
+                                                                                   &has_negative_indices)),
                     "QNN does not support negative index values for Gather* ops");
       indices_info.qnn_data_type = QNN_DATATYPE_INT_32;
     } else if (indices_info.qnn_data_type == QNN_DATATYPE_INT_32) {
-      RETURN_IF_NOT((MakeStaticIndicesPositiveAndValidate<int32_t, int32_t>(onnx_indices_bytes, input0_axis_dim,
-                                                                            qnn_indices_bytes,
-                                                                            &has_negative_indices)),
+      RETURN_IF_NOT((utils::MakeStaticIndicesPositiveAndValidate<int32_t, int32_t>(onnx_indices_bytes, input0_axis_dim,
+                                                                                   qnn_indices_bytes,
+                                                                                   &has_negative_indices)),
                     "QNN does not support negative index values for Gather* ops");
     } else {
       qnn_indices_bytes = std::move(onnx_indices_bytes);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/normalize_indices_utils.h
@@ -32,6 +32,40 @@ bool NormalizeIndicesBytes(gsl::span<const uint8_t> onnx_bytes,
                            std::vector<uint8_t>& qnn_bytes,
                            bool& has_negative_indices);
 
+// Makes negative indices positive and converts indices to another integer type
+// (typically int32 or uint32) over a single axis dimension. Returns false on
+// out-of-range index. Inputs and outputs are byte arrays.
+template <typename SrcType, typename DstType>
+bool MakeStaticIndicesPositiveAndValidate(const std::vector<uint8_t>& onnx_bytes,
+                                          int64_t input0_axis_dim,
+                                          /*out*/ std::vector<uint8_t>& qnn_bytes,
+                                          /*out*/ bool* has_negative_indices) {
+  const size_t num_elems = onnx_bytes.size() / sizeof(SrcType);
+  gsl::span<const SrcType> onnx_indices{reinterpret_cast<const SrcType*>(onnx_bytes.data()), num_elems};
+
+  qnn_bytes.resize(num_elems * sizeof(DstType));
+  gsl::span<DstType> qnn_indices{reinterpret_cast<DstType*>(qnn_bytes.data()), num_elems};
+
+  for (size_t i = 0; i < num_elems; i++) {
+    SrcType onnx_index = onnx_indices[i];
+
+    if (onnx_index < 0) {
+      if (has_negative_indices != nullptr) {
+        *has_negative_indices = true;
+      }
+      onnx_index += static_cast<SrcType>(input0_axis_dim);
+    }
+
+    if (onnx_index < 0 || static_cast<int64_t>(onnx_index) >= input0_axis_dim) {
+      return false;  // QNN does not support out-of-bounds indices.
+    }
+
+    qnn_indices[i] = static_cast<DstType>(onnx_index);
+  }
+
+  return true;
+}
+
 // Registers the indices tensor; for dynamic INT_64 inputs, inserts a
 // runtime Cast(INT_32) so downstream QNN ops see INT_32.
 Ort::Status AddNormalizedIndicesTensor(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -29,6 +29,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_rank5.h"
 #include "core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/transpose_reshape_transpose_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/transpose_gather_transpose_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/udo_fusion.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -99,7 +100,8 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"ReduceMean", {LayerNormFusion::TryFusion}},
     {"Einsum", {ReshapeEinsumReshapeNodeGroup::TryFusion}},
     {"Reshape", {SpaceToDepthFusion::TryFusion, Rank6ToRank5Fusion::TryFusion}},
-    {"Transpose", {ChannelShuffleFusion::TryFusion, TransposeReshapeTransposeFusion::TryFusion}}};
+    // {"Transpose", {ChannelShuffleFusion::TryFusion, TransposeReshapeTransposeFusion::TryFusion}}};
+    {"Transpose", {ChannelShuffleFusion::TryFusion, TransposeReshapeTransposeFusion::TryFusion, TransposeGatherTransposeFusion::TryFusion}}};
 
 void registerUDO(const std::string& node_type, const std::string& op_package) {
   std::function<std::unique_ptr<IQnnNodeGroup>(QnnModelWrapper & qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/transpose_gather_transpose_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/transpose_gather_transpose_fusion.cc
@@ -1,0 +1,344 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_node_group/transpose_gather_transpose_fusion.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <gsl/gsl>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/normalize_indices_utils.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace {
+
+constexpr char kAttrTransposePerm[] = "perm";
+constexpr char kOpTranspose[] = "Transpose";
+constexpr char kOpGather[] = "Gather";
+
+using MapNodeToNodeUnit = std::unordered_map<const OrtNode*, const OrtNodeUnit*>;
+using MapNodeUnitToGroup = std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>;
+
+std::optional<std::vector<int64_t>> GetTransposePerm(const OrtNodeUnit& transpose) {
+  if (transpose.OpType() != kOpTranspose) {
+    return std::nullopt;
+  }
+  OrtNodeAttrHelper helper(transpose);
+  return helper.Get(kAttrTransposePerm, std::vector<int64_t>());
+}
+
+// Match the pattern: Transpose -> Gather -> Transpose, all SingleNode, no QDQ wrapping.
+std::optional<std::array<const OrtNodeUnit*, 3>> MatchPattern(
+    const QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& transpose1,
+    const MapNodeToNodeUnit& node_to_node_unit,
+    const MapNodeUnitToGroup& node_unit_to_qnn_node_group) {
+  if (transpose1.OpType() != kOpTranspose ||
+      transpose1.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return std::nullopt;
+  }
+
+  const std::array<std::string_view, 1> gather_types{kOpGather};
+  const OrtNodeUnit* gather = GetOnlyChildOfType(qnn_model_wrapper, transpose1, gather_types,
+                                                 node_to_node_unit, node_unit_to_qnn_node_group);
+  if (gather == nullptr || gather->UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return std::nullopt;
+  }
+
+  const std::array<std::string_view, 1> transpose_types{kOpTranspose};
+  const OrtNodeUnit* transpose2 = GetOnlyChildOfType(qnn_model_wrapper, *gather, transpose_types,
+                                                     node_to_node_unit, node_unit_to_qnn_node_group);
+  if (transpose2 == nullptr || transpose2->UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return std::nullopt;
+  }
+
+  return std::array<const OrtNodeUnit*, 3>{&transpose1, gather, transpose2};
+}
+
+// Validate that perm2 cancels (perm1 + Gather) so that the whole pattern is equivalent to
+// Gather(x, indices, axis=perm1[gather_axis]).
+bool IsCancelingPair(const std::vector<int64_t>& perm1,
+                     const std::vector<int64_t>& perm2,
+                     int64_t gather_axis,
+                     int64_t indices_rank) {
+  const int64_t n = static_cast<int64_t>(perm1.size());
+  if (n <= 0) return false;
+  if (gather_axis < 0 || gather_axis >= n) return false;
+  if (indices_rank < 0) return false;
+  const int64_t out_rank = n - 1 + indices_rank;
+  if (static_cast<int64_t>(perm2.size()) != out_rank) return false;
+
+  // Sanity check: perm1 is a permutation of [0, n).
+  std::vector<bool> seen(static_cast<size_t>(n), false);
+  for (int64_t v : perm1) {
+    if (v < 0 || v >= n || seen[static_cast<size_t>(v)]) return false;
+    seen[static_cast<size_t>(v)] = true;
+  }
+
+  const int64_t fused_axis = perm1[static_cast<size_t>(gather_axis)];
+
+  // Build the inverse mapping: for each desired source position in the final
+  // output, find the index in g that holds it.
+  //
+  //   data_axis_to_g[d] = index in g that holds data axis d
+  //   indices_dim_to_g[k] = A + k
+  std::vector<int64_t> data_axis_to_g(static_cast<size_t>(n), -1);
+  for (int64_t i = 0; i < n; ++i) {
+    if (i == gather_axis) continue;
+    const int64_t g_pos = (i < gather_axis) ? i : (i + indices_rank - 1);
+    data_axis_to_g[static_cast<size_t>(perm1[static_cast<size_t>(i)])] = g_pos;
+  }
+
+  // Walk the desired output dim by dim and check that perm2 picks the right g index.
+  int64_t out_idx = 0;
+  for (int64_t d = 0; d < fused_axis; ++d, ++out_idx) {
+    if (perm2[static_cast<size_t>(out_idx)] != data_axis_to_g[static_cast<size_t>(d)]) return false;
+  }
+  for (int64_t k = 0; k < indices_rank; ++k, ++out_idx) {
+    if (perm2[static_cast<size_t>(out_idx)] != gather_axis + k) return false;
+  }
+  for (int64_t d = fused_axis + 1; d < n; ++d, ++out_idx) {
+    if (perm2[static_cast<size_t>(out_idx)] != data_axis_to_g[static_cast<size_t>(d)]) return false;
+  }
+
+  // If every position matched, perm2 was forced to be a valid permutation of [0, out_rank):
+  // each expected value is unique (data axes via the perm1-injective data_axis_to_g, indices
+  // via gather_axis + k for k in [0, indices_rank)) and they cover [0, out_rank) exactly.
+  return out_idx == out_rank;
+}
+
+Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
+                                  gsl::span<const OrtNodeUnit* const> node_units,
+                                  int32_t fused_axis,
+                                  bool validate,
+                                  const Ort::Logger& logger) {
+  const OrtNodeUnit* transpose1 = node_units[0];
+  const OrtNodeUnit* gather = node_units[1];
+  const OrtNodeUnit* transpose2 = node_units[2];
+
+  const OrtNodeUnitIODef& x_def = transpose1->Inputs()[0];   // input to transpose1 (= input to fused Gather)
+  const OrtNodeUnitIODef& idx_def = gather->Inputs()[1];     // gather indices
+  const OrtNodeUnitIODef& y_def = transpose2->Outputs()[0];  // final output
+
+  // Resolve the axis dim from the original (pre-transpose1) input shape.
+  std::vector<uint32_t> x_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(x_def.shape, x_shape),
+                "Failed to read input shape for TransposeGatherTransposeFusion.");
+  RETURN_IF_NOT(fused_axis >= 0 && static_cast<size_t>(fused_axis) < x_shape.size(),
+                "Fused axis out of range for TransposeGatherTransposeFusion.");
+  const int64_t axis_dim = static_cast<int64_t>(x_shape[static_cast<size_t>(fused_axis)]);
+
+  // Output info (final fused Gather output uses transpose2's output shape/quant).
+  TensorInfo y_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(y_def, y_info));
+
+  // Build the fused Gather inputs: x_def passed through unchanged; indices statically prepared.
+  // 1. x tensor: reuse existing wrapper if present, otherwise create from the def.
+  if (!qnn_model_wrapper.IsQnnTensorWrapperExist(x_def.name)) {
+    QnnTensorWrapper x_wrapper;
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(x_def, x_wrapper));
+    if (!validate) {
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(x_wrapper)),
+                    "Failed to add input tensor for TransposeGatherTransposeFusion.");
+    }
+  } else {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("Tensor already added, skip it: " + x_def.name).c_str());
+  }
+
+  // 2. Indices tensor: must be a constant initializer. Convert int64 -> int32 if needed
+  //    and resolve negative indices against the axis dim of x_def.
+  TensorInfo idx_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(idx_def, idx_info));
+  RETURN_IF_NOT(idx_info.is_initializer,
+                "TransposeGatherTransposeFusion requires constant Gather indices.");
+
+  std::vector<uint8_t> onnx_idx_bytes;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(idx_info.initializer_tensor, onnx_idx_bytes));
+
+  std::vector<uint8_t> qnn_idx_bytes;
+  Qnn_DataType_t idx_qnn_type = idx_info.qnn_data_type;
+  if (idx_qnn_type == QNN_DATATYPE_INT_64) {
+    RETURN_IF_NOT((utils::MakeStaticIndicesPositiveAndValidate<int64_t, int32_t>(
+                      onnx_idx_bytes, axis_dim, qnn_idx_bytes, /*has_negative_indices=*/nullptr)),
+                  "TransposeGatherTransposeFusion: failed to convert int64 indices to int32.");
+    idx_qnn_type = QNN_DATATYPE_INT_32;
+  } else if (idx_qnn_type == QNN_DATATYPE_INT_32) {
+    RETURN_IF_NOT((utils::MakeStaticIndicesPositiveAndValidate<int32_t, int32_t>(
+                      onnx_idx_bytes, axis_dim, qnn_idx_bytes, /*has_negative_indices=*/nullptr)),
+                  "TransposeGatherTransposeFusion: indices out of range.");
+  } else {
+    return MAKE_EP_FAIL("TransposeGatherTransposeFusion: unsupported indices data type.");
+  }
+
+  // Use a unique indices tensor name so the static buffer attaches cleanly to the fused Gather
+  // and does not collide with the original ONNX initializer reference.
+  const std::string fused_idx_name = utils::UniqueNameGenerator().New(*gather, "_tgt_idx");
+  if (!validate) {
+    QnnTensorWrapper idx_wrapper(fused_idx_name,
+                                 QNN_TENSOR_TYPE_STATIC,
+                                 idx_qnn_type,
+                                 QnnQuantParamsWrapper(),
+                                 std::vector<uint32_t>(idx_info.shape),
+                                 std::move(qnn_idx_bytes));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(idx_wrapper)),
+                  "Failed to add indices tensor for TransposeGatherTransposeFusion.");
+  }
+
+  // 3. Output tensor: shape from transpose2's output.
+  Qnn_TensorType_t out_tensor_type = qnn_model_wrapper.IsGraphOutput(y_def.name)
+                                         ? QNN_TENSOR_TYPE_APP_READ
+                                         : QNN_TENSOR_TYPE_NATIVE;
+  if (!validate) {
+    QnnTensorWrapper y_wrapper(y_def.name,
+                               out_tensor_type,
+                               y_info.qnn_data_type,
+                               y_info.quant_param.Copy(),
+                               std::vector<uint32_t>(y_info.shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(y_wrapper)),
+                  "Failed to add output tensor for TransposeGatherTransposeFusion.");
+  }
+
+  // 4. Axis param.
+  Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
+  axis_scalar.dataType = QNN_DATATYPE_INT_32;
+  axis_scalar.int32Value = fused_axis;
+  QnnParamWrapper axis_param(gather->Index(), gather->Name(), QNN_OP_GATHER_PARAM_AXIS, axis_scalar);
+  std::string axis_param_name = axis_param.GetParamTensorName();
+
+  if (validate) {
+    // Build transient wrappers for validation only.
+    QnnTensorWrapper x_wrapper;
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(x_def, x_wrapper));
+    QnnTensorWrapper idx_wrapper(fused_idx_name,
+                                 QNN_TENSOR_TYPE_STATIC,
+                                 idx_qnn_type,
+                                 QnnQuantParamsWrapper(),
+                                 std::vector<uint32_t>(idx_info.shape),
+                                 std::move(qnn_idx_bytes));
+    QnnTensorWrapper y_wrapper(y_def.name,
+                               out_tensor_type,
+                               y_info.qnn_data_type,
+                               y_info.quant_param.Copy(),
+                               std::vector<uint32_t>(y_info.shape));
+    return qnn_model_wrapper.ValidateQnnNode(
+        utils::UniqueNameGenerator().New(*gather),
+        QNN_OP_PACKAGE_NAME_QTI_AISW,
+        QNN_OP_GATHER,
+        {x_wrapper.GetQnnTensor(), idx_wrapper.GetQnnTensor()},
+        {y_wrapper.GetQnnTensor()},
+        {axis_param.GetQnnParam()});
+  }
+
+  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(*gather),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_GATHER,
+                                                {x_def.name, fused_idx_name},
+                                                {y_def.name},
+                                                {axis_param_name},
+                                                /*do_op_validation*/ false),
+                "Failed to add fused Gather node for TransposeGatherTransposeFusion.");
+
+  return Ort::Status();
+}
+
+}  // namespace
+
+std::unique_ptr<IQnnNodeGroup> TransposeGatherTransposeFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& transpose1_node_unit,
+    const MapNodeToNodeUnit& node_to_node_unit,
+    const MapNodeUnitToGroup& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  std::optional<std::array<const OrtNodeUnit*, 3>> pattern = MatchPattern(
+      qnn_model_wrapper, transpose1_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!pattern.has_value()) {
+    return nullptr;
+  }
+
+  const OrtNodeUnit* transpose1 = pattern->at(0);
+  const OrtNodeUnit* gather = pattern->at(1);
+  const OrtNodeUnit* transpose2 = pattern->at(2);
+
+  // Both Transposes must have a perm attribute.
+  std::optional<std::vector<int64_t>> perm1 = GetTransposePerm(*transpose1);
+  std::optional<std::vector<int64_t>> perm2 = GetTransposePerm(*transpose2);
+  if (!perm1.has_value() || !perm2.has_value() || perm1->empty() || perm2->empty()) {
+    return nullptr;
+  }
+
+  // Gather must have axis attribute and a constant indices initializer.
+  if (gather->Inputs().size() < 2) return nullptr;
+  const OrtNodeUnitIODef& idx_def = gather->Inputs()[1];
+  if (!qnn_model_wrapper.IsConstantInput(idx_def.name)) {
+    return nullptr;
+  }
+  std::vector<uint32_t> idx_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(idx_def.shape, idx_shape)) {
+    return nullptr;
+  }
+
+  const OrtNodeUnitIODef& x_def = transpose1->Inputs()[0];
+  std::vector<uint32_t> x_shape;
+  if (!qnn_model_wrapper.GetOnnxShape(x_def.shape, x_shape)) {
+    return nullptr;
+  }
+  if (x_shape.size() != perm1->size()) {
+    return nullptr;
+  }
+
+  // Resolve gather axis (relative to transpose1 output, which has rank == perm1->size()).
+  OrtNodeAttrHelper gather_attrs(*gather);
+  int64_t gather_axis = gather_attrs.Get("axis", static_cast<int64_t>(0));
+  if (gather_axis < 0) gather_axis += static_cast<int64_t>(perm1->size());
+  if (gather_axis < 0 || static_cast<size_t>(gather_axis) >= perm1->size()) {
+    return nullptr;
+  }
+
+  if (!IsCancelingPair(*perm1, *perm2, gather_axis, static_cast<int64_t>(idx_shape.size()))) {
+    return nullptr;
+  }
+
+  const int32_t fused_axis = static_cast<int32_t>((*perm1)[static_cast<size_t>(gather_axis)]);
+
+  // Validate on QNN.
+  Ort::Status status = CreateOrValidateOnQnn(qnn_model_wrapper, pattern.value(), fused_axis,
+                                             /*validate=*/true, logger);
+  if (!status.IsOK()) {
+    return nullptr;
+  }
+
+  return std::make_unique<TransposeGatherTransposeFusion>(pattern.value(), fused_axis);
+}
+
+gsl::span<const OrtNodeUnit* const> TransposeGatherTransposeFusion::GetNodeUnits() const {
+  return gsl::span<const OrtNodeUnit* const>{node_units_.data(), node_units_.size()};
+}
+
+Ort::Status TransposeGatherTransposeFusion::IsSupported(
+    QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn(qnn_model_wrapper, GetNodeUnits(), fused_axis_, /*validate=*/true, logger);
+}
+
+Ort::Status TransposeGatherTransposeFusion::AddToModelBuilder(
+    QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn(qnn_model_wrapper, GetNodeUnits(), fused_axis_, /*validate=*/false, logger);
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/transpose_gather_transpose_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/transpose_gather_transpose_fusion.h
@@ -1,0 +1,69 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <gsl/gsl>
+#include <array>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+/// Fuses Transpose -> Gather -> Transpose into a single Gather when the two
+/// Transposes cancel out around the Gather.
+///
+/// Pattern:
+///   x : rank N
+///   t1 = Transpose(x, perm=P1)               // rank N
+///   g  = Gather(t1, indices, axis=A)         // rank N - 1 + K, K = indices rank
+///   y  = Transpose(g, perm=P2)               // rank N - 1 + K
+///
+/// Fused:
+///   y  = Gather(x, indices, axis=P1[A])
+///
+/// The fusion is valid iff P2 is the unique permutation such that applying T2
+/// to (T1 then Gather) reproduces gathering directly on x at axis P1[A] -- i.e.,
+/// the data axes are returned to their original order and the indices block is
+/// kept contiguous in its original order.
+class TransposeGatherTransposeFusion : public IQnnNodeGroup {
+ public:
+  TransposeGatherTransposeFusion(gsl::span<const OrtNodeUnit* const> node_units,
+                                 int32_t fused_axis)
+      : fused_axis_(fused_axis) {
+    if (node_units.size() != 3) {
+      ORT_CXX_API_THROW("TransposeGatherTransposeFusion expects exactly 3 NodeUnits.", ORT_EP_FAIL);
+    }
+    node_units_[0] = node_units[0];  // Transpose1
+    node_units_[1] = node_units[1];  // Gather
+    node_units_[2] = node_units[2];  // Transpose2
+  }
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(TransposeGatherTransposeFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return node_units_[1]; }
+  std::string_view Type() const override { return "TransposeGatherTransposeFusion"; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& transpose1_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::array<const OrtNodeUnit*, 3> node_units_;  // [Transpose1, Gather, Transpose2]
+  int32_t fused_axis_;                            // Axis on the Gather input (= P1[A])
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_node_group/transpose_gather_transpose_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/transpose_gather_transpose_fusion_test.cc
@@ -1,0 +1,204 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <vector>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Builds: Input -> Transpose(perm1) -> Gather(axis, indices) -> Transpose(perm2) -> Output
+// `indices` is always a constant initializer (the fusion requires this).
+GetTestModelFn BuildTransposeGatherTransposeTestCase(
+    const TestInputDef<float>& input_def,
+    const std::vector<int64_t>& perm1,
+    const std::vector<int64_t>& indices_shape,
+    const std::vector<int64_t>& indices_data,
+    int64_t gather_axis,
+    const std::vector<int64_t>& perm2) {
+  return [input_def, perm1, indices_shape, indices_data, gather_axis, perm2](
+             ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("transpose1", "Transpose", {"input"}, {"transpose1_out"}, "",
+                    {test::MakeAttribute("perm", perm1)});
+
+    builder.MakeInitializer<int64_t>("indices", indices_shape, indices_data);
+    builder.AddNode("gather", "Gather", {"transpose1_out", "indices"}, {"gather_out"}, "",
+                    {test::MakeAttribute("axis", gather_axis)});
+
+    builder.MakeOutput("output");
+    builder.AddNode("transpose2", "Transpose", {"gather_out"}, {"output"}, "",
+                    {test::MakeAttribute("perm", perm2)});
+  };
+}
+
+ProviderOptions GetProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  return provider_options;
+}
+
+}  // namespace
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// Gather(axis=0, indices=[1] scalar-shape vec of rank 1) selects batch index 1, perm2=[0,2,3,1]
+TEST_F(QnnHTPBackendTests, TransposeGatherTransposeFusion_axis0) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "TransposeGatherTransposeFusion_axis0";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({2, 8, 4, 6}, false, -1.0f, 1.0f);
+  std::vector<int64_t> perm1 = {0, 3, 1, 2};  // [2,8,4,6] -> [2,6,8,4]
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<int64_t> indices_data = {1};  // pick batch index 1
+  int64_t gather_axis = 0;
+  std::vector<int64_t> perm2 = {0, 2, 3, 1};  // [1,6,8,4] -> [1,8,4,6]
+
+  RunQnnModelTest(BuildTransposeGatherTransposeTestCase(input_def, perm1, indices_shape, indices_data,
+                                                        gather_axis, perm2),
+                  provider_options, 13, ExpectedEPNodeAssignment::All, 1e-2f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gather", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 0);
+}
+
+// Input: [3, 5, 7, 4]
+// perm1 = [2, 0, 1, 3] -> t1 shape [7, 3, 5, 4]
+// Gather(axis=1, indices_shape=[1]) -> shape [7, 1, 5, 4]   (rank 4, K=1)
+// fused_axis = perm1[1] = 0. Equivalent fused op: Gather(x, indices, axis=0) -> [1, 5, 7, 4]
+// perm2 = [1, 2, 0, 3]
+TEST_F(QnnHTPBackendTests, TransposeGatherTransposeFusion_axis1) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "TransposeGatherTransposeFusion_K1InteriorAxis";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({3, 5, 7, 4}, false, -1.0f, 1.0f);
+  std::vector<int64_t> perm1 = {2, 0, 1, 3};  // [3,5,7,4] -> [7,3,5,4]
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<int64_t> indices_data = {1};
+  int64_t gather_axis = 1;  // dim of size 3 in t1 = source dim 0
+  std::vector<int64_t> perm2 = {1, 2, 0, 3};
+
+  RunQnnModelTest(BuildTransposeGatherTransposeTestCase(input_def, perm1, indices_shape, indices_data,
+                                                        gather_axis, perm2),
+                  provider_options, 13, ExpectedEPNodeAssignment::All, 1e-2f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gather", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 0);
+}
+
+// Negative gather_axis must be normalized before MatchPattern accepts it.
+// Same shape setup as the PSPNet case but with gather axis = -4 (== 0).
+TEST_F(QnnHTPBackendTests, TransposeGatherTransposeFusion_NegativeAxis) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "TransposeGatherTransposeFusion_NegativeAxis";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({2, 8, 4, 6}, false, -1.0f, 1.0f);
+  std::vector<int64_t> perm1 = {0, 3, 1, 2};
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<int64_t> indices_data = {0};
+  int64_t gather_axis = -4;  // == 0 after normalization
+  std::vector<int64_t> perm2 = {0, 2, 3, 1};
+
+  RunQnnModelTest(BuildTransposeGatherTransposeTestCase(input_def, perm1, indices_shape, indices_data,
+                                                        gather_axis, perm2),
+                  provider_options, 13, ExpectedEPNodeAssignment::All, 1e-2f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gather", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 0);
+}
+
+// Identity transposes on both ends: trivially cancelable. perm1 = perm2 = identity.
+// IsCancelingPair must accept this; the result is just a plain Gather.
+TEST_F(QnnHTPBackendTests, TransposeGatherTransposeFusion_IdentityTransposes) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "TransposeGatherTransposeFusion_IdentityTransposes";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({2, 4, 5, 6}, false, -1.0f, 1.0f);
+  std::vector<int64_t> perm1 = {0, 1, 2, 3};
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<int64_t> indices_data = {1};
+  int64_t gather_axis = 1;
+  std::vector<int64_t> perm2 = {0, 1, 2, 3};
+
+  RunQnnModelTest(BuildTransposeGatherTransposeTestCase(input_def, perm1, indices_shape, indices_data,
+                                                        gather_axis, perm2),
+                  provider_options, 13, ExpectedEPNodeAssignment::All, 1e-2f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gather", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 0);
+}
+
+// Non-canceling perm2: the second transpose does NOT undo perm1+gather, so IsCancelingPair
+// must return false and the three nodes must NOT collapse. They should still go through
+// QNN unfused (HTP supports each individually for these ranks/dtypes).
+TEST_F(QnnHTPBackendTests, TransposeGatherTransposeFusion_NotCanceling) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "TransposeGatherTransposeFusion_NotCanceling";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({2, 8, 4, 6}, false, -1.0f, 1.0f);
+  std::vector<int64_t> perm1 = {0, 3, 1, 2};
+  std::vector<int64_t> indices_shape = {1};
+  std::vector<int64_t> indices_data = {0};
+  int64_t gather_axis = 0;
+  // Correct cancel would be {0,2,3,1}; this swaps two dims so it doesn't cancel.
+  std::vector<int64_t> perm2 = {0, 3, 2, 1};
+
+  RunQnnModelTest(BuildTransposeGatherTransposeTestCase(input_def, perm1, indices_shape, indices_data,
+                                                        gather_axis, perm2),
+                  provider_options, 13, ExpectedEPNodeAssignment::All, 1e-2f);
+
+  // Both Transpose ops survive; Gather still present.
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 2);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gather", 1);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add transpose-gather-transpose node group to fuse into one gather when t1 and t2 are canceling pair.
This pattern is seen on pspnet and is 3x slower than QAIRT compiled model (which have this optimization). The observation is T-Gather-T pattern will harm scheduling algorithm in ctx-bin-gen and let nearby AvgPool idel on cycles.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Qairt job [305 ms]  https://workbench.aihub.qualcomm.com/jobs/j57vzn0l5/
EP job [986 ms] https://workbench.aihub.qualcomm.com/jobs/jgkrz0725/
EP job with this [403 ms] PR https://dev.aihub.qualcomm.com/jobs/j5w3jdj6p
