### PR TITLE
Allow float bias with Conv QDQ node group

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -177,6 +177,40 @@ Ort::Status ConvOpBuilder::GetInputChannelNumber(QnnModelWrapper& qnn_model_wrap
   return Ort::Status();
 }
 
+// Quantize a float bias using bias_scale = activation_scale * weight_scale.
+static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
+                                    const Ort::Logger& logger,
+                                    const OrtNodeUnitIODef& bias_def,
+                                    const TensorInfo& bias_info,
+                                    gsl::span<const float> weights_scales,
+                                    float activation_scale,
+                                    std::vector<std::string>& input_names) {
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("Quantizing float bias " + bias_def.name + " using activation_scale * weight_scale[c]").c_str());
+  std::vector<uint8_t> original_bias_data;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
+  const size_t num_channels = bias_info.shape[0];
+  RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
+                "Unexpected bias data size for float bias quantization");
+  std::vector<uint8_t> new_bias_data;
+  std::vector<float> new_scales;
+  std::vector<int32_t> new_offsets;
+  RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
+      gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
+      weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
+  int32_t bias_quant_axis = 0;
+  QnnQuantParamsWrapper quant_params = (weights_scales.size() == 1)
+                                           ? QnnQuantParamsWrapper::PerTensor(new_scales[0], 0)
+                                           : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
+  QnnTensorWrapper bias_wrapper(bias_def.name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
+                                std::move(quant_params), std::vector<uint32_t>(bias_info.shape),
+                                std::move(new_bias_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
+                "Failed to add bias tensor.");
+  input_names.push_back(bias_def.name);
+  return Ort::Status();
+}
+
 Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
                                          const Ort::Logger& logger,
@@ -740,6 +774,62 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
               }
             }
           }
+        }
+      } else if (bias_info.is_initializer && !bias_info.quant_param.IsQuantized()) {
+        // Get activation and weight quantization parameters
+        TensorInfo input0_info = {};
+        TensorInfo input1_info = {};
+        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
+        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
+
+        if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
+          // Get activation scale (must be per-tensor for Conv)
+          float activation_scale = 1.0f;
+          const auto& act_quant_params = input0_info.quant_param.Get();
+          if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+            activation_scale = act_quant_params.scaleOffsetEncoding.scale;
+          } else if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+            activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
+          }
+
+          // Get weight scales (per-tensor or per-channel)
+          std::vector<float> weights_scales;
+
+          if (input1_info.quant_param.IsPerTensor()) {
+            // Handle per-tensor quantization (encodings 0 and 2)
+            const auto& weight_quant_params = input1_info.quant_param.Get();
+
+            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+              weights_scales.push_back(weight_quant_params.scaleOffsetEncoding.scale);
+            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+              weights_scales.push_back(weight_quant_params.bwScaleOffsetEncoding.scale);
+            }
+          } else {
+            // Handle per-channel quantization (encodings 1 and 3)
+            const auto& weight_quant_params = input1_info.quant_param.Get();
+
+            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+              if (weight_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr &&
+                  weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0) {
+                for (size_t i = 0; i < weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets; ++i) {
+                  weights_scales.push_back(weight_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
+                }
+              }
+            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+              if (weight_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr &&
+                  weight_quant_params.bwAxisScaleOffsetEncoding.numElements > 0) {
+                for (size_t i = 0; i < weight_quant_params.bwAxisScaleOffsetEncoding.numElements; ++i) {
+                  weights_scales.push_back(weight_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
+                }
+              }
+            }
+          }
+
+          // Safety check to prevent crashes
+          RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
+
+          // Quantize a float bias using bias_scale = activation_scale * weight_scale
+          ProcessFloatBias(qnn_model_wrapper, logger, bias_input, bias_info, weights_scales, activation_scale, input_names);
         }
       }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -200,7 +200,7 @@ static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
       weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
   int32_t bias_quant_axis = 0;
   QnnQuantParamsWrapper quant_params = (weights_scales.size() == 1)
