### PR TITLE
Add explicit relu if encoding zp > 0

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <string>
 
+#include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/inlined_containers.h"
 #include "core/providers/qnn/common/qnn_graph_utils.h"
 
@@ -96,6 +97,146 @@ bool CheckQuantTypes(std::initializer_list<ONNXTensorElementDataType> dtypes,
     if (require_all_same && dt != first_dt) return false;
   }
   return true;
+}
+
+// Forward declaration
+const OrtValue* GetConstantInitializer(const OrtGraph* graph, const OrtApi& ort_api, const char* name);
+
+// Helper to get a constant initializer OrtValue from a ValueInfo (combines name lookup + initializer fetch).
+const OrtValue* GetInitializerFromValueInfo(const OrtGraph* graph, const OrtApi& ort_api,
+                                            const OrtValueInfo* value_info) {
+  const char* name = nullptr;
+  if (ort_api.GetValueInfoName(value_info, &name) != nullptr || name == nullptr) {
+    return nullptr;
+  }
+  return GetConstantInitializer(graph, ort_api, name);
+}
+
+// Helper to read a scalar zero_point value from an OrtValue initializer
+// Returns the zero_point as int64_t and the corresponding Qnn_DataType_t
+bool GetZeroPointValue(const OrtApi& ort_api, const OrtValue* zp_init,
+                       int64_t& zero_point, Qnn_DataType_t& qnn_data_type) {
+  OrtTensorTypeAndShapeInfo* zp_info = nullptr;
+  if (ort_api.GetTensorTypeAndShape(zp_init, &zp_info) != nullptr) {
+    return false;
+  }
+
+  ONNXTensorElementDataType zp_type;
+  if (ort_api.GetTensorElementType(zp_info, &zp_type) != nullptr) {
+    ort_api.ReleaseTensorTypeAndShapeInfo(zp_info);
+    return false;
+  }
+  ort_api.ReleaseTensorTypeAndShapeInfo(zp_info);
+
+  void* zp_data = nullptr;
+  if (ort_api.GetTensorMutableData(const_cast<OrtValue*>(zp_init), &zp_data) != nullptr || zp_data == nullptr) {
+    return false;
+  }
+
+  switch (zp_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      zero_point = static_cast<int64_t>(*reinterpret_cast<uint8_t*>(zp_data));
+      qnn_data_type = QNN_DATATYPE_UFIXED_POINT_8;
+      return true;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+      zero_point = static_cast<int64_t>(*reinterpret_cast<uint16_t*>(zp_data));
+      qnn_data_type = QNN_DATATYPE_UFIXED_POINT_16;
+      return true;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      zero_point = static_cast<int64_t>(*reinterpret_cast<int8_t*>(zp_data));
+      qnn_data_type = QNN_DATATYPE_SFIXED_POINT_8;
+      return true;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+      zero_point = static_cast<int64_t>(*reinterpret_cast<int16_t*>(zp_data));
+      qnn_data_type = QNN_DATATYPE_SFIXED_POINT_16;
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Helper to read a scalar value of type T from an OrtValue initializer.
+template <typename T>
+bool GetScalarValue(const OrtApi& ort_api, const OrtValue* initializer, T& value) {
+  T* data = nullptr;
+  if (ort_api.GetTensorMutableData(const_cast<OrtValue*>(initializer), (void**)&data) != nullptr) {
+    return false;
+  }
+  value = *data;
+  return true;
+}
+
+// Helper to read scale and zero_point from a Q/DQ node.
+// Returns true if both scale and zero_point could be read successfully.
+bool GetQNodeScaleAndZeroPoint(const OrtGraph* graph, const OrtApi& ort_api,
+                               const OrtNode* q_node,
+                               float& scale, int64_t& zero_point,
+                               Qnn_DataType_t& qnn_data_type) {
+  size_t num_inputs = 0;
+  if (ort_api.Node_GetNumInputs(q_node, &num_inputs) != nullptr || num_inputs < 3) {
+    return false;
+  }
+
+  std::vector<const OrtValueInfo*> inputs(num_inputs);
+  if (ort_api.Node_GetInputs(q_node, inputs.data(), inputs.size()) != nullptr) {
+    return false;
+  }
+
+  // Read scale (input[1])
+  const OrtValue* scale_init = GetInitializerFromValueInfo(graph, ort_api, inputs[1]);
+  if (scale_init == nullptr || !GetScalarValue(ort_api, scale_init, scale)) {
+    return false;
+  }
+
+  // Read zero_point (input[2])
+  const OrtValue* zp_init = GetInitializerFromValueInfo(graph, ort_api, inputs[2]);
+  if (zp_init == nullptr) {
+    return false;
+  }
+
+  return GetZeroPointValue(ort_api, zp_init, zero_point, qnn_data_type);
+}
+
+// Helper to read Clip node's min and max values.
+// Handles both opset 6 (attributes) and opset 11+ (input initializers).
+void GetClipMinMax(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* clip_node,
+                   float& clip_min, float& clip_max) {
+  clip_min = std::numeric_limits<float>::lowest();
+  clip_max = std::numeric_limits<float>::max();
+
+  // Try attributes (opset 6)
+  OrtNodeAttrHelper clip_helper(*clip_node);
+  if (clip_helper.HasAttr("min") || clip_helper.HasAttr("max")) {
+    clip_min = clip_helper.Get("min", clip_min);
+    clip_max = clip_helper.Get("max", clip_max);
+    return;
+  }
+
+  // Opset 11+: read from input initializers
+  size_t clip_num_inputs = 0;
+  if (ort_api.Node_GetNumInputs(clip_node, &clip_num_inputs) != nullptr || clip_num_inputs < 2) {
+    return;
+  }
+  std::vector<const OrtValueInfo*> clip_inputs(clip_num_inputs);
+  if (ort_api.Node_GetInputs(clip_node, clip_inputs.data(), clip_inputs.size()) != nullptr) {
+    return;
+  }
+
+  // input[1] = min
+  if (clip_num_inputs >= 2 && clip_inputs[1] != nullptr) {
+    const OrtValue* min_init = GetInitializerFromValueInfo(graph, ort_api, clip_inputs[1]);
+    if (min_init != nullptr) {
+      GetScalarValue(ort_api, min_init, clip_min);
+    }
+  }
+
+  // input[2] = max
+  if (clip_num_inputs >= 3 && clip_inputs[2] != nullptr) {
+    const OrtValue* max_init = GetInitializerFromValueInfo(graph, ort_api, clip_inputs[2]);
+    if (max_init != nullptr) {
+      GetScalarValue(ort_api, max_init, clip_max);
+    }
+  }
 }
 
 // Helper function to get a constant initializer from a node's input
@@ -1283,7 +1424,62 @@ std::optional<OrtNodeGroup> GetOrtQDQSelection(const OrtGraph* graph, const OrtA
           }
 
           if (next_num_consumers == 1 && !produces_graph_output) {
-            clip_node = next_node;
+            // Determine whether to fuse Relu/Clip into the QDQ node unit
+            //
+            // When fused, EP emits a single Conv/Gemm with the post-activation output encoding
+            // and no separate Relu/Clip node. QNN HTP will only clamp the output if the encoding
+            // cannot represent values outside the activation range — i.e., HTP respects the encoding
+            // bounds but does NOT apply Relu/Clip semantics independently.
+            //
+            // Safe to fuse when: encoding_min >= activation_min
+            //   encoding_min = scale * (type_min - zero_point)
+            //   - Relu:  activation_min = 0. Fuse if encoding_min >= 0 (zp == 0 for unsigned types).
+            //   - Clip:  activation_min = clip.min. Fuse if encoding_min >= clip.min.
+            //
+            // NOT safe to fuse when: encoding_min < activation_min
+            //   The encoding can represent values below activation_min (e.g., negatives after Relu). In which case,
+            //   HTP will NOT clamp these values — it just quantizes the Conv output as-is and hence breaking the orig model
+            //   Must keep Relu/Clip as a separate QNN ElementWiseNeuron node to enforce clamping
+            bool should_fuse = true;
+
+            // Find the Q node consuming the Relu/Clip output
+            const OrtValueInfo* relu_out_info = next_outputs[0];
+            const OrtNode* q_after_clip = nullptr;
+            size_t relu_out_consumers = 0;
+            ORT_CONTINUE_ON_ERROR(ort_api.ValueInfo_GetValueNumConsumers(relu_out_info, &relu_out_consumers), ort_api);
+            if (relu_out_consumers == 1) {
+              int64_t unused_idx = 0;
+              ORT_CONTINUE_ON_ERROR(ort_api.ValueInfo_GetValueConsumers(relu_out_info, &q_after_clip, &unused_idx, 1), ort_api);
+            }
+
+            if (q_after_clip != nullptr && Ort::ConstNode(q_after_clip).GetOperatorType() == "QuantizeLinear") {
+              float scale_val = 0.0f;
+              int64_t zero_point = 0;
+              Qnn_DataType_t qnn_dt = QNN_DATATYPE_UNDEFINED;
+
+              if (GetQNodeScaleAndZeroPoint(graph, ort_api, q_after_clip, scale_val, zero_point, qnn_dt)) {
+                int64_t qmin = 0, qmax = 0;
+                if (qnn::utils::GetQminQmax(qnn_dt, qmin, qmax).IsOK()) {
+                  float encoding_min = scale_val * static_cast<float>(qmin - zero_point);
+                  float encoding_max = scale_val * static_cast<float>(qmax - zero_point);
+
+                  // activation bounds: Relu has min=0, no max. Clip has both min and max.
+                  float activation_min = 0.0f;
+                  float activation_max = std::numeric_limits<float>::max();
+                  if (next_node_op_type == "Clip") {
+                    GetClipMinMax(graph, ort_api, next_node, activation_min, activation_max);
+                  }
+
+                  if (encoding_min < activation_min || encoding_max > activation_max) {
+                    should_fuse = false;
+                  }
+                }
+              }
+            }
+
+            if (should_fuse) {
+              clip_node = next_node;
+            }
           }
         }
       }

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1972,7 +1972,173 @@ TEST_F(QnnHTPBackendTests, ConvU16S8S32_PerChannel) {
                                                13);   // opset
 }
 
