### PR TITLE
[QNN EP] MatMul BQ Phase 1: support MatMul with block-quantized weight on HTP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -49,9 +49,7 @@ uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
 // (i.e. reshapeable to [1, 1, K, N]). Per ONNX opset 21 the scale has the same rank as the
 // weight with the contraction axis (K, at rank-2) dimension smaller: scale_shape[rank-2] <
 // weight_shape[rank-2]. Only meaningful on the NPU backend.
-// On success, sets num_blocks = scale_shape[rank-2] and block_size = K / num_blocks.
-bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight,
-                int64_t& num_blocks, int64_t& block_size) {
+bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight) {
   if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
     return false;
   }
@@ -87,11 +85,10 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   if (scale_shape[k_axis] >= static_cast<int64_t>(weight_shape[k_axis])) {
     return false;
   }
-  num_blocks = scale_shape[k_axis];
+  const int64_t num_blocks = scale_shape[k_axis];
   if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[k_axis]) % num_blocks != 0) {
     return false;
   }
-  block_size = static_cast<int64_t>(weight_shape[k_axis]) / num_blocks;
   return true;
 }
 
@@ -251,9 +248,7 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
 
   // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight.
   {
-    int64_t num_blocks = 0;
-    int64_t block_size = 0;
-    if (IsBQWeight(qnn_model_wrapper, inputs[1], num_blocks, block_size)) {
+    if (IsBQWeight(qnn_model_wrapper, inputs[1])) {
       return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
     }
   }
@@ -693,9 +688,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // A block-quantized weight is always emitted as a QNN MatMul (see ProcessInputsForBQMatMul), even
   // when CheckInputs would otherwise route a rank-2 initializer weight to FullyConnected. Force the
   // MatMul path here so the output handling matches how the inputs were built.
-  int64_t bq_num_blocks = 0;
-  int64_t bq_block_size = 0;
-  if (IsBQWeight(qnn_model_wrapper, inputs[1], bq_num_blocks, bq_block_size)) {
+  if (IsBQWeight(qnn_model_wrapper, inputs[1])) {
     use_fully_connected = false;
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -95,9 +95,12 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   return true;
 }
 
-// Flattens the leading dims of `shape` (all but the last) into a single uint32_t batch value.
-Ort::Status FlattenLeadingDims(const std::vector<uint32_t>& shape, uint32_t& batch) {
-  const int64_t batch_i64 = std::accumulate(shape.begin(), shape.end() - 1,
+// Flattens the leading dims of `shape` (all but the last `n_trailing` dims) into a single
+// uint32_t batch value. Defaults to n_trailing=1 (i.e. all dims except the last one).
+Ort::Status FlattenLeadingDims(const std::vector<uint32_t>& shape, uint32_t& batch,
+                               size_t n_trailing = 1) {
+  RETURN_IF(shape.size() < n_trailing, "FlattenLeadingDims: n_trailing exceeds shape rank.");
+  const int64_t batch_i64 = std::accumulate(shape.begin(), shape.end() - static_cast<ptrdiff_t>(n_trailing),
                                             static_cast<int64_t>(1), std::multiplies<int64_t>());
   RETURN_IF(batch_i64 <= 0 ||
                 batch_i64 > static_cast<int64_t>(std::numeric_limits<uint32_t>::max()),
@@ -542,31 +545,31 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
     std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
 
     std::string fp16_name = act_name;
-    if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
-      // Reuse the original DequantizeLinear node's output name (the target MatMul's input[0]) for the
-      // FP16 tensor. That tensor is conceptually the dequantized activation — exactly what this
-      // INT16→FP16 Dequantize produces — and QNN EP otherwise skips it, so the name is free and keeps
-      // the QNN graph aligned with the ONNX graph naming.
-      fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-      QnnTensorWrapper fp16_act_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
-                                        QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                        std::vector<uint32_t>(act_shape));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_act_wrapper)),
-                    "Failed to add FP16 activation tensor for BQ MatMul.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
-                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
-                        {act_name}, {fp16_name}, {}, do_op_validation),
-                    "Failed to add INT16→FP16 Dequantize node for BQ MatMul activation.");
-    }
+    // BW_FLOAT_BLOCK MatMul requires FP16 activation. The only activation dtype reaching this
+    // path through the QDQ selector is INT16 (SFIXED or UFIXED), so anything else is unexpected.
+    RETURN_IF_NOT(act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16,
+                  "QNN EP: BQ MatMul activation must be INT16-quantized for the BW_FLOAT_BLOCK kernel");
+    // Reuse the original DequantizeLinear node's output name (the target MatMul's input[0]) for the
+    // FP16 tensor. That tensor is conceptually the dequantized activation — exactly what this
+    // INT16→FP16 Dequantize produces — and QNN EP otherwise skips it, so the name is free and keeps
+    // the QNN graph aligned with the ONNX graph naming.
+    fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+    QnnTensorWrapper fp16_act_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
+                                      QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                      std::vector<uint32_t>(act_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_act_wrapper)),
+                  "Failed to add FP16 activation tensor for BQ MatMul.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                      {act_name}, {fp16_name}, {}, do_op_validation),
+                  "Failed to add INT16→FP16 Dequantize node for BQ MatMul activation.");
 
     // Reshape the FP16 activation [..., M, K] to 4-D [batch, 1, M, K] for the QNN HTP BQ MatMul.
     const uint32_t k_dim = act_shape.back();
     const uint32_t m_dim = act_shape[act_shape.size() - 2];
     uint32_t batch = 1u;
-    for (size_t i = 0; i + 2 < act_shape.size(); ++i) {
-      batch *= act_shape[i];
-    }
+    RETURN_IF_ERROR(FlattenLeadingDims(act_shape, batch, /*n_trailing=*/2));
     const std::vector<uint32_t> act_shape_4d = {batch, 1u, m_dim, k_dim};
     const std::string act_4d_name = utils::UniqueNameGenerator().New(fp16_name, "_reshape_4d");
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(fp16_name, act_4d_name, act_shape, act_shape_4d,
@@ -765,9 +768,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     const uint32_t n_dim = op_output_shape.back();
     const uint32_t m_dim = op_output_shape[op_output_shape.size() - 2];
     uint32_t batch = 1u;
-    for (size_t i = 0; i + 2 < op_output_shape.size(); ++i) {
-      batch *= op_output_shape[i];
-    }
+    RETURN_IF_ERROR(FlattenLeadingDims(op_output_shape, batch, /*n_trailing=*/2));
     const std::vector<uint32_t> matmul_out_shape_4d = {batch, 1u, m_dim, n_dim};
 
     const std::string matmul_4d_out = utils::UniqueNameGenerator().New(op_output_name, "_matmul_4d");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -17,59 +17,6 @@
 namespace onnxruntime {
 namespace qnn {
 
-/**
- * An ONNX MatMul can be translated to either a QNN MatMul or a QNN FullyConnected.
- * ONNX's MatMul supports inputs of rank 1, but neither QNN's MatMul nor FullyConnected support two rank 1 inputs.
- * So, we need to add Reshape Ops if necessary.
- * In two cases, FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op:
- * 1. input_1 is a rank 2 initializer.
- * 2. input_1 is a rank 1 tensor.
- */
-class MatMulOpBuilder : public BaseOpBuilder {
- public:
-  MatMulOpBuilder() : BaseOpBuilder("MatMulOpBuilder") {}
-  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(MatMulOpBuilder);
-
- protected:
-  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
-                            const OrtNodeUnit& node_unit,
-                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
-
-  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
-                            const OrtNodeUnit& node_unit,
-                            const Ort::Logger& logger,
-                            std::vector<std::string>& input_names,
-                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
-
-  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
-                                          std::vector<std::string>&& input_names, const Ort::Logger& logger,
-                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
-
- private:
-  Ort::Status ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_model_wrapper,
-                                        const OrtNodeUnit& node_unit,
-                                        const TensorInfo& input_info_0,
-                                        const TensorInfo& input_info_1,
-                                        const Ort::Logger& logger,
-                                        std::vector<std::string>& input_names,
-                                        bool do_op_validation) const ORT_MUST_USE_RESULT;
-  Ort::Status ProcessInputsForQnnFullyConnected(QnnModelWrapper& qnn_model_wrapper,
-                                                const OrtNodeUnit& node_unit,
-                                                const TensorInfo& input_info_0,
-                                                const TensorInfo& input_info_1,
-                                                const Ort::Logger& logger,
-                                                std::vector<std::string>& input_names,
-                                                bool do_op_validation) const ORT_MUST_USE_RESULT;
-  // Block-quantized (BW_FLOAT_BLOCK) weight path. Translates to a QNN MatMul whose weight carries a
-  // per-block float scale; activation is dequantized to FP16 and the FP16 output is re-quantized to INT16.
-  Ort::Status ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
-                                       const OrtNodeUnit& node_unit,
-                                       const TensorInfo& input_info_1,
-                                       const Ort::Logger& logger,
-                                       std::vector<std::string>& input_names,
-                                       bool do_op_validation) const ORT_MUST_USE_RESULT;
-};
-
 namespace {
 inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
   return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
@@ -97,11 +44,12 @@ uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
   }
 }
 
