### PR TITLE
Fix hardsigmoid output encodings

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -455,7 +455,7 @@ static bool OverrideQuantParams(const std::string& op_type, Qnn_DataType_t qnn_d
   const int32_t orig_offset = quant_params.offset;
   const float orig_scale = quant_params.scale;
 
-  if (op_type == "Sigmoid") {
+  if (op_type == "Sigmoid" || op_type == "HardSigmoid") {
     switch (qnn_data_type) {
       case QNN_DATATYPE_UFIXED_POINT_16:
         quant_params.offset = 0;
@@ -501,7 +501,7 @@ Ort::Status SimpleOpBuilder::OverrideOutputQuantParam(QnnModelWrapper& qnn_model
   // Override output quantization parameters for uint16 QDQ Sigmoid or Tanh.
   // QNN requires 16-bit QDQ Sigmoid and Tanh to use specific output scale and zero-point values
   // regardless of floating-point range.
-  if (op_type == "Sigmoid" || op_type == "Tanh") {
+  if (op_type == "Sigmoid" || op_type == "Tanh" || op_type == "HardSigmoid") {
     const auto& outputs = node_unit.Outputs();
     RETURN_IF_NOT(output_index < outputs.size(),
                   ("Invalid output index in OverrideOutputQuantParam for op " + op_type).c_str());

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -1839,6 +1839,45 @@ TEST_F(QnnHTPBackendTests, UnaryOp_HardSigmoid_QU16) {
                          ExpectedEPNodeAssignment::All);
 }
 
+// Test that QDQ uint16 HardSigmoid -> Mul produces correct output
+// Reproduces MobileNetV3 SE block accuracy bug where HardSigmoid output scale must be
+// overridden to 1/65536 for HTP to compute Mul correctly
+TEST_F(QnnHTPBackendTests, HardSigmoidMul_QU16_ScaleOverride) {
+  // Build: input -> HardSigmoid -> Mul(input, hardsigmoid_output) -> output
+  // This mimics SE attention: x * sigmoid(fc(x))
+  auto input_def = TestInputDef<float>({1, 16, 1, 1}, false, GetFloatDataInRange(-3.0f, 3.0f, 16));
+
+  auto build_f32_model = [input_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", input_def);
+    builder.AddNode("HardSigmoid", "HardSigmoid", {"input"}, {"hsig_out"});
+    builder.AddNode("Mul", "Mul", {"input", "hsig_out"}, {"output"});
+    builder.MakeOutput("output");
+  };
+
+  auto build_qdq_model = [input_def](ModelTestBuilder& builder,
+                                     std::vector<QuantParams<uint16_t>>& output_qparams) {
+    MakeTestInput<float>(builder, "input", input_def);
+    QuantParams<uint16_t> input_qparams = GetTestInputQuantParams<uint16_t>(input_def);
+
+    std::string input_dq = AddQDQNodePair<uint16_t>(builder, "input_qdq", "input",
+                                                    input_qparams.scale, input_qparams.zero_point, true);
+    builder.AddNode("HardSigmoid", "HardSigmoid", {input_dq}, {"hsig_out"});
+    std::string hsig_dq = AddQDQNodePair<uint16_t>(builder, "hsig_qdq", "hsig_out",
+                                                   1.0f / 65536.0f, static_cast<uint16_t>(0), true);
+    builder.AddNode("Mul", "Mul", {input_dq, hsig_dq}, {"mul_out"});
+    AddQDQNodePairWithOutputAsGraphOutput<uint16_t>(builder, "output_qdq", "mul_out",
+                                                    output_qparams[0].scale, output_qparams[0].zero_point, true);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  GetTestQDQModelFn<uint16_t> qdq_fn = build_qdq_model;
+  TestQDQModelAccuracy(build_f32_model, qdq_fn, provider_options, 21,
+                       ExpectedEPNodeAssignment::All, QDQTolerance());
+}
+
 // Test that QDQ HardSigmoid is supported by QNN EP.
 TEST_F(QnnHTPBackendTests, UnaryOp_HardSigmoid_QDQ_Supported) {
   RunQDQOpTest<uint8_t>("HardSigmoid",


### PR DESCRIPTION
### Description
HTP expects Hardsigmoid output encodings to be fixed to 1/2^<BW> which is addressed here 

### Motivation and Context
Critical fix affecting several models. HTP expects HardSigmoid output scale to represent full [0, 1] range and not just the activation range seen during calibration. This PR hardcodes the output encodings to satisfy the backend requirement. This is a limitation imposed by HTP for HardSigmoid and other ops like Sigmoid, Softmax etc

With this change, MobileNetV3 small accuracy gets recovered from ~2% to 66.7% (expected value). 

PS: Ideally this needs to be done in AIMET