### PR TITLE
[QNN EP] Gemm BQ Phase 1: support Gemm with block-quantized weight on HTP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -281,22 +281,24 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
     const std::string act_name = input_names[0];
     const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
     const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
-    if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
-      // Reuse the original DequantizeLinear node's output name for the FP16 tensor.
-      const std::string fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-      const std::vector<uint32_t> act_shape_2d = act_wrapper.GetTensorDims();
-      QnnTensorWrapper fp16_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
-                                    QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                    std::vector<uint32_t>(act_shape_2d));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
-                    "Failed to add FP16 activation tensor for BQ Gemm.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
-                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
-                        {act_name}, {fp16_name}, {}, do_op_validation),
-                    "Failed to add INT16→FP16 Dequantize node for BQ Gemm activation.");
-      input_names[0] = fp16_name;
-    }
+    // BW_FLOAT_BLOCK FC requires FP16 activation. The only activation dtype reaching this
+    // path through the QDQ selector is INT16 (SFIXED or UFIXED), so anything else is unexpected.
+    RETURN_IF_NOT(act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16,
+                  "QNN EP: BQ Gemm activation must be INT16-quantized for the BW_FLOAT_BLOCK kernel");
+    // Reuse the original DequantizeLinear node's output name for the FP16 tensor.
+    const std::string fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+    const std::vector<uint32_t> act_shape_2d = act_wrapper.GetTensorDims();
+    QnnTensorWrapper fp16_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
+                                  QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                  std::vector<uint32_t>(act_shape_2d));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
+                  "Failed to add FP16 activation tensor for BQ Gemm.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                      {act_name}, {fp16_name}, {}, do_op_validation),
+                  "Failed to add INT16→FP16 Dequantize node for BQ Gemm activation.");
+    input_names[0] = fp16_name;
   }
 
   //

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -1,13 +1,78 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <unordered_map>
+
+#include <gsl/gsl>
+
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
 
 namespace onnxruntime {
 namespace qnn {
+
+namespace {
+
+// HTP BQ Gemm/FC: supported weight bitwidths and their block_size divisor constraints.
+const std::unordered_map<uint32_t, int64_t> kHtpGemmBQBitsAndBlockSizeMultipliers{
+    {2, 16}, {4, 8}, {8, 4}};
+
+// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
+uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
+  switch (onnx_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+// Detects a block-quantized Gemm weight B, accounting for transB.
+// For transB=0: B is [K, N], scale is [K/block_size, N], blocked on axis 0.
+// For transB=1: B is [N, K], scale is [N, K/block_size], blocked on axis 1.
+// Both cases: K is the contraction axis (blocked axis). Returns true and sets
+// num_blocks = number of blocks along K, block_size = K / num_blocks.
+bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight,
+                    int64_t trans_b, int64_t& num_blocks, int64_t& block_size) {
+  if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return false;
+  }
+  if (!weight.quant_param.has_value() || weight.quant_param->scale == nullptr) {
+    return false;
+  }
+  const auto scale_shape = utils::GetInitializerShape(weight.quant_param->scale, qnn_model_wrapper.GetOrtApi());
+  std::vector<uint32_t> weight_shape;
+  if (!QnnModelWrapper::GetOnnxShape(weight.shape, weight_shape) || weight_shape.size() != 2) {
+    return false;  // BQ only for rank-2 Gemm weight.
+  }
+  if (scale_shape.size() != 2) {
+    return false;
+  }
+  // For transB=0: B=[K,N], blocked on axis 0 → scale=[num_blocks, N], scale_shape[0] < weight_shape[0].
+  // For transB=1: B=[N,K], blocked on axis 1 → scale=[N, num_blocks], scale_shape[1] < weight_shape[1].
+  const int blocked_axis = (trans_b == 0) ? 0 : 1;
+  if (scale_shape[blocked_axis] >= static_cast<int64_t>(weight_shape[blocked_axis])) {
+    return false;
+  }
+  num_blocks = scale_shape[blocked_axis];
+  if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[blocked_axis]) % num_blocks != 0) {
+    return false;
+  }
+  block_size = static_cast<int64_t>(weight_shape[blocked_axis]) / num_blocks;
+  return true;
+}
+
+}  // namespace
 
 class GemmOpBuilder : public BaseOpBuilder {
  public:
@@ -15,6 +80,10 @@ class GemmOpBuilder : public BaseOpBuilder {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GemmOpBuilder);
 
  protected:
+  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit,
+                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
+
   Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                             const OrtNodeUnit& node_unit,
                             const Ort::Logger& logger,
@@ -29,7 +98,43 @@ class GemmOpBuilder : public BaseOpBuilder {
 
  private:
   Ort::Status ExplictOpCheck(const OrtNodeUnit& node_unit) const;
+  // Block-quantized (BW_FLOAT_BLOCK) weight path for Gemm→QNN FullyConnected.
+  Ort::Status ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wrapper,
+                                     const OrtNodeUnit& node_unit,
+                                     int64_t trans_b,
+                                     float beta,
+                                     const Ort::Logger& logger,
+                                     std::vector<std::string>& input_names,
+                                     bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
+
+Ort::Status GemmOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
+                                         const Ort::Logger& logger) const {
+  const auto& inputs = node_unit.Inputs();
+  if (inputs.size() >= 2) {
+    OrtNodeAttrHelper node_helper(node_unit);
+    const int64_t trans_b = node_helper.Get("transB", static_cast<int64_t>(0));
+    int64_t num_blocks = 0, block_size = 0;
+    if (IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b, num_blocks, block_size)) {
+      const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+      auto bq_it = kHtpGemmBQBitsAndBlockSizeMultipliers.find(bitwidth);
+      RETURN_IF(bq_it == kHtpGemmBQBitsAndBlockSizeMultipliers.end(),
+                ("QNN HTP Gemm BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
+      RETURN_IF(block_size % bq_it->second != 0,
+                ("QNN HTP Gemm BQ: block_size=" + std::to_string(block_size) +
+                 " must be a multiple of " + std::to_string(bq_it->second) +
+                 " for " + std::to_string(bitwidth) + "-bit weight")
+                    .c_str());
+      TensorInfo weight_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], weight_info));
+      RETURN_IF_NOT(weight_info.is_initializer, "QNN EP: BQ Gemm weight must be a constant initializer");
+      TensorInfo act_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], act_info));
+      RETURN_IF(act_info.is_initializer, "QNN EP: BQ Gemm activation must be a dynamic tensor");
+    }
+  }
+  return BaseOpBuilder::IsOpSupported(qnn_model_wrapper, node_unit, logger);
+}
 
 Ort::Status GemmOpBuilder::ExplictOpCheck(const OrtNodeUnit& node_unit) const {
   OrtNodeAttrHelper node_helper(node_unit);
@@ -69,18 +174,29 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   if (do_op_validation) {
     RETURN_IF_ERROR(ExplictOpCheck(node_unit));
   }
+
+  OrtNodeAttrHelper node_helper(node_unit);
+  const int64_t trans_b = node_helper.Get("transB", static_cast<int64_t>(0));
+  const float beta = node_helper.Get("beta", 1.0f);
+  const auto& inputs = node_unit.Inputs();
+
+  // Block-quantized weight: translate to QNN FullyConnected with BW_FLOAT_BLOCK weight.
+  {
+    int64_t num_blocks = 0, block_size = 0;
+    if (IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b, num_blocks, block_size)) {
+      return ProcessInputsForBQGemm(qnn_model_wrapper, node_unit, trans_b, beta, logger, input_names,
+                                    do_op_validation);
+    }
+  }
+
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
 
   // for Input A, B, C: 1 -- need transpose, 0 -- not needed
   std::vector<int64_t> input_trans_flag(3, 0);
-  OrtNodeAttrHelper node_helper(node_unit);
-  auto beta = node_helper.Get("beta", (float)1.0);
   input_trans_flag.at(0) = node_helper.Get("transA", (int64_t)0);
   auto transB = node_helper.Get("transB", (int64_t)0);
   // QNN input_1 [m, n] vs Onnx [n, m]
   input_trans_flag.at(1) = transB == 0 ? 1 : 0;