-// Detects a block-quantized MatMul weight (ONNX MatMul input[1], shape [K, N]).
-// Per ONNX opset 21, the weight scale has the same rank as the weight with the blocked axis
-// dimension smaller. MatMul blocks the contraction axis K (axis 0), so the rank-2 scale is
-// [K/block_size, N] and scale_shape[0] < weight_shape[0]. Only meaningful on the NPU backend.
-// On success, sets num_blocks = scale_shape[0] and block_size = K / num_blocks.
+// Detects a block-quantized MatMul weight (ONNX MatMul input[1]).
+// Accepts weight rank 2–4: shape [..., K, N] where any leading dims beyond K/N must equal 1
+// (i.e. reshapeable to [1, 1, K, N]). Per ONNX opset 21 the scale has the same rank as the
+// weight with the contraction axis (K, at rank-2) dimension smaller: scale_shape[rank-2] <
+// weight_shape[rank-2]. Only meaningful on the NPU backend.
+// On success, sets num_blocks = scale_shape[rank-2] and block_size = K / num_blocks.
 bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight,
                 int64_t& num_blocks, int64_t& block_size) {
   if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
@@ -112,18 +60,38 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   }
   const auto scale_shape = utils::GetInitializerShape(weight.quant_param->scale, qnn_model_wrapper.GetOrtApi());
   std::vector<uint32_t> weight_shape;
-  if (!QnnModelWrapper::GetOnnxShape(weight.shape, weight_shape) || weight_shape.size() != 2) {
-    return false;  // BQ only supported for rank-2 MatMul weight [K, N].
-  }
-  if (scale_shape.size() != weight_shape.size() ||
-      scale_shape[0] >= static_cast<int64_t>(weight_shape[0])) {
+  if (!QnnModelWrapper::GetOnnxShape(weight.shape, weight_shape)) {
     return false;
   }
-  num_blocks = scale_shape[0];
-  if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[0]) % num_blocks != 0) {
+  const size_t rank = weight_shape.size();
+  if (rank < 2 || rank > 4) {
+    return false;  // BQ supports weight rank 2–4 (reshapeable to [1,1,K,N]).
+  }
+  // All leading dims (beyond the last two: K and N) must be 1.
+  for (size_t i = 0; i + 2 < rank; ++i) {
+    if (weight_shape[i] != 1) {
+      return false;
+    }
+  }
+  if (scale_shape.size() != rank) {
+    return false;  // Scale must have the same rank as the weight.
+  }
+  // All leading dims of the scale must also be 1.
+  for (size_t i = 0; i + 2 < rank; ++i) {
+    if (scale_shape[i] != 1) {
+      return false;
+    }
+  }
+  // Blocked axis is rank-2 (K dimension). scale_shape[rank-2] < weight_shape[rank-2].
+  const size_t k_axis = rank - 2;
+  if (scale_shape[k_axis] >= static_cast<int64_t>(weight_shape[k_axis])) {
     return false;
   }
-  block_size = static_cast<int64_t>(weight_shape[0]) / num_blocks;
+  num_blocks = scale_shape[k_axis];
+  if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[k_axis]) % num_blocks != 0) {
+    return false;
+  }
+  block_size = static_cast<int64_t>(weight_shape[k_axis]) / num_blocks;
   return true;
 }
 
@@ -223,39 +191,53 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
 }
 }  // namespace
 
-// Process operator inputs. Dispatches to other processing functions depending on whether we're
-// translating an ONNX MatMul to a QNN MatMul or a QNN FullyConnected.
-Ort::Status MatMulOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
-                                           const Ort::Logger& logger) const {
-  const auto& inputs = node_unit.Inputs();
+/**
+ * An ONNX MatMul can be translated to either a QNN MatMul or a QNN FullyConnected.
+ * ONNX's MatMul supports inputs of rank 1, but neither QNN's MatMul nor FullyConnected support two rank 1 inputs.
+ * So, we need to add Reshape Ops if necessary.
+ * In two cases, FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op:
+ * 1. input_1 is a rank 2 initializer.
+ * 2. input_1 is a rank 1 tensor.
+ */
+class MatMulOpBuilder : public BaseOpBuilder {
+ public:
+  MatMulOpBuilder() : BaseOpBuilder("MatMulOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(MatMulOpBuilder);
 
-  // Block-quantized (BW_FLOAT_BLOCK) weight: validate HTP constraints, then defer to the base
-  // implementation, which runs full QNN validation through our BQ ProcessInputs/Outputs path.
-  if (inputs.size() >= 2) {
-    int64_t num_blocks = 0;
-    int64_t block_size = 0;
-    if (IsBQWeight(qnn_model_wrapper, inputs[1], num_blocks, block_size)) {
-      const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
-      auto bq_it = kHtpMatMulBQBitsAndBlockSizeMultipliers.find(bitwidth);
-      RETURN_IF(bq_it == kHtpMatMulBQBitsAndBlockSizeMultipliers.end(),
-                ("QNN HTP MatMul BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
-      RETURN_IF(block_size % bq_it->second != 0,
-                ("QNN HTP MatMul BQ: block_size=" + std::to_string(block_size) +
-                 " must be a multiple of " + std::to_string(bq_it->second) +
-                 " for " + std::to_string(bitwidth) + "-bit weight")
-                    .c_str());
-      // BQ requires a constant weight and a dynamic (quantized) activation that we dequantize to FP16.
-      TensorInfo weight_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], weight_info));
-      RETURN_IF_NOT(weight_info.is_initializer, "QNN EP: BQ MatMul weight must be a constant initializer");
-      TensorInfo act_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], act_info));
-      RETURN_IF(act_info.is_initializer, "QNN EP: BQ MatMul activation must be a dynamic (non-constant) tensor");
-    }
-  }
+ protected:
+  Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger,
+                            std::vector<std::string>& input_names,
+                            bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
-  return BaseOpBuilder::IsOpSupported(qnn_model_wrapper, node_unit, logger);
-}
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names, const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+ private:
+  Ort::Status ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_model_wrapper,
+                                        const OrtNodeUnit& node_unit,
+                                        const TensorInfo& input_info_0,
+                                        const TensorInfo& input_info_1,
+                                        const Ort::Logger& logger,
+                                        std::vector<std::string>& input_names,
+                                        bool do_op_validation) const ORT_MUST_USE_RESULT;
+  Ort::Status ProcessInputsForQnnFullyConnected(QnnModelWrapper& qnn_model_wrapper,
+                                                const OrtNodeUnit& node_unit,
+                                                const TensorInfo& input_info_0,
+                                                const TensorInfo& input_info_1,
+                                                const Ort::Logger& logger,
+                                                std::vector<std::string>& input_names,
+                                                bool do_op_validation) const ORT_MUST_USE_RESULT;
+  // Block-quantized (BW_FLOAT_BLOCK) weight path. Translates to a QNN MatMul whose weight carries a
+  // per-block float scale; activation is dequantized to FP16 and the FP16 output is re-quantized to INT16.
+  Ort::Status ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       const Ort::Logger& logger,
+                                       std::vector<std::string>& input_names,
+                                       bool do_op_validation) const ORT_MUST_USE_RESULT;
+};
 
 // Process operator inputs. Dispatches to other processing functions depending on whether we're
 // translating an ONNX MatMul to a QNN MatMul or a QNN FullyConnected.
