### PR TITLE
[QNN EP] Add support for OneHot Op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -41,6 +41,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateMeanOpBuilder("Mean", *this);
   CreateModOpBuilder("Mod", *this);
   CreateNonZeroOpBuilder("NonZero", *this);
+  CreateOneHotOpBuilder("OneHot", *this);
   CreatePadOpBuilder("Pad", *this);
   CreatePoolOpBuilder("AveragePool", *this);
   CreatePoolOpBuilder("GlobalAveragePool", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -85,6 +85,7 @@ void CreateMatMulNBitsOpBuilder(const std::string& op_type, OpBuilderRegistratio
 void CreateMeanOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateModOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateNonZeroOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateOneHotOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateQuickGeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -185,6 +185,7 @@ class BaseOpBuilder : public IOpBuilder {
         {"Mul", QNN_OP_ELEMENT_WISE_MULTIPLY},
         {"Neg", QNN_OP_ELEMENT_WISE_NEG},
         {"Not", QNN_OP_ELEMENT_WISE_NOT},
+        {"OneHot", QNN_OP_ONE_HOT},
         {"Or", QNN_OP_ELEMENT_WISE_OR},
         {"PRelu", QNN_OP_PRELU},
         {"Pad", QNN_OP_PAD},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/one_hot_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/one_hot_op_builder.cc
@@ -1,0 +1,407 @@
+// Copyright (c) Qualcomm. All rights reserved.
+// Licensed under the MIT License.
+
+// ONNX OneHot has three tensor inputs (indices, depth, values); QNN OneHot has one
+// tensor input (indices) and three parameters (depth, on_value, off_value) plus an
+// optional axis parameter. This builder:
+//   - Passes only input[0] (indices) as a QNN tensor input.
+//   - Extracts depth from input[1] (must be a constant initializer).
+//   - Extracts on_value / off_value from input[2] (values[1] / values[0]).
+//   - Normalises the ONNX axis (default -1, allows negatives) to a non-negative
+//     UINT_32 for QNN.
+//   - Handles INT_64 indices by inserting a runtime Cast(INT_32) node.
+//   - Rejects unsupported types (string, complex) in IsOpSupported.
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class OneHotOpBuilder : public BaseOpBuilder {
+ public:
+  OneHotOpBuilder() : BaseOpBuilder("OneHotOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(OneHotOpBuilder);
+
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+// Reads a scalar initializer value and sets the corresponding field in a Qnn_Scalar_t.
+// Handles all non-quantized numeric types that QNN OneHot on_value/off_value can accept.
+// If the values tensor is quantized (DQ-wrapped), dequantizes the raw integer to float32
+// following the same convention as PadOpBuilder::ProcessConstantValue.
+static Ort::Status ExtractScalarFromInitializer(QnnModelWrapper& qnn_model_wrapper,
+                                                const OrtNodeUnitIODef& input_def,
+                                                size_t byte_offset,
+                                                Qnn_Scalar_t& out_scalar) {
+  TensorInfo info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, info));
+  RETURN_IF_NOT(info.initializer_tensor != nullptr,
+                "OneHot: values input must be a constant initializer.");
+
+  std::vector<uint8_t> bytes;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(info.initializer_tensor, bytes));
+
+  const uint8_t* data = bytes.data() + byte_offset;
+
+  // If the values tensor is quantized, dequantize back to float32 for the QNN scalar param.
+  // QNN expects on_value/off_value in the logical (float) domain; quantization of the output
+  // is handled separately via the output tensor's quant params.
+  if (input_def.quant_param.has_value()) {
+    RETURN_IF_NOT(info.quant_param.IsPerTensor(),
+                  "OneHot: values tensor must use per-tensor quantization.");
+    const Qnn_QuantizeParams_t& qp = info.quant_param.Get();
+    const float scale = qp.scaleOffsetEncoding.scale;
+    const int32_t offset = qp.scaleOffsetEncoding.offset;
+
+    double raw_val = 0.0;
+    switch (info.qnn_data_type) {
+      case QNN_DATATYPE_SFIXED_POINT_8: {
+        int8_t v = 0;
+        memcpy(&v, data, sizeof(int8_t));
+        raw_val = static_cast<double>(v);
+        break;
+      }
+      case QNN_DATATYPE_SFIXED_POINT_16: {
+        int16_t v = 0;
+        memcpy(&v, data, sizeof(int16_t));
+        raw_val = static_cast<double>(v);
+        break;
+      }
+      case QNN_DATATYPE_SFIXED_POINT_32: {
+        int32_t v = 0;
+        memcpy(&v, data, sizeof(int32_t));
+        raw_val = static_cast<double>(v);
+        break;
+      }
+      case QNN_DATATYPE_UFIXED_POINT_8: {
+        raw_val = static_cast<double>(data[0]);
+        break;
+      }
+      case QNN_DATATYPE_UFIXED_POINT_16: {
+        uint16_t v = 0;
+        memcpy(&v, data, sizeof(uint16_t));
+        raw_val = static_cast<double>(v);
+        break;
+      }
+      case QNN_DATATYPE_UFIXED_POINT_32: {
+        uint32_t v = 0;
+        memcpy(&v, data, sizeof(uint32_t));
+        raw_val = static_cast<double>(v);
+        break;
+      }
+      default:
+        return MAKE_EP_FAIL("OneHot: unexpected quantized data type for values tensor.");
+    }
+    out_scalar.dataType = QNN_DATATYPE_FLOAT_32;
+    out_scalar.floatValue = static_cast<float>(utils::Dequantize(offset, scale, raw_val));
+    return Ort::Status();
+  }
+
+  // Non-quantized path: read raw bytes directly.
+  out_scalar.dataType = info.qnn_data_type;
+
+  switch (info.qnn_data_type) {
+    case QNN_DATATYPE_FLOAT_32: {
+      float v = 0.0f;
+      memcpy(&v, data, sizeof(float));
+      out_scalar.floatValue = v;
+      break;
+    }
+    case QNN_DATATYPE_FLOAT_16: {
+      // Qnn_Scalar_t stores float16 as floatValue (no separate float16 field).
+      // Read the raw fp16 bits and convert to float32 for the scalar.
+      uint16_t bits = 0;
+      memcpy(&bits, data, sizeof(uint16_t));
+      Ort::Float16_t fp16_val;
+      fp16_val.val = bits;
+      out_scalar.floatValue = static_cast<float>(fp16_val);
+      break;
+    }
+    case QNN_DATATYPE_BFLOAT_16: {
+      // QNN does not support BFLOAT_16 as a scalar param type; represent as float32.
+      uint16_t bits = 0;
+      memcpy(&bits, data, sizeof(uint16_t));
+      Ort::BFloat16_t bf16_val;
+      bf16_val.val = bits;
+      out_scalar.dataType = QNN_DATATYPE_FLOAT_32;
+      out_scalar.floatValue = static_cast<float>(bf16_val);
+      break;
+    }
+    case QNN_DATATYPE_FLOAT_64: {
+      double v = 0.0;
+      memcpy(&v, data, sizeof(double));
+      out_scalar.doubleValue = v;
+      break;
+    }
+    case QNN_DATATYPE_INT_8: {
+      int8_t v = 0;
+      memcpy(&v, data, sizeof(int8_t));
+      out_scalar.int8Value = v;
+      break;
+    }
+    case QNN_DATATYPE_INT_16: {
+      int16_t v = 0;
+      memcpy(&v, data, sizeof(int16_t));
+      out_scalar.int16Value = v;
+      break;
+    }
+    case QNN_DATATYPE_INT_32: {
+      int32_t v = 0;
+      memcpy(&v, data, sizeof(int32_t));
+      out_scalar.int32Value = v;
+      break;
+    }
+    case QNN_DATATYPE_INT_64: {
+      int64_t v = 0;
+      memcpy(&v, data, sizeof(int64_t));
+      out_scalar.int64Value = v;
+      break;
+    }
+    case QNN_DATATYPE_UINT_8: {
+      out_scalar.uint8Value = data[0];
+      break;
+    }
+    case QNN_DATATYPE_UINT_16: {
+      uint16_t v = 0;
+      memcpy(&v, data, sizeof(uint16_t));
+      out_scalar.uint16Value = v;
+      break;
+    }
+    case QNN_DATATYPE_UINT_32: {
+      uint32_t v = 0;
+      memcpy(&v, data, sizeof(uint32_t));
+      out_scalar.uint32Value = v;
+      break;
+    }
+    case QNN_DATATYPE_UINT_64: {
+      uint64_t v = 0;
+      memcpy(&v, data, sizeof(uint64_t));
+      out_scalar.uint64Value = v;
+      break;
+    }
+    case QNN_DATATYPE_BOOL_8: {
+      out_scalar.bool8Value = data[0];
+      break;
+    }
+    default:
+      return MAKE_EP_FAIL("OneHot: unsupported data type for on_value/off_value.");
+  }
+  return Ort::Status();
+}
+
+Ort::Status OneHotOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit,
+                                            const Ort::Logger& logger,
+                                            std::vector<std::string>& input_names,
+                                            bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  RETURN_IF(inputs.size() < 3, "OneHot requires 3 inputs: indices, depth, values.");
+
+  if (do_op_validation) {
+    // depth must be a constant initializer — we extract it at compile time.
+    RETURN_IF_NOT(qnn_model_wrapper.IsConstantInput(inputs[1].name),
+                  "OneHot: depth input must be a constant initializer.");
+
+    // values must be a constant initializer.
+    RETURN_IF_NOT(qnn_model_wrapper.IsConstantInput(inputs[2].name),
+                  "OneHot: values input must be a constant initializer.");
+
+    // Reject unsupported indices types.
+    TensorInfo indices_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], indices_info));
+    const Qnn_DataType_t idx_type = indices_info.qnn_data_type;
+    RETURN_IF(idx_type != QNN_DATATYPE_INT_32 &&
+              idx_type != QNN_DATATYPE_INT_64 &&
+              idx_type != QNN_DATATYPE_UINT_32,
+              "OneHot: indices must be INT_32, INT_64, or UINT_32.");
+
+    // Reject unsupported values types (string and complex have no QNN equivalent).
+    TensorInfo values_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], values_info));
+    RETURN_IF(values_info.qnn_data_type == QNN_DATATYPE_UNDEFINED,
+              "OneHot: unsupported data type for values (string/complex not supported).");
+  }
+
+  // Only input[0] (indices) is passed as a QNN tensor input.
+  // input[1] (depth) and input[2] (values) become QNN parameters.
+  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+
+  // If indices are INT_64, insert a runtime Cast(INT_32) node.
+  const std::string& indices_name = inputs[0].name;
+  if (qnn_model_wrapper.IsQnnTensorWrapperExist(indices_name)) {
+    auto& indices_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(indices_name);
+    if (indices_wrapper.GetTensorDataType() == QNN_DATATYPE_INT_64) {
+      const std::string cast_name = utils::UniqueNameGenerator().New(indices_name, "_cast_int32");
+      std::vector<uint32_t> indices_shape;
+      RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, indices_shape),
+                    "OneHot: cannot get shape of indices input.");
+      RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(
+          utils::UniqueNameGenerator().New(indices_name, QNN_OP_CAST),
+          indices_name,
+          cast_name,
+          QNN_TENSOR_TYPE_NATIVE,
+          QNN_DATATYPE_INT_32,
+          QnnQuantParamsWrapper(),
+          std::move(indices_shape),
+          do_op_validation));
+      input_names.back() = cast_name;
+    }
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status OneHotOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                          const OrtNodeUnit& node_unit,
+                                                          std::vector<std::string>&& input_names,
+                                                          const Ort::Logger& logger,
+                                                          bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  std::vector<std::string> param_tensor_names;
+
+  // -----------------------------------------------------------------------
+  // Parameter 1: depth (UINT_32 scalar) — extracted from input[1] initializer
+  // -----------------------------------------------------------------------
+  {
+    TensorInfo depth_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], depth_info));
+    RETURN_IF_NOT(depth_info.initializer_tensor != nullptr,
+                  "OneHot: depth input must be a constant initializer.");
+
+    std::vector<uint8_t> depth_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(depth_info.initializer_tensor, depth_bytes));
+
+    uint32_t depth_val = 0;
+    switch (depth_info.qnn_data_type) {
+      case QNN_DATATYPE_INT_32: {
+        int32_t v = 0;
+        memcpy(&v, depth_bytes.data(), sizeof(int32_t));
+        RETURN_IF(v < 0, "OneHot: depth must be non-negative.");
+        depth_val = static_cast<uint32_t>(v);
+        break;
+      }
+      case QNN_DATATYPE_INT_64: {
+        int64_t v = 0;
+        memcpy(&v, depth_bytes.data(), sizeof(int64_t));
+        RETURN_IF(v < 0, "OneHot: depth must be non-negative.");
+        depth_val = static_cast<uint32_t>(v);
+        break;
+      }
+      case QNN_DATATYPE_UINT_32: {
+        memcpy(&depth_val, depth_bytes.data(), sizeof(uint32_t));
+        break;
+      }
+      case QNN_DATATYPE_FLOAT_32: {
+        float v = 0.0f;
+        memcpy(&v, depth_bytes.data(), sizeof(float));
+        RETURN_IF(v < 0.0f, "OneHot: depth must be non-negative.");
+        depth_val = static_cast<uint32_t>(v);
+        break;
+      }
+      case QNN_DATATYPE_FLOAT_64: {
+        double v = 0.0;
+        memcpy(&v, depth_bytes.data(), sizeof(double));
+        RETURN_IF(v < 0.0, "OneHot: depth must be non-negative.");
+        depth_val = static_cast<uint32_t>(v);
+        break;
+      }
+      default:
+        return MAKE_EP_FAIL("OneHot: unsupported data type for depth input.");
+    }
+
+    Qnn_Scalar_t depth_scalar = QNN_SCALAR_INIT;
+    depth_scalar.dataType = QNN_DATATYPE_UINT_32;
+    depth_scalar.uint32Value = depth_val;
+    QnnParamWrapper depth_param(node_unit.Index(), node_unit.Name(),
+                                QNN_OP_ONE_HOT_PARAM_DEPTH, depth_scalar);
+    param_tensor_names.push_back(depth_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(depth_param));
+  }
+
+  // -----------------------------------------------------------------------
+  // Parameters 2 & 3: off_value (values[0]) and on_value (values[1])
+  // -----------------------------------------------------------------------
+  {
+    TensorInfo values_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], values_info));
+    RETURN_IF_NOT(values_info.initializer_tensor != nullptr,
+                  "OneHot: values input must be a constant initializer.");
+
+    const size_t elem_size = utils::GetElementSizeByType(values_info.qnn_data_type);
+    RETURN_IF(elem_size == 0, "OneHot: cannot determine element size for values data type.");
+
+    // off_value is values[0]
+    Qnn_Scalar_t off_scalar = QNN_SCALAR_INIT;
+    RETURN_IF_ERROR(ExtractScalarFromInitializer(qnn_model_wrapper, inputs[2],
+                                                 /*byte_offset=*/0, off_scalar));
+    QnnParamWrapper off_param(node_unit.Index(), node_unit.Name(),
+                              QNN_OP_ONE_HOT_PARAM_OFF_VALUE, off_scalar);
+    param_tensor_names.push_back(off_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(off_param));
+
+    // on_value is values[1]
+    Qnn_Scalar_t on_scalar = QNN_SCALAR_INIT;
+    RETURN_IF_ERROR(ExtractScalarFromInitializer(qnn_model_wrapper, inputs[2],
+                                                 /*byte_offset=*/elem_size, on_scalar));
+    QnnParamWrapper on_param(node_unit.Index(), node_unit.Name(),
+                             QNN_OP_ONE_HOT_PARAM_ON_VALUE, on_scalar);
+    param_tensor_names.push_back(on_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(on_param));
+  }
+
+  // -----------------------------------------------------------------------
+  // Parameter 4: axis (optional) — ONNX default -1, QNN default N (innermost).
+  // Normalise to non-negative UINT_32 for QNN.
+  // -----------------------------------------------------------------------
+  {
+    std::vector<uint32_t> indices_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, indices_shape),
+                  "OneHot: cannot get shape of indices input.");
+    const int32_t rank = static_cast<int32_t>(indices_shape.size());
+
+    OrtNodeAttrHelper node_helper(node_unit);
+    int32_t onnx_axis = node_helper.Get("axis", static_cast<int32_t>(-1));
+    if (onnx_axis < 0) {
+      onnx_axis += rank + 1;  // output rank = indices rank + 1
+    }
+    RETURN_IF(onnx_axis < 0 || onnx_axis > rank,
+              "OneHot: axis out of valid range [-(rank+1), rank].");
+
+    Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
+    axis_scalar.dataType = QNN_DATATYPE_UINT_32;
+    axis_scalar.uint32Value = static_cast<uint32_t>(onnx_axis);
+    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
+                               QNN_OP_ONE_HOT_PARAM_AXIS, axis_scalar);
+    param_tensor_names.push_back(axis_param.GetParamTensorName());
+    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  }
+
+  RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
+                                 std::move(input_names),
+                                 std::move(param_tensor_names),
+                                 logger, do_op_validation, QNN_OP_ONE_HOT));
+
+  return Ort::Status();
+}
+
+void CreateOneHotOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<OneHotOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/one_hot_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/one_hot_op_builder.cc
@@ -205,10 +205,10 @@ static Ort::Status ExtractScalarFromInitializer(QnnModelWrapper& qnn_model_wrapp
 }
 
 Ort::Status OneHotOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