-
-  const auto& inputs = node_unit.Inputs();
   for (size_t input_i = 0; input_i < inputs.size(); ++input_i) {
     // beta=0.0: C has no effect on the output — skip it so FC receives only (A, B)
     if (input_i == 2 && beta == 0.0f) {
@@ -153,17 +269,282 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
+Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wrapper,
+                                                  const OrtNodeUnit& node_unit,
+                                                  int64_t trans_b,
+                                                  float beta,
+                                                  const Ort::Logger& logger,
+                                                  std::vector<std::string>& input_names,
+                                                  bool do_op_validation) const {
+  ORT_UNUSED_PARAMETER(logger);
+  const auto& inputs = node_unit.Inputs();
+
+  // Determine weight shape and K, N dimensions.
+  // transB=0: B=[K,N], blocked on axis 0; transB=1: B=[N,K], blocked on axis 1.
+  TensorInfo weight_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], weight_info));
+  RETURN_IF_NOT(weight_info.is_initializer, "QNN EP: BQ Gemm weight must be a constant initializer");
+  RETURN_IF_NOT(weight_info.shape.size() == 2, "QNN EP: BQ Gemm weight must be rank-2");
+
+  // QNN FC weight is [N, K]. From ONNX:
+  //   transB=0: B=[K,N] → must transpose to [N,K]; K is the blocked axis.
+  //   transB=1: B=[N,K] → already [N,K], no transpose needed.
+  const int64_t N = (trans_b == 0) ? static_cast<int64_t>(weight_info.shape[1])
+                                   : static_cast<int64_t>(weight_info.shape[0]);
+  const int64_t K = (trans_b == 0) ? static_cast<int64_t>(weight_info.shape[0])
+                                   : static_cast<int64_t>(weight_info.shape[1]);
+
+  //
+  // Input A (activation): dequantize INT16→FP16 if needed. Stays 2-D [M, K].
+  // QNN HTP BQ FullyConnected accepts 2-D activation with a 2-D BW_FLOAT_BLOCK weight.
+  //
+  TensorInfo act_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], act_info));
+  RETURN_IF_NOT(act_info.shape.size() == 2, "QNN EP: BQ Gemm activation must be rank-2 [M, K]");
+
+  // Add activation to QNN graph (handles graph-input / already-added cases).
+  if (!qnn_model_wrapper.IsQnnTensorWrapperExist(inputs[0].name)) {
+    QnnTensorWrapper act_wrapper;
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(act_info, inputs[0].name, act_wrapper));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(act_wrapper)), "Failed to add act tensor.");
+  }
+  input_names.push_back(inputs[0].name);
+
+  {
+    const std::string act_name = input_names[0];
+    const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
+    const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
+    if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
+      // Reuse the original DequantizeLinear node's output name for the FP16 tensor.
+      const std::string fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+      const std::vector<uint32_t> act_shape_2d = act_wrapper.GetTensorDims();
+      QnnTensorWrapper fp16_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
+                                    QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                    std::vector<uint32_t>(act_shape_2d));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
+                    "Failed to add FP16 activation tensor for BQ Gemm.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                        {act_name}, {fp16_name}, {}, do_op_validation),
+                    "Failed to add INT16→FP16 Dequantize node for BQ Gemm activation.");
+      input_names[0] = fp16_name;
+    }
+  }
+
+  //
+  // Weight B: orient to [N, K] (QNN FC weight layout), build 2-D BW_FLOAT_BLOCK quant params.
+  // QNN HTP BQ FullyConnected accepts a 2-D weight [N, K] with block_sizes={1, block_size}:
+  // K is the contraction axis (axis 1), blocked into num_blocks chunks.
+  //
+  const std::string& weight_name = inputs[1].name;
+  const auto scale_shape = utils::GetInitializerShape(inputs[1].quant_param->scale, qnn_model_wrapper.GetOrtApi());
+  RETURN_IF_NOT(scale_shape.size() == 2, "QNN EP: BQ Gemm scale must be rank-2");
+
+  // num_blocks is the number of blocks along K.
+  const int64_t num_blocks = (trans_b == 0) ? scale_shape[0] : scale_shape[1];
+  RETURN_IF(num_blocks <= 0 || K % num_blocks != 0, "QNN EP: BQ Gemm K must be divisible by num_blocks");
+  const int64_t block_size = K / num_blocks;
+  const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+
+  // Unpack weight to one byte per element (sub-byte INT2/INT4 expanded to INT8).
+  std::vector<uint8_t> unpacked_weight;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(weight_info.initializer_tensor, unpacked_weight));
+
+  // For unsigned types, shift to signed domain.
+  const bool is_unsigned = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
+                            inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
+                            inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+  if (is_unsigned) {
+    RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_weight, static_cast<int64_t>(bitwidth)));
+  }
+
+  // Transpose B to [N, K] if transB=0 (ONNX B is [K, N]).
+  if (trans_b == 0) {
+    std::vector<uint32_t> kn_shape = {static_cast<uint32_t>(K), static_cast<uint32_t>(N)};
+    std::vector<uint8_t> transposed;
+    RETURN_IF_ERROR(utils::TwoDimensionTranspose<uint8_t>(unpacked_weight, kn_shape, transposed,
+                                                          logger, do_op_validation));
+    unpacked_weight = std::move(transposed);
+  }
+  // transB=1: B=[N,K] already in the right layout.
+
+  // block_sizes for 2-D weight [N, K]: K is axis 1, so block_sizes = {1, block_size}.
+  const std::vector<uint32_t> block_size_arr = {1u, static_cast<uint32_t>(block_size)};
+
+  // Scales/offsets must be in [N, num_blocks] order (N-major = row-major for [N,K] weight):
+  //   transB=0: ONNX scale=[num_blocks, N] → transpose to [N, num_blocks].
+  //   transB=1: ONNX scale=[N, num_blocks] → already correct.
+  std::vector<float> onnx_scales;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, onnx_scales));
+  RETURN_IF_NOT(static_cast<int64_t>(onnx_scales.size()) == N * num_blocks,
+                "QNN EP: BQ Gemm scale size mismatch");
+
+  // Float offsets: unsigned_bias - onnx_zp (matching Conv BQ convention).
+  const float unsigned_bias = is_unsigned ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
+  std::vector<float> onnx_offsets(static_cast<size_t>(N * num_blocks), unsigned_bias);
+  if (inputs[1].quant_param->zero_point != nullptr) {
+    std::vector<int32_t> zp_values;
+    ONNXTensorElementDataType zp_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point, zp_values, zp_type));
+    RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == N * num_blocks,
+                  "QNN EP: BQ Gemm zero_point size must match N * num_blocks");
+    for (size_t i = 0; i < zp_values.size(); ++i) {
+      onnx_offsets[i] = unsigned_bias - static_cast<float>(zp_values[i]);
+    }
+  }
+
+  std::vector<float> scales_qnn, offsets_qnn;
+  if (trans_b == 0) {
+    // Transpose from [num_blocks, N] to [N, num_blocks].
+    scales_qnn.resize(static_cast<size_t>(N * num_blocks));
+    offsets_qnn.resize(static_cast<size_t>(N * num_blocks));
+    for (int64_t b = 0; b < num_blocks; ++b) {
+      for (int64_t n = 0; n < N; ++n) {
+        const size_t src = static_cast<size_t>(b * N + n);
+        const size_t dst = static_cast<size_t>(n * num_blocks + b);
+        scales_qnn[dst] = onnx_scales[src];
+        offsets_qnn[dst] = onnx_offsets[src];
+      }
+    }
+  } else {
+    scales_qnn = std::move(onnx_scales);
+    offsets_qnn = std::move(onnx_offsets);
+  }
+
+  QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
+                                        gsl::span<const float>(offsets_qnn),
+                                        bitwidth,
+                                        gsl::span<const uint32_t>(block_size_arr));
+
+  // 2-D weight [N, K] with BW_FLOAT_BLOCK encoding.
+  std::vector<uint32_t> weight_shape_2d = {static_cast<uint32_t>(N), static_cast<uint32_t>(K)};
+  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_name);
+  QnnTensorWrapper bq_weight_wrapper(weight_name, tensor_type,
+                                     QNN_DATATYPE_SFIXED_POINT_8,
+                                     std::move(bq_quant_params),
+                                     std::move(weight_shape_2d),
+                                     std::move(unpacked_weight));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bq_weight_wrapper)),
+                "Failed to add BQ Gemm weight tensor.");
+  input_names.push_back(weight_name);
+
+  //
+  // Input C (bias): required to be FP16 for the BQ kernel. Two cases:
+  //   (a) INT32-quantized initializer → dequantize INT32→FP16.
+  //   (b) float initializer → cast to FP16.
+  // If beta=0.0, skip bias (existing convention).
+  //
+  if (inputs.size() == 3 && beta != 0.0f) {
+    TensorInfo bias_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
+    RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Gemm bias must be a constant initializer");
+
+    std::vector<uint32_t> bias_shape = bias_info.shape;
+    // Collapse [1, N]→[N] (the existing Gemm convention for bias).
+    if (bias_shape.size() == 2 && bias_shape[0] == 1) {
+      bias_shape = {bias_shape[1]};
+    }
+
+    const std::string fp16_bias_name = utils::UniqueNameGenerator().New(inputs[2].name, "_fp16");
+    std::vector<uint8_t> fp16_bias_bytes(static_cast<size_t>(N) * sizeof(uint16_t));
+
+    if (bias_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_32) {
+      // (a) INT32-quantized bias: dequantize to FP16 using per-tensor or per-channel scale.
+      std::vector<uint8_t> raw_bias_bytes;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes));
+      std::vector<float> bias_scales;
+      if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
+        RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scales));
+      }
+      RETURN_IF_NOT(raw_bias_bytes.size() == static_cast<size_t>(N) * sizeof(int32_t),
+                    "QNN EP: BQ Gemm INT32 bias size mismatch");
+      const bool is_per_channel_bias = bias_scales.size() == static_cast<size_t>(N);
+      const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_bias_bytes.data());
+      auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
+      for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
+        const float scale = bias_scales.empty() ? 1.0f : (is_per_channel_bias ? bias_scales[i] : bias_scales[0]);
+        const Ort::Float16_t fp16(static_cast<float>(i32_ptr[i]) * scale);
+        memcpy(&u16_ptr[i], &fp16.val, sizeof(uint16_t));
+      }
+    } else {
+      // (b) Float bias: cast each element to FP16.
+      std::vector<uint8_t> raw_bias_bytes;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes,
+                                                              /*unpack_sub_byte_to_8_bit=*/false));
+      RETURN_IF_NOT(raw_bias_bytes.size() == static_cast<size_t>(N) * sizeof(float),
+                    "QNN EP: BQ Gemm float bias size mismatch");
+      const auto* f32_ptr = reinterpret_cast<const float*>(raw_bias_bytes.data());
+      auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
+      for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
+        const Ort::Float16_t fp16(f32_ptr[i]);
+        memcpy(&u16_ptr[i], &fp16.val, sizeof(uint16_t));
+      }
+    }
+
+    QnnTensorWrapper fp16_bias_wrapper(fp16_bias_name, QNN_TENSOR_TYPE_STATIC,
+                                       QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                       std::move(bias_shape),
+                                       std::move(fp16_bias_bytes));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_bias_wrapper)),
+                  "Failed to add FP16 bias tensor for BQ Gemm.");
+    input_names.push_back(fp16_bias_name);
+  }
+
+  return Ort::Status();
+}
+
 Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                        const OrtNodeUnit& node_unit,
                                                        std::vector<std::string>&& input_names,
                                                        const Ort::Logger& logger,
                                                        bool do_op_validation) const {
-  // Decompose Gemm into FullyConnected + Add when:
-  // 1. Bias (input C) has 2D shape [N, M] where N != 1 (FC doesn't support this shape), OR
-  // 2. Bias is an intermediate (NATIVE) tensor produced by another op (QNN FC requires static bias).
-  bool split_gemm = false;
   OrtNodeAttrHelper node_helper(node_unit);
   auto beta = node_helper.Get("beta", (float)1.0);
+
+  // Detect BQ (BW_FLOAT_BLOCK) Gemm from the weight tensor's encoding.
+  // BQ Gemm→FC: activation stays 2-D, weight is 2-D [N,K] with BW_FLOAT_BLOCK.
+  // FC outputs FP16 → re-quantize to INT16.
+  if (input_names.size() >= 2 &&
+      qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1]) &&
+      qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized()) {
+    const std::string& org_output_name = node_unit.Outputs()[0].name;
+    TensorInfo output_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+    const std::vector<uint32_t>& output_shape = output_info.shape;  // [M, N]
+    RETURN_IF_NOT(output_shape.size() == 2, "QNN EP: BQ Gemm output must be rank-2 [M, N]");
+
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
+    Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+    // FullyConnected → 2-D FP16 output. Reuse the original QL node's input name.
+    const std::string fc_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
+    QnnTensorWrapper fc_fp16_wrapper(fc_fp16_out, QNN_TENSOR_TYPE_NATIVE,
+                                     QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                     std::vector<uint32_t>(output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_fp16_wrapper)),
+                  "Failed to add FP16 BQ Gemm FC output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
+                                                  std::move(input_names), {fc_fp16_out},
+                                                  {}, do_op_validation),
+                  "Failed to add BQ FullyConnected node.");
+
+    // FP16 → INT16 quantized output.
+    QnnTensorWrapper int16_out_wrapper(org_output_name, out_tensor_type, output_info.qnn_data_type,
+                                       output_info.quant_param.Copy(), std::vector<uint32_t>(output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                  "Failed to add INT16 BQ Gemm output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(org_output_name, "_fp16_quantize"),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                      {fc_fp16_out}, {org_output_name}, {}, do_op_validation),
+                  "Failed to add FP16→INT16 Quantize node for BQ Gemm output.");
+    return Ort::Status();
+  }
+
+  // Non-BQ path: decompose Gemm into FullyConnected + Add when needed.
+  bool split_gemm = false;
   if (node_unit.Inputs().size() == 3 && beta != 0.0f) {
     auto& input_c = node_unit.Inputs()[2];
     std::vector<uint32_t> input_c_shape;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -40,10 +40,9 @@ uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
 // Detects a block-quantized Gemm weight B, accounting for transB.
 // For transB=0: B is [K, N], scale is [K/block_size, N], blocked on axis 0.
 // For transB=1: B is [N, K], scale is [N, K/block_size], blocked on axis 1.
-// Both cases: K is the contraction axis (blocked axis). Returns true and sets
-// num_blocks = number of blocks along K, block_size = K / num_blocks.
+// Both cases: K is the contraction axis (blocked axis). Returns true if blocked weight detected.
 bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& weight,
-                    int64_t trans_b, int64_t& num_blocks, int64_t& block_size) {
+                    int64_t trans_b) {
   if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
     return false;
   }