@@ -264,15 +246,12 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
                                            bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
 
-  // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight (weight stays 2-D).
+  // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight.
   {
     int64_t num_blocks = 0;
     int64_t block_size = 0;
     if (IsBQWeight(qnn_model_wrapper, inputs[1], num_blocks, block_size)) {
-      TensorInfo input_info_1{};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info_1));
-      return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, input_info_1, logger, input_names,
-                                      do_op_validation);
+      return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
     }
   }
 
@@ -527,17 +506,21 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
 
 Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
                                                       const OrtNodeUnit& node_unit,
-                                                      const TensorInfo& input_info_1,
                                                       const Ort::Logger& logger,
                                                       std::vector<std::string>& input_names,
                                                       bool do_op_validation) const {
-  ORT_UNUSED_PARAMETER(logger);
   const auto& inputs = node_unit.Inputs();
 
+  // Weight may be rank 2–4 with shape [..., K, N] (leading dims are 1).
+  // K and N are always the last two dimensions; the weight is registered as [1, 1, K, N] in QNN.
+  TensorInfo input_info_1{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info_1));
   RETURN_IF_NOT(input_info_1.is_initializer, "QNN EP: BQ MatMul weight must be a constant initializer");
-  RETURN_IF_NOT(input_info_1.shape.size() == 2, "QNN EP: BQ MatMul weight must be rank-2 [K, N]");
-  const int64_t K = static_cast<int64_t>(input_info_1.shape[0]);
-  const int64_t N = static_cast<int64_t>(input_info_1.shape[1]);
+  const size_t w_rank = input_info_1.shape.size();
+  RETURN_IF_NOT(w_rank >= 2 && w_rank <= 4,
+                "QNN EP: BQ MatMul weight must be rank 2, 3, or 4 with shape [..., K, N]");
+  const int64_t K = static_cast<int64_t>(input_info_1.shape[w_rank - 2]);
+  const int64_t N = static_cast<int64_t>(input_info_1.shape[w_rank - 1]);
 
   //
   // Input 0: activation. BW_FLOAT_BLOCK MatMul computes in FP16, so an INT16 activation must be
@@ -594,18 +577,27 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
   }
 
   //
-  // Input 1: weight. Build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params on the 2-D weight
-  // [K, N], blocked along the contraction axis K.
+  // Input 1: weight. Build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params.
+  // The weight is always registered as 4-D [1, 1, K, N] in QNN regardless of the ONNX rank.
   //
   const std::string& input1_name = inputs[1].name;
 
-  // Determine num_blocks/block_size from the ONNX scale shape [K/block_size, N].
+  // Scale shape mirrors weight rank: [..., num_blocks, N] — blocked axis is rank-2.
   const auto scale_shape = utils::GetInitializerShape(inputs[1].quant_param->scale, qnn_model_wrapper.GetOrtApi());
-  RETURN_IF_NOT(scale_shape.size() == 2, "QNN EP: BQ MatMul scale must be rank-2 [K/block_size, N]");
-  const int64_t num_blocks = scale_shape[0];
+  RETURN_IF_NOT(scale_shape.size() == w_rank,
+                "QNN EP: BQ MatMul scale rank must match weight rank");
+  const int64_t num_blocks = scale_shape[w_rank - 2];
   RETURN_IF(num_blocks <= 0 || K % num_blocks != 0, "QNN EP: BQ MatMul K must be divisible by num_blocks");
   const int64_t block_size = K / num_blocks;
   const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+  auto bq_it = kHtpMatMulBQBitsAndBlockSizeMultipliers.find(bitwidth);
+  RETURN_IF(bq_it == kHtpMatMulBQBitsAndBlockSizeMultipliers.end(),
+            ("QNN HTP MatMul BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
+  RETURN_IF(block_size % bq_it->second != 0,
+            ("QNN HTP MatMul BQ: block_size=" + std::to_string(block_size) +
+             " must be a multiple of " + std::to_string(bq_it->second) +
+             " for " + std::to_string(bitwidth) + "-bit weight")
+                .c_str());
 
   // Unpack the weight to one byte per element (sub-byte INT2/INT4 expanded to INT8).
   std::vector<uint8_t> unpacked_tensor;
@@ -621,13 +613,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
   }
 
   // QNN HTP requires a BQ MatMul to be expressed with 4-D activation, 4-D weight, and a 4-D blockSize.
-  // The weight [K, N] is reshaped to [1, 1, K, N]; with transpose_in1 = 0 the contraction axis K is
-  // axis 2, so blockSize is {1, 1, block_size, 1}.
+  // The weight [..., K, N] is always registered as [1, 1, K, N]; with transpose_in1 = 0 the
+  // contraction axis K is axis 2, so blockSize is {1, 1, block_size, 1}.
   const std::vector<uint32_t> block_size_arr = {1u, 1u, static_cast<uint32_t>(block_size), 1u};
 
-  // ONNX per-block float scales are laid out [num_blocks, N] (block-major). QNN expects the
-  // scale/offset array ordered output-channel-major with the output channel (N) as the last weight
-  // axis and the block index inner — i.e. [N, num_blocks]. Transpose from [num_blocks, N] → [N, nb].
+  // ONNX per-block float scales are laid out [..., num_blocks, N] (block-major along K-axis).
+  // QNN expects the scale/offset array output-channel-major: [N, num_blocks].
+  // Transpose from [num_blocks, N] → [N, num_blocks] (leading dims are always 1, so we just
+  // look at the last two dims of the flat scale array).
   std::vector<float> onnx_scales;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, onnx_scales));
   RETURN_IF_NOT(static_cast<int64_t>(onnx_scales.size()) == num_blocks * N,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -542,12 +542,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
   //
   // Input 0: activation. BW_FLOAT_BLOCK MatMul computes in FP16, so an INT16 activation must be
   // dequantized to FP16 first (mirrors the Conv BQ activation path). QNN HTP additionally requires the
-  // activation to be 4-D, so the [..., M, K] activation is reshaped to [batch, 1, M, K].
+  // activation to be 4-D, so the [..., M, K] activation is reshaped to [batch, 1, M, K], where batch is
+  // the product of all leading dims. Any rank >= 2 reshapes cleanly; the output is reshaped back the
+  // same way.
   //
   TensorInfo input_info_0{};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info_0));