-                                           ? QnnQuantParamsWrapper::PerTensor(new_scales[0], 0)
+                                           ? QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0])
                                            : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
   QnnTensorWrapper bias_wrapper(bias_def.name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
                                 std::move(quant_params), std::vector<uint32_t>(bias_info.shape),
@@ -591,6 +591,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
 
         if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
           // Get activation scale (must be per-tensor for Conv)
+          RETURN_IF_NOT(input0_info.quant_param.IsPerTensor(/*include_bw*/ true),
+                        "Activation must be per-tensor quantized for Conv 2D");
           float activation_scale = 1.0f;
           const auto& act_quant_params = input0_info.quant_param.Get();
           if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
@@ -632,7 +634,6 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
             }
           }
 
-          // Safety check to prevent crashes
           RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
 
           // Check bias quantization type
@@ -784,6 +785,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
 
         if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
           // Get activation scale (must be per-tensor for Conv)
+          RETURN_IF_NOT(input0_info.quant_param.IsPerTensor(/*include_bw*/ true),
+                        "Activation must be per-tensor quantized for Conv 2D");
           float activation_scale = 1.0f;
           const auto& act_quant_params = input0_info.quant_param.Get();
           if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
@@ -825,11 +828,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
             }
           }
 
-          // Safety check to prevent crashes
           RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
 
           // Quantize a float bias using bias_scale = activation_scale * weight_scale
-          ProcessFloatBias(qnn_model_wrapper, logger, bias_input, bias_info, weights_scales, activation_scale, input_names);
+          RETURN_IF_ERROR(ProcessFloatBias(qnn_model_wrapper, logger, bias_input, bias_info, weights_scales, activation_scale, input_names));
         }
       }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1741,6 +1741,35 @@ bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation
   return std::abs(bias_scale - expected_scale) <= tolerance;
 }
 
+Ort::Status QuantizeFloatBiasTensor(gsl::span<const float> float_bias_data,
+                                    gsl::span<const float> weights_scales,
+                                    float activation_scale,
+                                    /*out*/ std::vector<uint8_t>& quantized_bias_bytes,
+                                    /*out*/ std::vector<float>& bias_scales,
+                                    /*out*/ std::vector<int32_t>& bias_offsets) {
+  RETURN_IF_NOT(!float_bias_data.empty(), "Float bias data must not be empty");
+  RETURN_IF_NOT(!weights_scales.empty(), "Weight scales must not be empty");
+  const size_t num_channels = float_bias_data.size();
+  bias_scales.resize(num_channels);
+  bias_offsets.assign(num_channels, 0);
+  // Compute bias_scale = activation_scale * weight_scale and quantize to int32.
+  // If weights_scales has a single element (per-tensor weight), all channels share the same scale.
+  std::vector<int32_t> quantized_bias(num_channels, 0);
+  for (size_t c = 0; c < num_channels; ++c) {
+    const float weight_scale = (c < weights_scales.size()) ? weights_scales[c] : weights_scales[0];
+    bias_scales[c] = activation_scale * weight_scale;
+    RETURN_IF_NOT(bias_scales[c] > 0.0f, "Bias scale value is non-positive");
+    const double rounded = std::round(static_cast<double>(float_bias_data[c]) / static_cast<double>(bias_scales[c]));
+    quantized_bias[c] = static_cast<int32_t>(std::clamp(rounded,
+                                                        static_cast<double>(std::numeric_limits<int32_t>::min()),
+                                                        static_cast<double>(std::numeric_limits<int32_t>::max())));
+  }
+  // Pack quantized int32 values into bytes
+  quantized_bias_bytes.resize(num_channels * sizeof(int32_t));
+  std::memcpy(quantized_bias_bytes.data(), quantized_bias.data(), quantized_bias_bytes.size());
+  return Ort::Status();
+}
+
 Ort::Status RequantizeBiasTensor(const std::vector<uint8_t>& original_bias_data,
                                  const std::vector<uint32_t>& bias_shape,
                                  gsl::span<const float> current_scales,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1747,8 +1747,8 @@ Ort::Status QuantizeFloatBiasTensor(gsl::span<const float> float_bias_data,
                                     /*out*/ std::vector<uint8_t>& quantized_bias_bytes,
                                     /*out*/ std::vector<float>& bias_scales,
                                     /*out*/ std::vector<int32_t>& bias_offsets) {
-  RETURN_IF_NOT(!float_bias_data.empty(), "Float bias data must not be empty");
-  RETURN_IF_NOT(!weights_scales.empty(), "Weight scales must not be empty");
+  RETURN_IF(float_bias_data.empty(), "Float bias data must not be empty");
+  RETURN_IF(weights_scales.empty(), "Weight scales must not be empty");
   const size_t num_channels = float_bias_data.size();
   bias_scales.resize(num_channels);
   bias_offsets.assign(num_channels, 0);

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -653,6 +653,19 @@ uint64_t GetTimeStampInUs();
 bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale,
                          float tolerance = 1e-5f);
 
+// Quantizes a float bias tensor to int32 using bias_scale = activation_scale * weight_scale.
+// Used when the bias is provided as float (no quantization info) but activation and weight are quantized.
+// If weights_scales has a single element, per-tensor bias quantization is used (all channels share one scale).
+// Otherwise, per-channel bias quantization is used (one scale per output channel).
+// The output quantized_bias_bytes contains packed int32 values (4 bytes per channel).
+// bias_offsets is always all-zeros (symmetric quantization).
+Ort::Status QuantizeFloatBiasTensor(gsl::span<const float> float_bias_data,
+                                    gsl::span<const float> weights_scales,
+                                    float activation_scale,
+                                    /*out*/ std::vector<uint8_t>& quantized_bias_bytes,
+                                    /*out*/ std::vector<float>& bias_scales,
+                                    /*out*/ std::vector<int32_t>& bias_offsets);
+
 // Requantizes a static bias tensor with new quantization parameters
 // This function:
 // 1. Dequantizes the bias tensor to float using current parameters

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -854,6 +854,10 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     return false;
   }
 