@@ -64,11 +63,10 @@ bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitI
   if (scale_shape[blocked_axis] >= static_cast<int64_t>(weight_shape[blocked_axis])) {
     return false;
   }
-  num_blocks = scale_shape[blocked_axis];
+  const int64_t num_blocks = scale_shape[blocked_axis];
   if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[blocked_axis]) % num_blocks != 0) {
     return false;
   }
-  block_size = static_cast<int64_t>(weight_shape[blocked_axis]) / num_blocks;
   return true;
 }
 
@@ -149,12 +147,9 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   const auto& inputs = node_unit.Inputs();
 
   // Block-quantized weight: translate to QNN FullyConnected with BW_FLOAT_BLOCK weight.
-  {
-    int64_t num_blocks = 0, block_size = 0;
-    if (IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b, num_blocks, block_size)) {
-      return ProcessInputsForBQGemm(qnn_model_wrapper, node_unit, trans_b, beta, logger, input_names,
-                                    do_op_validation);
-    }
+  if (IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b)) {
+    return ProcessInputsForBQGemm(qnn_model_wrapper, node_unit, trans_b, beta, logger, input_names,
+                                  do_op_validation);
   }
 
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
@@ -463,29 +458,26 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                        bool do_op_validation) const {
   OrtNodeAttrHelper node_helper(node_unit);
   auto beta = node_helper.Get("beta", (float)1.0);
+  const int64_t trans_b_out = node_helper.Get("transB", static_cast<int64_t>(0));
 
-  // Detect BQ (BW_FLOAT_BLOCK) Gemm from the weight tensor's encoding.
+  // Detect BQ (BW_FLOAT_BLOCK) Gemm using IsBQGemmWeight, consistent with ProcessInputs detection.
   // BQ Gemm→FC: activation stays 2-D, weight is 2-D [N,K] with BW_FLOAT_BLOCK.
   // FC outputs FP16 → re-quantize to INT16.
-  if (input_names.size() >= 2 &&
-      qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1]) &&
-      qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized()) {
+  if (IsBQGemmWeight(qnn_model_wrapper, node_unit.Inputs()[1], trans_b_out)) {
     const std::string& org_output_name = node_unit.Outputs()[0].name;
     TensorInfo output_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
     const std::vector<uint32_t>& output_shape = output_info.shape;  // [M, N]
     RETURN_IF_NOT(output_shape.size() == 2, "QNN EP: BQ Gemm output must be rank-2 [M, N]");
+    RETURN_IF_NOT(output_info.quant_param.IsQuantized(),
+                  "QNN EP: BQ Gemm output must be INT16-quantized; float output is not yet supported");
 
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
-    Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+    const Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-    // FullyConnected → 2-D FP16 output.
-    // When output is quantized: reuse the original QL node's input name for the FP16 tensor,
-    // keeping the QNN graph aligned with the ONNX graph naming.
-    // When output is unquantized (float): output directly to org_output_name.
-    const std::string fc_fp16_out = output_info.quant_param.IsQuantized()
-                                        ? Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName()
-                                        : org_output_name;
+    // FullyConnected → 2-D FP16 intermediate tensor. Reuse the original QL node's input name
+    // to keep the QNN graph aligned with the ONNX graph naming.
+    const std::string fc_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
     QnnTensorWrapper fc_fp16_wrapper(fc_fp16_out, QNN_TENSOR_TYPE_NATIVE,
                                      QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
                                      std::vector<uint32_t>(output_shape));
@@ -497,19 +489,16 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                   {}, do_op_validation),
                   "Failed to add BQ FullyConnected node.");
 