-  RETURN_IF_NOT(input_info_0.shape.size() >= 2 && input_info_0.shape.size() <= 3,
-                "QNN EP: BQ MatMul activation must be rank 2 or 3");
+  RETURN_IF_NOT(input_info_0.shape.size() >= 2,
+                "QNN EP: BQ MatMul activation must be rank >= 2 so it can be reshaped to 4-D [batch, 1, M, K]");
   RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_info_0, inputs[0].name, input_names, logger,
                                 do_op_validation, /*use_fully_connected=*/false));
   {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -247,10 +247,8 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
   const auto& inputs = node_unit.Inputs();
 
   // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight.
-  {
-    if (IsBQWeight(qnn_model_wrapper, inputs[1])) {
-      return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
-    }
+  if (IsBQWeight(qnn_model_wrapper, inputs[1])) {
+    return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
   }
 
   TensorInfo input_info_0{};
@@ -756,7 +754,9 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   if (is_bq_matmul) {
     // The QNN HTP BQ MatMul runs on 4-D tensors and outputs FP16.
     // Pipeline: MatMul (4-D FP16 [batch,1,M,N]) → Reshape (to ONNX [...,M,N] FP16)
-    //           → Quantize (FP16 → INT16) [only when output is quantized]
+    //           → Quantize (FP16 → INT16)
+    RETURN_IF_NOT(output_info.quant_param.IsQuantized(),
+                  "QNN EP: BQ MatMul output must be INT16-quantized; float output is not yet supported");
     const uint32_t n_dim = op_output_shape.back();
     const uint32_t m_dim = op_output_shape[op_output_shape.size() - 2];
     uint32_t batch = 0;
@@ -776,31 +776,24 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                   "Failed to add BQ MatMul node.");
 
     // Reshape 4-D FP16 [batch,1,M,N] back to the ONNX FP16 output shape [...,M,N].
-    // Reuses the original QuantizeLinear node's input name when the output is quantized,
-    // keeping the QNN graph aligned with the ONNX graph naming.
-    const std::string matmul_fp16_out = output_info.quant_param.IsQuantized()
-                                            ? Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName()
-                                            : op_output_name;
+    // Reuse the original QuantizeLinear node's input name to keep the QNN graph aligned
+    // with the ONNX graph naming.
+    const std::string matmul_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(matmul_4d_out, matmul_fp16_out, matmul_out_shape_4d,
                                                      op_output_shape, QNN_DATATYPE_FLOAT_16,
                                                      QnnQuantParamsWrapper(), do_op_validation,
                                                      /*is_for_input=*/false, /*is_for_output=*/false));
 
-    if (output_info.quant_param.IsQuantized()) {
-      // INT16 quantized output tensor consumed by downstream nodes (or the graph output).
-      QnnTensorWrapper int16_out_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
-                                         op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                    "Failed to add INT16 BQ MatMul output tensor.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::UniqueNameGenerator().New(op_output_name, "_fp16_quantize"),
-                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                        {matmul_fp16_out}, {op_output_name}, {}, do_op_validation),
-                    "Failed to add FP16→INT16 Quantize node for BQ MatMul output.");
-    }
-    // Unquantized (float) output: the Reshape above already registered op_output_name as
-    // QNN_TENSOR_TYPE_NATIVE. No further action needed; the caller's reshape_output path
-    // (if applicable) handles promotion to APP_READ.
+    // INT16 quantized output tensor consumed by downstream nodes (or the graph output).
+    QnnTensorWrapper int16_out_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
+                                       op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                  "Failed to add INT16 BQ MatMul output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(op_output_name, "_fp16_quantize"),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                      {matmul_fp16_out}, {op_output_name}, {}, do_op_validation),
+                  "Failed to add FP16→INT16 Quantize node for BQ MatMul output.");
   } else {
     QnnTensorWrapper op_output_tensor_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
                                               op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -568,7 +568,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
     // Reshape the FP16 activation [..., M, K] to 4-D [batch, 1, M, K] for the QNN HTP BQ MatMul.
     const uint32_t k_dim = act_shape.back();
     const uint32_t m_dim = act_shape[act_shape.size() - 2];
-    uint32_t batch = 1u;
+    uint32_t batch = 0;
     RETURN_IF_ERROR(FlattenLeadingDims(act_shape, batch, /*n_trailing=*/2));
     const std::vector<uint32_t> act_shape_4d = {batch, 1u, m_dim, k_dim};
     const std::string act_4d_name = utils::UniqueNameGenerator().New(fp16_name, "_reshape_4d");
@@ -760,14 +760,13 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     is_bq_matmul = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized();
   }
 
-  if (is_bq_matmul && output_info.quant_param.IsQuantized()) {
-    // The QNN HTP BQ MatMul runs on 4-D tensors and outputs FP16. The ONNX output is INT16-quantized,
-    // so the pipeline is: MatMul (4-D FP16 [batch,1,M,N]) → Reshape (to ONNX [...,M,N] FP16) → Quantize
-    // (FP16 → INT16). The reshape target reuses the original QuantizeLinear node's input name (the
-    // un-quantized MatMul output), keeping the QNN graph aligned with the ONNX graph naming.
+  if (is_bq_matmul) {
+    // The QNN HTP BQ MatMul runs on 4-D tensors and outputs FP16.
+    // Pipeline: MatMul (4-D FP16 [batch,1,M,N]) → Reshape (to ONNX [...,M,N] FP16)
+    //           → Quantize (FP16 → INT16) [only when output is quantized]
     const uint32_t n_dim = op_output_shape.back();
     const uint32_t m_dim = op_output_shape[op_output_shape.size() - 2];
-    uint32_t batch = 1u;
+    uint32_t batch = 0;
     RETURN_IF_ERROR(FlattenLeadingDims(op_output_shape, batch, /*n_trailing=*/2));
     const std::vector<uint32_t> matmul_out_shape_4d = {batch, 1u, m_dim, n_dim};
 
@@ -784,22 +783,31 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                   "Failed to add BQ MatMul node.");
 
     // Reshape 4-D FP16 [batch,1,M,N] back to the ONNX FP16 output shape [...,M,N].
-    const std::string matmul_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
+    // Reuses the original QuantizeLinear node's input name when the output is quantized,
+    // keeping the QNN graph aligned with the ONNX graph naming.
+    const std::string matmul_fp16_out = output_info.quant_param.IsQuantized()
+                                            ? Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName()
+                                            : op_output_name;
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(matmul_4d_out, matmul_fp16_out, matmul_out_shape_4d,
                                                      op_output_shape, QNN_DATATYPE_FLOAT_16,
                                                      QnnQuantParamsWrapper(), do_op_validation,
                                                      /*is_for_input=*/false, /*is_for_output=*/false));
 
-    // INT16 quantized output tensor consumed by downstream nodes (or the graph output).
-    QnnTensorWrapper int16_out_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
-                                       op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                  "Failed to add INT16 BQ MatMul output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::UniqueNameGenerator().New(op_output_name, "_fp16_quantize"),
-                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                      {matmul_fp16_out}, {op_output_name}, {}, do_op_validation),
-                  "Failed to add FP16→INT16 Quantize node for BQ MatMul output.");
+    if (output_info.quant_param.IsQuantized()) {
+      // INT16 quantized output tensor consumed by downstream nodes (or the graph output).
+      QnnTensorWrapper int16_out_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
+                                         op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                    "Failed to add INT16 BQ MatMul output tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(op_output_name, "_fp16_quantize"),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                        {matmul_fp16_out}, {op_output_name}, {}, do_op_validation),
+                    "Failed to add FP16→INT16 Quantize node for BQ MatMul output.");
+    }
+    // Unquantized (float) output: the Reshape above already registered op_output_name as
+    // QNN_TENSOR_TYPE_NATIVE. No further action needed; the caller's reshape_output path
+    // (if applicable) handles promotion to APP_READ.
   } else {
     QnnTensorWrapper op_output_tensor_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
                                               op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -4,6 +4,9 @@
 #include <functional>
 #include <limits>
 #include <numeric>
+#include <unordered_map>
+
+#include <gsl/gsl>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
@@ -28,6 +31,10 @@ class MatMulOpBuilder : public BaseOpBuilder {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(MatMulOpBuilder);
 
  protected:
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
+
   Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                             const OrtNodeUnit& node_unit,
                             const Ort::Logger& logger,
@@ -53,11 +60,71 @@ class MatMulOpBuilder : public BaseOpBuilder {
                                                 const Ort::Logger& logger,
                                                 std::vector<std::string>& input_names,
                                                 bool do_op_validation) const ORT_MUST_USE_RESULT;
+  // Block-quantized (BW_FLOAT_BLOCK) weight path. Translates to a QNN MatMul whose weight carries a
+  // per-block float scale; activation is dequantized to FP16 and the FP16 output is re-quantized to INT16.
+  Ort::Status ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       const TensorInfo& input_info_1,
+                                       const Ort::Logger& logger,
+                                       std::vector<std::string>& input_names,
+                                       bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
 
 namespace {
 inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
   return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
+}
+
+// HTP BQ MatMul: supported weight bitwidths and their block_size divisor constraints.
+// block_size must be a multiple of the corresponding value (same as Conv BQ / MatMulNBits HTP constraints).
+const std::unordered_map<uint32_t, int64_t> kHtpMatMulBQBitsAndBlockSizeMultipliers{
+    {2, 16}, {4, 8}, {8, 4}};
+
+// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
+uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
+  switch (onnx_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+// Detects a block-quantized MatMul weight (ONNX MatMul input[1], shape [K, N]).
+// Per ONNX opset 21, the weight scale has the same rank as the weight with the blocked axis
+// dimension smaller. MatMul blocks the contraction axis K (axis 0), so the rank-2 scale is
+// [K/block_size, N] and scale_shape[0] < weight_shape[0]. Only meaningful on the NPU backend.
+// On success, sets num_blocks = scale_shape[0] and block_size = K / num_blocks.
+bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight,
+                int64_t& num_blocks, int64_t& block_size) {
+  if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return false;
+  }
+  if (!weight.quant_param.has_value() || weight.quant_param->scale == nullptr) {
+    return false;
+  }
+  const auto scale_shape = utils::GetInitializerShape(weight.quant_param->scale, qnn_model_wrapper.GetOrtApi());
+  std::vector<uint32_t> weight_shape;
+  if (!QnnModelWrapper::GetOnnxShape(weight.shape, weight_shape) || weight_shape.size() != 2) {
+    return false;  // BQ only supported for rank-2 MatMul weight [K, N].
+  }
+  if (scale_shape.size() != weight_shape.size() ||
+      scale_shape[0] >= static_cast<int64_t>(weight_shape[0])) {
+    return false;
+  }
+  num_blocks = scale_shape[0];
+  if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[0]) % num_blocks != 0) {
+    return false;
+  }
+  block_size = static_cast<int64_t>(weight_shape[0]) / num_blocks;
+  return true;
 }
 
 // Flattens the leading dims of `shape` (all but the last) into a single uint32_t batch value.
