### PR TITLE
Migrate the Artifactory used for release

### DIFF
--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -232,7 +232,7 @@ jobs:
           NETRC_FILE=$(mktemp -p /tmp)
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" <<EOF
-          machine re-artifactory.qualcomm.com
+          machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
@@ -249,7 +249,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
         run: |
           source uplevel_venv/bin/activate
-          twine upload -r re-artifactory-pypi-test-project \
+          twine upload -r artifactory-pypi-test-project \
             --cert ./qcom/scripts/upleveling/certs/artifactory-ca.pem \
             --config-file ./qcom/scripts/upleveling/.pypirc \
             ${{ github.workspace }}/build/dist/*.whl
@@ -299,7 +299,7 @@ jobs:
         run: |
           $netrcFile = New-TemporaryFile
           @"
-          machine re-artifactory.qualcomm.com
+          machine artifactory-las.qualcomm.com
           login $env:ARTIFACTORY_USERNAME
           password $env:ARTIFACTORY_PASSWORD
           "@ | Set-Content -Path $netrcFile
@@ -447,7 +447,7 @@ jobs:
           NETRC_FILE=$(mktemp -p /tmp)
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" <<EOF
-          machine re-artifactory.qualcomm.com
+          machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
@@ -467,7 +467,7 @@ jobs:
                        mktemp -p "${{ github.workspace }}")
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" << EOF
-          machine re-artifactory.qualcomm.com
+          machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -234,7 +234,7 @@ jobs:
           cat > "$NETRC_FILE" <<EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
           VERSION=$(ls "${{ github.workspace }}/build/dist/"*win_arm64*.whl 2>/dev/null | head -1 | xargs -I{} basename {} | sed 's/.*-\([0-9.]*rc[0-9]*\).*/\1/' | sed 's/-//g')
           ./qcom/scripts/signing/upload_unsigned_to_artifactory.sh \
@@ -246,7 +246,7 @@ jobs:
         if: ${{ !inputs.skip_publish }}
         env:
           TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
         run: |
           source uplevel_venv/bin/activate
           twine upload -r artifactory-pypi-test-project \
@@ -295,7 +295,7 @@ jobs:
         shell: powershell
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
         run: |
           $netrcFile = New-TemporaryFile
           @"
@@ -321,7 +321,7 @@ jobs:
         shell: powershell
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
         run: |
           py -m venv uplevel_venv
           .\uplevel_venv\Scripts\activate
@@ -449,7 +449,7 @@ jobs:
           cat > "$NETRC_FILE" <<EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
           VERSION=$(basename "$(ls "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.zip 2>/dev/null | grep -v pdb | head -1)" | sed 's/.*-\([0-9.]*rc[0-9]*\).*/\1/' | sed 's/-//g')
           ./qcom/scripts/signing/upload_unsigned_to_artifactory.sh \
@@ -469,7 +469,7 @@ jobs:
           cat > "$NETRC_FILE" << EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
 
           # Upload Windows ARM64 archive and PDB archive

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -234,7 +234,7 @@ jobs:
           cat > "$NETRC_FILE" <<EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           EOF
           VERSION=$(ls "${{ github.workspace }}/build/dist/"*win_arm64*.whl 2>/dev/null | head -1 | xargs -I{} basename {} | sed 's/.*-\([0-9.]*rc[0-9]*\).*/\1/' | sed 's/-//g')
           ./qcom/scripts/signing/upload_unsigned_to_artifactory.sh \
@@ -246,7 +246,7 @@ jobs:
         if: ${{ !inputs.skip_publish }}
         env:
           TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
         run: |
           source uplevel_venv/bin/activate
           twine upload -r artifactory-pypi-test-project \
@@ -295,7 +295,7 @@ jobs:
         shell: powershell
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
         run: |
           $netrcFile = New-TemporaryFile
           @"
@@ -321,7 +321,7 @@ jobs:
         shell: powershell
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
         run: |
           py -m venv uplevel_venv
           .\uplevel_venv\Scripts\activate