-    if (output_info.quant_param.IsQuantized()) {
-      // FP16 → INT16 quantized output.
-      QnnTensorWrapper int16_out_wrapper(org_output_name, out_tensor_type, output_info.qnn_data_type,
-                                         output_info.quant_param.Copy(), std::vector<uint32_t>(output_shape));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                    "Failed to add INT16 BQ Gemm output tensor.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::UniqueNameGenerator().New(org_output_name, "_fp16_quantize"),
-                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                        {fc_fp16_out}, {org_output_name}, {}, do_op_validation),
-                    "Failed to add FP16→INT16 Quantize node for BQ Gemm output.");
-    }
-    // Unquantized (float) output: the FC node already outputs to org_output_name.
+    // FP16 → INT16 quantized output.
+    QnnTensorWrapper int16_out_wrapper(org_output_name, out_tensor_type, output_info.qnn_data_type,
+                                       output_info.quant_param.Copy(), std::vector<uint32_t>(output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                  "Failed to add INT16 BQ Gemm output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                      utils::UniqueNameGenerator().New(org_output_name, "_fp16_quantize"),
+                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                      {fc_fp16_out}, {org_output_name}, {}, do_op_validation),
+                  "Failed to add FP16→INT16 Quantize node for BQ Gemm output.");
     return Ort::Status();
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -244,7 +244,6 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
                                                   const Ort::Logger& logger,
                                                   std::vector<std::string>& input_names,
                                                   bool do_op_validation) const {
-  ORT_UNUSED_PARAMETER(logger);
   const auto& inputs = node_unit.Inputs();
 
   // Determine weight shape and K, N dimensions.
@@ -314,6 +313,14 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
   RETURN_IF(num_blocks <= 0 || K % num_blocks != 0, "QNN EP: BQ Gemm K must be divisible by num_blocks");
   const int64_t block_size = K / num_blocks;
   const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+  auto bq_it = kHtpGemmBQBitsAndBlockSizeMultipliers.find(bitwidth);
+  RETURN_IF(bq_it == kHtpGemmBQBitsAndBlockSizeMultipliers.end(),
+            ("QNN HTP Gemm BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
+  RETURN_IF(block_size % bq_it->second != 0,
+            ("QNN HTP Gemm BQ: block_size=" + std::to_string(block_size) +
+             " must be a multiple of " + std::to_string(bq_it->second) +
+             " for " + std::to_string(bitwidth) + "-bit weight")
+                .c_str());
 
   // Unpack weight to one byte per element (sub-byte INT2/INT4 expanded to INT8).
   std::vector<uint8_t> unpacked_weight;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -479,8 +479,13 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
     Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-    // FullyConnected → 2-D FP16 output. Reuse the original QL node's input name.
-    const std::string fc_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
+    // FullyConnected → 2-D FP16 output.
+    // When output is quantized: reuse the original QL node's input name for the FP16 tensor,
+    // keeping the QNN graph aligned with the ONNX graph naming.
+    // When output is unquantized (float): output directly to org_output_name.
+    const std::string fc_fp16_out = output_info.quant_param.IsQuantized()
+                                        ? Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName()
+                                        : org_output_name;
     QnnTensorWrapper fc_fp16_wrapper(fc_fp16_out, QNN_TENSOR_TYPE_NATIVE,
                                      QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
                                      std::vector<uint32_t>(output_shape));
@@ -492,16 +497,19 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                   {}, do_op_validation),
                   "Failed to add BQ FullyConnected node.");
 
-    // FP16 → INT16 quantized output.
-    QnnTensorWrapper int16_out_wrapper(org_output_name, out_tensor_type, output_info.qnn_data_type,
-                                       output_info.quant_param.Copy(), std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                  "Failed to add INT16 BQ Gemm output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::UniqueNameGenerator().New(org_output_name, "_fp16_quantize"),
-                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                      {fc_fp16_out}, {org_output_name}, {}, do_op_validation),
-                  "Failed to add FP16→INT16 Quantize node for BQ Gemm output.");
+    if (output_info.quant_param.IsQuantized()) {
+      // FP16 → INT16 quantized output.
+      QnnTensorWrapper int16_out_wrapper(org_output_name, out_tensor_type, output_info.qnn_data_type,
+                                         output_info.quant_param.Copy(), std::vector<uint32_t>(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
+                    "Failed to add INT16 BQ Gemm output tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(org_output_name, "_fp16_quantize"),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                        {fc_fp16_out}, {org_output_name}, {}, do_op_validation),
+                    "Failed to add FP16→INT16 Quantize node for BQ Gemm output.");
+    }
+    // Unquantized (float) output: the FC node already outputs to org_output_name.
     return Ort::Status();
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -80,10 +80,6 @@ class GemmOpBuilder : public BaseOpBuilder {
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(GemmOpBuilder);
 
  protected:
-  Ort::Status IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
-                            const OrtNodeUnit& node_unit,
-                            const Ort::Logger& logger) const override ORT_MUST_USE_RESULT;
-
   Ort::Status ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                             const OrtNodeUnit& node_unit,
                             const Ort::Logger& logger,
@@ -107,34 +103,6 @@ class GemmOpBuilder : public BaseOpBuilder {
                                      std::vector<std::string>& input_names,
                                      bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
-
-Ort::Status GemmOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit,
-                                         const Ort::Logger& logger) const {
-  const auto& inputs = node_unit.Inputs();
-  if (inputs.size() >= 2) {
-    OrtNodeAttrHelper node_helper(node_unit);
-    const int64_t trans_b = node_helper.Get("transB", static_cast<int64_t>(0));
-    int64_t num_blocks = 0, block_size = 0;
-    if (IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b, num_blocks, block_size)) {
-      const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
-      auto bq_it = kHtpGemmBQBitsAndBlockSizeMultipliers.find(bitwidth);
-      RETURN_IF(bq_it == kHtpGemmBQBitsAndBlockSizeMultipliers.end(),
-                ("QNN HTP Gemm BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
-      RETURN_IF(block_size % bq_it->second != 0,
-                ("QNN HTP Gemm BQ: block_size=" + std::to_string(block_size) +
-                 " must be a multiple of " + std::to_string(bq_it->second) +
-                 " for " + std::to_string(bitwidth) + "-bit weight")
-                    .c_str());
-      TensorInfo weight_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], weight_info));
-      RETURN_IF_NOT(weight_info.is_initializer, "QNN EP: BQ Gemm weight must be a constant initializer");
-      TensorInfo act_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], act_info));
-      RETURN_IF(act_info.is_initializer, "QNN EP: BQ Gemm activation must be a dynamic tensor");
-    }
-  }
-  return BaseOpBuilder::IsOpSupported(qnn_model_wrapper, node_unit, logger);
-}
 
 Ort::Status GemmOpBuilder::ExplictOpCheck(const OrtNodeUnit& node_unit) const {
   OrtNodeAttrHelper node_helper(node_unit);
@@ -430,10 +398,8 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
   input_names.push_back(weight_name);
 
   //
-  // Input C (bias): required to be FP16 for the BQ kernel. Two cases:
-  //   (a) INT32-quantized initializer → dequantize INT32→FP16.
-  //   (b) float initializer → cast to FP16.
-  // If beta=0.0, skip bias (existing convention).
+  // Input C (bias): must be an INT32-quantized initializer; dequantize to FP16 for the BQ kernel.
+  // If beta=0.0, skip bias (existing convention). Float bias is not yet supported.
   //
   if (inputs.size() == 3 && beta != 0.0f) {
     TensorInfo bias_info = {};
@@ -449,37 +415,24 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
     const std::string fp16_bias_name = utils::UniqueNameGenerator().New(inputs[2].name, "_fp16");
     std::vector<uint8_t> fp16_bias_bytes(static_cast<size_t>(N) * sizeof(uint16_t));
 
-    if (bias_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_32) {
-      // (a) INT32-quantized bias: dequantize to FP16 using per-tensor or per-channel scale.
-      std::vector<uint8_t> raw_bias_bytes;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes));
-      std::vector<float> bias_scales;
-      if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
-        RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scales));
-      }
-      RETURN_IF_NOT(raw_bias_bytes.size() == static_cast<size_t>(N) * sizeof(int32_t),
-                    "QNN EP: BQ Gemm INT32 bias size mismatch");
-      const bool is_per_channel_bias = bias_scales.size() == static_cast<size_t>(N);
-      const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_bias_bytes.data());
-      auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
-      for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
-        const float scale = bias_scales.empty() ? 1.0f : (is_per_channel_bias ? bias_scales[i] : bias_scales[0]);
-        const Ort::Float16_t fp16(static_cast<float>(i32_ptr[i]) * scale);
-        memcpy(&u16_ptr[i], &fp16.val, sizeof(uint16_t));
-      }
-    } else {
-      // (b) Float bias: cast each element to FP16.
-      std::vector<uint8_t> raw_bias_bytes;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes,
-                                                              /*unpack_sub_byte_to_8_bit=*/false));
-      RETURN_IF_NOT(raw_bias_bytes.size() == static_cast<size_t>(N) * sizeof(float),
-                    "QNN EP: BQ Gemm float bias size mismatch");
-      const auto* f32_ptr = reinterpret_cast<const float*>(raw_bias_bytes.data());
-      auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
-      for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
-        const Ort::Float16_t fp16(f32_ptr[i]);
-        memcpy(&u16_ptr[i], &fp16.val, sizeof(uint16_t));
-      }
+    RETURN_IF_NOT(bias_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_32,
+                  "QNN EP: BQ Gemm bias must be INT32-quantized; float bias is not yet supported");
+    // Dequantize INT32 bias to FP16 using per-tensor or per-channel scale.
+    std::vector<uint8_t> raw_bias_bytes;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes));
+    std::vector<float> bias_scales;
+    if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scales));
+    }
+    RETURN_IF_NOT(raw_bias_bytes.size() == static_cast<size_t>(N) * sizeof(int32_t),
+                  "QNN EP: BQ Gemm INT32 bias size mismatch");
+    const bool is_per_channel_bias = bias_scales.size() == static_cast<size_t>(N);
+    const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_bias_bytes.data());
+    auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
+    for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
+      const float scale = bias_scales.empty() ? 1.0f : (is_per_channel_bias ? bias_scales[i] : bias_scales[0]);
+      const Ort::Float16_t fp16(static_cast<float>(i32_ptr[i]) * scale);
+      memcpy(&u16_ptr[i], &fp16.val, sizeof(uint16_t));
     }
 
     QnnTensorWrapper fp16_bias_wrapper(fp16_bias_name, QNN_TENSOR_TYPE_STATIC,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -241,6 +241,11 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
                                                   bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
 
+  // transA=1 means the ONNX activation is [K, M]; QNN FullyConnected needs [M, K], so we insert a
+  // Transpose after the FP16 dequantize.
+  OrtNodeAttrHelper node_helper(node_unit);
+  const int64_t trans_a = node_helper.Get("transA", static_cast<int64_t>(0));
+
   // Determine weight shape and K, N dimensions.
   // transB=0: B=[K,N], blocked on axis 0; transB=1: B=[N,K], blocked on axis 1.
   TensorInfo weight_info = {};
@@ -257,12 +262,13 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
                                    : static_cast<int64_t>(weight_info.shape[1]);
 
   //
-  // Input A (activation): dequantize INT16→FP16 if needed. Stays 2-D [M, K].
-  // QNN HTP BQ FullyConnected accepts 2-D activation with a 2-D BW_FLOAT_BLOCK weight.
+  // Input A (activation): dequantize INT16→FP16 if needed, then transpose to [M, K] if transA=1.
+  // QNN HTP BQ FullyConnected accepts a 2-D [M, K] activation with a 2-D BW_FLOAT_BLOCK weight.
   //
   TensorInfo act_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], act_info));