+  if (dq_nodes.size() < 2) {
+    return false;  // Conv requires at least DQ nodes for input and weight
+  }
+
   // Input and output types need to be same
   auto dt_input = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
   auto dt_weight = GetNodeInputDataType(dq_nodes[1], ort_api, 0);

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -850,12 +850,38 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const OrtNode* redundant_clip_node,
                                      const std::vector<const OrtNode*>& dq_nodes,
                                      const std::vector<const OrtNode*>& q_nodes) const {
-  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, static_cast<int>(dq_nodes.size()))) {
+  // Conv allows the bias (input[2]) to lack a DQ node; inputs[0] (data) and inputs[1] (weight)
+  // must always be DQ-produced. Unlike ORT-core ConvNodeGroupSelector (which requires all inputs
+  // to be quantized), we relax the count to [2,3] to support a float bias at input[2].
+  const size_t num_dq_nodes = dq_nodes.size();
+  if (num_dq_nodes < 2 || num_dq_nodes > 3) {
+    return false;
+  }
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, static_cast<int>(num_dq_nodes))) {
     return false;
   }
 
-  if (dq_nodes.size() < 2) {
-    return false;  // Conv requires at least DQ nodes for input and weight
+  // DQ nodes are positional. Verify explicitly that both inputs[0] (data) and inputs[1] (weight) are DQ-produced.
+  {
+    size_t num_inputs = 0;
+    if (ort_api.Node_GetNumInputs(node, &num_inputs) != nullptr || num_inputs < 2) {
+      return false;
+    }
+    std::vector<const OrtValueInfo*> inputs(num_inputs);
+    if (ort_api.Node_GetInputs(node, inputs.data(), inputs.size()) != nullptr) {
+      return false;
+    }
+    for (int slot : {0, 1}) {
+      if (inputs[slot] == nullptr) {
+        return false;
+      }
+      const OrtNode* producer = nullptr;
+      ort_api.ValueInfo_GetValueProducer(inputs[slot], &producer, nullptr);
+      if (producer == nullptr ||
+          Ort::ConstNode(producer).GetOperatorType() != "DequantizeLinear") {
+        return false;  // inputs[0] and inputs[1] must be DQ-produced; only inputs[2] (bias) may be float.
+      }
+    }
   }
 
   // Input and output types need to be same

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -850,7 +850,7 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
                                      const OrtNode* redundant_clip_node,
                                      const std::vector<const OrtNode*>& dq_nodes,
                                      const std::vector<const OrtNode*>& q_nodes) const {
-  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes)) {
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, static_cast<int>(dq_nodes.size()))) {
     return false;
   }
 