@@ -449,7 +449,7 @@ jobs:
           cat > "$NETRC_FILE" <<EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           EOF
           VERSION=$(basename "$(ls "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.zip 2>/dev/null | grep -v pdb | head -1)" | sed 's/.*-\([0-9.]*rc[0-9]*\).*/\1/' | sed 's/-//g')
           ./qcom/scripts/signing/upload_unsigned_to_artifactory.sh \
@@ -469,7 +469,7 @@ jobs:
           cat > "$NETRC_FILE" << EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           EOF
 
           # Upload Windows ARM64 archive and PDB archive

--- a/.github/workflows/qualcomm-internal-upload-artifactory.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory.yml
@@ -201,7 +201,7 @@ jobs:
                        mktemp -p "${{ github.workspace }}")
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" << EOF
-          machine re-artifactory.qualcomm.com
+          machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
@@ -252,7 +252,7 @@ jobs:
                        mktemp -p "${{ github.workspace }}")
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" << EOF
-          machine re-artifactory.qualcomm.com
+          machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF

--- a/.github/workflows/qualcomm-internal-upload-artifactory.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           PYPI_API_KEY: ${{ secrets.PYPI_UPLOADER_PASSWORD }}
           TEST_PYPI_API_KEY: ${{ secrets.TEST_PYPI_UPLOADER_PASSWORD }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
@@ -145,7 +145,7 @@ jobs:
         shell: powershell
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           NUGET_API_KEY: ${{ secrets.NUGET_UPLOADER_PASSWORD }}
           TEST_NUGET_API_KEY: ${{ secrets.TEST_NUGET_UPLOADER_PASSWORD }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
@@ -188,7 +188,7 @@ jobs:
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -203,7 +203,7 @@ jobs:
           cat > "$NETRC_FILE" << EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           EOF
 
           # Run the upleveling script with netrc file
@@ -240,7 +240,7 @@ jobs:
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           GH_TOKEN: ${{ github.token }}
         run: |
           source uplevel_venv/bin/activate
@@ -254,7 +254,7 @@ jobs:
           cat > "$NETRC_FILE" << EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
           EOF
 
           # Run the upleveling script with netrc file

--- a/.github/workflows/qualcomm-internal-upload-artifactory.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           PYPI_API_KEY: ${{ secrets.PYPI_UPLOADER_PASSWORD }}
           TEST_PYPI_API_KEY: ${{ secrets.TEST_PYPI_UPLOADER_PASSWORD }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
@@ -145,7 +145,7 @@ jobs:
         shell: powershell
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           NUGET_API_KEY: ${{ secrets.NUGET_UPLOADER_PASSWORD }}
           TEST_NUGET_API_KEY: ${{ secrets.TEST_NUGET_UPLOADER_PASSWORD }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
@@ -188,7 +188,7 @@ jobs:
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -203,7 +203,7 @@ jobs:
           cat > "$NETRC_FILE" << EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
 
           # Run the upleveling script with netrc file
@@ -240,7 +240,7 @@ jobs:
       - name: Publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           GH_TOKEN: ${{ github.token }}
         run: |
           source uplevel_venv/bin/activate
@@ -254,7 +254,7 @@ jobs:
           cat > "$NETRC_FILE" << EOF
           machine artifactory-las.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
-          password ${{ secrets.ARTIFACTORY_NEW_UPLOADER_PASSWORD }}
+          password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
 
           # Run the upleveling script with netrc file

--- a/qcom/scripts/signing/upload_unsigned_to_artifactory.ps1
+++ b/qcom/scripts/signing/upload_unsigned_to_artifactory.ps1
@@ -31,7 +31,7 @@ $repoRoot = git rev-parse --show-toplevel
 Write-Host "Uploading $Filename"
 
 $caCertPath = Join-Path $repoRoot "qcom/scripts/upleveling/certs/artifactory-ca.pem"
-$uploadUrl = "https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/$Version/unsigned_libs/$Filename"
+$uploadUrl = "https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/$Version/unsigned_libs/$Filename"
 
 curl.exe -T "$ZipFile" --fail `
     --cacert "$caCertPath" `

--- a/qcom/scripts/signing/upload_unsigned_to_artifactory.sh
+++ b/qcom/scripts/signing/upload_unsigned_to_artifactory.sh
@@ -35,6 +35,6 @@ echo "Uploading $FILENAME"
 curl --fail -s -T "$ZIP_FILE" \
     --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
     --netrc-file "$NETRC_FILE" \
-    https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${VERSION}"/unsigned_libs/"$FILENAME" > /dev/null
+    https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/"${VERSION}"/unsigned_libs/"$FILENAME" > /dev/null
 
 echo "Successfully uploaded $FILENAME"

--- a/qcom/scripts/upleveling/.pypirc
+++ b/qcom/scripts/upleveling/.pypirc
@@ -2,31 +2,31 @@
 index-servers =
   pypi
   testpypi
-  re-artifactory-pypi-test-users
-  re-artifactory-pypi-test-project
-  re-artifactory-pypi-test-public
-  re-artifactory-pypi-project
-  re-artifactory-pypi-public
+  artifactory-pypi-test-users
+  artifactory-pypi-test-project
+  artifactory-pypi-test-public
+  artifactory-pypi-project
+  artifactory-pypi-public
 
 
-[re-artifactory-pypi-test-users]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/pypi/aisw-pypi-test-users-local
+[artifactory-pypi-test-users]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-test-users-pypi-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-pypi-test-project]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/pypi/aisw-pypi-test-project-local
+[artifactory-pypi-test-project]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-test-project-pypi-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-pypi-test-public]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/pypi/aisw-pypi-test-public-local
+[artifactory-pypi-test-public]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-test-public-pypi-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-pypi-project]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/pypi/aisw-pypi-project-local
+[artifactory-pypi-project]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-project-pypi-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-pypi-public]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/pypi/aisw-pypi-public-local
+[artifactory-pypi-public]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-public-pypi-virtual
 cert: certs/artifactory-ca.pem
 
 [pypi]