-  RETURN_IF_NOT(act_info.shape.size() == 2, "QNN EP: BQ Gemm activation must be rank-2 [M, K]");
+  RETURN_IF_NOT(act_info.shape.size() == 2,
+                "QNN EP: BQ Gemm activation must be rank-2 ([M, K], or [K, M] when transA=1)");
 
   // Add activation to QNN graph (handles graph-input / already-added cases).
   if (!qnn_model_wrapper.IsQnnTensorWrapperExist(inputs[0].name)) {
@@ -294,6 +300,19 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
                       {act_name}, {fp16_name}, {}, do_op_validation),
                   "Failed to add INT16→FP16 Dequantize node for BQ Gemm activation.");
     input_names[0] = fp16_name;
+
+    // transA=1: the FP16 activation is [K, M]; transpose to [M, K] for QNN FullyConnected.
+    if (trans_a != 0) {
+      RETURN_IF_NOT(act_shape_2d.size() == 2, "QNN EP: BQ Gemm transA=1 requires a rank-2 activation");
+      const std::vector<uint32_t> transposed_shape = {act_shape_2d[1], act_shape_2d[0]};
+      const std::string transposed_name = utils::UniqueNameGenerator().New(fp16_name, "_transpose");
+      RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(node_unit.Index(), fp16_name, transposed_name,
+                                                         act_shape_2d, /*transpose_perm=*/{1u, 0u},
+                                                         transposed_shape, QNN_DATATYPE_FLOAT_16,
+                                                         QnnQuantParamsWrapper(), do_op_validation,
+                                                         /*is_for_input=*/false, /*is_for_output=*/false));
+      input_names[0] = transposed_name;
+    }
   }
 
   //
@@ -427,6 +446,17 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
     std::vector<float> bias_scales;
     if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scales));
+    }
+    // The dequantization below assumes a symmetric (zero-point == 0) bias, which is the convention
+    // for INT32 QDQ bias (bias_scale = input_scale * weight_scale, zp = 0). A non-zero zero-point
+    // would require subtracting it before scaling; reject it rather than silently mis-dequantizing.
+    if (inputs[2].quant_param.has_value() && inputs[2].quant_param->zero_point != nullptr) {
+      std::vector<int32_t> bias_zps;
+      ONNXTensorElementDataType bias_zp_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[2].quant_param->zero_point, bias_zps, bias_zp_type));
+      for (const int32_t zp : bias_zps) {
+        RETURN_IF(zp != 0, "QNN EP: BQ Gemm bias must use zero-point 0 (symmetric); non-zero is not supported");
+      }
     }
     RETURN_IF_NOT(raw_bias_bytes.size() == static_cast<size_t>(N) * sizeof(int32_t),
                   "QNN EP: BQ Gemm INT32 bias size mismatch");

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3046,7 +3046,7 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
     builder.MakeOutput("output");
     builder.AddNode("out_dql", "DequantizeLinear",
-                    {"out_ql_out", "out_dql_scale", "out_ql_zp"}, {"output"});
+                    {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
   };
 }
 

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -2933,14 +2933,7 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     // uint16 symmetric per-tensor: scale = 2/65534, zp = 32767 (~[-1, 1])
     const float act_scale = 2.0f / 65534.0f;
     const uint16_t act_zp = 32767;
