### PR TITLE
Remove workaround for GPU log level

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -552,16 +552,8 @@ Ort::Status QnnBackendManager::InitializeQnnValidatorLog() {
 QnnLog_Level_t QnnBackendManager::MapOrtSeverityToQNNLogLevel(OrtLoggingLevel ort_log_level) {
   // Map ORT log severity to Qnn log level
   switch (ort_log_level) {
-    case ORT_LOGGING_LEVEL_VERBOSE: {
-      switch ((GetQnnBackendType())) {
-        case QnnBackendType::GPU:
-          // Currently GPU needs this log level to work.
-          // This switch will be removed once this is resolved.
-          return QNN_LOG_LEVEL_DEBUG;
-        default:
-          return QNN_LOG_LEVEL_VERBOSE;
-      }
-    }
+    case ORT_LOGGING_LEVEL_VERBOSE:
+      return QNN_LOG_LEVEL_VERBOSE;
     case ORT_LOGGING_LEVEL_INFO:
       return QNN_LOG_LEVEL_INFO;
     case ORT_LOGGING_LEVEL_WARNING:


### PR DESCRIPTION
### Description
* Reverts [onnxruntime/pull/24444](https://github.com/microsoft/onnxruntime/pull/24444).

### Motivation and Context
* The workaround to map `ORT_LOGGING_LEVEL_VERBOSE` to `QNN_LOG_LEVEL_DEBUG` for the GPU backend is no longer needed.