--- a/qcom/scripts/upleveling/config.ini
+++ b/qcom/scripts/upleveling/config.ini
@@ -2,45 +2,45 @@
 index-servers =
   nuget
   testnuget
-  re-artifactory-nuget-test-users
-  re-artifactory-nuget-test-project
-  re-artifactory-nuget-project
-  re-artifactory-nuget-public
-  re-artifactory-zip-test-users
-  re-artifactory-zip-test-project
-  re-artifactory-zip-project
-  re-artifactory-zip-public
+  artifactory-nuget-test-users
+  artifactory-nuget-test-project
+  artifactory-nuget-project
+  artifactory-nuget-public
+  artifactory-zip-test-users
+  artifactory-zip-test-project
+  artifactory-zip-project
+  artifactory-zip-public
 
-[re-artifactory-nuget-test-users]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/nuget/aisw-nuget-test-users
+[artifactory-nuget-test-users]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-test-users-nuget-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-nuget-test-project]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/nuget/aisw-nuget-test-project
+[artifactory-nuget-test-project]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-test-project-nuget-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-nuget-project]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/nuget/aisw-nuget-project
+[artifactory-nuget-project]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-project-nuget-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-nuget-public]
-repository: https://re-artifactory.qualcomm.com/artifactory/api/nuget/aisw-nuget-public
+[artifactory-nuget-public]
+repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-public-nuget-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-zip-test-users]
-repository: https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-users
+[artifactory-zip-test-users]
+repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testuser-generic-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-zip-test-project]
-repository: https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project
+[artifactory-zip-test-project]
+repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-zip-project]
-repository: https://re-artifactory.qualcomm.com/artifactory/aisw-zip-project
+[artifactory-zip-project]
+repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-project-generic-virtual
 cert: certs/artifactory-ca.pem
 
-[re-artifactory-zip-public]
-repository: https://re-artifactory.qualcomm.com/artifactory/aisw-zip-public
+[artifactory-zip-public]
+repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-public-generic-virtual
 cert: certs/artifactory-ca.pem
 
 [nuget]