-// Conv3D per-channel
+// Helper: Builds QDQ Conv model with fused activation (Relu or Clip) between Conv and output Q.
+// Pattern: DQ(input) + DQ(weight) + float_bias -> Conv -> Relu/Clip -> Q(forced encoding) -> DQ
+// Uses a forced output encoding with zp > 0 (encoding allows negatives) to trigger the
+// non-fusion path. Without the fix, HTP won't clamp and the test fails.
+template <typename ActivationQType, typename WeightQType>
+static GetTestQDQModelFn<ActivationQType> BuildQDQConvWithFusedActivationTestCase(
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weights_def,
+    const TestInputDef<float>& bias_def,
+    const std::string& activation_type,
+    float forced_output_scale,
+    ActivationQType forced_output_zp,
+    float clip_min = 0.0f,
+    float clip_max = 6.0f) {
+  return [input_def, weights_def, bias_def, activation_type, forced_output_scale, forced_output_zp,
+          clip_min, clip_max](
+             ModelTestBuilder& builder,
+             std::vector<QuantParams<ActivationQType>>& output_qparams) {
+    (void)output_qparams;
+
+    MakeTestInput<float>(builder, "input", input_def);
+    QuantParams<ActivationQType> input_qparams = GetTestInputQuantParams<ActivationQType>(input_def);
+    std::string input_dq = AddQDQNodePair<ActivationQType>(builder, "input_qdq", "input",
+                                                           input_qparams.scale, input_qparams.zero_point, true);
+
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zps;
+    GetTestInputQuantParamsPerChannel<WeightQType>(weights_def, weight_scales, weight_zps, 0, true);
+    std::vector<WeightQType> quantized_weights(SizeOfShape(weights_def.GetShape()));
+    QuantizeValues<float, WeightQType>(weights_def.GetRawData(), quantized_weights,
+                                       weights_def.GetShape(), weight_scales, weight_zps, 0);
+    builder.MakeInitializer<WeightQType>("weights_quant", weights_def.GetShape(), quantized_weights);
+    std::vector<ONNX_NAMESPACE::AttributeProto> w_dq_attrs;
+    w_dq_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+    builder.AddDequantizeLinearNode("WeightDQ", "weights_quant", weight_scales, weight_zps,
+                                    "weights_dq", w_dq_attrs, true);
+
+    builder.MakeInitializer<float>("bias", bias_def.GetShape(), bias_def.GetRawData());
+
+    builder.AddNode("Conv", "Conv", {input_dq, "weights_dq", "bias"}, {"conv_out"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("kernel_shape", {1, 1}),
+                     builder.MakeIntsAttribute("strides", {1, 1}),
+                     builder.MakeIntsAttribute("pads", {0, 0, 0, 0})});
+
+    if (activation_type == "Relu") {
+      builder.AddNode("Relu", "Relu", {"conv_out"}, {"act_out"});
+    } else {
+      builder.MakeScalarInitializer<float>("clip_min", clip_min);
+      builder.MakeScalarInitializer<float>("clip_max", clip_max);
+      builder.AddNode("Clip", "Clip", {"conv_out", "clip_min", "clip_max"}, {"act_out"});
+    }
+
+    // Use FORCED output encoding (not auto-calibrated) to guarantee encoding_min < activation_min
+    AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(builder, "output_qdq", "act_out",
+                                                           forced_output_scale, forced_output_zp, true);
+  };
+}
+
+// Test 1: Conv+Relu where output encoding min < 0 (Relu's activation_min).
+TEST_F(QnnHTPBackendTests, ConvReluFusion_EncodingMinBelowZero) {
+  std::vector<int64_t> input_shape = {1, 128, 4, 4};
+  std::vector<int64_t> weight_shape = {64, 128, 1, 1};
+  std::vector<int64_t> bias_shape = {64};
+
+  TestInputDef<float> input_def(input_shape, false, GetFloatDataInRange(0.0f, 40.0f, SizeOfShape(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, true, GetFloatDataInRange(-1.0f, 1.0f, SizeOfShape(weight_shape)));
+  TestInputDef<float> bias_def(bias_shape, true, GetFloatDataInRange(-3.0f, 10.0f, SizeOfShape(bias_shape)));
+
+  auto build_f32_model = [input_def, weight_def, bias_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weight_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"conv_out"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("kernel_shape", {1, 1}),
+                     builder.MakeIntsAttribute("strides", {1, 1}),
+                     builder.MakeIntsAttribute("pads", {0, 0, 0, 0})});
+    builder.AddNode("Relu", "Relu", {"conv_out"}, {"relu_out"});
+    builder.MakeOutput("relu_out");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Force output encoding: scale=0.000196, zp=14601 → encoding_min = 0.000196*(0-14601) = -2.86 < 0
+  GetTestQDQModelFn<uint16_t> qdq_fn = BuildQDQConvWithFusedActivationTestCase<uint16_t, int8_t>(
+      input_def, weight_def, bias_def, "Relu",
+      0.000196270834f, static_cast<uint16_t>(14601));
+  TestQDQModelAccuracy(build_f32_model, qdq_fn, provider_options, 21,
+                       ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
+// Test 2: Conv+Clip where output encoding min < clip_min.
+TEST_F(QnnHTPBackendTests, ConvClipFusion_EncodingMinBelowClipMin) {
+  std::vector<int64_t> input_shape = {1, 64, 4, 4};
+  std::vector<int64_t> weight_shape = {32, 64, 1, 1};
+  std::vector<int64_t> bias_shape = {32};
+
+  TestInputDef<float> input_def(input_shape, false, GetFloatDataInRange(-5.0f, 40.0f, SizeOfShape(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, true, GetFloatDataInRange(-1.0f, 1.0f, SizeOfShape(weight_shape)));
+  TestInputDef<float> bias_def(bias_shape, true, GetFloatDataInRange(-5.0f, 5.0f, SizeOfShape(bias_shape)));
+
+  auto build_f32_model = [input_def, weight_def, bias_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weight_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"conv_out"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("kernel_shape", {1, 1}),
+                     builder.MakeIntsAttribute("strides", {1, 1}),
+                     builder.MakeIntsAttribute("pads", {0, 0, 0, 0})});
+    builder.MakeScalarInitializer<float>("clip_min_val", -1.0f);
+    builder.MakeScalarInitializer<float>("clip_max_val", 6.0f);
+    builder.AddNode("Clip", "Clip", {"conv_out", "clip_min_val", "clip_max_val"}, {"clip_out"});
+    builder.MakeOutput("clip_out");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Force output encoding: scale=0.0003, zp=20000 → encoding_min = 0.0003*(0-20000) = -6.0 < clip_min(-1)
+  GetTestQDQModelFn<uint16_t> qdq_fn = BuildQDQConvWithFusedActivationTestCase<uint16_t, int8_t>(
+      input_def, weight_def, bias_def, "Clip",
+      0.0003f, static_cast<uint16_t>(20000),
+      -1.0f, 6.0f);
+  TestQDQModelAccuracy(build_f32_model, qdq_fn, provider_options, 21,
+                       ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
+// Test 3: Conv+Clip where output encoding max > clip_max.
+TEST_F(QnnHTPBackendTests, ConvClipFusion_EncodingMaxAboveClipMax) {
+  std::vector<int64_t> input_shape = {1, 64, 4, 4};
+  std::vector<int64_t> weight_shape = {32, 64, 1, 1};
+  std::vector<int64_t> bias_shape = {32};
+
+  TestInputDef<float> input_def(input_shape, false, GetFloatDataInRange(0.0f, 50.0f, SizeOfShape(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, true, GetFloatDataInRange(-0.5f, 0.5f, SizeOfShape(weight_shape)));
+  TestInputDef<float> bias_def(bias_shape, true, GetFloatDataInRange(0.0f, 8.0f, SizeOfShape(bias_shape)));
+
+  auto build_f32_model = [input_def, weight_def, bias_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weight_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"conv_out"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("kernel_shape", {1, 1}),
+                     builder.MakeIntsAttribute("strides", {1, 1}),
+                     builder.MakeIntsAttribute("pads", {0, 0, 0, 0})});
+    builder.MakeScalarInitializer<float>("clip_min_val", 0.0f);
+    builder.MakeScalarInitializer<float>("clip_max_val", 6.0f);
+    builder.AddNode("Clip", "Clip", {"conv_out", "clip_min_val", "clip_max_val"}, {"clip_out"});
+    builder.MakeOutput("clip_out");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Force output encoding: scale=0.0002, zp=0 → encoding_max = 0.0002*65535 = 13.1 > clip_max(6)
+  GetTestQDQModelFn<uint16_t> qdq_fn = BuildQDQConvWithFusedActivationTestCase<uint16_t, int8_t>(
+      input_def, weight_def, bias_def, "Clip",
+      0.0002f, static_cast<uint16_t>(0),
+      0.0f, 6.0f);
+  TestQDQModelAccuracy(build_f32_model, qdq_fn, provider_options, 21,
+                       ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
+// Conv3D per-channel (known issue)
 // \QNN\HTP\HTP\src\hexagon\prepare\graph_prepare.cc:203:ERROR:could not create op: q::QNN_Conv3d_w_scale
 // \QNN\HTP\HTP\src\hexagon\prepare\graph_prepare.cc:1187:ERROR:Op 0x1a preparation failed with err:-1
 // QnnDsp <E> "Conv" generated: could not create op


### PR DESCRIPTION
### Description
This PR adds an explicit relu op if zero point > 0 in output encodings of Conv + Relu 

### Motivation and Context

tldr: fixes YOLOv6 accuracy issue. Previous: 28.9 mAP. After this fix: 42.626 mAP (simulated accuracy is 42.6 as well).

Explanation: 
If we have a model like this Q/DQ (s1, zp1) -> Conv -> Relu -> Q/DQ (s2, zp2). The output of Relu would have a min=0 (or zp2 == 0). EP currently fuses Relu into Conv since the output encodings would have a min of zero which essentially simulates Relu layer.  

But in YoloV6, output of Relu is fed into a concat op as below
<img width="709" height="552" alt="image" src="https://github.com/user-attachments/assets/0d09639f-498c-4f13-a98d-023a94094554" />

HTP has a requirement that the concat op's inputs and output encoding match to run on target. So, AIMET updates the encodings at the output of Relu to be equal to other tensors surrounding the concat op. In this scenario, because of this requirement of concat, tensor 2 has a zp > 0. Since EP is fusing Relu into Conv layer, the effective graph does not actually include a Relu layer which causes accuracy drops on-device. 

This PR fixes this by observing the output encodings, and add an explicit Relu layer if zp > 0.

  




