### PR TITLE
Exclude QnnCPUBackendTests.UDO_Op_MyAdd from ASan run (upstream QAIRT bug)

### DIFF
--- a/.github/workflows/qualcomm-internal-asan.yml
+++ b/.github/workflows/qualcomm-internal-asan.yml
@@ -41,7 +41,14 @@ jobs:
             exit 1
           fi
 
-          if echo "${changed}" | grep -qE 'onnxruntime/(core|test)/providers/qnn/'; then
+          # Trigger ASan when QNN EP source/test code changes, or when the
+          # ASan pipeline files themselves change so pipeline edits don't
+          # land unvalidated (chicken-and-egg with the gate itself).
+          if echo "${changed}" | grep -qE \
+              -e 'onnxruntime/(core|test)/providers/qnn/' \
+              -e '^\.github/workflows/qualcomm-internal-asan\.yml$' \
+              -e '^qcom/scripts/linux/(run_asan|asan_filter_leaks)\.sh$' \
+              -e '^tools/ci_build/lsan_suppressions\.txt$'; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
           else
             echo "run=false" >> "${GITHUB_OUTPUT}"

--- a/qcom/scripts/linux/run_asan.sh
+++ b/qcom/scripts/linux/run_asan.sh
@@ -100,7 +100,26 @@ export LSAN_OPTIONS="exitcode=1:suppressions=${REPO_ROOT}/tools/ci_build/lsan_su
 
 # ---------------------------------------------------------------------------
 # Run the test binary through asan_filter_leaks.sh
+#
+# QnnCPUBackendTests.UDO_Op_MyAdd is excluded under ASan. It dlopens a
+# generated libMyAddOpPackage_cpu.so whose REGISTER_OP macro registers
+# a global OpRegistrationReceiver. The receiver's ctor heap-allocates
+# 8 bytes (a CustomOpRegistrationFunction_t) via std::unique_ptr; pop()
+# transfers ownership to the caller via release(), and neither the
+# receiver's dtor nor the caller in CustomOpPackage.hpp's REGISTER_PACKAGE_OP
+# macro ever frees it. The leak fires from call_init (elf/dl-init.c) at
+# .so load time, with all in-package frames showing "<unknown module>"
+# (LSan cannot resolve them, so lsan_suppressions.txt patterns also miss).
+#
+# This is an upstream QAIRT SDK bug in
+# share/QNN/OpPackageGenerator/CustomOp/CustomOpRegister.hpp. The HTP
+# variant of UDO_Op_MyAdd does not exhibit this leak (host-side boilerplate
+# differs), so only the CPU test is filtered out.
+#
+# Re-enable once the QAIRT fix lands and asan_filter_leaks.sh gains
+# attribution-by-source-path so 3rd-party leaks no longer block CI.
 # ---------------------------------------------------------------------------
 log_info "--- Running onnxruntime_provider_test under ASan ---"
 "${REPO_ROOT}/qcom/scripts/linux/asan_filter_leaks.sh" \
-    "./onnxruntime_provider_test"
+    "./onnxruntime_provider_test" \
+    "--gtest_filter=-QnnCPUBackendTests.UDO_Op_MyAdd"


### PR DESCRIPTION
## Summary

Two pipeline-only changes to unblock and harden the Linux x86 ASan job:

1. **Skip `QnnCPUBackendTests.UDO_Op_MyAdd`** — the leak it triggers is a
   known upstream QAIRT SDK bug, not an ORT-EP issue.
2. **Extend the ASan gate** so the job triggers when the ASan pipeline
   files themselves change. Previously a chicken-and-egg: edits to
   `run_asan.sh` / `asan_filter_leaks.sh` / `qualcomm-internal-asan.yml`
   landed unvalidated because the gate only matched QNN EP source paths.

The rest of the suite (including `QnnHTPBackendTests.UDO_Op_MyAdd`) still
runs under strict ASan.