@@ -877,7 +877,8 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     }
   }
 
-  if (dq_nodes.size() == 3) {  // has bias
+  if (dq_nodes.size() == 3) {
+    // Bias has a DQ node: it must be INT32.
     auto dt_bias = GetNodeInputDataType(dq_nodes[2], ort_api, 0);
     if (!dt_bias.has_value() || dt_bias.value() != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
       return false;

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -876,7 +876,9 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
         return false;
       }
       const OrtNode* producer = nullptr;
-      ort_api.ValueInfo_GetValueProducer(inputs[slot], &producer, nullptr);
+      if (ort_api.ValueInfo_GetValueProducer(inputs[slot], &producer, nullptr) != nullptr) {
+        return false;
+      }
       if (producer == nullptr ||
           Ort::ConstNode(producer).GetOperatorType() != "DequantizeLinear") {
         return false;  // inputs[0] and inputs[1] must be DQ-produced; only inputs[2] (bias) may be float.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -369,7 +369,7 @@ static GetTestQDQModelFn<ActivationQType> BuildQDQConvTestCase(
     // bias ->
     if (!bias_def.GetShape().empty()) {
       if (use_float_bias) {
-        QNN_ASSERT(bias_def.IsInitializer() && bias_def.IsRawData());
+        ASSERT_TRUE(bias_def.IsInitializer() && bias_def.IsRawData()) << "Float bias must be an initializer with raw data";
         builder.MakeInitializer<float>("bias", bias_def.GetShape(), bias_def.GetRawData());
         conv_input_names.push_back("bias");
       } else {

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -344,11 +344,12 @@ static GetTestQDQModelFn<ActivationQType> BuildQDQConvTestCase(
     const std::string& auto_pad = "NOTSET",
     bool use_contrib_qdq = false,
     std::optional<OutputActivationInfo> output_activation = std::nullopt,
-    std::optional<std::vector<int64_t>> output_shape = std::nullopt) {
+    std::optional<std::vector<int64_t>> output_shape = std::nullopt,
+    bool use_float_bias = false) {
   return [conv_op_type, input_def, weights_def, bias_def, strides, pads,
           dilations, group, auto_pad,
-          use_contrib_qdq, output_activation, output_shape](ModelTestBuilder& builder,
-                                                            std::vector<QuantParams<ActivationQType>>& output_qparams) {
+          use_contrib_qdq, use_float_bias, output_activation, output_shape](ModelTestBuilder& builder,
+                                                                            std::vector<QuantParams<ActivationQType>>& output_qparams) {
     std::vector<std::string> conv_input_names;
 
     // input -> Q/DQ ->
@@ -367,9 +368,15 @@ static GetTestQDQModelFn<ActivationQType> BuildQDQConvTestCase(
 
     // bias ->
     if (!bias_def.GetShape().empty()) {
-      // Bias requirement taken from python quantization tool: onnx_quantizer.py::quantize_bias_static()
-      const float bias_scale = input_qparams.scale * weights_qparams.scale;
-      conv_input_names.push_back(MakeTestQDQBiasInput(builder, "bias", bias_def, bias_scale, use_contrib_qdq));
+      if (use_float_bias) {
+        QNN_ASSERT(bias_def.IsInitializer() && bias_def.IsRawData());
+        builder.MakeInitializer<float>("bias", bias_def.GetShape(), bias_def.GetRawData());
+        conv_input_names.push_back("bias");
+      } else {
+        // Bias requirement taken from python quantization tool: onnx_quantizer.py::quantize_bias_static()
+        const float bias_scale = input_qparams.scale * weights_qparams.scale;
+        conv_input_names.push_back(MakeTestQDQBiasInput(builder, "bias", bias_def, bias_scale, use_contrib_qdq));
+      }
     }
 
     // Conv attrs (must be provided at node creation)
@@ -438,9 +445,10 @@ static GetTestQDQModelFn<ActivationQType> BuildQDQPerChannelConvTestCase(
     std::optional<int64_t> group,
     const std::string& auto_pad = "NOTSET",
     bool use_contrib_qdq = false,
-    std::optional<OutputActivationInfo> output_activation = std::nullopt) {
+    std::optional<OutputActivationInfo> output_activation = std::nullopt,
+    bool use_float_bias = false) {
   return [conv_op_type, input_def, weights_def, bias_def, strides, pads,
-          dilations, group, auto_pad, use_contrib_qdq,
+          dilations, group, auto_pad, use_contrib_qdq, use_float_bias,
           weight_quant_axis, output_activation](ModelTestBuilder& builder,
                                                 std::vector<QuantParams<ActivationQType>>& output_qparams) {
     std::vector<std::string> conv_input_names;
@@ -491,38 +499,43 @@ static GetTestQDQModelFn<ActivationQType> BuildQDQPerChannelConvTestCase(
         use_contrib_qdq);
     conv_input_names.push_back("weights_dq");
 
-    // Quantized(bias) -> DQ ->
+    // bias ->
     if (!bias_def.GetShape().empty()) {
       QNN_ASSERT(bias_def.IsInitializer() && bias_def.IsRawData());
+      if (use_float_bias) {
+        builder.MakeInitializer<float>("bias", bias_def.GetShape(), bias_def.GetRawData());
+        conv_input_names.push_back("bias");
+      } else {
+        // Quantized(bias) -> DQ -> (per-channel quantization)
+        // bias_scale = input_scale * weight_scale (per-channel)
+        std::vector<float> bias_scales(weight_scales);
+        for (float& s : bias_scales) {
+          s *= input_qparams.scale;
+        }
 
-      // bias_scale = input_scale * weight_scale (per-channel)
-      std::vector<float> bias_scales(weight_scales);
-      for (float& s : bias_scales) {
-        s *= input_qparams.scale;
+        std::vector<int32_t> bias_zero_points(bias_scales.size(), 0);
+        auto bias_shape = bias_def.GetShape();
+
+        std::vector<int32_t> quantized_biases(SizeOfShape(bias_shape));
+        QuantizeValues<float, int32_t>(bias_def.GetRawData(), quantized_biases,
+                                       bias_def.GetShape(), bias_scales, bias_zero_points,
+                                       0 /* axis */);
+
+        builder.MakeInitializer<int32_t>("bias_quant", bias_def.GetShape(), quantized_biases);
+        builder.MakeInitializer<float>("bias_scale", {static_cast<int64_t>(bias_scales.size())}, bias_scales);
+        builder.MakeInitializer<int32_t>("bias_zp", {static_cast<int64_t>(bias_zero_points.size())}, bias_zero_points);
+
+        std::vector<ONNX_NAMESPACE::AttributeProto> bias_dq_attrs;
+        bias_dq_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+
+        builder.AddNode("BiasDQ",
+                        "DequantizeLinear",
+                        {"bias_quant", "bias_scale", "bias_zp"},
+                        {"bias_dq"},
+                        use_contrib_qdq ? kMSDomain : kOnnxDomain,
+                        bias_dq_attrs);
+        conv_input_names.push_back("bias_dq");
       }
-
-      std::vector<int32_t> bias_zero_points(bias_scales.size(), 0);
-      auto bias_shape = bias_def.GetShape();
-
-      std::vector<int32_t> quantized_biases(SizeOfShape(bias_shape));
-      QuantizeValues<float, int32_t>(bias_def.GetRawData(), quantized_biases,
-                                     bias_def.GetShape(), bias_scales, bias_zero_points,
-                                     0 /* axis */);
-
-      builder.MakeInitializer<int32_t>("bias_quant", bias_def.GetShape(), quantized_biases);
-      builder.MakeInitializer<float>("bias_scale", {static_cast<int64_t>(bias_scales.size())}, bias_scales);
-      builder.MakeInitializer<int32_t>("bias_zp", {static_cast<int64_t>(bias_zero_points.size())}, bias_zero_points);
-
-      std::vector<ONNX_NAMESPACE::AttributeProto> bias_dq_attrs;
-      bias_dq_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
-
-      builder.AddNode("BiasDQ",
-                      "DequantizeLinear",
-                      {"bias_quant", "bias_scale", "bias_zp"},
-                      {"bias_dq"},
-                      use_contrib_qdq ? kMSDomain : kOnnxDomain,
-                      bias_dq_attrs);
-      conv_input_names.push_back("bias_dq");
     }
 
     // Conv attrs (must be provided at node creation)
@@ -1336,6 +1349,49 @@ TEST_F(QnnHTPBackendTests, ConvU8S8S32_PerChannel_BiasRequantization) {
                        13,  // opset
                        ExpectedEPNodeAssignment::All,
                        QDQTolerance(0.015f));
+}
+
+// Tests QDQ Conv where activation and weight are per-tensor quantized but bias is a plain float
+// initializer.
+TEST_F(QnnHTPBackendTests, ConvU8U8_FloatBias) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestInputDef<float> input_def({1, 2, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 32));
+  TestInputDef<float> weight_def({3, 2, 2, 2}, true, GetFloatDataInRange(-1.0f, 5.0f, 24));
+  TestInputDef<float> bias_def({3}, true, GetFloatDataInRange(-1.0f, 1.0f, 3));
+
+  TestQDQModelAccuracy(
+      BuildF32ConvTestCase("Conv", input_def, weight_def, bias_def,
+                           {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, "NOTSET"),
+      BuildQDQConvTestCase<uint8_t, uint8_t>("Conv", input_def, weight_def, bias_def,
+                                             {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, "NOTSET",
+                                             /*use_contrib_qdq=*/false, std::nullopt, std::nullopt,
+                                             /*use_float_bias=*/true),
+      provider_options, 13, ExpectedEPNodeAssignment::All, QDQTolerance(0.015f));
+}
+
+// Tests QDQ Conv where activation is per-tensor quantized, weight is per-channel quantized (int8),
+// and bias is a plain float initializer.
+TEST_F(QnnHTPBackendTests, ConvU8S8_PerChannel_FloatBias) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestInputDef<float> input_def({1, 2, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 32));
+  TestInputDef<float> weight_def({3, 2, 2, 2}, true, GetFloatDataInRange(-1.0f, 5.0f, 24));
+  TestInputDef<float> bias_def({3}, true, GetFloatDataInRange(-1.0f, 1.0f, 3));
+
+  TestQDQModelAccuracy(
+      BuildF32ConvTestCase("Conv", input_def, weight_def, bias_def,
+                           {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, "NOTSET"),
+      BuildQDQPerChannelConvTestCase<uint8_t, int8_t>("Conv", input_def, weight_def, bias_def,
+                                                      0,  // weight quant axis
+                                                      {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, "NOTSET",
+                                                      /*use_contrib_qdq=*/false, std::nullopt,
+                                                      /*use_float_bias=*/true),
+      provider_options, 13, ExpectedEPNodeAssignment::All, QDQTolerance(0.015f));
 }
 
 // Test per-channel QDQ Conv with INT4 weights and no bias.

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -535,16 +535,25 @@ TEST(QnnUnit_EpUtilsTest, Split_Rejects4BitWhenDisallowed) {
 
 TEST(QnnUnit_EpUtilsTest, Conv_Accepts2DqUint8) {
   EpUtilsTestContext ctx;
-  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
   FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
   FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
 
+  // Conv inputs are the DQ outputs — wire them so the positional DQ check passes.
+  FakeValueInfo conv_in0{"conv_in0", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo conv_in1{"conv_in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
-  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&conv_in0, &conv_in1}, {&main_out}};
 
   FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
   FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  // Install producer stub: conv_in0 → dq_data, conv_in1 → dq_wt.
+  ConvProducerGuard guard({{conv_in0.AsValueInfo(), dq_data.AsNode()},
+                           {conv_in1.AsValueInfo(), dq_wt.AsNode()}});
+  ctx.api.ValueInfo_GetValueProducer = &FakeConvProducerStub;
+  OrtGlobalApiOverride global_guard(&ctx.api);
 
   OrtConvNodeGroupSelector sel;
   EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
@@ -571,16 +580,25 @@ TEST(QnnUnit_EpUtilsTest, Conv_RejectsInt8WhenDisallowed) {
 
 TEST(QnnUnit_EpUtilsTest, Conv_AcceptsInt8WhenAllowed) {
   EpUtilsTestContext ctx;
-  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
   FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
   FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
 
+  // Conv inputs are the DQ outputs — wire them so the positional DQ check passes.
+  FakeValueInfo conv_in0{"conv_in0", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo conv_in1{"conv_in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
-  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&conv_in0, &conv_in1}, {&main_out}};
 
   FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
   FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  // Install producer stub: conv_in0 → dq_data, conv_in1 → dq_wt.
+  ConvProducerGuard guard({{conv_in0.AsValueInfo(), dq_data.AsNode()},
+                           {conv_in1.AsValueInfo(), dq_wt.AsNode()}});
+  ctx.api.ValueInfo_GetValueProducer = &FakeConvProducerStub;
+  OrtGlobalApiOverride global_guard(&ctx.api);
 
   OrtConvNodeGroupSelector sel(/*int8_allowed=*/true);
   EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
@@ -605,6 +623,73 @@ TEST(QnnUnit_EpUtilsTest, Conv_Rejects3DqWithNonInt32Bias) {
   OrtConvNodeGroupSelector sel;
   EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
                          {dq_data.AsNode(), dq_wt.AsNode(), dq_bias.AsNode()}, {q.AsNode()}));
+}
+
+// Tests that Conv with quantized input, quantized weight, and a plain float bias
+// (no DQ node for bias) is accepted.
+TEST(QnnUnit_EpUtilsTest, Conv_AcceptsFloatBias) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  // Conv inputs: DQ output for activation, DQ output for weight, float bias (no DQ).
+  FakeValueInfo conv_in0{"conv_in0", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo conv_in1{"conv_in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo float_bias{"bias", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&conv_in0, &conv_in1, &float_bias}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  // Install producer stub: conv_in0 → dq_data, conv_in1 → dq_wt.
+  // float_bias has no entry → producer = nullptr (float, no DQ node).
+  ConvProducerGuard guard({{conv_in0.AsValueInfo(), dq_data.AsNode()},
+                           {conv_in1.AsValueInfo(), dq_wt.AsNode()}});
+  ctx.api.ValueInfo_GetValueProducer = &FakeConvProducerStub;
+  OrtGlobalApiOverride global_guard(&ctx.api);
+
+  OrtConvNodeGroupSelector sel;
+  // 2 DQ nodes (activation + weight, no bias DQ) → float bias is allowed.
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+// Tests that Conv with a float (unquantized) activation input is rejected
+// when weight and bias are quantized. inputs[0] is not DQ-produced, so the
+// positional DQ check fails.
+TEST(QnnUnit_EpUtilsTest, Conv_RejectsFloatInputWithQuantWeight) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_wt_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo dq_bias_in{"b", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_wt_in}, {}};
+  FakeNode dq_bias{"dq2", "DequantizeLinear", "", 13, {&dq_bias_in}, {}};
+
+  // Conv inputs: float activation (no DQ), DQ output for weight, DQ output for bias.
+  FakeValueInfo float_input{"input", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo conv_in1{"conv_in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo conv_in2{"conv_in2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&float_input, &conv_in1, &conv_in2}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  // Install producer stub: conv_in1 → dq_wt, conv_in2 → dq_bias.
+  // float_input has no entry → producer = nullptr → positional check fails at slot 0.
+  ConvProducerGuard guard({{conv_in1.AsValueInfo(), dq_wt.AsNode()},
+                           {conv_in2.AsValueInfo(), dq_bias.AsNode()}});
+  ctx.api.ValueInfo_GetValueProducer = &FakeConvProducerStub;
+  // OrtGlobalApiOverride not needed: producer for inputs[0] is nullptr so
+  // GetOperatorType() is never reached.
+
+  OrtConvNodeGroupSelector sel;
+  // inputs[0] is not DQ-produced → positional check fails → false.
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_wt.AsNode(), dq_bias.AsNode()}, {q.AsNode()}));
 }
 
 // =============================================================================
@@ -1889,6 +1974,23 @@ OrtStatus* FakeClipProducerStub(const OrtValueInfo* /*value_info*/,
 struct ClipProducerGuard {
   explicit ClipProducerGuard(const OrtNode* n) { g_clip_producer_dq = n; }
   ~ClipProducerGuard() { g_clip_producer_dq = nullptr; }
+};
+
+// Conv producer map for the positional DQ check in OrtConvNodeGroupSelector::Check.
+// Maps each Conv input (OrtValueInfo*) to the DQ node that produces it.
+std::unordered_map<const OrtValueInfo*, const OrtNode*> g_conv_producer_map;
+OrtStatus* FakeConvProducerStub(const OrtValueInfo* vi, const OrtNode** producer,
+                                size_t* output_index) noexcept {
+  auto it = g_conv_producer_map.find(vi);
+  if (producer) *producer = (it != g_conv_producer_map.end()) ? it->second : nullptr;
+  if (output_index) *output_index = 0;
+  return nullptr;
+}
+struct ConvProducerGuard {
+  explicit ConvProducerGuard(std::unordered_map<const OrtValueInfo*, const OrtNode*> map) {
+    g_conv_producer_map = std::move(map);
+  }
+  ~ConvProducerGuard() { g_conv_producer_map.clear(); }
 };
 }  // namespace
 

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -524,6 +524,25 @@ TEST(QnnUnit_EpUtilsTest, Split_Rejects4BitWhenDisallowed) {
                          {dq.AsNode()}, {q.AsNode()}));
 }
 
+namespace {
+// Conv producer map for the positional DQ check in OrtConvNodeGroupSelector::Check.
+// Maps each Conv input (OrtValueInfo*) to the DQ node that produces it.
+std::unordered_map<const OrtValueInfo*, const OrtNode*> g_conv_producer_map;
+OrtStatus* FakeConvProducerStub(const OrtValueInfo* vi, const OrtNode** producer,
+                                size_t* output_index) noexcept {
+  auto it = g_conv_producer_map.find(vi);
+  if (producer) *producer = (it != g_conv_producer_map.end()) ? it->second : nullptr;
+  if (output_index) *output_index = 0;
+  return nullptr;
+}
+struct ConvProducerGuard {
+  explicit ConvProducerGuard(std::unordered_map<const OrtValueInfo*, const OrtNode*> map) {
+    g_conv_producer_map = std::move(map);
+  }
+  ~ConvProducerGuard() { g_conv_producer_map.clear(); }
+};
+}
+
 // =============================================================================
 // OrtConvNodeGroupSelector::Check
 //
@@ -1974,23 +1993,6 @@ OrtStatus* FakeClipProducerStub(const OrtValueInfo* /*value_info*/,
 struct ClipProducerGuard {
   explicit ClipProducerGuard(const OrtNode* n) { g_clip_producer_dq = n; }
   ~ClipProducerGuard() { g_clip_producer_dq = nullptr; }
-};
-
-// Conv producer map for the positional DQ check in OrtConvNodeGroupSelector::Check.
-// Maps each Conv input (OrtValueInfo*) to the DQ node that produces it.
-std::unordered_map<const OrtValueInfo*, const OrtNode*> g_conv_producer_map;
-OrtStatus* FakeConvProducerStub(const OrtValueInfo* vi, const OrtNode** producer,
-                                size_t* output_index) noexcept {
-  auto it = g_conv_producer_map.find(vi);
-  if (producer) *producer = (it != g_conv_producer_map.end()) ? it->second : nullptr;
-  if (output_index) *output_index = 0;
-  return nullptr;
-}
-struct ConvProducerGuard {
-  explicit ConvProducerGuard(std::unordered_map<const OrtValueInfo*, const OrtNode*> map) {
-    g_conv_producer_map = std::move(map);
-  }
-  ~ConvProducerGuard() { g_conv_producer_map.clear(); }
 };
 }  // namespace
 

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -541,7 +541,7 @@ struct ConvProducerGuard {
   }
   ~ConvProducerGuard() { g_conv_producer_map.clear(); }
 };
-}
+}  // namespace
 
 // =============================================================================
 // OrtConvNodeGroupSelector::Check


### PR DESCRIPTION
### Description
Allow bias to be float when selecting QDQ node group for Conv Op



### Motivation and Context
If the bias is float (non-quantized) while the weights and activations are quantized, the Q and DQ nodes aren't getting properly partitioned into 1 group along with the conv op. As a result, graph finalization error occurs. This change will allow the node group to be formed even when bias is float.

The bias quantization is handled in https://github.com/onnxruntime/onnxruntime-qnn/pull/483