-    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
-    builder.AddNode("act_ql", "QuantizeLinear",
-                    {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
-    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
-    builder.AddNode("act_dql", "DequantizeLinear",
-                    {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
+    const std::string act_dql_out = AddQDQNodePair<uint16_t>(builder, "act", "input", act_scale, act_zp);
 
     // ── Weight initializer + DQ(block_size, axis=1) ──────────────────────────
     // Scale rank == weight rank per ONNX opset 21: [OC, IC/block_size, 1, 1].
@@ -3000,7 +2993,7 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
                      builder.MakeScalarAttribute("block_size", block_size)});
 
     // ── Conv ─────────────────────────────────────────────────────────────────
-    std::vector<std::string> conv_inputs{"act_dql_out", "weight_dql_out"};
+    std::vector<std::string> conv_inputs{act_dql_out, "weight_dql_out"};
     if (include_bias) {
       // Use INT32-quantized bias directly (no QL node — avoids ORT QL opset validation for INT32).
       // OrtConvNodeGroupSelector requires bias DQL input type == INT32 (qnn_ep_utils.cc:741).
@@ -3038,15 +3031,7 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     // ── Output: Conv → Q(uint16) → DQ → graph output ─────────────────────────
     const float out_scale = 2.0f / 65534.0f;
     const uint16_t out_zp = 32767;
-    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
-    builder.AddNode("out_ql", "QuantizeLinear",
-                    {"conv_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
-    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
-    builder.MakeOutput("output");
-    builder.AddNode("out_dql", "DequantizeLinear",
-                    {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
+    AddQDQNodePairWithOutputAsGraphOutput<uint16_t>(builder, "out", "conv_out", out_scale, out_zp);
   };
 }
 

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -600,7 +600,7 @@ namespace {
 //               rank-2 scale (blocked on K axis); axis/scale shape depend on transB.
 //     transB=0: B=[K,N], scale=[K/block_size,N], axis=0.
 //     transB=1: B=[N,K], scale=[N,K/block_size], axis=1.
-//   - optional bias C: INT32 quantized (per-tensor) or plain float initializer, shape [N].
+//   - optional bias C: INT32 quantized (per-tensor), shape [N].
 //   - output: Gemm → Q(uint16) → DQ → graph output, shape [M, N].
 GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
                                      int64_t trans_b = 0, bool include_bias = false,

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -604,13 +604,17 @@ namespace {
 //   - output: Gemm → Q(uint16) → DQ → graph output, shape [M, N].
 GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
                                      int64_t trans_b = 0, bool include_bias = false,
-                                     int weight_bits = 4, bool weight_is_unsigned = false) {
+                                     int weight_bits = 4, bool weight_is_unsigned = false,
+                                     int64_t trans_a = 0) {
   return [M, K, N, block_size, trans_b, include_bias, weight_bits,
-          weight_is_unsigned](ModelTestBuilder& builder) -> void {
+          weight_is_unsigned, trans_a](ModelTestBuilder& builder) -> void {
     const int64_t num_blocks = K / block_size;  // caller ensures K % block_size == 0
 
     // ── Activation A: float → Q(uint16) → DQ ─────────────────────────────────
-    auto input_def = TestInputDef<float>({M, K}, false, -1.0f, 1.0f);
+    // transA=0: A=[M,K]; transA=1: A=[K,M].
+    const std::vector<int64_t> act_shape = trans_a == 0 ? std::vector<int64_t>{M, K}
+                                                        : std::vector<int64_t>{K, M};
+    auto input_def = TestInputDef<float>(act_shape, false, -1.0f, 1.0f);
     MakeTestInput<float>(builder, "input", input_def);
     const float act_scale = 2.0f / 65534.0f;
     const uint16_t act_zp = 32767;
@@ -653,6 +657,9 @@ GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t bl
     std::vector<std::string> gemm_inputs = {act_dql_out, "weight_dql_out"};
     std::vector<ONNX_NAMESPACE::AttributeProto> gemm_attrs;
     gemm_attrs.push_back(builder.MakeScalarAttribute("transB", trans_b));
+    if (trans_a != 0) {
+      gemm_attrs.push_back(builder.MakeScalarAttribute("transA", trans_a));
+    }
     if (include_bias) {
       // INT32-quantized bias (per-tensor scale). Matches Conv BQ bias pattern.
       const float bias_scale = act_scale * 0.03f;
@@ -695,6 +702,24 @@ TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_NoBias) {
 TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB1_NoBias) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/1),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// transA=1: ONNX activation is [K, M]; QNN EP inserts a Transpose to [M, K] before the FC.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransA1_TransB0) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false, /*transA=*/1),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// transA=1 with transB=1: both A and B transposed.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransA1_TransB1) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/1,
+                                      /*include_bias=*/false, /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false, /*transA=*/1),
                   GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
 }
 

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -592,6 +592,162 @@ TEST_F(QnnCPUBackendTests, GemmFromMatMulAddNonStaticBias) {
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
 }
 
+namespace {
+
+// Builds an ONNX QDQ graph for a Gemm with a block-quantized (BW_FLOAT_BLOCK) weight.
+//   - activation A: float → Q(uint16) → DQ, shape [M, K]
+//   - weight B: INT4/INT8 (or UINT4/UINT8) initializer + DQ with block_size attribute and a
+//               rank-2 scale (blocked on K axis); axis/scale shape depend on transB.
+//     transB=0: B=[K,N], scale=[K/block_size,N], axis=0.
+//     transB=1: B=[N,K], scale=[N,K/block_size], axis=1.
+//   - optional bias C: INT32 quantized (per-tensor) or plain float initializer, shape [N].
+//   - output: Gemm → Q(uint16) → DQ → graph output, shape [M, N].
+GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
+                                     int64_t trans_b = 0, bool include_bias = false,
+                                     int weight_bits = 4, bool weight_is_unsigned = false) {
+  return [M, K, N, block_size, trans_b, include_bias, weight_bits,
+          weight_is_unsigned](ModelTestBuilder& builder) -> void {
+    const int64_t num_blocks = K / block_size;  // caller ensures K % block_size == 0
+
+    // ── Activation A: float → Q(uint16) → DQ ─────────────────────────────────
+    auto input_def = TestInputDef<float>({M, K}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+    const float act_scale = 2.0f / 65534.0f;
+    const uint16_t act_zp = 32767;
+    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
+    builder.AddNode("act_ql", "QuantizeLinear", {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
+    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
+    builder.AddNode("act_dql", "DequantizeLinear", {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
+
+    // ── Weight B initializer + DQ(block_size) ─────────────────────────────────
+    // transB=0: B=[K,N], scale=[K/bs, N], axis=0.
+    // transB=1: B=[N,K], scale=[N, K/bs], axis=1.
+    const std::vector<int64_t> weight_shape = trans_b == 0 ? std::vector<int64_t>{K, N}
+                                                           : std::vector<int64_t>{N, K};
+    const std::vector<int64_t> scale_shape = trans_b == 0 ? std::vector<int64_t>{num_blocks, N}
+                                                          : std::vector<int64_t>{N, num_blocks};
+    const int64_t block_axis = trans_b == 0 ? 0 : 1;
+    builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
+
+    const size_t num_elems = static_cast<size_t>(K * N);
+    if (weight_bits == 4 && !weight_is_unsigned) {
+      std::vector<Int4x2> wd(Int4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) wd[i >> 1].SetElem(i & 1, static_cast<int8_t>((i % 7) - 3));
+      builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, wd);
+    } else if (weight_bits == 4 && weight_is_unsigned) {
+      std::vector<UInt4x2> wd(UInt4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) wd[i >> 1].SetElem(i & 1, static_cast<uint8_t>(i % 15));
+      builder.MakeInitializer<UInt4x2>("weight_quant", weight_shape, wd);
+    } else if (weight_is_unsigned) {
+      std::vector<uint8_t> wd(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) wd[i] = static_cast<uint8_t>(i % 127);
+      builder.MakeInitializer<uint8_t>("weight_quant", weight_shape, wd);
+    } else {
+      std::vector<int8_t> wd(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) wd[i] = static_cast<int8_t>((i % 127) - 63);
+      builder.MakeInitializer<int8_t>("weight_quant", weight_shape, wd);
+    }
+    builder.AddNode("weight_dql", "DequantizeLinear",
+                    {"weight_quant", "weight_scale"}, {"weight_dql_out"}, "",
+                    {builder.MakeScalarAttribute("axis", block_axis),
+                     builder.MakeScalarAttribute("block_size", block_size)});
+
+    // ── Gemm ─────────────────────────────────────────────────────────────────
+    std::vector<std::string> gemm_inputs = {"act_dql_out", "weight_dql_out"};
+    std::vector<ONNX_NAMESPACE::AttributeProto> gemm_attrs;
+    gemm_attrs.push_back(builder.MakeScalarAttribute("transB", trans_b));
+    if (include_bias) {
+      // INT32-quantized bias (per-tensor scale). Matches Conv BQ bias pattern.
+      const float bias_scale = act_scale * 0.03f;
+      builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
+      builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
+      builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(N), 0));
+      builder.AddNode("bias_dql", "DequantizeLinear",
+                      {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
+      gemm_inputs.push_back("bias_dql_out");
+    }
+    builder.AddNode("gemm", "Gemm", gemm_inputs, {"gemm_out"}, kOnnxDomain, gemm_attrs);
+
+    // ── Output: Gemm → Q(uint16) → DQ → graph output ─────────────────────────
+    const float out_scale = 4.0f / 65534.0f;
+    const uint16_t out_zp = 32767;
+    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
+    builder.AddNode("out_ql", "QuantizeLinear", {"gemm_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
+    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
+    builder.MakeOutput("output");
+    builder.AddNode("out_dql", "DequantizeLinear", {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
+  };
+}
+
+ProviderOptions GetBQGemmProviderOptions() {
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return opts;
+}
+
+}  // namespace
+
+// INT4 weight transB=0, [K,N]=[16,4], block_size=8, no bias.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT4 weight transB=1, [N,K]=[4,16], block_size=8, no bias.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB1_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/1),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT4 transB=0, larger K with multiple blocks. Guards scale reordering.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_MultiBlock) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/32, /*N=*/8, /*block_size=*/8, /*transB=*/0),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT4 transB=0 with INT32-quantized bias.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_WithBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
+                                      /*include_bias=*/true),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT8, block_size=4, transB=0.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int8_TransB0_BlockSize4) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/4, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/8),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// UINT4 transB=0: exercises unsigned→signed conversion.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16UInt4_TransB0_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/4, /*weight_is_unsigned=*/true),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 2e-2f);
+}
+
+// INT2 DISABLED — CPU lacks 2-bit Q/DQ; HTP 2-bit BQ requires QAIRT >= 2.47 (float MatMul/FC kernel).
+TEST_F(QnnHTPBackendTests, DISABLED_GemmBQ_U16Int2_TransB0_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/32, /*N=*/4, /*block_size=*/16, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/2),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 2e-2f);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if defined(_M_ARM64)
@@ -767,162 +923,6 @@ TEST_F(QnnGPUBackendTests, ReshapeGemmFusion) {
 }
 
 #endif  // defined(_M_ARM64) GPU tests
-
-namespace {
-
-// Builds an ONNX QDQ graph for a Gemm with a block-quantized (BW_FLOAT_BLOCK) weight.
-//   - activation A: float → Q(uint16) → DQ, shape [M, K]
-//   - weight B: INT4/INT8 (or UINT4/UINT8) initializer + DQ with block_size attribute and a
-//               rank-2 scale (blocked on K axis); axis/scale shape depend on transB.
-//     transB=0: B=[K,N], scale=[K/block_size,N], axis=0.
-//     transB=1: B=[N,K], scale=[N,K/block_size], axis=1.
-//   - optional bias C: INT32 quantized (per-tensor) or plain float initializer, shape [N].
-//   - output: Gemm → Q(uint16) → DQ → graph output, shape [M, N].
-GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
-                                     int64_t trans_b = 0, bool include_bias = false,
-                                     int weight_bits = 4, bool weight_is_unsigned = false) {
-  return [M, K, N, block_size, trans_b, include_bias, weight_bits,
-          weight_is_unsigned](ModelTestBuilder& builder) -> void {
-    const int64_t num_blocks = K / block_size;  // caller ensures K % block_size == 0
-
-    // ── Activation A: float → Q(uint16) → DQ ─────────────────────────────────
-    auto input_def = TestInputDef<float>({M, K}, false, -1.0f, 1.0f);
-    MakeTestInput<float>(builder, "input", input_def);
-    const float act_scale = 2.0f / 65534.0f;
-    const uint16_t act_zp = 32767;
-    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
-    builder.AddNode("act_ql", "QuantizeLinear", {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
-    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
-    builder.AddNode("act_dql", "DequantizeLinear", {"act_ql_out", "act_dql_scale", "act_ql_zp"}, {"act_dql_out"});
-
-    // ── Weight B initializer + DQ(block_size) ─────────────────────────────────
-    // transB=0: B=[K,N], scale=[K/bs, N], axis=0.
-    // transB=1: B=[N,K], scale=[N, K/bs], axis=1.
-    const std::vector<int64_t> weight_shape = trans_b == 0 ? std::vector<int64_t>{K, N}
-                                                           : std::vector<int64_t>{N, K};
-    const std::vector<int64_t> scale_shape = trans_b == 0 ? std::vector<int64_t>{num_blocks, N}
-                                                          : std::vector<int64_t>{N, num_blocks};
-    const int64_t block_axis = trans_b == 0 ? 0 : 1;
-    builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
-
-    const size_t num_elems = static_cast<size_t>(K * N);
-    if (weight_bits == 4 && !weight_is_unsigned) {
-      std::vector<Int4x2> wd(Int4x2::CalcNumInt4Pairs(num_elems));
-      for (size_t i = 0; i < num_elems; ++i) wd[i >> 1].SetElem(i & 1, static_cast<int8_t>((i % 7) - 3));
-      builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, wd);
-    } else if (weight_bits == 4 && weight_is_unsigned) {
-      std::vector<UInt4x2> wd(UInt4x2::CalcNumInt4Pairs(num_elems));
-      for (size_t i = 0; i < num_elems; ++i) wd[i >> 1].SetElem(i & 1, static_cast<uint8_t>(i % 15));
-      builder.MakeInitializer<UInt4x2>("weight_quant", weight_shape, wd);
-    } else if (weight_is_unsigned) {
-      std::vector<uint8_t> wd(num_elems);
-      for (size_t i = 0; i < num_elems; ++i) wd[i] = static_cast<uint8_t>(i % 127);
-      builder.MakeInitializer<uint8_t>("weight_quant", weight_shape, wd);
-    } else {
-      std::vector<int8_t> wd(num_elems);
-      for (size_t i = 0; i < num_elems; ++i) wd[i] = static_cast<int8_t>((i % 127) - 63);
-      builder.MakeInitializer<int8_t>("weight_quant", weight_shape, wd);
-    }
-    builder.AddNode("weight_dql", "DequantizeLinear",
-                    {"weight_quant", "weight_scale"}, {"weight_dql_out"}, "",
-                    {builder.MakeScalarAttribute("axis", block_axis),
-                     builder.MakeScalarAttribute("block_size", block_size)});
-
-    // ── Gemm ─────────────────────────────────────────────────────────────────
-    std::vector<std::string> gemm_inputs = {"act_dql_out", "weight_dql_out"};
-    std::vector<ONNX_NAMESPACE::AttributeProto> gemm_attrs;
-    gemm_attrs.push_back(builder.MakeScalarAttribute("transB", trans_b));
-    if (include_bias) {
-      // INT32-quantized bias (per-tensor scale). Matches Conv BQ bias pattern.
-      const float bias_scale = act_scale * 0.03f;
-      builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
-      builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
-      builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(N), 0));
-      builder.AddNode("bias_dql", "DequantizeLinear",
-                      {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
-      gemm_inputs.push_back("bias_dql_out");
-    }
-    builder.AddNode("gemm", "Gemm", gemm_inputs, {"gemm_out"}, kOnnxDomain, gemm_attrs);
-
-    // ── Output: Gemm → Q(uint16) → DQ → graph output ─────────────────────────
-    const float out_scale = 4.0f / 65534.0f;
-    const uint16_t out_zp = 32767;
-    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
-    builder.AddNode("out_ql", "QuantizeLinear", {"gemm_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
-    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
-    builder.MakeOutput("output");
-    builder.AddNode("out_dql", "DequantizeLinear", {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
-  };
-}
-
-ProviderOptions GetBQGemmProviderOptions() {
-  ProviderOptions opts;
-  opts["backend_type"] = "htp";
-  opts["offload_graph_io_quantization"] = "0";
-#if defined(__linux__) && !defined(__aarch64__)
-  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
-#endif
-  return opts;
-}
-
-}  // namespace
-
-// INT4 weight transB=0, [K,N]=[16,4], block_size=8, no bias.
-TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_NoBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
-}
-
-// INT4 weight transB=1, [N,K]=[4,16], block_size=8, no bias.
-TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB1_NoBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/1),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
-}
-
-// INT4 transB=0, larger K with multiple blocks. Guards scale reordering.
-TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_MultiBlock) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/32, /*N=*/8, /*block_size=*/8, /*transB=*/0),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
-}
-
-// INT4 transB=0 with INT32-quantized bias.
-TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_WithBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
-                                      /*include_bias=*/true),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
-}
-
-// INT8, block_size=4, transB=0.
-TEST_F(QnnHTPBackendTests, GemmBQ_U16Int8_TransB0_BlockSize4) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/4, /*transB=*/0,
-                                      /*include_bias=*/false, /*weight_bits=*/8),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
-}
-
-// UINT4 transB=0: exercises unsigned→signed conversion.
-TEST_F(QnnHTPBackendTests, GemmBQ_U16UInt4_TransB0_NoBias) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
-                                      /*include_bias=*/false, /*weight_bits=*/4, /*weight_is_unsigned=*/true),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 2e-2f);
-}
-
-// INT2 DISABLED — CPU lacks 2-bit Q/DQ; HTP 2-bit BQ requires QAIRT >= 2.47 (float MatMul/FC kernel).
-TEST_F(QnnHTPBackendTests, DISABLED_GemmBQ_U16Int2_TransB0_BlockSize16) {
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/32, /*N=*/4, /*block_size=*/16, /*transB=*/0,
-                                      /*include_bias=*/false, /*weight_bits=*/2),
-                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 2e-2f);
-}
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -614,12 +614,7 @@ GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t bl
     MakeTestInput<float>(builder, "input", input_def);
     const float act_scale = 2.0f / 65534.0f;
     const uint16_t act_zp = 32767;