@@ -158,10 +225,57 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
 
 // Process operator inputs. Dispatches to other processing functions depending on whether we're
 // translating an ONNX MatMul to a QNN MatMul or a QNN FullyConnected.
+Ort::Status MatMulOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
+                                           const Ort::Logger& logger) const {
+  const auto& inputs = node_unit.Inputs();
+
+  // Block-quantized (BW_FLOAT_BLOCK) weight: validate HTP constraints, then defer to the base
+  // implementation, which runs full QNN validation through our BQ ProcessInputs/Outputs path.
+  if (inputs.size() >= 2) {
+    int64_t num_blocks = 0;
+    int64_t block_size = 0;
+    if (IsBQWeight(qnn_model_wrapper, inputs[1], num_blocks, block_size)) {
+      const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+      auto bq_it = kHtpMatMulBQBitsAndBlockSizeMultipliers.find(bitwidth);
+      RETURN_IF(bq_it == kHtpMatMulBQBitsAndBlockSizeMultipliers.end(),
+                ("QNN HTP MatMul BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
+      RETURN_IF(block_size % bq_it->second != 0,
+                ("QNN HTP MatMul BQ: block_size=" + std::to_string(block_size) +
+                 " must be a multiple of " + std::to_string(bq_it->second) +
+                 " for " + std::to_string(bitwidth) + "-bit weight")
+                    .c_str());
+      // BQ requires a constant weight and a dynamic (quantized) activation that we dequantize to FP16.
+      TensorInfo weight_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], weight_info));
+      RETURN_IF_NOT(weight_info.is_initializer, "QNN EP: BQ MatMul weight must be a constant initializer");
+      TensorInfo act_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], act_info));
+      RETURN_IF(act_info.is_initializer, "QNN EP: BQ MatMul activation must be a dynamic (non-constant) tensor");
+    }
+  }
+
+  return BaseOpBuilder::IsOpSupported(qnn_model_wrapper, node_unit, logger);
+}
+
+// Process operator inputs. Dispatches to other processing functions depending on whether we're
+// translating an ONNX MatMul to a QNN MatMul or a QNN FullyConnected.
 Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
                                            const Ort::Logger& logger, std::vector<std::string>& input_names,
                                            bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
+
+  // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight (weight stays 2-D).
+  {
+    int64_t num_blocks = 0;
+    int64_t block_size = 0;
+    if (IsBQWeight(qnn_model_wrapper, inputs[1], num_blocks, block_size)) {
+      TensorInfo input_info_1{};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info_1));
+      return ProcessInputsForBQMatMul(qnn_model_wrapper, node_unit, input_info_1, logger, input_names,
+                                      do_op_validation);
+    }
+  }
+
   TensorInfo input_info_0{};
   TensorInfo input_info_1{};
   bool use_fully_connected = false;
@@ -411,6 +525,162 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   return Ort::Status();
 }
 
+Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model_wrapper,
+                                                      const OrtNodeUnit& node_unit,
+                                                      const TensorInfo& input_info_1,
+                                                      const Ort::Logger& logger,
+                                                      std::vector<std::string>& input_names,
+                                                      bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+  const auto& inputs = node_unit.Inputs();
+
+  RETURN_IF_NOT(input_info_1.is_initializer, "QNN EP: BQ MatMul weight must be a constant initializer");
+  RETURN_IF_NOT(input_info_1.shape.size() == 2, "QNN EP: BQ MatMul weight must be rank-2 [K, N]");
+  const int64_t K = static_cast<int64_t>(input_info_1.shape[0]);
+  const int64_t N = static_cast<int64_t>(input_info_1.shape[1]);
+
+  //
+  // Input 0: activation. BW_FLOAT_BLOCK MatMul computes in FP16, so an INT16 activation must be
+  // dequantized to FP16 first (mirrors the Conv BQ activation path). QNN HTP additionally requires the
+  // activation to be 4-D, so the [..., M, K] activation is reshaped to [batch, 1, M, K].
+  //
+  TensorInfo input_info_0{};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info_0));
+  RETURN_IF_NOT(input_info_0.shape.size() >= 2 && input_info_0.shape.size() <= 3,
+                "QNN EP: BQ MatMul activation must be rank 2 or 3");
+  RETURN_IF_ERROR(ProcessInput0(qnn_model_wrapper, input_info_0, inputs[0].name, input_names, logger,
+                                do_op_validation, /*use_fully_connected=*/false));
+  {
+    const std::string act_name = input_names[0];
+    const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
+    const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
+    std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
+
+    std::string fp16_name = act_name;
+    if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
+      // Reuse the original DequantizeLinear node's output name (the target MatMul's input[0]) for the
+      // FP16 tensor. That tensor is conceptually the dequantized activation — exactly what this
+      // INT16→FP16 Dequantize produces — and QNN EP otherwise skips it, so the name is free and keeps
+      // the QNN graph aligned with the ONNX graph naming.
+      fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+      QnnTensorWrapper fp16_act_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
+                                        QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                        std::vector<uint32_t>(act_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_act_wrapper)),
+                    "Failed to add FP16 activation tensor for BQ MatMul.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                        {act_name}, {fp16_name}, {}, do_op_validation),
+                    "Failed to add INT16→FP16 Dequantize node for BQ MatMul activation.");
+    }
+
+    // Reshape the FP16 activation [..., M, K] to 4-D [batch, 1, M, K] for the QNN HTP BQ MatMul.
+    const uint32_t k_dim = act_shape.back();
+    const uint32_t m_dim = act_shape[act_shape.size() - 2];
+    uint32_t batch = 1u;
+    for (size_t i = 0; i + 2 < act_shape.size(); ++i) {
+      batch *= act_shape[i];
+    }
+    const std::vector<uint32_t> act_shape_4d = {batch, 1u, m_dim, k_dim};
+    const std::string act_4d_name = utils::UniqueNameGenerator().New(fp16_name, "_reshape_4d");
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(fp16_name, act_4d_name, act_shape, act_shape_4d,
+                                                     QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                                     do_op_validation,
+                                                     /*is_for_input=*/false, /*is_for_output=*/false));
+    input_names[0] = act_4d_name;
+  }
+
+  //
+  // Input 1: weight. Build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params on the 2-D weight
+  // [K, N], blocked along the contraction axis K.
+  //
+  const std::string& input1_name = inputs[1].name;
+
+  // Determine num_blocks/block_size from the ONNX scale shape [K/block_size, N].
+  const auto scale_shape = utils::GetInitializerShape(inputs[1].quant_param->scale, qnn_model_wrapper.GetOrtApi());
+  RETURN_IF_NOT(scale_shape.size() == 2, "QNN EP: BQ MatMul scale must be rank-2 [K/block_size, N]");
+  const int64_t num_blocks = scale_shape[0];
+  RETURN_IF(num_blocks <= 0 || K % num_blocks != 0, "QNN EP: BQ MatMul K must be divisible by num_blocks");
+  const int64_t block_size = K / num_blocks;
+  const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+
+  // Unpack the weight to one byte per element (sub-byte INT2/INT4 expanded to INT8).
+  std::vector<uint8_t> unpacked_tensor;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info_1.initializer_tensor, unpacked_tensor));
+
+  // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain. QNN BW_FLOAT_BLOCK
+  // only supports SFIXED_POINT_8 (signed); unsigned data must be converted (see conv_op_builder.cc).
+  const bool is_unsigned_weight = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
+                                   inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
+                                   inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+  if (is_unsigned_weight) {
+    RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor, static_cast<int64_t>(bitwidth)));
+  }
+
+  // QNN HTP requires a BQ MatMul to be expressed with 4-D activation, 4-D weight, and a 4-D blockSize.
+  // The weight [K, N] is reshaped to [1, 1, K, N]; with transpose_in1 = 0 the contraction axis K is
+  // axis 2, so blockSize is {1, 1, block_size, 1}.
+  const std::vector<uint32_t> block_size_arr = {1u, 1u, static_cast<uint32_t>(block_size), 1u};
+
+  // ONNX per-block float scales are laid out [num_blocks, N] (block-major). QNN expects the
+  // scale/offset array ordered output-channel-major with the output channel (N) as the last weight
+  // axis and the block index inner — i.e. [N, num_blocks]. Transpose from [num_blocks, N] → [N, nb].
+  std::vector<float> onnx_scales;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, onnx_scales));
+  RETURN_IF_NOT(static_cast<int64_t>(onnx_scales.size()) == num_blocks * N,
+                "QNN EP: BQ MatMul scale size mismatch");
+
+  // Float offsets in ONNX [num_blocks, N] order before transpose. Matches the Conv BQ formula:
+  //   offsets_qnn[idx] = unsigned_bias - zp_values[idx]
+  // where zp_values come from UnpackZeroPoints and unsigned_bias = (1 << (bits-1)) for unsigned weights
+  // (compensating for the unsigned→signed shift above), 0 for signed weights.
+  const float unsigned_bias = is_unsigned_weight ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
+  std::vector<float> onnx_offsets(static_cast<size_t>(num_blocks * N), unsigned_bias);
+  if (inputs[1].quant_param->zero_point != nullptr) {
+    std::vector<int32_t> zp_values;
+    ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point, zp_values, zp_onnx_type));
+    RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == num_blocks * N,
+                  "QNN EP: BQ MatMul zero_point size must match num_blocks * N");
+    for (size_t idx = 0; idx < zp_values.size(); ++idx) {
+      onnx_offsets[idx] = unsigned_bias - static_cast<float>(zp_values[idx]);
+    }
+  }
+
+  // Transpose scales/offsets [num_blocks, N] → [N, num_blocks].
+  std::vector<float> scales_qnn(static_cast<size_t>(N * num_blocks));
+  std::vector<float> offsets_qnn(static_cast<size_t>(N * num_blocks));
+  for (int64_t b = 0; b < num_blocks; ++b) {
+    for (int64_t n = 0; n < N; ++n) {
+      const size_t src = static_cast<size_t>(b * N + n);
+      const size_t dst = static_cast<size_t>(n * num_blocks + b);
+      scales_qnn[dst] = onnx_scales[src];
+      offsets_qnn[dst] = onnx_offsets[src];
+    }
+  }
+
+  QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
+                                        gsl::span<const float>(offsets_qnn),
+                                        bitwidth,
+                                        gsl::span<const uint32_t>(block_size_arr));
+
+  // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
+  // Weight is reshaped to 4-D [1, 1, K, N] to satisfy the QNN HTP BQ MatMul requirement.
+  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(input1_name);
+  std::vector<uint32_t> weight_shape = {1u, 1u, static_cast<uint32_t>(K), static_cast<uint32_t>(N)};
+  QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
+                                     QNN_DATATYPE_SFIXED_POINT_8,
+                                     std::move(bq_quant_params),
+                                     std::move(weight_shape),
+                                     std::move(unpacked_tensor));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bq_weight_wrapper)),
+                "Failed to add BQ MatMul weight tensor.");
+  input_names.push_back(input1_name);
+
+  return Ort::Status();
+}
+
 Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                          const OrtNodeUnit& node_unit,
                                                          std::vector<std::string>&& input_names,
@@ -421,6 +691,16 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   bool use_fully_connected = false;
   RETURN_IF_ERROR(
       CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1, use_fully_connected));
+
+  // A block-quantized weight is always emitted as a QNN MatMul (see ProcessInputsForBQMatMul), even
+  // when CheckInputs would otherwise route a rank-2 initializer weight to FullyConnected. Force the
+  // MatMul path here so the output handling matches how the inputs were built.
+  int64_t bq_num_blocks = 0;
+  int64_t bq_block_size = 0;
+  if (IsBQWeight(qnn_model_wrapper, inputs[1], bq_num_blocks, bq_block_size)) {
+    use_fully_connected = false;
+  }
+
   bool reshape_input_0 = input_info_0.shape.size() == 1;
   bool reshape_input_1 = input_info_1.shape.size() == 1;
   bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2);
@@ -472,15 +752,69 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   const bool is_op_output_graph_output = is_graph_output && !reshape_output;
   Qnn_TensorType_t op_output_tensor_type =
       is_op_output_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-  QnnTensorWrapper op_output_tensor_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
