### PR TITLE
Limit UDO dependency

### DIFF
--- a/tools/ci_build/github/linux/python/requirements.txt
+++ b/tools/ci_build/github/linux/python/requirements.txt
@@ -14,5 +14,5 @@ jinja2
 markupsafe
 onnx==1.21.0; python_version < "3.14"
 # Required by qnn-op-package-generator (UDO unit test build, see cmake/onnxruntime_unittests_udo.cmake).
-mako==1.3.5
-lxml==5.2.2
+mako==1.3.5; python_version == "3.10"
+lxml==5.2.2; python_version == "3.10"


### PR DESCRIPTION
### Description
Limit the UDO dependency to Python 3.10 as required for UDO.


### Motivation and Context
The `lxml` dependency introduced by https://github.com/onnxruntime/onnxruntime-qnn/pull/362 causes the nightly workflow to fail at `build-linux-aarch64_manylinux_2_34-py3.13`.