-                                            const OrtNodeUnit& node_unit,
-                                            const Ort::Logger& logger,
-                                            std::vector<std::string>& input_names,
-                                            bool do_op_validation) const {
+                                           const OrtNodeUnit& node_unit,
+                                           const Ort::Logger& logger,
+                                           std::vector<std::string>& input_names,
+                                           bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
   RETURN_IF(inputs.size() < 3, "OneHot requires 3 inputs: indices, depth, values.");
 
@@ -226,8 +226,8 @@ Ort::Status OneHotOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], indices_info));
     const Qnn_DataType_t idx_type = indices_info.qnn_data_type;
     RETURN_IF(idx_type != QNN_DATATYPE_INT_32 &&
-              idx_type != QNN_DATATYPE_INT_64 &&
-              idx_type != QNN_DATATYPE_UINT_32,
+                  idx_type != QNN_DATATYPE_INT_64 &&
+                  idx_type != QNN_DATATYPE_UINT_32,
               "OneHot: indices must be INT_32, INT_64, or UINT_32.");
 
     // Reject unsupported values types (string and complex have no QNN equivalent).
@@ -267,10 +267,10 @@ Ort::Status OneHotOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 }
 
 Ort::Status OneHotOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
-                                                          const OrtNodeUnit& node_unit,
-                                                          std::vector<std::string>&& input_names,
-                                                          const Ort::Logger& logger,
-                                                          bool do_op_validation) const {
+                                                         const OrtNodeUnit& node_unit,
+                                                         std::vector<std::string>&& input_names,
+                                                         const Ort::Logger& logger,
+                                                         bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
   std::vector<std::string> param_tensor_names;
 

--- a/onnxruntime/test/providers/qnn/one_hot_test.cc
+++ b/onnxruntime/test/providers/qnn/one_hot_test.cc
@@ -23,10 +23,8 @@ static GetTestModelFn BuildOneHotTestCase(
     const TestInputDef<IndicesType>& indices_def,
     const TestInputDef<int64_t>& depth_def,
     const TestInputDef<ValuesType>& values_def,
-    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
-    int opset = 11) {
-  return [indices_def, depth_def, values_def, attrs, opset](ModelTestBuilder& builder) {
-    ORT_UNUSED_PARAMETER(opset);
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
+  return [indices_def, depth_def, values_def, attrs](ModelTestBuilder& builder) {
     MakeTestInput<IndicesType>(builder, "indices", indices_def);
     MakeTestInput<int64_t>(builder, "depth", depth_def);
     MakeTestInput<ValuesType>(builder, "values", values_def);
@@ -73,7 +71,7 @@ static void RunOneHotTest(
   provider_options["backend_type"] = backend_name;
   provider_options["offload_graph_io_quantization"] = "0";
 
-  RunQnnModelTest(BuildOneHotTestCase<IndicesType, ValuesType>(indices_def, depth_def, values_def, attrs, opset),
+  RunQnnModelTest(BuildOneHotTestCase<IndicesType, ValuesType>(indices_def, depth_def, values_def, attrs),
                   provider_options,
                   opset,
                   expected_ep_assignment,
@@ -93,7 +91,7 @@ static void RunQDQOneHotTest(
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  auto f32_model_fn = BuildOneHotTestCase<int64_t, float>(indices_def, depth_def, values_def, attrs, opset);
+  auto f32_model_fn = BuildOneHotTestCase<int64_t, float>(indices_def, depth_def, values_def, attrs);
   auto qdq_model_fn = BuildQDQOneHotTestCase<QuantType>(indices_def, depth_def, values_def, attrs);
 
   TestQDQModelAccuracy<QuantType>(f32_model_fn, qdq_model_fn, provider_options, opset, expected_ep_assignment);

--- a/onnxruntime/test/providers/qnn/one_hot_test.cc
+++ b/onnxruntime/test/providers/qnn/one_hot_test.cc
@@ -1,0 +1,330 @@
+// Copyright (c) Qualcomm. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Returns a function that builds a single OneHot node with three inputs:
+//   input[0]: indices  (IndicesType)
+//   input[1]: depth    (int64 or int32 constant initializer)
+//   input[2]: values   (ValuesType constant initializer, 2 elements: [off_value, on_value])
+template <typename IndicesType = int64_t, typename ValuesType = float>
+static GetTestModelFn BuildOneHotTestCase(
+    const TestInputDef<IndicesType>& indices_def,
+    const TestInputDef<int64_t>& depth_def,
+    const TestInputDef<ValuesType>& values_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    int opset = 11) {
+  return [indices_def, depth_def, values_def, attrs, opset](ModelTestBuilder& builder) {
+    ORT_UNUSED_PARAMETER(opset);
+    MakeTestInput<IndicesType>(builder, "indices", indices_def);
+    MakeTestInput<int64_t>(builder, "depth", depth_def);
+    MakeTestInput<ValuesType>(builder, "values", values_def);
+
+    builder.MakeOutput("Y");
+    builder.AddNode("OneHot_node", "OneHot", {"indices", "depth", "values"}, {"Y"}, "", attrs);
+  };
+}
+
+// Returns a function that builds a QDQ OneHot node.
+// Only the output is quantized (indices is int, depth/values are constants).
+template <typename QuantType>
+static GetTestQDQModelFn<QuantType> BuildQDQOneHotTestCase(
+    const TestInputDef<int64_t>& indices_def,
+    const TestInputDef<int64_t>& depth_def,
+    const TestInputDef<float>& values_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
+  return [indices_def, depth_def, values_def, attrs](
+             ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
+    MakeTestInput<int64_t>(builder, "indices", indices_def);
+    MakeTestInput<int64_t>(builder, "depth", depth_def);
+    MakeTestInput<float>(builder, "values", values_def);
+
+    const std::string one_hot_out = "one_hot_out";
+    builder.AddNode("OneHot_node", "OneHot", {"indices", "depth", "values"}, {one_hot_out}, "", attrs);
+
+    AddQDQNodePairWithOutputAsGraphOutput<QuantType>(
+        builder, "qdq_out", one_hot_out, output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+}
+
+// Runs a float32 OneHot model on the given QNN backend and compares output to CPU EP.
+template <typename IndicesType = int64_t, typename ValuesType = float>
+static void RunOneHotTest(
+    const TestInputDef<IndicesType>& indices_def,
+    const TestInputDef<int64_t>& depth_def,
+    const TestInputDef<ValuesType>& values_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    const std::string& backend_name,
+    ExpectedEPNodeAssignment expected_ep_assignment,
+    int opset = 11,
+    float fp32_abs_err = 1e-5f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildOneHotTestCase<IndicesType, ValuesType>(indices_def, depth_def, values_def, attrs, opset),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment,
+                  fp32_abs_err);
+}
+
+// Runs a QDQ OneHot model on HTP and checks accuracy against a float32 reference.
+template <typename QuantType>
+static void RunQDQOneHotTest(
+    const TestInputDef<int64_t>& indices_def,
+    const TestInputDef<int64_t>& depth_def,
+    const TestInputDef<float>& values_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    ExpectedEPNodeAssignment expected_ep_assignment,
+    int opset = 11) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  auto f32_model_fn = BuildOneHotTestCase<int64_t, float>(indices_def, depth_def, values_def, attrs, opset);
+  auto qdq_model_fn = BuildQDQOneHotTestCase<QuantType>(indices_def, depth_def, values_def, attrs);
+
+  TestQDQModelAccuracy<QuantType>(f32_model_fn, qdq_model_fn, provider_options, opset, expected_ep_assignment);
+}
+
+//
+// CPU backend tests
+//
+
+TEST_F(QnnCPUBackendTests, OneHot_FP32_Axis_Default) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "cpu",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, OneHot_FP32_Axis0) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {test::MakeAttribute("axis", static_cast<int64_t>(0))},
+      "cpu",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, OneHot_FP32_2DIndices) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
+      TestInputDef<int64_t>({1}, true, {4}),
+      TestInputDef<float>({2}, true, {-1.0f, 1.0f}),
+      {},
+      "cpu",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, OneHot_FP32_Int32Indices) {
+  RunOneHotTest(
+      TestInputDef<int32_t>({4}, false, {0, 1, 2, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "cpu",
+      ExpectedEPNodeAssignment::All);
+}
+
+// depth must be a constant initializer — dynamic depth is not supported.
+TEST_F(QnnCPUBackendTests, OneHot_DynamicDepth_Unsupported) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({4}, false, {0, 1, 2, 3}),
+      TestInputDef<int64_t>({1}, false, {5}),  // false = dynamic (graph input)
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "cpu",
+      ExpectedEPNodeAssignment::None);
+}
+
+//
+// HTP and GPU backend tests — run on Linux, ARM64 Windows
+//
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+TEST_F(QnnHTPBackendTests, OneHot_FP32_Axis_Default) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "htp",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_FP32_Axis0) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {test::MakeAttribute("axis", static_cast<int64_t>(0))},
+      "htp",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_FP32_NegativeAxis) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
+      TestInputDef<int64_t>({1}, true, {4}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+      "htp",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_FP32_2DIndices) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
+      TestInputDef<int64_t>({1}, true, {4}),
+      TestInputDef<float>({2}, true, {-1.0f, 1.0f}),
+      {},
+      "htp",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_FP32_Int32Indices) {
+  RunOneHotTest(
+      TestInputDef<int32_t>({4}, false, {0, 1, 2, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "htp",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_FP32_LargeDepth) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({8}, false, {0, 1, 2, 3, 4, 5, 6, 7}),
+      TestInputDef<int64_t>({1}, true, {32}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "htp",
+      ExpectedEPNodeAssignment::All);
+}
+
+// QDQ uint8 test
+TEST_F(QnnHTPBackendTests, OneHot_QDQ_U8) {
+  RunQDQOneHotTest<uint8_t>(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      ExpectedEPNodeAssignment::All);
+}
+
+// QDQ uint16 test
+TEST_F(QnnHTPBackendTests, OneHot_QDQ_U16) {
+  RunQDQOneHotTest<uint16_t>(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      ExpectedEPNodeAssignment::All);
+}
+
+// QDQ with axis attribute
+TEST_F(QnnHTPBackendTests, OneHot_QDQ_U8_Axis1) {
+  RunQDQOneHotTest<uint8_t>(
+      TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
+      TestInputDef<int64_t>({1}, true, {4}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {test::MakeAttribute("axis", static_cast<int64_t>(1))},
+      ExpectedEPNodeAssignment::All);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+//
+// BFloat16 and GPU tests — ARM64 Windows only
+//
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+static void RunOneHotHTPBF16Test(
+    const TestInputDef<int64_t>& indices_def,
+    const TestInputDef<int64_t>& depth_def,
+    const TestInputDef<float>& values_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    ExpectedEPNodeAssignment expected_ep_assignment,
+    float tolerance = 0.008f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["htp_bf16_enable"] = "1";
+  provider_options["soc_model"] = "88";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildOneHotTestCase<int64_t, float>(indices_def, depth_def, values_def, attrs),
+                  provider_options,
+                  11,
+                  expected_ep_assignment,
+                  tolerance);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_BF16_Axis_Default) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V79);
+  RunOneHotHTPBF16Test(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, OneHot_BF16_Axis0) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V79);
+  RunOneHotHTPBF16Test(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {test::MakeAttribute("axis", static_cast<int64_t>(0))},
+      ExpectedEPNodeAssignment::All);
+}
+
+//
+// GPU tests — ARM64 Windows only
+//
+
+TEST_F(QnnGPUBackendTests, OneHot_FP32_Axis_Default) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
+      TestInputDef<int64_t>({1}, true, {5}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "gpu",
+      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnGPUBackendTests, OneHot_FP32_2DIndices) {
+  RunOneHotTest(
+      TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
+      TestInputDef<int64_t>({1}, true, {4}),
+      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
+      {},
+      "gpu",
+      ExpectedEPNodeAssignment::All);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/one_hot_test.cc
+++ b/onnxruntime/test/providers/qnn/one_hot_test.cc
@@ -41,8 +41,9 @@ static GetTestQDQModelFn<QuantType> BuildQDQOneHotTestCase(
     const TestInputDef<int64_t>& indices_def,
     const TestInputDef<int64_t>& depth_def,
     const TestInputDef<float>& values_def,
-    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs) {
-  return [indices_def, depth_def, values_def, attrs](
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    bool use_contrib_qdq = false) {
+  return [indices_def, depth_def, values_def, attrs, use_contrib_qdq](
              ModelTestBuilder& builder, std::vector<QuantParams<QuantType>>& output_qparams) {
     MakeTestInput<int64_t>(builder, "indices", indices_def);
     MakeTestInput<int64_t>(builder, "depth", depth_def);
@@ -52,7 +53,7 @@ static GetTestQDQModelFn<QuantType> BuildQDQOneHotTestCase(
     builder.AddNode("OneHot_node", "OneHot", {"indices", "depth", "values"}, {one_hot_out}, "", attrs);
 
     AddQDQNodePairWithOutputAsGraphOutput<QuantType>(
-        builder, "qdq_out", one_hot_out, output_qparams[0].scale, output_qparams[0].zero_point);
+        builder, "qdq_out", one_hot_out, output_qparams[0].scale, output_qparams[0].zero_point, use_contrib_qdq);
   };
 }
 
@@ -86,13 +87,14 @@ static void RunQDQOneHotTest(
     const TestInputDef<float>& values_def,
     const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
     ExpectedEPNodeAssignment expected_ep_assignment,
-    int opset = 11) {
+    int opset = 11,
+    bool use_contrib_qdq = false) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
   auto f32_model_fn = BuildOneHotTestCase<int64_t, float>(indices_def, depth_def, values_def, attrs);
-  auto qdq_model_fn = BuildQDQOneHotTestCase<QuantType>(indices_def, depth_def, values_def, attrs);
+  auto qdq_model_fn = BuildQDQOneHotTestCase<QuantType>(indices_def, depth_def, values_def, attrs, use_contrib_qdq);
 
   TestQDQModelAccuracy<QuantType>(f32_model_fn, qdq_model_fn, provider_options, opset, expected_ep_assignment);
 }
@@ -126,16 +128,6 @@ TEST_F(QnnCPUBackendTests, OneHot_FP32_2DIndices) {
       TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
       TestInputDef<int64_t>({1}, true, {4}),
       TestInputDef<float>({2}, true, {-1.0f, 1.0f}),
-      {},
-      "cpu",
-      ExpectedEPNodeAssignment::All);
-}
-
-TEST_F(QnnCPUBackendTests, OneHot_FP32_Int32Indices) {
-  RunOneHotTest(
-      TestInputDef<int32_t>({4}, false, {0, 1, 2, 3}),
-      TestInputDef<int64_t>({1}, true, {5}),
-      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
       {},
       "cpu",
       ExpectedEPNodeAssignment::All);
@@ -198,16 +190,6 @@ TEST_F(QnnHTPBackendTests, OneHot_FP32_2DIndices) {
       ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnHTPBackendTests, OneHot_FP32_Int32Indices) {
-  RunOneHotTest(
-      TestInputDef<int32_t>({4}, false, {0, 1, 2, 3}),
-      TestInputDef<int64_t>({1}, true, {5}),
-      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
-      {},
-      "htp",
-      ExpectedEPNodeAssignment::All);
-}
-
 TEST_F(QnnHTPBackendTests, OneHot_FP32_LargeDepth) {
   RunOneHotTest(
       TestInputDef<int64_t>({8}, false, {0, 1, 2, 3, 4, 5, 6, 7}),
@@ -228,14 +210,17 @@ TEST_F(QnnHTPBackendTests, OneHot_QDQ_U8) {
       ExpectedEPNodeAssignment::All);
 }
 
-// QDQ uint16 test
+// QDQ uint16 test — uses com.microsoft Q/DQ ops since ONNX QuantizeLinear
+// only supports uint16 zero-points from opset 21.
 TEST_F(QnnHTPBackendTests, OneHot_QDQ_U16) {
   RunQDQOneHotTest<uint16_t>(
       TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
       TestInputDef<int64_t>({1}, true, {5}),
       TestInputDef<float>({2}, true, {0.0f, 1.0f}),
       {},
-      ExpectedEPNodeAssignment::All);
+      ExpectedEPNodeAssignment::All,
+      11,
+      true);  // use_contrib_qdq
 }
 
 // QDQ with axis attribute
@@ -293,30 +278,6 @@ TEST_F(QnnHTPBackendTests, OneHot_BF16_Axis0) {
       TestInputDef<int64_t>({1}, true, {5}),
       TestInputDef<float>({2}, true, {0.0f, 1.0f}),
       {test::MakeAttribute("axis", static_cast<int64_t>(0))},
-      ExpectedEPNodeAssignment::All);
-}
-
-//
-// GPU tests — ARM64 Windows only
-//
-
-TEST_F(QnnGPUBackendTests, OneHot_FP32_Axis_Default) {
-  RunOneHotTest(
-      TestInputDef<int64_t>({4}, false, {0, 2, 1, 3}),
-      TestInputDef<int64_t>({1}, true, {5}),
-      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
-      {},
-      "gpu",
-      ExpectedEPNodeAssignment::All);
-}
-
-TEST_F(QnnGPUBackendTests, OneHot_FP32_2DIndices) {
-  RunOneHotTest(
-      TestInputDef<int64_t>({2, 3}, false, {0, 1, 2, 1, 0, 2}),
-      TestInputDef<int64_t>({1}, true, {4}),
-      TestInputDef<float>({2}, true, {0.0f, 1.0f}),
-      {},
-      "gpu",
       ExpectedEPNodeAssignment::All);
 }
 


### PR DESCRIPTION
### Description

Adds support for the ONNX `OneHot` operator (opset 11) in the QNN Execution Provider, targeting the QNN CPU and HTP backends via the native `QNN_OP_ONE_HOT` op.

---

### Motivation & Context

ONNX defines `OneHot` at opset 11: https://onnx.ai/onnx/operators/onnx__OneHot.html

The ONNX and QNN op definitions differ significantly in how inputs are structured:

|                       | ONNX                                      | QNN                              |
|-----------------------|-------------------------------------------|----------------------------------|
| `indices`             | Tensor input                              | Tensor input                     |
| `depth`               | Tensor input (scalar/rank-1)              | `UINT_32` parameter              |
| `on_value`/`off_value`| Single tensor input `values = [off, on]`  | Two separate scalar parameters   |
| `axis`                | INT attribute, default `-1`, negatives allowed | `UINT_32` parameter, default `N`, no negatives |

This builder bridges the gap at compile time: `depth` and `values` are unpacked from constant initializers and passed to QNN as scalar parameters, while `indices` is the only tensor input forwarded to QNN.

---

### Supported Configuration

| Attribute      | Supported values |
|----------------|-----------------|
| `axis`         | Any value in `[-(rank+1), rank]`; default `-1` (innermost). Negative values normalised to non-negative before passing to QNN. |
| `depth`        | Constant initializer only. Types: `INT_32`, `INT_64`, `UINT_32`, `FLOAT_32`, `FLOAT_64`. |
| `values`       | Constant initializer only. 2-element tensor `[off_value, on_value]`. |
| `indices` dtype | `INT_32`, `INT_64`, `UINT_32`. |
| Input rank     | Any rank ≥ 1. |

---

### Unsupported Configuration (falls back to CPU EP)

- **Dynamic `depth`**: QNN requires depth at compile time. Rejected with:
  *"OneHot: depth input must be a constant initializer"*
- **`indices` dtype other than `INT_32`, `INT_64`, `UINT_32`**: rejected in `IsOpSupported`
- **`values` dtype `string` or `complex64/128`**: no QNN equivalent
- **Negative indices**: QNN only supports the `[0, depth-1]` range; ONNX models using negative indices (`[-depth, depth-1]`) will fall back to CPU EP

---

### Data Types

| Backend | `indices`              | `on/off_value` & output               |
|---------|------------------------|---------------------------------------|
| CPU     | `INT_32`, `INT_64`     | `float32`                             |
| HTP     | `INT_32`, `INT_64`     | `float32`, `float16`, `bfloat16` (v81+) |

**QDQ:** Supported on HTP. The output is quantized via the standard trailing Q node; `on_value`/`off_value` are dequantized to `FLOAT_32` before being passed as QNN scalar parameters when the `values` initializer is DQ-wrapped (following the same convention as `PadOpBuilder::ProcessConstantValue`). `uint8` QDQ uses standard ONNX Q/DQ ops.
`uint16` QDQ uses `com.microsoft` contrib Q/DQ ops since standard ONNX `QuantizeLinear` only supports `uint16` zero-points from opset 21.

---

### Files Changed

| File | Change |
|------|--------|
| `builder/opbuilder/one_hot_op_builder.cc` | `OneHotOpBuilder` |
| `builder/opbuilder/base_op_builder.h`     | Added `{"OneHot", QNN_OP_ONE_HOT}` to op type map |
| `builder/op_builder_factory.h`            | Added `CreateOneHotOpBuilder` declaration |
| `builder/op_builder_factory.cc`           | Registered `CreateOneHotOpBuilder("OneHot", *this)` |
| `test/providers/qnn/one_hot_test.cc`      | CPU and HTP tests |

---

### Implementation Notes

- **`INT_64` indices:** A runtime `Cast(INT_32)` node is inserted automatically — the same pattern used by `GatherOpBuilder` and `ScatterNDOpBuilder`. `UINT_32` indices pass through directly.

- **`axis` normalisation:** ONNX allows `axis` in `[-(rank+1), rank]` with default `-1`. QNN requires a non-negative `UINT_32`. The normalisation uses output rank (`indices_rank + 1`) not indices rank, because the inserted dimension shifts the valid range.

- **`on_value`/`off_value` extraction:** `ExtractScalarFromInitializer` handles all non-quantized numeric types by reading raw bytes from the initializer. When the `values` tensor is DQ-wrapped (`input_def.quant_param.has_value()`), the raw quantized integer is dequantized back to `FLOAT_32` via `utils::Dequantize` before being set as the QNN scalar parameter — matching the pattern in `PadOpBuilder::ProcessConstantValue`.

- **`FLOAT_16` / `BFLOAT_16` scalars:** `Qnn_Scalar_t` has no `float16` or `bfloat16` field. FP16 bits are widened to `float32` for the scalar param. BF16 is similarly widened to `float32` for the scalar while the output tensor retains its `BFLOAT_16` type.

- **`depth` types:** The ONNX spec allows any numeric type for `depth` (cast to `int64` before use). The builder handles `INT_32`, `INT_64`, `UINT_32`, `FLOAT_32`, and `FLOAT_64`, converting to `UINT_32` for QNN in all cases.