-                                            op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(op_output_tensor_wrapper)),
-                "Failed to add output tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit), QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                use_fully_connected ? QNN_OP_FULLY_CONNECTED : QNN_OP_MAT_MUL,
-                                                std::move(input_names), {op_output_name},
-                                                std::move(param_tensor_names), do_op_validation),
-                "Failed to add fused Matmul node.");
+
+  // Detect a BQ (BW_FLOAT_BLOCK) MatMul from the weight tensor's quant encoding. input_names[1] is
+  // the weight (BQ MatMul always has exactly 2 inputs and is never reshaped). A BQ MatMul computes
+  // in FP16, so it must output FP16 and then re-quantize to the INT16 the downstream QDQ expects.
+  bool is_bq_matmul = false;
+  if (!use_fully_connected && input_names.size() > 1 &&
+      qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1])) {
+    is_bq_matmul = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized();
+  }
+
+  if (is_bq_matmul && output_info.quant_param.IsQuantized()) {
+    // The QNN HTP BQ MatMul runs on 4-D tensors and outputs FP16. The ONNX output is INT16-quantized,
+    // so the pipeline is: MatMul (4-D FP16 [batch,1,M,N]) → Reshape (to ONNX [...,M,N] FP16) → Quantize
+    // (FP16 → INT16). The reshape target reuses the original QuantizeLinear node's input name (the
+    // un-quantized MatMul output), keeping the QNN graph aligned with the ONNX graph naming.
+    const uint32_t n_dim = op_output_shape.back();
+    const uint32_t m_dim = op_output_shape[op_output_shape.size() - 2];
+    uint32_t batch = 1u;
+    for (size_t i = 0; i + 2 < op_output_shape.size(); ++i) {
+      batch *= op_output_shape[i];
+    }
+    const std::vector<uint32_t> matmul_out_shape_4d = {batch, 1u, m_dim, n_dim};
+
+    const std::string matmul_4d_out = utils::UniqueNameGenerator().New(op_output_name, "_matmul_4d");
+    QnnTensorWrapper matmul_4d_wrapper(matmul_4d_out, QNN_TENSOR_TYPE_NATIVE,
+                                       QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(matmul_out_shape_4d));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(matmul_4d_wrapper)),
+                  "Failed to add 4-D FP16 BQ MatMul output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_MAT_MUL,
+                                                  std::move(input_names), {matmul_4d_out},
+                                                  std::move(param_tensor_names), do_op_validation),
+                  "Failed to add BQ MatMul node.");
+
+    // Reshape 4-D FP16 [batch,1,M,N] back to the ONNX FP16 output shape [...,M,N].
+    const std::string matmul_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(matmul_4d_out, matmul_fp16_out, matmul_out_shape_4d,
+                                                     op_output_shape, QNN_DATATYPE_FLOAT_16,
+                                                     QnnQuantParamsWrapper(), do_op_validation,
+                                                     /*is_for_input=*/false, /*is_for_output=*/false));
+
+    // INT16 quantized output tensor consumed by downstream nodes (or the graph output).
+    QnnTensorWrapper int16_out_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
+                                       op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                  "Failed to add INT16 BQ MatMul output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(op_output_name, "_fp16_quantize"),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                      {matmul_fp16_out}, {op_output_name}, {}, do_op_validation),
+                  "Failed to add FP16→INT16 Quantize node for BQ MatMul output.");
+  } else {
+    QnnTensorWrapper op_output_tensor_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
+                                              op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(op_output_tensor_wrapper)),
+                  "Failed to add output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit), QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  use_fully_connected ? QNN_OP_FULLY_CONNECTED : QNN_OP_MAT_MUL,
+                                                  std::move(input_names), {op_output_name},
+                                                  std::move(param_tensor_names), do_op_validation),
+                  "Failed to add fused Matmul node.");
+  }
 
   if (reshape_output) {
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -262,6 +262,181 @@ TEST_F(QnnCPUBackendTests, MatMulOp) {
 //
 // HTP tests:
 //
+
+namespace {
+
+// Builds an ONNX QDQ graph for a MatMul with a block-quantized (BW_FLOAT_BLOCK) weight.
+//   - activation A: float → Q(uint16) → DQ, shape [M, K]
+//   - weight B: INT4/INT8 (or UINT4/UINT8) initializer + DQ with block_size attribute and a rank-2
+//               float scale [K/block_size, N] (axis=0, K is the blocked contraction dimension)
+//   - output:  MatMul → Q(uint16) → DQ → graph output, shape [M, N]
+//
+// weight_bits: 4 for INT4/UINT4 (default), 8 for INT8/UINT8, 2 for INT2/UINT2.
+// block_size must be a multiple of 8 (4-bit), 4 (8-bit), or 16 (2-bit) per HTP.
+// weight_is_unsigned: true → use UINT weight type; exercises the unsigned→signed conversion path.
+GetQDQTestCaseFn BuildBQMatMulTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
+                                       int weight_bits = 4, bool weight_is_unsigned = false) {
+  return [M, K, N, block_size, weight_bits, weight_is_unsigned](ModelTestBuilder& builder) -> void {
+    const int64_t num_blocks = K / block_size;  // caller ensures K % block_size == 0
+
+    // ── Activation A: float → Q(uint16) → DQ ─────────────────────────────────
+    auto input_def = TestInputDef<float>({M, K}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    const float act_scale = 2.0f / 65534.0f;  // uint16 symmetric per-tensor, ~[-1, 1]
+    const uint16_t act_zp = 32767;
+    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
+    builder.AddNode("act_ql", "QuantizeLinear", {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
+    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
+    builder.AddNode("act_dql", "DequantizeLinear", {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
+
+    // ── Weight B initializer + DQ(block_size, axis=0) ────────────────────────
+    // Scale rank == weight rank per ONNX opset 21: [K/block_size, N].
+    const std::vector<int64_t> weight_shape{K, N};
+    const std::vector<int64_t> scale_shape{num_blocks, N};
+    builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
+
+    const size_t num_elems = static_cast<size_t>(K * N);
+    if (weight_bits == 4 && !weight_is_unsigned) {
+      std::vector<Int4x2> weight_data(Int4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 1].SetElem(i & 1, static_cast<int8_t>((i % 7) - 3));
+      }
+      builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, weight_data);
+    } else if (weight_bits == 4 && weight_is_unsigned) {
+      std::vector<UInt4x2> weight_data(UInt4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 1].SetElem(i & 1, static_cast<uint8_t>(i % 15));
+      }
+      builder.MakeInitializer<UInt4x2>("weight_quant", weight_shape, weight_data);
+    } else if (weight_bits == 2 && !weight_is_unsigned) {
+      std::vector<Int2x4> weight_data(Int2x4::CalcNumInt2Quads(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 2].SetElem(i & 3, static_cast<int8_t>((i % 3) - 1));
+      }
+      builder.MakeInitializer<Int2x4>("weight_quant", weight_shape, weight_data);
+    } else if (weight_bits == 2 && weight_is_unsigned) {
+      std::vector<UInt2x4> weight_data(UInt2x4::CalcNumInt2Quads(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i >> 2].SetElem(i & 3, static_cast<uint8_t>(i % 4));
+      }
+      builder.MakeInitializer<UInt2x4>("weight_quant", weight_shape, weight_data);
+    } else if (weight_is_unsigned) {
+      std::vector<uint8_t> weight_data(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i] = static_cast<uint8_t>(i % 127);
+      }
+      builder.MakeInitializer<uint8_t>("weight_quant", weight_shape, weight_data);
+    } else {
+      std::vector<int8_t> weight_data(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) {
+        weight_data[i] = static_cast<int8_t>((i % 127) - 63);
+      }
+      builder.MakeInitializer<int8_t>("weight_quant", weight_shape, weight_data);
+    }
+
+    // DQ with block_size; omit zero_point (symmetric). axis=0: K is the blocked dimension.
+    builder.AddNode("weight_dql", "DequantizeLinear",
+                    {"weight_quant", "weight_scale"}, {"weight_dql_out"}, "",
+                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                     builder.MakeScalarAttribute("block_size", block_size)});
+
+    // ── MatMul ───────────────────────────────────────────────────────────────
+    builder.AddNode("matmul", "MatMul", {"act_dql_out", "weight_dql_out"}, {"matmul_out"}, kOnnxDomain);
+
+    // ── Output: MatMul → Q(uint16) → DQ → graph output ───────────────────────
+    const float out_scale = 4.0f / 65534.0f;
+    const uint16_t out_zp = 32767;
+    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
+    builder.AddNode("out_ql", "QuantizeLinear", {"matmul_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
+    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
+    builder.MakeOutput("output");
+    builder.AddNode("out_dql", "DequantizeLinear", {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
+  };
+}
+
+ProviderOptions GetBQMatMulProviderOptions() {
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  // On the x86_64 Linux HTP simulator, specify SM8850 to enable BW_FLOAT_BLOCK support.
+  // On real ARM64 hardware, the SoC model is auto-detected by QNN EP.
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return opts;
+}
+
+}  // namespace
+
+// INT4 weight, K=16, N=4, block_size=8 (2 blocks/N), uint16 activation, no bias.
+// Checks: all nodes assigned to QNN EP; output matches CPU EP within 1e-2.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// Larger K with more blocks per output channel. Guards the [num_blocks, N] → [N, num_blocks]
+// scale reordering: a wrong order fails on accuracy, not on QNN validation.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_MultiBlock) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/32, /*N=*/8, /*block_size=*/8),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// INT4, block_size=16: still a valid HTP multiple-of-8 block size.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/32, /*N=*/4, /*block_size=*/16),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// INT8, block_size=4: minimum valid HTP multiple-of-4 block size for 8-bit.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int8_BlockSize4) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/4,
+                                        /*weight_bits=*/8),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// UINT4 weight: exercises the unsigned→signed conversion path (TransformUnsignedToSignedFixedPoint).
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16UInt4_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8,
+                                        /*weight_bits=*/4, /*weight_is_unsigned=*/true),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-2f);
+}
+
+// UINT8 weight: unsigned 8-bit path.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16UInt8_BlockSize4) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/4,
+                                        /*weight_bits=*/8, /*weight_is_unsigned=*/true),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-2f);
+}
+
+// INT2, block_size=16: DISABLED. Two independent blockers (same as Conv BQ):
+//   1. ORT CPU backend does not support 2-bit Q/DQ (rejects tensor(int2)).
+//   2. QAIRT HTP backend does not support 2-bit BQ until QAIRT 2.47.
+TEST_F(QnnHTPBackendTests, DISABLED_MatMulBQ_U16Int2_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/32, /*N=*/4, /*block_size=*/16,
+                                        /*weight_bits=*/2),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-2f);
+}
+
 TEST_F(QnnHTPBackendTests, MatMulOp) {
   // RunMatMulOpTest(shape_0, shape_1, is_initializer_0, is_initializer_1, expected_ep_assignment,
   // opset, f32_abs_err)

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -275,22 +275,32 @@ namespace {
 // block_size must be a multiple of 8 (4-bit), 4 (8-bit), or 16 (2-bit) per HTP.
 // weight_is_unsigned: true → use UINT weight type; exercises the unsigned→signed conversion path.
 GetQDQTestCaseFn BuildBQMatMulTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
-                                       int weight_bits = 4, bool weight_is_unsigned = false) {
-  return [M, K, N, block_size, weight_bits, weight_is_unsigned](ModelTestBuilder& builder) -> void {
+                                       int weight_bits = 4, bool weight_is_unsigned = false,
+                                       std::vector<int64_t> act_shape_override = {},
+                                       std::vector<int64_t> weight_shape_override = {}) {
+  return [M, K, N, block_size, weight_bits, weight_is_unsigned, act_shape_override,
+          weight_shape_override](ModelTestBuilder& builder) -> void {
     const int64_t num_blocks = K / block_size;  // caller ensures K % block_size == 0
 
     // ── Activation A: float → Q(uint16) → DQ ─────────────────────────────────
-    auto input_def = TestInputDef<float>({M, K}, false, -1.0f, 1.0f);
+    const std::vector<int64_t> act_shape = act_shape_override.empty() ? std::vector<int64_t>{M, K}
+                                                                      : act_shape_override;
+    auto input_def = TestInputDef<float>(act_shape, false, -1.0f, 1.0f);
     MakeTestInput<float>(builder, "input", input_def);
 
     const float act_scale = 2.0f / 65534.0f;  // uint16 symmetric per-tensor, ~[-1, 1]
     const uint16_t act_zp = 32767;
     const std::string act_dql_out = AddQDQNodePair<uint16_t>(builder, "act", "input", act_scale, act_zp);
 
-    // ── Weight B initializer + DQ(block_size, axis=0) ────────────────────────
-    // Scale rank == weight rank per ONNX opset 21: [K/block_size, N].
-    const std::vector<int64_t> weight_shape{K, N};
-    const std::vector<int64_t> scale_shape{num_blocks, N};
+    // ── Weight B initializer + DQ(block_size, axis=rank-2) ──────────────────
+    // Scale rank == weight rank per ONNX opset 21.
+    const std::vector<int64_t> weight_shape = weight_shape_override.empty()
+                                                  ? std::vector<int64_t>{K, N}
+                                                  : weight_shape_override;
+    // Build scale shape: same as weight shape with the K-axis (rank-2) replaced by num_blocks.
+    std::vector<int64_t> scale_shape = weight_shape;
+    scale_shape[scale_shape.size() - 2] = num_blocks;
+    const int64_t block_axis = static_cast<int64_t>(weight_shape.size()) - 2;
     builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
 
     const size_t num_elems = static_cast<size_t>(K * N);
@@ -335,7 +345,7 @@ GetQDQTestCaseFn BuildBQMatMulTestCase(int64_t M, int64_t K, int64_t N, int64_t 
     // DQ with block_size; omit zero_point (symmetric). axis=0: K is the blocked dimension.
     builder.AddNode("weight_dql", "DequantizeLinear",
                     {"weight_quant", "weight_scale"}, {"weight_dql_out"}, "",
-                    {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)),
+                    {builder.MakeScalarAttribute("axis", block_axis),
                      builder.MakeScalarAttribute("block_size", block_size)});
 
     // ── MatMul ───────────────────────────────────────────────────────────────
@@ -424,6 +434,46 @@ TEST_F(QnnHTPBackendTests, DISABLED_MatMulBQ_U16Int2_BlockSize16) {
                                         /*weight_bits=*/2),
                   GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
                   /*fp32_abs_err=*/2e-2f);
+}
+
+// Rank-3 activation [1, M, K]: leading dim=1, reshapes to [1, 1, M, K] matching weight [1, 1, K, N].
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_Rank3Activation) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8,
+                                        /*weight_bits=*/4, /*weight_is_unsigned=*/false,
+                                        /*act_shape_override=*/{1, 2, 16}),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// Rank-3 weight [1, K, N]: leading dim = 1, reshapeable to [1, 1, K, N].
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_Rank3Weight) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8,
+                                        /*weight_bits=*/4, /*weight_is_unsigned=*/false,
+                                        /*act_shape_override=*/{}, /*weight_shape_override=*/{1, 16, 4}),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// Rank-4 activation [1, 1, M, K]: already in 4-D form, no reshape needed.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_Rank4Activation) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8,
+                                        /*weight_bits=*/4, /*weight_is_unsigned=*/false,
+                                        /*act_shape_override=*/{1, 1, 2, 16}),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
+}
+
+// Rank-4 weight [1, 1, K, N]: already in the [1,1,K,N] form QNN requires.
+TEST_F(QnnHTPBackendTests, MatMulBQ_U16Int4_Rank4Weight) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQMatMulTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8,
+                                        /*weight_bits=*/4, /*weight_is_unsigned=*/false,
+                                        /*act_shape_override=*/{}, /*weight_shape_override=*/{1, 1, 16, 4}),
+                  GetBQMatMulProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/1e-2f);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulOp) {

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -285,12 +285,7 @@ GetQDQTestCaseFn BuildBQMatMulTestCase(int64_t M, int64_t K, int64_t N, int64_t 
 
     const float act_scale = 2.0f / 65534.0f;  // uint16 symmetric per-tensor, ~[-1, 1]
     const uint16_t act_zp = 32767;
-    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
-    builder.AddNode("act_ql", "QuantizeLinear", {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
-    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
-    builder.AddNode("act_dql", "DequantizeLinear", {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
+    const std::string act_dql_out = AddQDQNodePair<uint16_t>(builder, "act", "input", act_scale, act_zp);
 
     // ── Weight B initializer + DQ(block_size, axis=0) ────────────────────────
     // Scale rank == weight rank per ONNX opset 21: [K/block_size, N].
@@ -344,18 +339,12 @@ GetQDQTestCaseFn BuildBQMatMulTestCase(int64_t M, int64_t K, int64_t N, int64_t 
                      builder.MakeScalarAttribute("block_size", block_size)});
 
     // ── MatMul ───────────────────────────────────────────────────────────────
-    builder.AddNode("matmul", "MatMul", {"act_dql_out", "weight_dql_out"}, {"matmul_out"}, kOnnxDomain);
+    builder.AddNode("matmul", "MatMul", {act_dql_out, "weight_dql_out"}, {"matmul_out"}, kOnnxDomain);
 
     // ── Output: MatMul → Q(uint16) → DQ → graph output ───────────────────────
     const float out_scale = 4.0f / 65534.0f;
     const uint16_t out_zp = 32767;
-    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
-    builder.AddNode("out_ql", "QuantizeLinear", {"matmul_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
-    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
-    builder.MakeOutput("output");
-    builder.AddNode("out_dql", "DequantizeLinear", {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
+    AddQDQNodePairWithOutputAsGraphOutput<uint16_t>(builder, "out", "matmul_out", out_scale, out_zp);
   };
 }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds BW_FLOAT_BLOCK (block-quantized) weight support to the QNN EP MatMul op builder, mirroring the merged Conv BQ PR (#429). QNN HTP requires the BQ MatMul to run with 4-D tensors, so the implementation:
  - Dequantizes INT16 activation to FP16
  - Reshapes activation [..., M, K] → [batch, 1, M, K]
  - Adds weight as [1, 1, K, N] SFIXED_POINT_8 with BW_FLOAT_BLOCK quant (block_sizes = {1, 1, block_size, 1}, transpose_in1 = 0)
  - Transposes ONNX [num_blocks, N] scales to QNN [N, num_blocks] order
  - Reshapes 4-D FP16 MatMul output back to [..., M, N]
  - Re-quantizes FP16 output to INT16


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Supports INT4/UINT4/INT8/UINT8 weights with HTP block_size constraints ({4-bit: ×8, 8-bit: ×4}). Requires QAIRT >= 2.47.

