### PR TITLE
Run ASan in non-blocking mode

### DIFF
--- a/.github/workflows/qualcomm-internal-asan.yml
+++ b/.github/workflows/qualcomm-internal-asan.yml
@@ -14,6 +14,15 @@ jobs:
   asan-linux-x86_64:
     name: "asan-linux-x86_64"
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
+    # Run ASan in non-blocking mode: the job's red X / log are still
+    # surfaced in the PR checks UI for human review, but a failure does
+    # not gate merge. ASan is a heuristic detector — it can flag
+    # third-party noise (stripped libQnn*.so init leaks, UDO op-package
+    # `<unknown module>` Direct leaks, transient LSan tracer SIGSEGVs)
+    # that are out of our control, and we don't want unrelated PRs
+    # blocked while we triage. Real ORT-side regressions are still
+    # visible; reviewers should glance at the ASan check before merging.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Add `continue-on-error: true` to the `asan-linux-x86_64` job so a failure no longer gates PR merge. The job still runs on every PR that touches QNN EP code (or the ASan pipeline files), and the red X / log remain visible in the PR checks UI for human review. Keep it until ASan CI is more stable, and then decide whether we should switch to blocking mode.

## Why

ASan is a heuristic detector that frequently flags third-party noise we cannot fix from this repo:

- **`Direct leak ... <unknown module>`** rooted in UDO op-package static initializers — upstream QAIRT SDK bug in `CustomOpRegister.hpp`'s `OpRegistrationReceiver` (`pop()` / `release()` transfer pattern leaks 8 bytes per registration; tracked separately with the QAIRT team).
- **Stripped `libQnn*.so` init-time leaks** whose stacks resolve to `<unknown module>`, so `leak:libQnn*` suppression patterns cannot match.
- 
Per reviewer feedback, switch to non-blocking so unrelated PRs are not held up while we triage these patterns. Real ORT-side regressions are still visible — the check goes red, the log is collected, and reviewers should glance at the ASan check before merging.

## Trade-off

| Mode | Catches real ORT leaks? | Blocks PRs on 3rd-party noise? |
|---|---|---|
| Strict (before) | ✅ | ❌ — also blocks unrelated PRs |
| Non-blocking (this PR) | ✅ (visible, not auto-blocking) | ✅ |

Reviewers must look at the ASan check on PRs that touch QNN EP code; the signal is still there, just advisory.

## Follow-ups (separate PRs)

1. **Attribution-by-source-path in `asan_filter_leaks.sh`** — any frame in `onnxruntime/{core,test}/providers/qnn/` or `qcom/` ⇒ ORT's responsibility (FAIL); otherwise ⇒ log + accept. Once attribution lands, this PR can be reverted (back to blocking) because real ORT leaks become reliably distinguishable from third-party noise.
2. **Track upstream QAIRT fixes** — the `OpRegistrationReceiver` leak and the libQnn init-time leaks are real upstream bugs to chase down independently.