-    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
-    builder.AddNode("act_ql", "QuantizeLinear", {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
-    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
-    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
-    builder.AddNode("act_dql", "DequantizeLinear", {"act_ql_out", "act_dql_scale", "act_dql_zp"}, {"act_dql_out"});
+    const std::string act_dql_out = AddQDQNodePair<uint16_t>(builder, "act", "input", act_scale, act_zp);
 
     // ── Weight B initializer + DQ(block_size) ─────────────────────────────────
     // transB=0: B=[K,N], scale=[K/bs, N], axis=0.
@@ -655,7 +650,7 @@ GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t bl
                      builder.MakeScalarAttribute("block_size", block_size)});
 
     // ── Gemm ─────────────────────────────────────────────────────────────────
-    std::vector<std::string> gemm_inputs = {"act_dql_out", "weight_dql_out"};
+    std::vector<std::string> gemm_inputs = {act_dql_out, "weight_dql_out"};
     std::vector<ONNX_NAMESPACE::AttributeProto> gemm_attrs;
     gemm_attrs.push_back(builder.MakeScalarAttribute("transB", trans_b));
     if (include_bias) {
@@ -673,13 +668,7 @@ GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t bl
     // ── Output: Gemm → Q(uint16) → DQ → graph output ─────────────────────────
     const float out_scale = 4.0f / 65534.0f;
     const uint16_t out_zp = 32767;
-    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
-    builder.AddNode("out_ql", "QuantizeLinear", {"gemm_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
-    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
-    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
-    builder.MakeOutput("output");
-    builder.AddNode("out_dql", "DequantizeLinear", {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
+    AddQDQNodePairWithOutputAsGraphOutput<uint16_t>(builder, "out", "gemm_out", out_scale, out_zp);
   };
 }
 

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -768,6 +768,162 @@ TEST_F(QnnGPUBackendTests, ReshapeGemmFusion) {
 
 #endif  // defined(_M_ARM64) GPU tests
 
+namespace {
+
+// Builds an ONNX QDQ graph for a Gemm with a block-quantized (BW_FLOAT_BLOCK) weight.
+//   - activation A: float → Q(uint16) → DQ, shape [M, K]
+//   - weight B: INT4/INT8 (or UINT4/UINT8) initializer + DQ with block_size attribute and a
+//               rank-2 scale (blocked on K axis); axis/scale shape depend on transB.
+//     transB=0: B=[K,N], scale=[K/block_size,N], axis=0.
+//     transB=1: B=[N,K], scale=[N,K/block_size], axis=1.
+//   - optional bias C: INT32 quantized (per-tensor) or plain float initializer, shape [N].
+//   - output: Gemm → Q(uint16) → DQ → graph output, shape [M, N].
+GetQDQTestCaseFn BuildBQGemmTestCase(int64_t M, int64_t K, int64_t N, int64_t block_size,
+                                     int64_t trans_b = 0, bool include_bias = false,
+                                     int weight_bits = 4, bool weight_is_unsigned = false) {
+  return [M, K, N, block_size, trans_b, include_bias, weight_bits,
+          weight_is_unsigned](ModelTestBuilder& builder) -> void {
+    const int64_t num_blocks = K / block_size;  // caller ensures K % block_size == 0
+
+    // ── Activation A: float → Q(uint16) → DQ ─────────────────────────────────
+    auto input_def = TestInputDef<float>({M, K}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+    const float act_scale = 2.0f / 65534.0f;
+    const uint16_t act_zp = 32767;
+    builder.MakeScalarInitializer<float>("act_ql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_ql_zp", act_zp);
+    builder.AddNode("act_ql", "QuantizeLinear", {"input", "act_ql_scale", "act_ql_zp"}, {"act_ql_out"});
+    builder.MakeScalarInitializer<float>("act_dql_scale", act_scale);
+    builder.MakeScalarInitializer<uint16_t>("act_dql_zp", act_zp);
+    builder.AddNode("act_dql", "DequantizeLinear", {"act_ql_out", "act_dql_scale", "act_ql_zp"}, {"act_dql_out"});
+
+    // ── Weight B initializer + DQ(block_size) ─────────────────────────────────
+    // transB=0: B=[K,N], scale=[K/bs, N], axis=0.
+    // transB=1: B=[N,K], scale=[N, K/bs], axis=1.
+    const std::vector<int64_t> weight_shape = trans_b == 0 ? std::vector<int64_t>{K, N}
+                                                           : std::vector<int64_t>{N, K};
+    const std::vector<int64_t> scale_shape = trans_b == 0 ? std::vector<int64_t>{num_blocks, N}
+                                                          : std::vector<int64_t>{N, num_blocks};
+    const int64_t block_axis = trans_b == 0 ? 0 : 1;
+    builder.MakeInitializer<float>("weight_scale", scale_shape, 0.01f, 0.05f);
+
+    const size_t num_elems = static_cast<size_t>(K * N);
+    if (weight_bits == 4 && !weight_is_unsigned) {
+      std::vector<Int4x2> wd(Int4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) wd[i >> 1].SetElem(i & 1, static_cast<int8_t>((i % 7) - 3));
+      builder.MakeInitializer<Int4x2>("weight_quant", weight_shape, wd);
+    } else if (weight_bits == 4 && weight_is_unsigned) {
+      std::vector<UInt4x2> wd(UInt4x2::CalcNumInt4Pairs(num_elems));
+      for (size_t i = 0; i < num_elems; ++i) wd[i >> 1].SetElem(i & 1, static_cast<uint8_t>(i % 15));
+      builder.MakeInitializer<UInt4x2>("weight_quant", weight_shape, wd);
+    } else if (weight_is_unsigned) {
+      std::vector<uint8_t> wd(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) wd[i] = static_cast<uint8_t>(i % 127);
+      builder.MakeInitializer<uint8_t>("weight_quant", weight_shape, wd);
+    } else {
+      std::vector<int8_t> wd(num_elems);
+      for (size_t i = 0; i < num_elems; ++i) wd[i] = static_cast<int8_t>((i % 127) - 63);
+      builder.MakeInitializer<int8_t>("weight_quant", weight_shape, wd);
+    }
+    builder.AddNode("weight_dql", "DequantizeLinear",
+                    {"weight_quant", "weight_scale"}, {"weight_dql_out"}, "",
+                    {builder.MakeScalarAttribute("axis", block_axis),
+                     builder.MakeScalarAttribute("block_size", block_size)});
+
+    // ── Gemm ─────────────────────────────────────────────────────────────────
+    std::vector<std::string> gemm_inputs = {"act_dql_out", "weight_dql_out"};
+    std::vector<ONNX_NAMESPACE::AttributeProto> gemm_attrs;
+    gemm_attrs.push_back(builder.MakeScalarAttribute("transB", trans_b));
+    if (include_bias) {
+      // INT32-quantized bias (per-tensor scale). Matches Conv BQ bias pattern.
+      const float bias_scale = act_scale * 0.03f;
+      builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
+      builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
+      builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(N), 0));
+      builder.AddNode("bias_dql", "DequantizeLinear",
+                      {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
+      gemm_inputs.push_back("bias_dql_out");
+    }
+    builder.AddNode("gemm", "Gemm", gemm_inputs, {"gemm_out"}, kOnnxDomain, gemm_attrs);
+
+    // ── Output: Gemm → Q(uint16) → DQ → graph output ─────────────────────────
+    const float out_scale = 4.0f / 65534.0f;
+    const uint16_t out_zp = 32767;
+    builder.MakeScalarInitializer<float>("out_ql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_ql_zp", out_zp);
+    builder.AddNode("out_ql", "QuantizeLinear", {"gemm_out", "out_ql_scale", "out_ql_zp"}, {"out_ql_out"});
+    builder.MakeScalarInitializer<float>("out_dql_scale", out_scale);
+    builder.MakeScalarInitializer<uint16_t>("out_dql_zp", out_zp);
+    builder.MakeOutput("output");
+    builder.AddNode("out_dql", "DequantizeLinear", {"out_ql_out", "out_dql_scale", "out_dql_zp"}, {"output"});
+  };
+}
+
+ProviderOptions GetBQGemmProviderOptions() {
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return opts;
+}
+
+}  // namespace
+
+// INT4 weight transB=0, [K,N]=[16,4], block_size=8, no bias.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT4 weight transB=1, [N,K]=[4,16], block_size=8, no bias.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB1_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/1),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT4 transB=0, larger K with multiple blocks. Guards scale reordering.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_MultiBlock) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/32, /*N=*/8, /*block_size=*/8, /*transB=*/0),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT4 transB=0 with INT32-quantized bias.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int4_TransB0_WithBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
+                                      /*include_bias=*/true),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// INT8, block_size=4, transB=0.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16Int8_TransB0_BlockSize4) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/4, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/8),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 1e-2f);
+}
+
+// UINT4 transB=0: exercises unsigned→signed conversion.
+TEST_F(QnnHTPBackendTests, GemmBQ_U16UInt4_TransB0_NoBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/16, /*N=*/4, /*block_size=*/8, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/4, /*weight_is_unsigned=*/true),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 2e-2f);
+}
+
+// INT2 DISABLED — CPU lacks 2-bit Q/DQ; HTP 2-bit BQ requires QAIRT >= 2.47 (float MatMul/FC kernel).
+TEST_F(QnnHTPBackendTests, DISABLED_GemmBQ_U16Int2_TransB0_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQGemmTestCase(/*M=*/2, /*K=*/32, /*N=*/4, /*block_size=*/16, /*transB=*/0,
+                                      /*include_bias=*/false, /*weight_bits=*/2),
+                  GetBQGemmProviderOptions(), /*opset=*/21, ExpectedEPNodeAssignment::All, 2e-2f);
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 #endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- QNN HTP FullyConnected accepts BW_FLOAT_BLOCK on a 2-D weight [N, K] with block_sizes = {1, block_size} (K is the contraction axis, axis 1). Activation stays 2-D [M, K]; no reshape needed.
- Supports INT4/UINT4/INT8/UINT8 weights with transB=0 and transB=1.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Adds BW_FLOAT_BLOCK (block-quantized) weight support to the QNN EP Gemm op builder, translating BQ Gemm to QNN FullyConnected. Requires QAIRT >= 2.47.