--- a/qcom/scripts/upleveling/maven/README.md
+++ b/qcom/scripts/upleveling/maven/README.md
@@ -121,7 +121,7 @@ Central Portal account settings.
 The self-hosted build runners must satisfy:
 
 1. **Qualcomm Root CA in the Java truststore** — `artifactory-qdc-global.qualcomm.com`
-   uses the Qualcomm Root CA G2 (same CA as `re-artifactory.qualcomm.com`).
+   uses the Qualcomm Root CA G2 (same CA as `artifactory-las.qualcomm.com`).
    If `mvn deploy:deploy-file` fails with an SSL handshake error, import the CA
    cert (`qcom/scripts/upleveling/certs/artifactory-ca.pem`) into the JDK's
    `cacerts` keystore once on the runner:

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -41,10 +41,10 @@ INI_FILE = os.path.join(SCRIPT_DIR, "config.ini")
 
 # Artifact format mappings
 ARTIFACTORY_PREFIXES = {
-    "wheel": "re-artifactory-pypi",
-    "nuget": "re-artifactory-nuget",
-    "zip": "re-artifactory-zip",
-    "tgz": "re-artifactory-zip",
+    "wheel": "artifactory-pypi",
+    "nuget": "artifactory-nuget",
+    "zip": "artifactory-zip",
+    "tgz": "artifactory-zip",
 }
 
 ARTIFACT_SUFFIXES = {"wheel": ".whl", "nuget": ".nupkg", "zip": ".zip", "tgz": ".tgz"}
@@ -684,7 +684,7 @@ class NugetUpleveler(ArtifactUpleveler):
 
     def _add_nuget_source(self, username: str, password: str, source_url: str, server: str, version: str) -> str:
         """Add a single NuGet source using PackageSourceCredentials environment variables."""
-        if "re-artifactory-nuget-" in server:
+        if "artifactory-nuget-" in server:
             source_name = f"{server}-{version}"
             actual_source_url = source_url
         elif server == "testnuget":

--- a/qcom/scripts/upleveling/qnn_ep_uplevel_nuget.ps1
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel_nuget.ps1
@@ -71,7 +71,7 @@ function Set-NuGetCredentials {
             }
         }
     } else {
-        $source_name = "re-artifactory-nuget-$server-$version"
+        $source_name = "artifactory-nuget-$server-$version"
     }
 
     # Sanitize source name for environment variable

--- a/qcom/scripts/upleveling/upload_nupkg_to_artifactory.ps1
+++ b/qcom/scripts/upleveling/upload_nupkg_to_artifactory.ps1
@@ -24,8 +24,8 @@ foreach ($file in $nugetFiles) {
     $version = $fileBasename -replace "^Qualcomm\.ML\.OnnxRuntime\.QNN\.", ""
     Write-Host "${fileBasename}: $version"
 
-    $sourceName = "re-artifactory-nuget-test-project-$version"
-    $sourceUrl = "https://re-artifactory.qualcomm.com/artifactory/api/nuget/aisw-nuget-test-project/onnxruntime-qnn/$version"
+    $sourceName = "artifactory-nuget-test-project-$version"
+    $sourceUrl = "https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-test-project-nuget-virtual/onnxruntime-qnn/$version"
 
     # Use PackageSourceCredentials environment variables for secure authentication
     # NuGet automatically reads credentials from environment variables in the format:

--- a/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
+++ b/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
@@ -48,7 +48,7 @@ find "$INPUT_DIR" \( -name "*.zip" -o -name "*.tgz" \) -type f -print0 | while I
     curl --fail -s -T "$file" \
         --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
         --netrc-file "$NETRC_FILE" \
-        https://re-artifactory.qualcomm.com/artifactory/aisw-zip-test-project/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename" > /dev/null
+        https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename" > /dev/null
 
     echo "Successfully uploaded $file_basename"
 done


### PR DESCRIPTION
### Description
Migrate the Artifactory server from re-artifactory to artifactory-las.


### Motivation and Context
The re-artifactory is going to be deprecated. Update the code to use the new migrated Artifactory.