## Root cause for the UDO CPU skip — upstream QAIRT SDK bug

In `<QAIRT_SDK>/share/QNN/OpPackageGenerator/CustomOp/CustomOpRegister.hpp`:

```cpp
struct OpRegistrationReceiver {
  OpRegistrationReceiver(const char* opTypeName, CustomOpRegistrationFunction_t regFunction) {
    opType = opTypeName;
    func.reset(new CustomOpRegistrationFunction_t(regFunction));   // ← 8 bytes
  }
  CustomOpRegistrationFunction_t* pop() { return func.release(); } // ← transfers raw ptr; never delete'd
  ~OpRegistrationReceiver() { if (func) func.release(); }          // ← release() does NOT free
 private:
  std::unique_ptr<CustomOpRegistrationFunction_t> func;
};
```

`REGISTER_OP(MyAdd, register_MyaddCustomOp)` (in the generated
`MyAddCPU.cpp`) declares a global `MyAdd_receiver`. Its constructor runs at
`.so` load time and heap-allocates an 8-byte function pointer through
`std::unique_ptr`. The macro `REGISTER_PACKAGE_OP` later calls
`receiver.pop()` (which is just `func.release()`) and dereferences the raw
pointer to call the registration function — but it never `delete`s the
8-byte allocation. The destructor's `release()` is also a no-op once
`pop()` has run.

Net effect: every UDO op leaks 8 bytes per `.so` load.

LSan reports this as:

```
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 operator new
    #1 0x...  (<unknown module>)
    #2 0x...  (<unknown module>)
    #3 0x...  (<unknown module>)
    #4 call_init elf/dl-init.c:70
```

All in-package frames resolve to `<unknown module>`, so two of our existing
safeguards both miss it:

- `tools/ci_build/lsan_suppressions.txt`'s `leak:libQnnHtp.so` /
  `leak:libQnnCpu.so` patterns require a module path on the frame;
  `<unknown module>` carries none.
- `asan_filter_leaks.sh` treats every `Direct leak` as ORT-side and exits 1.

## Why CPU only, not HTP

`QnnHTPBackendTests.UDO_Op_MyAdd` does not reproduce the same leak. The HTP
variant uses a different host-side boilerplate (separate Makefile,
generator output path) and the receiver pattern doesn't trigger the
`<unknown module>` failure mode there. So we filter only the CPU test and
keep HTP coverage live.

## Gate extension

Before:

```bash
grep -qE 'onnxruntime/(core|test)/providers/qnn/'
```

After:

```bash
grep -qE \
    -e 'onnxruntime/(core|test)/providers/qnn/' \
    -e '^\.github/workflows/qualcomm-internal-asan\.yml$' \
    -e '^qcom/scripts/linux/(run_asan|asan_filter_leaks)\.sh$' \
    -e '^tools/ci_build/lsan_suppressions\.txt$'
```

This PR itself exercises the new gate path: the changes land under
`qcom/scripts/linux/run_asan.sh` and
`.github/workflows/qualcomm-internal-asan.yml`, both of which now trip
the gate and run the ASan job for self-validation.

## Follow-ups (not in this PR)

1. **Upstream fix in QAIRT SDK** — store `CustomOpRegistrationFunction_t` by
   value in `OpRegistrationReceiver` (no heap, no `release()` / `reset()`
   confusion). Single-file local patch validates the fix; we will report to
   the QAIRT team.
2. **Smarter filter** — teach `asan_filter_leaks.sh` to attribute Direct
   leaks by source path: any frame in `onnxruntime/{core,test}/providers/qnn/`
   or `qcom/` ⇒ ORT's responsibility (FAIL); otherwise ⇒ 3rd-party noise
   (log + accept). After this lands, the per-test `--gtest_filter` exclusion
   here can be removed.
3. **Suppression registry hygiene** — convert `lsan_suppressions.txt` into a
   transparent registry of known 3rd-party leaks with owner / tracker /
   expected-fix metadata.