### PR TITLE
[QNN EP] Support LPBQ encodings for Conv Op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -235,61 +235,6 @@ Ort::Status ConvOpBuilder::GetInputChannelNumber(QnnModelWrapper& qnn_model_wrap
   return Ort::Status();
 }
 
-// Quantize a float bias using bias_scale = activation_scale * weight_scale.
-static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
-                                    const Ort::Logger& logger,
-                                    const OrtNodeUnitIODef& bias_def,
-                                    const TensorInfo& bias_info,
-                                    gsl::span<const float> weights_scales,
-                                    float activation_scale,
-                                    std::vector<std::string>& input_names) {
-  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-              ("Quantizing float bias " + bias_def.name + " using activation_scale * weight_scale[c]").c_str());
-  std::vector<uint8_t> original_bias_data;
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
-  const size_t num_channels = bias_info.shape[0];
-  RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
-                "Unexpected bias data size for float bias quantization");
-  std::vector<uint8_t> new_bias_data;
-  std::vector<float> new_scales;
-  std::vector<int32_t> new_offsets;
-  RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
-      gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
-      weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
-  int32_t bias_quant_axis = 0;
-  QnnQuantParamsWrapper quant_params = (weights_scales.size() == 1)
-                                           ? QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0])
-                                           : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
-  QnnTensorWrapper bias_wrapper(bias_def.name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
-                                std::move(quant_params), std::vector<uint32_t>(bias_info.shape),
-                                std::move(new_bias_data));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
-                "Failed to add bias tensor.");
-  input_names.push_back(bias_def.name);
-  return Ort::Status();
-}
-
-Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
-                                         const OrtNodeUnit& node_unit,
-                                         const Ort::Logger& logger,
-                                         std::vector<std::string>& input_names,
-                                         bool do_op_validation) const {
-  const auto& inputs = node_unit.Inputs();
-  assert(inputs.size() >= 2);
-
-  std::vector<uint32_t> input0_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input0_shape),
-                "QNN EP: Cannot get shape for first input");
-
-  if (input0_shape.size() == 3) {
-    return ProcessConv1DInputs(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
-  } else if (input0_shape.size() == 4 || input0_shape.size() == 5) {
-    return ProcessConv2D3DInputs(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
-  }
-
-  return MAKE_EP_FAIL("QNN Conv only supports 3D(rank 5), 2D (rank 4) or 1D (rank 3) inputs.");
-}
-
 // Dequantize INT32 bias to FP16 for BW_FLOAT_BLOCK Conv.
 static Ort::Status ProcessBqFp16Bias(QnnModelWrapper& qnn_model_wrapper,
                                      const OrtNodeUnitIODef& bias_def,
@@ -373,6 +318,40 @@ static Ort::Status ProcessRequantizeBias(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
+// Quantize a float bias using bias_scale = activation_scale * weight_scale.
+static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
+                                    const Ort::Logger& logger,
+                                    const OrtNodeUnitIODef& bias_def,
+                                    const TensorInfo& bias_info,
+                                    gsl::span<const float> weights_scales,
+                                    float activation_scale,
+                                    std::vector<std::string>& input_names) {
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("Quantizing float bias " + bias_def.name + " using activation_scale * weight_scale[c]").c_str());
+  std::vector<uint8_t> original_bias_data;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
+  const size_t num_channels = bias_info.shape[0];
+  RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
+                "Unexpected bias data size for float bias quantization");
+  std::vector<uint8_t> new_bias_data;
+  std::vector<float> new_scales;
+  std::vector<int32_t> new_offsets;
+  RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
+      gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
+      weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
+  int32_t bias_quant_axis = 0;
+  QnnQuantParamsWrapper quant_params = (weights_scales.size() == 1)
+                                           ? QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0])
+                                           : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
+  QnnTensorWrapper bias_wrapper(bias_def.name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
+                                std::move(quant_params), std::vector<uint32_t>(bias_info.shape),
+                                std::move(new_bias_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
+                "Failed to add bias tensor.");
+  input_names.push_back(bias_def.name);
+  return Ort::Status();
+}
+
 Ort::Status ConvOpBuilder::ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
                                            const Ort::Logger& logger,
                                            const std::vector<OrtNodeUnitIODef>& inputs,
@@ -419,6 +398,27 @@ Ort::Status ConvOpBuilder::ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
 
   // Process bias normally: non-initializer, or activation/weight not quantized, or scales already match.
   return ProcessInput(qnn_model_wrapper, bias_def, logger, input_names);
+}
+
+Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
+                                         const OrtNodeUnit& node_unit,
+                                         const Ort::Logger& logger,
+                                         std::vector<std::string>& input_names,
+                                         bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  assert(inputs.size() >= 2);
+
+  std::vector<uint32_t> input0_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input0_shape),
+                "QNN EP: Cannot get shape for first input");
+
+  if (input0_shape.size() == 3) {
+    return ProcessConv1DInputs(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
+  } else if (input0_shape.size() == 4 || input0_shape.size() == 5) {
+    return ProcessConv2D3DInputs(qnn_model_wrapper, node_unit, logger, input_names, do_op_validation);
+  }
+
+  return MAKE_EP_FAIL("QNN Conv only supports 3D(rank 5), 2D (rank 4) or 1D (rank 3) inputs.");
 }
 
 Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -13,6 +13,12 @@
 namespace onnxruntime {
 namespace qnn {
 
+namespace {
+inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
+  return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
+}
+}  // namespace
+
 // ONNX convolution types supported by this builder.
 // We translate node_unit.OpType() into this enum to avoid repeated string comparisons.
 enum class OnnxConvType {
@@ -248,6 +254,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   // Input 0
   //
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
+  const std::string act_name = input_names[0];  // activation (input 0)
+  const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
+  const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
+  const bool is_act_16bit = act_dtype == IsQuant16bit(act_dtype);
 
   // Detect block-quantized weight. Per ONNX opset 21, the scale rank equals the weight rank
   // with scale_shape[1] < weight_shape[1] (the blocked IC axis). Weight is always NCHW
@@ -272,14 +282,16 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
 
-  if (is_bq_weight && !input_info.quant_param.IsLPBQ()) {
+  const bool is_lpbq_weight = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+                              is_act_16bit &&
+                              input_info.is_initializer &&
+                              input_info.quant_param.IsLPBQ();
+
+  if (is_bq_weight && !is_lpbq_weight) {
     RETURN_IF(!input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
 
     // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
-    const std::string act_name = input_names[0];  // activation (input 0), pushed by ProcessInput above
-    const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
-    const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
-    if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
+    if (is_act_16bit) {
       // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
       // stays aligned with the ONNX graph naming.
       const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
@@ -341,10 +353,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
                                          is_unsigned_weight, bitwidth, OC * nb, offsets_qnn));
 
-      QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
-                                                                                  gsl::span<const float>(offsets_qnn),
-                                                                                  bitwidth,
-                                                                                  gsl::span<const uint32_t>(block_size_arr));
+    QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
+                                                                                gsl::span<const float>(offsets_qnn),
+                                                                                bitwidth,
+                                                                                gsl::span<const uint32_t>(block_size_arr));
 
     // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
     QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
@@ -375,7 +387,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     }
 
     bool is_3d = (input_info.shape.size() == 5);
-    RETURN_IF(is_3d && input_info.quant_param.IsLPBQ(), "LPBQ is only supported for Conv2d (rank-4 weights)");
+    RETURN_IF(is_3d && is_lpbq_weight, "LPBQ is only supported for Conv2d (rank-4 weights)");
 
     std::vector<uint8_t> unpacked_tensor;
     if (input_info.is_initializer) {
@@ -389,7 +401,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       }
 
       // Transpose quantization parameter's axis if this is using per-channel or LPBQ quantization.
-      if (input_info.quant_param.IsPerChannel() || input_info.quant_param.IsLPBQ()) {
+      if (input_info.quant_param.IsPerChannel() || is_lpbq_weight) {
         std::vector<size_t> perm;
         if (is_3d) {
           perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
@@ -402,7 +414,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       }
     } else {
       // Add transpose node above weight input.
-      RETURN_IF(input_info.quant_param.IsPerChannel() || input_info.quant_param.IsLPBQ(),
+      RETURN_IF(input_info.quant_param.IsPerChannel() || is_lpbq_weight,
                 "Non-constant Conv inputs only support per-tensor quantization");
       bool is_graph_input = qnn_model_wrapper.IsGraphInput(input1_name);
       ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Add HWCN Transpose node after input: " + input1_name).c_str());
@@ -498,7 +510,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   if (has_bias_input) {
     // For BQ Conv: QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
     // The bias in the QDQ NodeUnit is an INT32 quantized initializer — dequantize it to FP16.
-    if (is_bq_weight && !input_info.quant_param.IsLPBQ()) {
+    if (is_bq_weight && !is_lpbq_weight) {
       TensorInfo bias_info = {};
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
       RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
@@ -570,16 +582,16 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
             activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
           }
 
+          int32_t bias_quant_axis = 0;
           std::vector<float> weights_scales;
-          RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, bias_info.shape[0], weights_scales));
+          RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, weights_scales));
           RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for bias quantization");
 
           if (bias_info.quant_param.IsQuantized()) {
             // Bias is already quantized: check if scales match, requantize if needed.
             std::vector<float> current_scales;
             std::vector<int32_t> current_offsets;
-            int32_t quant_axis = 0;
-            RETURN_IF_ERROR(utils::GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales, current_offsets, quant_axis));
+            RETURN_IF_ERROR(utils::GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales, current_offsets, bias_quant_axis));
 
             const size_t num_channels = current_scales.size();
             bool needs_requantization = false;
@@ -600,7 +612,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
               std::vector<uint8_t> requantized_bias_data;
               std::vector<float> new_scales;
               std::vector<int32_t> new_offsets;
-              const std::optional<int64_t> axis_opt = (num_channels > 1) ? std::optional<int64_t>(quant_axis) : std::nullopt;
+              const std::optional<int64_t> axis_opt = (num_channels > 1) ? std::optional<int64_t>(bias_quant_axis) : std::nullopt;
               RETURN_IF_ERROR(utils::RequantizeBiasTensor(
                   original_bias_data, bias_info.shape, current_scales, current_offsets,
                   weights_scales, activation_scale, bias_info.qnn_data_type,
@@ -610,7 +622,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
               if (new_scales.size() == 1) {
                 new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
               } else {
-                new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, quant_axis, false);
+                new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
               }
 
               std::string bias_name = bias_input.name;
@@ -647,7 +659,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
             if (weights_scales.size() == 1) {
               new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], 0);
             } else {
-              new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, /*axis=*/0, /*is_int4=*/false);
+              new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
             }
 
             std::string bias_name = bias_input.name;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -17,6 +17,47 @@ namespace {
 inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
   return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
 }
+
+// Extracts the per-tensor activation scale from a QNN quant params wrapper.
+// Returns 1.0f for unrecognized encodings (treated as unquantized).
+inline float GetActivationScale(const QnnQuantParamsWrapper& quant_params) {
+  const auto& qp = quant_params.Get();
+  if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+    return qp.scaleOffsetEncoding.scale;
+  }
+  if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+    return qp.bwScaleOffsetEncoding.scale;
+  }
+  return 1.0f;
+}
+
+// Builds a QnnQuantParamsWrapper for a bias tensor from computed scales and offsets.
+// Uses per-tensor encoding when there is exactly one scale, per-channel otherwise.
+inline QnnQuantParamsWrapper BuildBiasQuantParams(const std::vector<float>& new_scales,
+                                                  const std::vector<int32_t>& new_offsets,
+                                                  int32_t bias_quant_axis) {
+  if (new_scales.size() == 1) {
+    return QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
+  }
+  return QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
+}
+
+// Creates a static bias tensor wrapper and registers it with the model.
+inline Ort::Status AddStaticBiasTensor(QnnModelWrapper& qnn_model_wrapper,
+                                       const std::string& bias_name,
+                                       const std::vector<uint32_t>& bias_shape,
+                                       Qnn_DataType_t data_type,
+                                       QnnQuantParamsWrapper quant_params,
+                                       std::vector<uint8_t> bias_data,
+                                       std::vector<std::string>& input_names) {
+  QnnTensorWrapper bias_wrapper(bias_name, QNN_TENSOR_TYPE_STATIC, data_type,
+                                std::move(quant_params), std::vector<uint32_t>(bias_shape),
+                                std::move(bias_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
+                "Failed to add bias tensor.");
+  input_names.push_back(bias_name);
+  return Ort::Status();
+}
 }  // namespace
 
 // ONNX convolution types supported by this builder.
@@ -72,6 +113,17 @@ class ConvOpBuilder : public BaseOpBuilder {
   Ort::Status GetInputChannelNumber(QnnModelWrapper& qnn_model_wrapper,
                                     const OrtNodeUnit& node_unit,
                                     uint32_t& input_channel_number) const;
+
+  // Handles all bias strategies for Conv.
+  //   1. BQ FP16 path (is_bq_weight && !use_lpbq_path): dequantize INT32 bias to FP16.
+  //   2. Requantize-if-mismatch path: fix bias scales to match activation_scale * weight_scale.
+  //   3. Normal path: pass bias through ProcessInput unchanged.
+  Ort::Status ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
+                              const Ort::Logger& logger,
+                              const std::vector<OrtNodeUnitIODef>& inputs,
+                              bool is_bq_weight,
+                              bool use_lpbq_path,
+                              std::vector<std::string>& input_names) const ORT_MUST_USE_RESULT;
 };
 
 // Conv/ConvTranspose ops are sensitive with data layout, no special validation so far
@@ -238,6 +290,137 @@ Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   return MAKE_EP_FAIL("QNN Conv only supports 3D(rank 5), 2D (rank 4) or 1D (rank 3) inputs.");
 }
 
+// Dequantize INT32 bias to FP16 for BW_FLOAT_BLOCK Conv.
+static Ort::Status ProcessBqFp16Bias(QnnModelWrapper& qnn_model_wrapper,
+                                      const OrtNodeUnitIODef& bias_def,
+                                      std::vector<std::string>& input_names) {
+  TensorInfo bias_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_def, bias_info));
+  RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
+
+  std::vector<uint8_t> raw_bias_bytes;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes));
+
+  std::vector<float> bias_scale_vals;
+  if (bias_def.quant_param.has_value() && bias_def.quant_param->scale != nullptr) {
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(bias_def.quant_param->scale, bias_scale_vals));
+  }
+
+  const size_t num_elems = bias_info.shape[0];
+  RETURN_IF_NOT(raw_bias_bytes.size() == num_elems * sizeof(int32_t), "BQ bias size mismatch");
+  RETURN_IF_NOT(bias_scale_vals.size() <= 1 || bias_scale_vals.size() == num_elems,
+                "QNN EP: BQ Conv bias scale count must be 1 (per-tensor) or OC (per-channel)");
+
+  std::vector<uint8_t> fp16_bias_bytes;
+  RETURN_IF_ERROR(utils::DequantizeInt32BiasToFp16(raw_bias_bytes, bias_scale_vals, fp16_bias_bytes));
+
+  const std::string fp16_bias_name = utils::UniqueNameGenerator().New(bias_def.name, "_fp16");
+  return AddStaticBiasTensor(qnn_model_wrapper, fp16_bias_name, bias_info.shape,
+                             QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                             std::move(fp16_bias_bytes), input_names);
+}
+
+// Requantize a quantized bias whose scales don't match activation_scale * weight_scale.
+// Sets was_requantized=true and adds the tensor if requantization was needed; false if scales match.
+static Ort::Status ProcessRequantizeBias(QnnModelWrapper& qnn_model_wrapper,
+                                          const Ort::Logger& logger,
+                                          const OrtNodeUnitIODef& bias_def,
+                                          const TensorInfo& bias_info,
+                                          gsl::span<const float> weights_scales,
+                                          float activation_scale,
+                                          std::vector<std::string>& input_names,
+                                          bool& was_requantized) {
+  was_requantized = false;
+  int32_t bias_quant_axis = 0;
+  std::vector<float> current_scales;
+  std::vector<int32_t> current_offsets;
+  RETURN_IF_ERROR(utils::GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales,
+                                                      current_offsets, bias_quant_axis));
+
+  const size_t num_channels = current_scales.size();
+  bool needs_requantization = false;
+  for (size_t i = 0; i < num_channels && !needs_requantization; ++i) {
+    const float w = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
+    if (current_offsets[i] != 0 ||
+        !utils::CheckBiasScaleMatch(current_scales[i], w, activation_scale, 1e-5f)) {
+      needs_requantization = true;
+    }
+  }
+
+  if (!needs_requantization) {
+    return Ort::Status();  // Scales already match; process bias normally.
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing bias " + bias_def.name).c_str());
+
+  std::vector<uint8_t> original_bias_data;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
+
+  std::vector<uint8_t> new_bias_data;
+  std::vector<float> new_scales;
+  std::vector<int32_t> new_offsets;
+  const auto axis_opt = (num_channels > 1) ? std::optional<int64_t>(bias_quant_axis) : std::nullopt;
+  RETURN_IF_ERROR(utils::RequantizeBiasTensor(
+      original_bias_data, bias_info.shape, current_scales, current_offsets,
+      weights_scales, activation_scale, bias_info.qnn_data_type,
+      new_bias_data, new_scales, new_offsets, axis_opt));
+
+  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, bias_def.name, bias_info.shape,
+                                      bias_info.qnn_data_type,
+                                      BuildBiasQuantParams(new_scales, new_offsets, bias_quant_axis),
+                                      std::move(new_bias_data), input_names));
+  was_requantized = true;
+  return Ort::Status();
+}
+
+Ort::Status ConvOpBuilder::ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
+                                           const Ort::Logger& logger,
+                                           const std::vector<OrtNodeUnitIODef>& inputs,
+                                           bool is_bq_weight,
+                                           bool use_lpbq_path,
+                                           std::vector<std::string>& input_names) const {
+  // BQ FP16 path.
+  if (is_bq_weight && !use_lpbq_path) {
+    return ProcessBqFp16Bias(qnn_model_wrapper, inputs[2], input_names);
+  }
+
+  const auto& bias_def = inputs[2];
+  TensorInfo bias_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_def, bias_info));
+
+  if (bias_info.is_initializer) {
+    TensorInfo input0_info = {}, input1_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
+
+    if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
+      const float activation_scale = GetActivationScale(input0_info.quant_param);
+      std::vector<float> weights_scales;
+      RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, weights_scales));
+      RETURN_IF(weights_scales.empty(), "No weight scales found for bias quantization");
+
+      if (bias_info.quant_param.IsQuantized()) {
+        // Requantize if bias scales don't match activation_scale * weight_scale.
+        bool was_requantized = false;
+        RETURN_IF_ERROR(ProcessRequantizeBias(qnn_model_wrapper, logger, bias_def, bias_info,
+                                              weights_scales, activation_scale, input_names,
+                                              was_requantized));
+        if (was_requantized) {
+          return Ort::Status();
+        }
+        // Else scales already match, process bias normally.
+      } else {
+        // Bias is float, quantize using activation_scale * weight_scale
+        ORT_RETURN_IF_ERROR(ProcessFloatBias(qnn_model_wrapper, logger, bias_def, bias_info,
+                                             weights_scales, activation_scale, input_names));
+      }
+    }
+  }
+
+  // Process bias normally: non-initializer, or activation/weight not quantized, or scales already match.
+  return ProcessInput(qnn_model_wrapper, bias_def, logger, input_names);
+}
+
 Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrapper,
                                                  const OrtNodeUnit& node_unit,
                                                  const Ort::Logger& logger,
@@ -281,12 +464,39 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
 
-  const bool is_lpbq_weight = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
-                              IsQuant16bit(act_dtype) &&
-                              input_info.is_initializer &&
-                              input_info.quant_param.IsLPBQ();
+  // use_lpbq_path: take the BLOCKWISE_EXPANSION (LPBQ) kernel path instead of BW_FLOAT_BLOCK.
+  // All four conditions must hold:
+  //   1. NPU backend - LPBQ is an HTP-only encoding.
+  //   2. 16-bit quantized activation (uint16/int16) - LPBQ requires INT16 activation input.
+  //   3. Weight is a constant initializer - dynamic weights cannot be LPBQ-encoded at graph-prepare time.
+  //   4. Weight quant params are LPBQ - enable_block_quant_weight_optimization=1 and INT4 weight with symmetric ZPs.
+  const bool use_lpbq_path = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+                             IsQuant16bit(act_dtype) &&
+                             input_info.is_initializer &&
+                             input_info.quant_param.IsLPBQ();
 
-  if (is_bq_weight && !is_lpbq_weight) {
+  // For logging and debugging purposes.
+  if (is_bq_weight) {
+    if (use_lpbq_path) {
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Conv weight encoding: LPBQ (BLOCKWISE_EXPANSION) for " + input1_name).c_str());
+    } else {
+      const char* reason = !IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())
+                               ? "non-NPU backend"
+                           : !IsQuant16bit(act_dtype)
+                               ? "activation not 16-bit quantized"
+                           : !input_info.is_initializer
+                               ? "weight is not a constant initializer"
+                           : !input_info.quant_param.IsLPBQ()
+                               ? "weight quant params not LPBQ (enable_block_quant_weight_optimization=0, non-INT4, or asymmetric ZP)"
+                               : "unknown";
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Conv weight encoding: BW_FLOAT_BLOCK for " + input1_name +
+                   " [LPBQ skipped: " + reason + "]").c_str());
+    }
+  }
+
+  if (is_bq_weight && !use_lpbq_path) {
     RETURN_IF(!input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
 
     // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
@@ -385,7 +595,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     }
 
     bool is_3d = (input_info.shape.size() == 5);
-    RETURN_IF(is_3d && is_lpbq_weight, "LPBQ is only supported for Conv2d (rank-4 weights)");
+    RETURN_IF(is_3d && use_lpbq_path, "LPBQ is only supported for Conv2d (rank-4 weights)");
 
     std::vector<uint8_t> unpacked_tensor;
     if (input_info.is_initializer) {
@@ -399,7 +609,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       }
 
       // Transpose quantization parameter's axis if this is using per-channel or LPBQ quantization.
-      if (input_info.quant_param.IsPerChannel() || is_lpbq_weight) {
+      if (input_info.quant_param.IsPerChannel() || use_lpbq_path) {
         std::vector<size_t> perm;
         if (is_3d) {
           perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
@@ -412,7 +622,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       }
     } else {
       // Add transpose node above weight input.
-      RETURN_IF(input_info.quant_param.IsPerChannel() || is_lpbq_weight,
+      RETURN_IF(input_info.quant_param.IsPerChannel() || use_lpbq_path,
                 "Non-constant Conv inputs only support per-tensor quantization");
       bool is_graph_input = qnn_model_wrapper.IsGraphInput(input1_name);
       ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Add HWCN Transpose node after input: " + input1_name).c_str());
@@ -506,176 +716,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   //
   const bool has_bias_input = num_inputs == 3;
   if (has_bias_input) {
-    // For BQ Conv: QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
-    // The bias in the QDQ NodeUnit is an INT32 quantized initializer — dequantize it to FP16.
-    if (is_bq_weight && !is_lpbq_weight) {
-      TensorInfo bias_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
-      RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
-
-      // Read the INT32 quantized bias and its scale(s), then dequantize to FP16.
-      // QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
-      // Bias scale may be per-tensor (1 value) or per-channel (one value per output channel).
-      std::vector<uint8_t> raw_bias_bytes;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor,
-                                                              raw_bias_bytes));
-      std::vector<float> bias_scale_vals;
-      if (inputs[2].quant_param.has_value() && inputs[2].quant_param->scale != nullptr) {
-        RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[2].quant_param->scale, bias_scale_vals));
-      }
-
-      // Dequantize INT32 → FP16 (stored as uint16 in memory): bias[i] = q[i] * scale[i or 0].
-      const size_t num_elems = bias_info.shape[0];
-      RETURN_IF_NOT(raw_bias_bytes.size() == num_elems * sizeof(int32_t), "BQ bias size mismatch");
-      // Scale is per-tensor (1), per-channel (num_elems == OC), or absent (defaults to 1.0f).
-      const bool is_per_channel_bias = bias_scale_vals.size() == num_elems;
-      RETURN_IF_NOT(bias_scale_vals.size() <= 1 || is_per_channel_bias,
-                    "QNN EP: BQ Conv bias scale count must be 1 (per-tensor) or OC (per-channel)");
-      std::vector<uint8_t> fp16_bias_bytes(num_elems * sizeof(uint16_t));
-      const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_bias_bytes.data());
-      auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bias_bytes.data());
-      for (size_t i = 0; i < num_elems; ++i) {
-        const float scale = bias_scale_vals.empty() ? 1.0f
-                                                    : (is_per_channel_bias ? bias_scale_vals[i]
-                                                                           : bias_scale_vals[0]);
-        const float f = static_cast<float>(i32_ptr[i]) * scale;
-        const Ort::Float16_t fp16_val(f);
-        memcpy(&u16_ptr[i], &fp16_val.val, sizeof(uint16_t));
-      }
-
-      const std::string fp16_bias_name = utils::UniqueNameGenerator().New(inputs[2].name, "_fp16");
-      QnnTensorWrapper fp16_bias_wrapper(fp16_bias_name, QNN_TENSOR_TYPE_STATIC,
-                                         QNN_DATATYPE_FLOAT_16,
-                                         QnnQuantParamsWrapper(),
-                                         std::vector<uint32_t>(bias_info.shape),
-                                         std::move(fp16_bias_bytes));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_bias_wrapper)),
-                    "Failed to add FP16 bias for BQ Conv.");
-      input_names.push_back(fp16_bias_name);
-    } else {
-      const auto& bias_input = inputs[2];
-      TensorInfo bias_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_input, bias_info));
-
-      bool bias_handled = false;
-
-      // For a static bias when activation and weight are both quantized, ensure
-      // bias_scale = activation_scale * weight_scale.
-      // This applies whether the bias is already quantized (requantize if needed) or float (quantize it).
-      if (bias_info.is_initializer) {
-        TensorInfo input0_info = {};
-        TensorInfo input1_info = {};
-        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
-        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
-
-        if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
-          // Get activation scale (must be per-tensor for Conv)
-          RETURN_IF_NOT(input0_info.quant_param.IsPerTensor(/*include_bw*/ true),
-                        "Activation must be per-tensor quantized for Conv 2D");
-          float activation_scale = 1.0f;
-          const auto& act_quant_params = input0_info.quant_param.Get();
-          if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-            activation_scale = act_quant_params.scaleOffsetEncoding.scale;
-          } else if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-            activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
-          }
-
-          int32_t bias_quant_axis = 0;
-          std::vector<float> weights_scales;
-          RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, weights_scales));
-          RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for bias quantization");
-
-          if (bias_info.quant_param.IsQuantized()) {
-            // Bias is already quantized: check if scales match, requantize if needed.
-            std::vector<float> current_scales;
-            std::vector<int32_t> current_offsets;
-            RETURN_IF_ERROR(utils::GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales, current_offsets, bias_quant_axis));
-
-            const size_t num_channels = current_scales.size();
-            bool needs_requantization = false;
-            for (size_t i = 0; i < num_channels && !needs_requantization; ++i) {
-              const float weight_scale = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
-              if (current_offsets[i] != 0 ||
-                  !utils::CheckBiasScaleMatch(current_scales[i], weight_scale, activation_scale, 1e-5f)) {
-                needs_requantization = true;
-              }
-            }
-
-            if (needs_requantization) {
-              ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing bias " + bias_input.name).c_str());
-
-              std::vector<uint8_t> original_bias_data;
-              RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
-
-              std::vector<uint8_t> requantized_bias_data;
-              std::vector<float> new_scales;
-              std::vector<int32_t> new_offsets;
-              const std::optional<int64_t> axis_opt = (num_channels > 1) ? std::optional<int64_t>(bias_quant_axis) : std::nullopt;
-              RETURN_IF_ERROR(utils::RequantizeBiasTensor(
-                  original_bias_data, bias_info.shape, current_scales, current_offsets,
-                  weights_scales, activation_scale, bias_info.qnn_data_type,
-                  requantized_bias_data, new_scales, new_offsets, axis_opt));
-
-              QnnQuantParamsWrapper new_quant_params;
-              if (new_scales.size() == 1) {
-                new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
-              } else {
-                new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
-              }
-
-              std::string bias_name = bias_input.name;
-              QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
-                                                  std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
-                                                  std::move(requantized_bias_data));
-              RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)),
-                            "Failed to add requantized bias tensor.");
-              input_names.push_back(bias_name);
-              bias_handled = true;
-            }
-          } else {
-            // Bias is float: quantize using bias_scale = activation_scale * weight_scale.
-            ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                        ("Quantizing float bias " + bias_input.name + " using activation_scale * weight_scale[c]").c_str());
-
-            std::vector<uint8_t> original_bias_data;
-                RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
-
-            const size_t num_channels = bias_info.shape[0];
-            RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
-                          "Unexpected bias data size for float bias quantization");
-            auto bias_float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels);
-
-            std::vector<uint8_t> quantized_bias_data;
-            std::vector<float> new_scales;
-            std::vector<int32_t> new_offsets;
-            RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
-                bias_float_data, weights_scales, activation_scale,
-                quantized_bias_data, new_scales, new_offsets));
-
-            QnnQuantParamsWrapper new_quant_params;
-            if (weights_scales.size() == 1) {
-              new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], 0);
-            } else {
-              new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
-            }
-
-            std::string bias_name = bias_input.name;
-            QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
-                                                std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
-                                                std::move(quantized_bias_data));
-            RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)),
-                          "Failed to add quantized float bias tensor.");
-            input_names.push_back(bias_name);
-            bias_handled = true;
-          }
-        }
-      }
-
-      if (!bias_handled) {
-        // Process bias normally: non-initializer, or activation/weight not quantized, or scales already match.
-        RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, bias_input, logger, input_names));
-      }
-    }
+    RETURN_IF_ERROR(ProcessConvBias(qnn_model_wrapper, logger,
+                                    inputs, is_bq_weight, use_lpbq_path, input_names));
   }
 
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 16 && QNN_API_VERSION_MINOR <= 18)

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -14,18 +14,12 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
-inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
-  return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
-}
-
 // Extracts the per-tensor activation scale from a QNN quant params wrapper.
-// Returns 1.0f for unrecognized encodings (treated as unquantized).
 inline float GetActivationScale(const QnnQuantParamsWrapper& quant_params) {
   const auto& qp = quant_params.Get();
   if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
     return qp.scaleOffsetEncoding.scale;
-  }
-  if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
     return qp.bwScaleOffsetEncoding.scale;
   }
   return 1.0f;
@@ -117,7 +111,8 @@ class ConvOpBuilder : public BaseOpBuilder {
   // Handles all bias strategies for Conv.
   //   1. BQ FP16 path (is_bq_weight && !use_lpbq_path): dequantize INT32 bias to FP16.
   //   2. Requantize-if-mismatch path: fix bias scales to match activation_scale * weight_scale.
-  //   3. Normal path: pass bias through ProcessInput unchanged.
+  //   3. Quantize bias scale using activation_scale * weight_scale if float bias present.
+  //   4. Normal path: pass bias through ProcessInput unchanged.
   Ort::Status ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
                               const Ort::Logger& logger,
                               const std::vector<OrtNodeUnitIODef>& inputs,
@@ -241,7 +236,7 @@ static Ort::Status ProcessBqFp16Bias(QnnModelWrapper& qnn_model_wrapper,
                                      std::vector<std::string>& input_names) {
   TensorInfo bias_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_def, bias_info));
-  RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
+  RETURN_IF_NOT(bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
 
   std::vector<uint8_t> raw_bias_bytes;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, raw_bias_bytes));
@@ -336,19 +331,14 @@ static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
   std::vector<uint8_t> new_bias_data;
   std::vector<float> new_scales;
   std::vector<int32_t> new_offsets;
+  int32_t bias_quant_axis = 0;
   RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
       gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
       weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
-  int32_t bias_quant_axis = 0;
-  QnnQuantParamsWrapper quant_params = (weights_scales.size() == 1)
-                                           ? QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0])
-                                           : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
-  QnnTensorWrapper bias_wrapper(bias_def.name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
-                                std::move(quant_params), std::vector<uint32_t>(bias_info.shape),
-                                std::move(new_bias_data));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
-                "Failed to add bias tensor.");
-  input_names.push_back(bias_def.name);
+  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, bias_def.name, bias_info.shape,
+                                      QNN_DATATYPE_SFIXED_POINT_32,
+                                      BuildBiasQuantParams(new_scales, new_offsets, bias_quant_axis),
+                                      std::move(new_bias_data), input_names));
   return Ort::Status();
 }
 
@@ -373,6 +363,9 @@ Ort::Status ConvOpBuilder::ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
 
     if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
+      // Get activation scale (must be per-tensor for Conv)
+      RETURN_IF_NOT(input0_info.quant_param.IsPerTensor(/*include_bw*/ true),
+                    "Activation must be per-tensor quantized for Conv 2D");
       const float activation_scale = GetActivationScale(input0_info.quant_param);
       std::vector<float> weights_scales;
       RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, weights_scales));
@@ -390,8 +383,8 @@ Ort::Status ConvOpBuilder::ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
         // Else scales already match, process bias normally.
       } else {
         // Bias is float, quantize using activation_scale * weight_scale
-        ORT_RETURN_IF_ERROR(ProcessFloatBias(qnn_model_wrapper, logger, bias_def, bias_info,
-                                             weights_scales, activation_scale, input_names));
+        return ProcessFloatBias(qnn_model_wrapper, logger, bias_def, bias_info,
+                                weights_scales, activation_scale, input_names);
       }
     }
   }
@@ -471,7 +464,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   //   3. Weight is a constant initializer - dynamic weights cannot be LPBQ-encoded at graph-prepare time.
   //   4. Weight quant params are LPBQ - enable_block_quant_weight_optimization=1 and INT4 weight with symmetric ZPs.
   const bool use_lpbq_path = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
-                             IsQuant16bit(act_dtype) &&
+                             utils::IsQuant16bit(act_dtype) &&
                              input_info.is_initializer &&
                              input_info.quant_param.IsLPBQ();
 
@@ -483,7 +476,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     } else {
       const char* reason = !IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())
                                ? "non-NPU backend"
-                           : !IsQuant16bit(act_dtype)
+                           : !utils::IsQuant16bit(act_dtype)
                                ? "activation not 16-bit quantized"
                            : !input_info.is_initializer
                                ? "weight is not a constant initializer"
@@ -498,10 +491,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   }
 
   if (is_bq_weight && !use_lpbq_path) {
-    RETURN_IF(!input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
+    RETURN_IF_NOT(input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
 
     // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
-    if (IsQuant16bit(act_dtype)) {
+    if (utils::IsQuant16bit(act_dtype)) {
       // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
       // stays aligned with the ONNX graph naming.
       const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -268,32 +268,25 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     }
   }
 
-  if (is_bq_weight) {
-    // Determine BQ vs LPBQ by reading weight quant params via GetTensorInfo.
-    // When PR307 is active, Init() auto-converts BQ scales → LPBQ (BLOCKWISE_EXPANSION).
-    // Before PR307: Init() cannot handle block_size, so IsLPBQ() is false → BQ path.
-    const std::string& input1_name = inputs[1].name;
-    TensorInfo input_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
-    RETURN_IF(!input_info.is_initializer,
-              "QNN EP: BQ/LPBQ Conv weight must be a constant initializer");
+  const std::string& input1_name = inputs[1].name;
+  TensorInfo input_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
 
-    const bool is_lpbq = input_info.quant_param.IsLPBQ();
+  if (is_bq_weight && !input_info.quant_param.IsLPBQ()) {
+    RETURN_IF(!input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
 
     // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
-    //                      LPBQ kernel (BLOCKWISE_EXPANSION) accepts INT16 as-is.
-    if (!is_lpbq) {
-      const std::string act_name = input_names[0];  // activation (input 0), pushed by ProcessInput above
-      const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
-      const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
-      if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
-        // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
-        // stays aligned with the ONNX graph naming.
-        const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-        RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
-                                                               fp16_act_name, do_op_validation, "Conv"));
-        input_names[0] = fp16_act_name;
-      }
+    const std::string act_name = input_names[0];  // activation (input 0), pushed by ProcessInput above
+    const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
+    const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
+    if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
+      // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
+      // stays aligned with the ONNX graph naming.
+      const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+      std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
+      RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
+                                                             fp16_act_name, do_op_validation, "Conv"));
+      input_names[0] = fp16_act_name;
     }
 
     // Common: transpose weight data from OIHW→HWIO (or IOHW→HWIO for ConvTranspose).
@@ -317,211 +310,184 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     }
     Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(input1_name);
 
-    if (is_lpbq) {
-      // LPBQ path (PR307 active): Init() already produced BLOCKWISE_EXPANSION quant params.
-      // Update the LPBQ axis for the HWCN transposition (PR307 extended HandleTranspose for LPBQ).
-      std::vector<size_t> perm;
-      if (is_3d) {
-        perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
-      } else {
-        perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm : cnhw2hwcn_perm;
-      }
-      std::vector<size_t> perm_inv(perm.size());
-      RETURN_IF_ERROR(utils::InvertPerm<size_t>(perm, perm_inv));
-      RETURN_IF_ERROR(input_info.quant_param.HandleTranspose<size_t>(perm_inv));
+    // BQ path: manually build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params.
+    const int64_t OC = static_cast<int64_t>(input_info.shape[0]);
+    const int64_t IC = static_cast<int64_t>(input_info.shape[1]);
+    const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc
+    const int64_t block_size = 0;
+    RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], IC, nb, "Conv", block_size));
+    const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
 
-      QnnTensorWrapper lpbq_weight_wrapper(input1_name, tensor_type,
-                                           input_info.qnn_data_type,
-                                           std::move(input_info.quant_param),
-                                           std::move(hwcn_shape),
-                                           std::move(unpacked_tensor));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(lpbq_weight_wrapper)),
-                    "Failed to add LPBQ Conv weight tensor.");
-    } else {
-      // BQ path: manually build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params.
-      const int64_t OC = static_cast<int64_t>(input_info.shape[0]);
-      const int64_t IC = static_cast<int64_t>(input_info.shape[1]);
-      const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc
-      int64_t block_size = 0;
-      RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], IC, nb, "Conv", block_size));
-      const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
+    // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain.
+    const bool is_unsigned_weight = bq::IsUnsignedBQType(inputs[1].type);
+    if (is_unsigned_weight) {
+      RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor,
+                                                                 static_cast<int64_t>(bitwidth)));
+    }
 
-      // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain.
-      const bool is_unsigned_weight = bq::IsUnsignedBQType(inputs[1].type);
-      if (is_unsigned_weight) {
-        RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor,
-                                                                   static_cast<int64_t>(bitwidth)));
-      }
+    // QNN BW_FLOAT_BLOCK blockSize for HWCN weight: {1, 1, block_size, 1}.
+    // Each block spans block_size consecutive IC elements; H and W dimensions are not blocked.
+    const std::vector<uint32_t> block_size_arr = {1u, 1u, static_cast<uint32_t>(block_size), 1u};
 
-      // QNN BW_FLOAT_BLOCK blockSize for HWCN weight: {1, 1, block_size, 1}.
-      // Each block spans block_size consecutive IC elements; H and W dimensions are not blocked.
-      const std::vector<uint32_t> block_size_arr = {1u, 1u, static_cast<uint32_t>(block_size), 1u};
+    // Read ONNX per-block float scales: flat [OC * nb] in OC-major order.
+    // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
+    std::vector<float> scales_qnn;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, scales_qnn));
+    RETURN_IF_NOT(static_cast<int64_t>(scales_qnn.size()) == OC * nb,
+                  "QNN EP: BQ Conv scale size mismatch");
 
-      // Read ONNX per-block float scales: flat [OC * nb] in OC-major order.
-      // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
-      std::vector<float> scales_qnn;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, scales_qnn));
-      RETURN_IF_NOT(static_cast<int64_t>(scales_qnn.size()) == OC * nb,
-                    "QNN EP: BQ Conv scale size mismatch");
-
-      // Float offsets in [OC, nb] order.
-      std::vector<float> offsets_qnn;
-      RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
-                                           is_unsigned_weight, bitwidth, OC * nb, offsets_qnn));
+    // Float offsets in [OC, nb] order.
+    std::vector<float> offsets_qnn;
+    RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
+                                         is_unsigned_weight, bitwidth, OC * nb, offsets_qnn));
 
       QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
                                                                                   gsl::span<const float>(offsets_qnn),
                                                                                   bitwidth,
                                                                                   gsl::span<const uint32_t>(block_size_arr));
 
-      // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
-      QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
-                                         QNN_DATATYPE_SFIXED_POINT_8,
-                                         std::move(bq_quant_params),
-                                         std::move(hwcn_shape),
-                                         std::move(unpacked_tensor));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bq_weight_wrapper)),
-                    "Failed to add BQ Conv weight tensor.");
-    }
+    // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
+    QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
+                                       QNN_DATATYPE_SFIXED_POINT_8,
+                                       std::move(bq_quant_params),
+                                       std::move(hwcn_shape),
+                                       std::move(unpacked_tensor));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bq_weight_wrapper)),
+                  "Failed to add BQ Conv weight tensor.");
     input_names.push_back(input1_name);
   } else {
     //
     // Input 1: weight. This input must be transposed manually by QNN EP.
     //
-    {
-      const std::string& input1_name = inputs[1].name;
-      TensorInfo input_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
+    std::string actual_name = input_info.is_initializer ? input1_name : utils::UniqueNameGenerator().New(input1_name, "_transpose");
+    input_names.push_back(actual_name);
 
-      std::string actual_name = input_info.is_initializer ? input1_name : utils::UniqueNameGenerator().New(input1_name, "_transpose");
-      input_names.push_back(actual_name);
+    std::vector<uint32_t> actual_shape;
+    actual_shape.resize(input_info.shape.size());
 
-      std::vector<uint32_t> actual_shape;
-      actual_shape.resize(input_info.shape.size());
+    // Change shape to HWCN, it could be initializer or normal input
+    if (conv_type == OnnxConvType::kConv) {
+      RETURN_IF_ERROR(utils::NchwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
+    } else if (conv_type == OnnxConvType::kConvTranspose) {
+      RETURN_IF_ERROR(utils::CnhwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
+    } else {
+      return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
+    }
 
-      // Change shape to HWCN, it could be initializer or normal input
+    bool is_3d = (input_info.shape.size() == 5);
+    RETURN_IF(is_3d && input_info.quant_param.IsLPBQ(), "LPBQ is only supported for Conv2d (rank-4 weights)");
+
+    std::vector<uint8_t> unpacked_tensor;
+    if (input_info.is_initializer) {
+      // Get transposed initializer bytes.
       if (conv_type == OnnxConvType::kConv) {
-        RETURN_IF_ERROR(utils::NchwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
+        RETURN_IF_ERROR(utils::TransposeFromNchwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
       } else if (conv_type == OnnxConvType::kConvTranspose) {
-        RETURN_IF_ERROR(utils::CnhwShapeToHwcn<uint32_t>(input_info.shape, actual_shape));
+        RETURN_IF_ERROR(utils::TransposeFromCnhwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
       } else {
         return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
       }
 
-      bool is_3d = (input_info.shape.size() == 5);
-
-      std::vector<uint8_t> unpacked_tensor;
-      if (input_info.is_initializer) {
-        // Get transposed initializer bytes.
-        if (conv_type == OnnxConvType::kConv) {
-          RETURN_IF_ERROR(utils::TransposeFromNchwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
-        } else if (conv_type == OnnxConvType::kConvTranspose) {
-          RETURN_IF_ERROR(utils::TransposeFromCnhwToHwcn(qnn_model_wrapper, input_info.initializer_tensor, unpacked_tensor, is_3d));
+      // Transpose quantization parameter's axis if this is using per-channel or LPBQ quantization.
+      if (input_info.quant_param.IsPerChannel() || input_info.quant_param.IsLPBQ()) {
+        std::vector<size_t> perm;
+        if (is_3d) {
+          perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
         } else {
-          return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
+          perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm : cnhw2hwcn_perm;
         }
+        std::vector<size_t> perm_inv(perm.size());
+        RETURN_IF_ERROR(utils::InvertPerm<size_t>(perm, perm_inv));
+        RETURN_IF_ERROR(input_info.quant_param.HandleTranspose<size_t>(perm_inv));
+      }
+    } else {
+      // Add transpose node above weight input.
+      RETURN_IF(input_info.quant_param.IsPerChannel() || input_info.quant_param.IsLPBQ(),
+                "Non-constant Conv inputs only support per-tensor quantization");
+      bool is_graph_input = qnn_model_wrapper.IsGraphInput(input1_name);
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Add HWCN Transpose node after input: " + input1_name).c_str());
 
-        // Transpose quantization parameter's axis if this is using per-channel quantization.
-        if (input_info.quant_param.IsPerChannel()) {
-          std::vector<size_t> perm;
-          if (is_3d) {
-            perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm_3d : cnhw2hwcn_perm_3d;
-          } else {
-            perm = conv_type == OnnxConvType::kConv ? nchw2hwcn_perm : cnhw2hwcn_perm;
-          }
-          std::vector<size_t> perm_inv(perm.size());
-          RETURN_IF_ERROR(utils::InvertPerm<size_t>(perm, perm_inv));
-          RETURN_IF_ERROR(input_info.quant_param.HandleTranspose<size_t>(perm_inv));
-        }
+      if (!qnn_model_wrapper.IsQnnTensorWrapperExist(input1_name)) {
+        QnnTensorWrapper weight_tensor_wrapper;
+        RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(inputs[1], weight_tensor_wrapper));
+        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)), "Failed to add weight tensor.");
+      }
+
+      if (conv_type == OnnxConvType::kConv) {
+        RETURN_IF_ERROR(qnn_model_wrapper.AddNchwToHwcnTranspose(node_unit.Index(),
+                                                                 input1_name,
+                                                                 actual_name,
+                                                                 input_info.shape,
+                                                                 actual_shape,
+                                                                 input_info.qnn_data_type,
+                                                                 input_info.quant_param,
+                                                                 do_op_validation,
+                                                                 is_graph_input,
+                                                                 false,
+                                                                 is_3d));
+      } else if (conv_type == OnnxConvType::kConvTranspose) {
+        RETURN_IF_ERROR(qnn_model_wrapper.AddCnhwToHwcnTranspose(node_unit.Index(),
+                                                                 input1_name,
+                                                                 actual_name,
+                                                                 input_info.shape,
+                                                                 actual_shape,
+                                                                 input_info.qnn_data_type,
+                                                                 input_info.quant_param,
+                                                                 do_op_validation,
+                                                                 is_graph_input,
+                                                                 false,
+                                                                 is_3d));
       } else {
-        // Add transpose node above weight input.
-        RETURN_IF(input_info.quant_param.IsPerChannel(),
-                  "Non-constant Conv inputs only support per-tensor quantization");
-        bool is_graph_input = qnn_model_wrapper.IsGraphInput(input1_name);
-        ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Add HWCN Transpose node after input: " + input1_name).c_str());
-
-        if (!qnn_model_wrapper.IsQnnTensorWrapperExist(input1_name)) {
-          QnnTensorWrapper weight_tensor_wrapper;
-          RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(inputs[1], weight_tensor_wrapper));
-          RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensor_wrapper)), "Failed to add weight tensor.");
-        }
-
-        if (conv_type == OnnxConvType::kConv) {
-          RETURN_IF_ERROR(qnn_model_wrapper.AddNchwToHwcnTranspose(node_unit.Index(),
-                                                                   input1_name,
-                                                                   actual_name,
-                                                                   input_info.shape,
-                                                                   actual_shape,
-                                                                   input_info.qnn_data_type,
-                                                                   input_info.quant_param,
-                                                                   do_op_validation,
-                                                                   is_graph_input,
-                                                                   false,
-                                                                   is_3d));
-        } else if (conv_type == OnnxConvType::kConvTranspose) {
-          RETURN_IF_ERROR(qnn_model_wrapper.AddCnhwToHwcnTranspose(node_unit.Index(),
-                                                                   input1_name,
-                                                                   actual_name,
-                                                                   input_info.shape,
-                                                                   actual_shape,
-                                                                   input_info.qnn_data_type,
-                                                                   input_info.quant_param,
-                                                                   do_op_validation,
-                                                                   is_graph_input,
-                                                                   false,
-                                                                   is_3d));
-        } else {
-          return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
-        }
+        return MAKE_EP_FAIL(("QNN EP: Unexpected convolution op type: " + node_unit.OpType()).c_str());
       }
+    }
 
-      Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(actual_name);
-      QnnTensorWrapper input_tensorwrapper(actual_name, tensor_type, input_info.qnn_data_type,
-                                           std::move(input_info.quant_param),
-                                           std::move(actual_shape), std::move(unpacked_tensor));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
+    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(actual_name);
+    QnnTensorWrapper input_tensorwrapper(actual_name, tensor_type, input_info.qnn_data_type,
+                                         std::move(input_info.quant_param),
+                                         std::move(actual_shape), std::move(unpacked_tensor));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
 
-      // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to signed symmetric int16)
-      // to avoid a QNN validation failure.
-      //
-      // QNN graph WITHOUT workaround (fails validation):
-      //     input_0_uint16 ---> Conv ---> output_uint16
-      //                         ^
-      //                         |
-      //     input_1_uint16 -----+
-      //
-      // QNN graph WITH workaround (passes validation):
-      //     input_0_uint16 ----------------------> Conv ---> output_uint16
-      //                                            ^
-      //                                            |
-      //     input_1_uint16 --> Convert(to int16) --+
+    // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to signed symmetric int16)
+    // to avoid a QNN validation failure.
+    //
+    // QNN graph WITHOUT workaround (fails validation):
+    //     input_0_uint16 ---> Conv ---> output_uint16
+    //                         ^
+    //                         |
+    //     input_1_uint16 -----+
+    //
+    // QNN graph WITH workaround (passes validation):
+    //     input_0_uint16 ----------------------> Conv ---> output_uint16
+    //                                            ^
+    //                                            |
+    //     input_1_uint16 --> Convert(to int16) --+
 
-      std::string weight_input_name = input_names.back();
-      const auto& weight_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(weight_input_name);
+    std::string weight_input_name = input_names.back();
+    const auto& weight_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(weight_input_name);
 
-      if (weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
-        const auto& quant_param_wrapper = weight_tensor_wrapper.GetQnnQuantParams();
-        const Qnn_QuantizeParams_t& quant_param = quant_param_wrapper.Get();
-        const auto& transformed_input1_shape = weight_tensor_wrapper.GetTensorDims();
+    if (weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
+      const auto& quant_param_wrapper = weight_tensor_wrapper.GetQnnQuantParams();
+      const Qnn_QuantizeParams_t& quant_param = quant_param_wrapper.Get();
+      const auto& transformed_input1_shape = weight_tensor_wrapper.GetTensorDims();
 
-        RETURN_IF_NOT(quant_param_wrapper.IsPerTensor(),
-                      "Conv's INT16 weight inputs only support INT16 per-tensor quantization");
+      RETURN_IF_NOT(quant_param_wrapper.IsPerTensor(),
+                    "Conv's INT16 weight inputs only support INT16 per-tensor quantization");
 
-        // Insert Convert op after Weight, replacing the weight name (last element) in place.
-        std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
+      // Insert Convert op after Weight, replacing the weight name (last element) in place.
+      std::string convert_output_name = utils::UniqueNameGenerator().New(weight_input_name, "_convert");
 
-        RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
-                                               weight_input_name,
-                                               convert_output_name,
-                                               QNN_DATATYPE_UFIXED_POINT_16,
-                                               QNN_DATATYPE_SFIXED_POINT_16,
-                                               quant_param.scaleOffsetEncoding.offset,
-                                               quant_param.scaleOffsetEncoding.scale,
-                                               transformed_input1_shape,
-                                               true,  // Symmetric
-                                               do_op_validation));
-        input_names.back() = convert_output_name;
-      }
+      RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
+                                             weight_input_name,
+                                             convert_output_name,
+                                             QNN_DATATYPE_UFIXED_POINT_16,
+                                             QNN_DATATYPE_SFIXED_POINT_16,
+                                             quant_param.scaleOffsetEncoding.offset,
+                                             quant_param.scaleOffsetEncoding.scale,
+                                             transformed_input1_shape,
+                                             true,  // Symmetric
+                                             do_op_validation));
+      input_names.back() = convert_output_name;
     }
   }  // end else (non-BQ weight path)
 
@@ -532,7 +498,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   if (has_bias_input) {
     // For BQ Conv: QNN BW_FLOAT_BLOCK Conv2d requires FP16 bias matching the computation precision.
     // The bias in the QDQ NodeUnit is an INT32 quantized initializer — dequantize it to FP16.
-    if (is_bq_weight) {
+    if (is_bq_weight && !input_info.quant_param.IsLPBQ()) {
       TensorInfo bias_info = {};
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], bias_info));
       RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
@@ -581,9 +547,12 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       TensorInfo bias_info = {};
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_input, bias_info));
 
-      // For static quantized bias, handle requantization if needed
-      if (bias_info.is_initializer && bias_info.quant_param.IsQuantized()) {
-        // Get activation and weight quantization parameters
+      bool bias_handled = false;
+
+      // For a static bias when activation and weight are both quantized, ensure
+      // bias_scale = activation_scale * weight_scale.
+      // This applies whether the bias is already quantized (requantize if needed) or float (quantize it).
+      if (bias_info.is_initializer) {
         TensorInfo input0_info = {};
         TensorInfo input1_info = {};
         RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
@@ -601,243 +570,103 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
             activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
           }
 
-          // Get weight scales (per-tensor or per-channel)
           std::vector<float> weights_scales;
+          RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, bias_info.shape[0], weights_scales));
+          RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for bias quantization");
 
-          if (input1_info.quant_param.IsPerTensor()) {
-            // Handle per-tensor quantization (encodings 0 and 2)
-            const auto& weight_quant_params = input1_info.quant_param.Get();
+          if (bias_info.quant_param.IsQuantized()) {
+            // Bias is already quantized: check if scales match, requantize if needed.
+            std::vector<float> current_scales;
+            std::vector<int32_t> current_offsets;
+            int32_t quant_axis = 0;
+            RETURN_IF_ERROR(utils::GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales, current_offsets, quant_axis));
 
-            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-              weights_scales.push_back(weight_quant_params.scaleOffsetEncoding.scale);
-            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-              weights_scales.push_back(weight_quant_params.bwScaleOffsetEncoding.scale);
-            }
-          } else {
-            // Handle per-channel quantization (encodings 1 and 3)
-            const auto& weight_quant_params = input1_info.quant_param.Get();
-
-            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-              if (weight_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr &&
-                  weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0) {
-                for (size_t i = 0; i < weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets; ++i) {
-                  weights_scales.push_back(weight_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
-                }
-              }
-            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-              if (weight_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr &&
-                  weight_quant_params.bwAxisScaleOffsetEncoding.numElements > 0) {
-                for (size_t i = 0; i < weight_quant_params.bwAxisScaleOffsetEncoding.numElements; ++i) {
-                  weights_scales.push_back(weight_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
-                }
+            const size_t num_channels = current_scales.size();
+            bool needs_requantization = false;
+            for (size_t i = 0; i < num_channels && !needs_requantization; ++i) {
+              const float weight_scale = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
+              if (current_offsets[i] != 0 ||
+                  !utils::CheckBiasScaleMatch(current_scales[i], weight_scale, activation_scale, 1e-5f)) {
+                needs_requantization = true;
               }
             }
-          }
 
-          RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
+            if (needs_requantization) {
+              ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing bias " + bias_input.name).c_str());
 
-          // Check bias quantization type
-          if (bias_info.quant_param.IsPerTensor()) {
-            float bias_scale = 0.0f;
-            int32_t bias_offset = 0;
-            const auto& bias_quant_params = bias_info.quant_param.Get();
-            if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-              bias_scale = bias_quant_params.scaleOffsetEncoding.scale;
-              bias_offset = bias_quant_params.scaleOffsetEncoding.offset;
-            } else if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-              bias_scale = bias_quant_params.bwScaleOffsetEncoding.scale;
-              bias_offset = bias_quant_params.bwScaleOffsetEncoding.offset;
-            } else {
-              return MAKE_EP_FAIL("Unsupported bias quantization encoding for per-tensor quantization.");
-            }
-
-            // Check if bias_offset = 0 AND bias_scale = (weights_scale[0] * activation_scale)
-            if (bias_offset == 0 && utils::CheckBiasScaleMatch(bias_scale, weights_scales[0], activation_scale, 1e-5f)) {
-              // No change needed - scales match and offset is 0
-            } else {
-              ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing per-tensor bias " + bias_input.name).c_str());
-              // Need to requantize the bias tensor
               std::vector<uint8_t> original_bias_data;
               RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
 
-              std::vector<float> current_scales = {bias_scale};
-              std::vector<int32_t> current_offsets = {bias_offset};
               std::vector<uint8_t> requantized_bias_data;
               std::vector<float> new_scales;
               std::vector<int32_t> new_offsets;
-
+              const std::optional<int64_t> axis_opt = (num_channels > 1) ? std::optional<int64_t>(quant_axis) : std::nullopt;
               RETURN_IF_ERROR(utils::RequantizeBiasTensor(
                   original_bias_data, bias_info.shape, current_scales, current_offsets,
                   weights_scales, activation_scale, bias_info.qnn_data_type,
-                  requantized_bias_data, new_scales, new_offsets));
+                  requantized_bias_data, new_scales, new_offsets, axis_opt));
 
-              // Create new tensor wrapper with requantized data
+              QnnQuantParamsWrapper new_quant_params;
+              if (new_scales.size() == 1) {
+                new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
+              } else {
+                new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, quant_axis, false);
+              }
+
               std::string bias_name = bias_input.name;
-              QnnQuantParamsWrapper new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
               QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
                                                   std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
                                                   std::move(requantized_bias_data));
-              RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)), "Failed to add requantized bias tensor.");
+              RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)),
+                            "Failed to add requantized bias tensor.");
               input_names.push_back(bias_name);
-              return Ort::Status();  // We've handled the bias, return early
+              bias_handled = true;
             }
           } else {
-            // Handle per-channel bias
-            const auto& bias_quant_params = bias_info.quant_param.Get();
+            // Bias is float: quantize using bias_scale = activation_scale * weight_scale.
+            ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                        ("Quantizing float bias " + bias_input.name + " using activation_scale * weight_scale[c]").c_str());
 
-            if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET ||
-                bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-              // Extract scales and offsets based on encoding type
-              std::vector<float> current_scales;
-              std::vector<int32_t> current_offsets;
-              int32_t quant_axis = 0;
-              size_t num_channels = 0;
-
-              if (bias_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-                // Safety checks for AXIS_SCALE_OFFSET encoding
-                RETURN_IF_NOT(bias_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr,
-                              "Invalid bias quantization parameters: scaleOffset is null");
-                RETURN_IF_NOT(bias_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0,
-                              "Invalid bias quantization parameters: numScaleOffsets is zero");
-
-                num_channels = bias_quant_params.axisScaleOffsetEncoding.numScaleOffsets;
-                quant_axis = bias_quant_params.axisScaleOffsetEncoding.axis;
-                for (size_t i = 0; i < num_channels; ++i) {
-                  current_scales.push_back(bias_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
-                  current_offsets.push_back(bias_quant_params.axisScaleOffsetEncoding.scaleOffset[i].offset);
-                }
-              } else {  // QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET
-                // Safety checks for BW_AXIS_SCALE_OFFSET encoding
-                RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr,
-                              "Invalid bias quantization parameters: scales is null");
-                RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.offsets != nullptr,
-                              "Invalid bias quantization parameters: offsets is null");
-                RETURN_IF_NOT(bias_quant_params.bwAxisScaleOffsetEncoding.numElements > 0,
-                              "Invalid bias quantization parameters: numElements is zero");
-
-                num_channels = bias_quant_params.bwAxisScaleOffsetEncoding.numElements;
-                quant_axis = bias_quant_params.bwAxisScaleOffsetEncoding.axis;
-                for (size_t i = 0; i < num_channels; ++i) {
-                  current_scales.push_back(bias_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
-                  current_offsets.push_back(bias_quant_params.bwAxisScaleOffsetEncoding.offsets[i]);
-                }
-              }
-
-              // Check if all offsets are 0 and scales match expected values
-              bool all_offsets_zero = true;
-              bool all_scales_match = true;
-
-              for (size_t i = 0; i < num_channels; ++i) {
-                if (current_offsets[i] != 0) {
-                  all_offsets_zero = false;
-                }
-
-                // Calculate expected scale for this channel
-                // Use the corresponding weight scale if available, otherwise use the first one
-                float weight_scale = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
-
-                if (!utils::CheckBiasScaleMatch(current_scales[i], weight_scale, activation_scale, 1e-5f)) {
-                  all_scales_match = false;
-                }
-              }
-
-              if (all_offsets_zero && all_scales_match) {
-                // No change needed - scales match and offsets are 0
-              } else {
-                // Need to requantize per-channel bias
-                ORT_CXX_LOG(logger,
-                            ORT_LOGGING_LEVEL_VERBOSE,
-                            ("Requantizing per-channel bias " + bias_input.name).c_str());
-
-                // Get current bias data and requantize
-                std::vector<uint8_t> original_bias_data;
+            std::vector<uint8_t> original_bias_data;
                 RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
 
-                std::vector<uint8_t> requantized_bias_data;
-                std::vector<float> new_scales;
-                std::vector<int32_t> new_offsets;
+            const size_t num_channels = bias_info.shape[0];
+            RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
+                          "Unexpected bias data size for float bias quantization");
+            const float* bias_float_data = reinterpret_cast<const float*>(original_bias_data.data());
 
-                RETURN_IF_ERROR(utils::RequantizeBiasTensor(
-                    original_bias_data, bias_info.shape, current_scales, current_offsets,
-                    weights_scales, activation_scale, bias_info.qnn_data_type,
-                    requantized_bias_data, new_scales, new_offsets,
-                    quant_axis));
+            std::vector<uint8_t> quantized_bias_data;
+            std::vector<float> new_scales;
+            std::vector<int32_t> new_offsets;
+            RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
+                gsl::span<const float>(bias_float_data, num_channels),
+                weights_scales, activation_scale,
+                quantized_bias_data, new_scales, new_offsets));
 
-                // Create new tensor wrapper with requantized data
-                std::string bias_name = bias_input.name;
-                QnnQuantParamsWrapper new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, quant_axis);
-                QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
-                                                    std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
-                                                    std::move(requantized_bias_data));
-                RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)), "Failed to add requantized bias tensor.");
-                input_names.push_back(bias_name);
-                return Ort::Status();  // We've handled the bias, return early
-              }
+            QnnQuantParamsWrapper new_quant_params;
+            if (weights_scales.size() == 1) {
+              new_quant_params = QnnQuantParamsWrapper::PerTensor(new_scales[0], 0);
+            } else {
+              new_quant_params = QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, /*axis=*/0, /*is_int4=*/false);
             }
+
+            std::string bias_name = bias_input.name;
+            QnnTensorWrapper bias_tensorwrapper(bias_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
+                                                std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
+                                                std::move(quantized_bias_data));
+            RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_tensorwrapper)),
+                          "Failed to add quantized float bias tensor.");
+            input_names.push_back(bias_name);
+            bias_handled = true;
           }
-        }
-      } else if (bias_info.is_initializer && !bias_info.quant_param.IsQuantized()) {
-        // Get activation and weight quantization parameters
-        TensorInfo input0_info = {};
-        TensorInfo input1_info = {};
-        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
-        RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
-
-        if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
-          // Get activation scale (must be per-tensor for Conv)
-          RETURN_IF_NOT(input0_info.quant_param.IsPerTensor(/*include_bw*/ true),
-                        "Activation must be per-tensor quantized for Conv 2D");
-          float activation_scale = 1.0f;
-          const auto& act_quant_params = input0_info.quant_param.Get();
-          if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-            activation_scale = act_quant_params.scaleOffsetEncoding.scale;
-          } else if (act_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-            activation_scale = act_quant_params.bwScaleOffsetEncoding.scale;
-          }
-
-          // Get weight scales (per-tensor or per-channel)
-          std::vector<float> weights_scales;
-
-          if (input1_info.quant_param.IsPerTensor()) {
-            // Handle per-tensor quantization (encodings 0 and 2)
-            const auto& weight_quant_params = input1_info.quant_param.Get();
-
-            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-              weights_scales.push_back(weight_quant_params.scaleOffsetEncoding.scale);
-            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-              weights_scales.push_back(weight_quant_params.bwScaleOffsetEncoding.scale);
-            }
-          } else {
-            // Handle per-channel quantization (encodings 1 and 3)
-            const auto& weight_quant_params = input1_info.quant_param.Get();
-
-            if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-              if (weight_quant_params.axisScaleOffsetEncoding.scaleOffset != nullptr &&
-                  weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets > 0) {
-                for (size_t i = 0; i < weight_quant_params.axisScaleOffsetEncoding.numScaleOffsets; ++i) {
-                  weights_scales.push_back(weight_quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale);
-                }
-              }
-            } else if (weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-              if (weight_quant_params.bwAxisScaleOffsetEncoding.scales != nullptr &&
-                  weight_quant_params.bwAxisScaleOffsetEncoding.numElements > 0) {
-                for (size_t i = 0; i < weight_quant_params.bwAxisScaleOffsetEncoding.numElements; ++i) {
-                  weights_scales.push_back(weight_quant_params.bwAxisScaleOffsetEncoding.scales[i]);
-                }
-              }
-            }
-          }
-
-          RETURN_IF_NOT(!weights_scales.empty(), "No weight scales found for quantized weights");
-
-          // Quantize a float bias using bias_scale = activation_scale * weight_scale
-          RETURN_IF_ERROR(ProcessFloatBias(qnn_model_wrapper, logger, bias_input, bias_info, weights_scales, activation_scale, input_names));
         }
       }
 
-      // Process bias normally (non-quantized or static non-quantized or scales already match)
-      RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, bias_input, logger, input_names));
-    }  // end else (non-BQ bias path)
+      if (!bias_handled) {
+        // Process bias normally: non-initializer, or activation/weight not quantized, or scales already match.
+        RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, bias_input, logger, input_names));
+      }
+    }
   }
 
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 16 && QNN_API_VERSION_MINOR <= 18)
@@ -1336,9 +1165,8 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
   RETURN_IF_ERROR(utils::GetQnnDataType(is_quantized_tensor, output_type, qnn_data_type));
 
-  // Detect BQ or LPBQ Conv from the weight tensor's quant encoding.
+  // Detect BQ Conv from the weight tensor's quant encoding.
   // BQ  (BW_FLOAT_BLOCK):       Conv outputs FP16 → need FP16 intermediate + Convert(FP16→INT16).
-  // LPBQ (BLOCKWISE_EXPANSION): Conv outputs INT16 → standard quantized output path.
   // input_names[1] is the weight — IsOpSupported guarantees Conv has >= 2 inputs.
   bool is_bq_conv = false;
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1])) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -292,8 +292,8 @@ Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
 // Dequantize INT32 bias to FP16 for BW_FLOAT_BLOCK Conv.
 static Ort::Status ProcessBqFp16Bias(QnnModelWrapper& qnn_model_wrapper,
-                                      const OrtNodeUnitIODef& bias_def,
-                                      std::vector<std::string>& input_names) {
+                                     const OrtNodeUnitIODef& bias_def,
+                                     std::vector<std::string>& input_names) {
   TensorInfo bias_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_def, bias_info));
   RETURN_IF(!bias_info.is_initializer, "QNN EP: BQ Conv bias must be a constant initializer");
@@ -323,13 +323,13 @@ static Ort::Status ProcessBqFp16Bias(QnnModelWrapper& qnn_model_wrapper,
 // Requantize a quantized bias whose scales don't match activation_scale * weight_scale.
 // Sets was_requantized=true and adds the tensor if requantization was needed; false if scales match.
 static Ort::Status ProcessRequantizeBias(QnnModelWrapper& qnn_model_wrapper,
-                                          const Ort::Logger& logger,
-                                          const OrtNodeUnitIODef& bias_def,
-                                          const TensorInfo& bias_info,
-                                          gsl::span<const float> weights_scales,
-                                          float activation_scale,
-                                          std::vector<std::string>& input_names,
-                                          bool& was_requantized) {
+                                         const Ort::Logger& logger,
+                                         const OrtNodeUnitIODef& bias_def,
+                                         const TensorInfo& bias_info,
+                                         gsl::span<const float> weights_scales,
+                                         float activation_scale,
+                                         std::vector<std::string>& input_names,
+                                         bool& was_requantized) {
   was_requantized = false;
   int32_t bias_quant_axis = 0;
   std::vector<float> current_scales;
@@ -492,7 +492,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                                : "unknown";
       ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
                   ("Conv weight encoding: BW_FLOAT_BLOCK for " + input1_name +
-                   " [LPBQ skipped: " + reason + "]").c_str());
+                   " [LPBQ skipped: " + reason + "]")
+                      .c_str());
     }
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -257,7 +257,6 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   const std::string act_name = input_names[0];  // activation (input 0)
   const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
   const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
-  const bool is_act_16bit = act_dtype == IsQuant16bit(act_dtype);
 
   // Detect block-quantized weight. Per ONNX opset 21, the scale rank equals the weight rank
   // with scale_shape[1] < weight_shape[1] (the blocked IC axis). Weight is always NCHW
@@ -283,7 +282,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input_info));
 
   const bool is_lpbq_weight = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
-                              is_act_16bit &&
+                              IsQuant16bit(act_dtype) &&
                               input_info.is_initializer &&
                               input_info.quant_param.IsLPBQ();
 
@@ -291,7 +290,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     RETURN_IF(!input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
 
     // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
-    if (is_act_16bit) {
+    if (IsQuant16bit(act_dtype)) {
       // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
       // stays aligned with the ONNX graph naming.
       const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
@@ -326,7 +325,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     const int64_t OC = static_cast<int64_t>(input_info.shape[0]);
     const int64_t IC = static_cast<int64_t>(input_info.shape[1]);
     const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc
-    const int64_t block_size = 0;
+    int64_t block_size = 0;
     RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], IC, nb, "Conv", block_size));
     const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -305,7 +305,8 @@ static Ort::Status ProcessRequantizeBias(QnnModelWrapper& qnn_model_wrapper,
       weights_scales, activation_scale, bias_info.qnn_data_type,
       new_bias_data, new_scales, new_offsets, axis_opt));
 
-  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, bias_def.name, bias_info.shape,
+  const std::string rq_bias_name = utils::UniqueNameGenerator().New(bias_def.name, "_rq");
+  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, rq_bias_name, bias_info.shape,
                                       bias_info.qnn_data_type,
                                       BuildBiasQuantParams(new_scales, new_offsets, bias_quant_axis),
                                       std::move(new_bias_data), input_names));
@@ -335,7 +336,8 @@ static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
       gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
       weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
-  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, bias_def.name, bias_info.shape,
+  const std::string q_bias_name = utils::UniqueNameGenerator().New(bias_def.name, "_q");
+  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, q_bias_name, bias_info.shape,
                                       QNN_DATATYPE_SFIXED_POINT_32,
                                       BuildBiasQuantParams(new_scales, new_offsets, bias_quant_axis),
                                       std::move(new_bias_data), input_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -294,7 +294,6 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
       // stays aligned with the ONNX graph naming.
       const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-      std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
       RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
                                                              fp16_act_name, do_op_validation, "Conv"));
       input_names[0] = fp16_act_name;
@@ -644,14 +643,13 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
             const size_t num_channels = bias_info.shape[0];
             RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
                           "Unexpected bias data size for float bias quantization");
-            const float* bias_float_data = reinterpret_cast<const float*>(original_bias_data.data());
+            auto bias_float_data = gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels);
 
             std::vector<uint8_t> quantized_bias_data;
             std::vector<float> new_scales;
             std::vector<int32_t> new_offsets;
             RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
-                gsl::span<const float>(bias_float_data, num_channels),
-                weights_scales, activation_scale,
+                bias_float_data, weights_scales, activation_scale,
                 quantized_bias_data, new_scales, new_offsets));
 
             QnnQuantParamsWrapper new_quant_params;

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -708,7 +708,8 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
     const int64_t qnn_axis = 1 - axis;
 
     *this = QnnQuantParamsWrapper::LowPowerBlockwise(per_channel_scales, per_block_int_scales, lpbq_offsets,
-                                                     qnn_axis, /*block_scale_bitwidth=*/4);
+                                                     qnn_axis, /*block_scale_bitwidth=*/4);  // LPBQ conversion only supports INT4;
+                                                                                             // guarded by the check at the start of this block
   } else {
     return MAKE_EP_FAIL("Unexpected tensor kind for QuantParamsWrapper::Init()");
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -83,6 +83,7 @@ QnnQuantParamsWrapper QnnQuantParamsWrapper::PerChannel(gsl::span<const float> s
   qp.params_.axisScaleOffsetEncoding.axis = axis;
 
   if (num_elems > 0) {
+    qp.per_channel_scales_size_ = num_elems;
     const size_t num_bytes = num_elems * sizeof(Qnn_ScaleOffset_t);
     constexpr std::uintptr_t align = alignof(Qnn_ScaleOffset_t);
     qp.per_channel_data_ = std::make_unique<char[]>(num_bytes + align);
@@ -707,7 +708,7 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
     const int64_t qnn_axis = 1 - axis;
 
     *this = QnnQuantParamsWrapper::LowPowerBlockwise(per_channel_scales, per_block_int_scales, lpbq_offsets,
-                                                     qnn_axis, /*block_scale_bitwidth=*/is_int4_type ? 4 : 8);
+                                                     qnn_axis, /*block_scale_bitwidth=*/4);
   } else {
     return MAKE_EP_FAIL("Unexpected tensor kind for QuantParamsWrapper::Init()");
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -121,6 +121,11 @@ class QnnQuantParamsWrapper {
             params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
   }
 
+  // Returns the number of per-channel scale entries stored in this wrapper.
+  // Valid for LPBQ (BLOCKWISE_EXPANSION) and per-channel (AXIS_SCALE_OFFSET / BW_AXIS_SCALE_OFFSET)
+  // encodings. Returns 0 for per-tensor or unquantized encodings.
+  uint32_t GetPerChannelScalesSize() const { return per_channel_scales_size_; }
+
   // Get a copy of scales. Works for both per-tensor and per-channel.
   Ort::Status GetScales(/*out*/ std::vector<float>& scales) const;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1977,8 +1977,8 @@ std::string PtrToString(const void* const ptr) {
 }
 
 Ort::Status DequantizeInt32BiasToFp16(gsl::span<const uint8_t> raw_int32_bytes,
-                                       gsl::span<const float> scales,
-                                       std::vector<uint8_t>& fp16_bytes) {
+                                      gsl::span<const float> scales,
+                                      std::vector<uint8_t>& fp16_bytes) {
   RETURN_IF_NOT(raw_int32_bytes.size() % sizeof(int32_t) == 0,
                 "raw_int32_bytes size must be a multiple of sizeof(int32_t)");
   const size_t num_elems = raw_int32_bytes.size() / sizeof(int32_t);

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1741,6 +1741,90 @@ bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation
   return std::abs(bias_scale - expected_scale) <= tolerance;
 }
 
+Ort::Status GetWeightQuantScales(const QnnQuantParamsWrapper& weight_quant_param,
+                                 uint32_t num_output_channels,
+                                 std::vector<float>& weights_scales) {
+  const auto& qp = weight_quant_param.Get();
+
+  if (weight_quant_param.IsPerTensor()) {
+    if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+      weights_scales.push_back(qp.scaleOffsetEncoding.scale);
+    } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+      weights_scales.push_back(qp.bwScaleOffsetEncoding.scale);
+    }
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+    RETURN_IF_NOT(qp.axisScaleOffsetEncoding.scaleOffset != nullptr &&
+                      qp.axisScaleOffsetEncoding.numScaleOffsets > 0,
+                  "Invalid AXIS_SCALE_OFFSET weight quant params");
+    for (size_t i = 0; i < qp.axisScaleOffsetEncoding.numScaleOffsets; ++i) {
+      weights_scales.push_back(qp.axisScaleOffsetEncoding.scaleOffset[i].scale);
+    }
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+    RETURN_IF_NOT(qp.bwAxisScaleOffsetEncoding.scales != nullptr &&
+                      qp.bwAxisScaleOffsetEncoding.numElements > 0,
+                  "Invalid BW_AXIS_SCALE_OFFSET weight quant params");
+    for (size_t i = 0; i < qp.bwAxisScaleOffsetEncoding.numElements; ++i) {
+      weights_scales.push_back(qp.bwAxisScaleOffsetEncoding.scales[i]);
+    }
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) {
+    RETURN_IF_NOT(qp.blockwiseExpansion != nullptr &&
+                      qp.blockwiseExpansion->scaleOffsets != nullptr,
+                  "Invalid BLOCKWISE_EXPANSION weight quant params");
+    for (size_t c = 0; c < num_output_channels; ++c) {
+      weights_scales.push_back(qp.blockwiseExpansion->scaleOffsets[c].scale);
+    }
+  } else {
+    return MAKE_EP_FAIL("Unsupported weight quantization encoding for bias quantization.");
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status GetBiasQuantScalesAndOffsets(const QnnQuantParamsWrapper& bias_quant_param,
+                                         std::vector<float>& scales,
+                                         std::vector<int32_t>& offsets,
+                                         int32_t& axis) {
+  const auto& qp = bias_quant_param.Get();
+  axis = 0;
+
+  if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+    scales = {qp.scaleOffsetEncoding.scale};
+    offsets = {qp.scaleOffsetEncoding.offset};
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+    scales = {qp.bwScaleOffsetEncoding.scale};
+    offsets = {qp.bwScaleOffsetEncoding.offset};
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+    RETURN_IF_NOT(qp.axisScaleOffsetEncoding.scaleOffset != nullptr &&
+                      qp.axisScaleOffsetEncoding.numScaleOffsets > 0,
+                  "Invalid AXIS_SCALE_OFFSET bias quant params");
+    axis = qp.axisScaleOffsetEncoding.axis;
+    const size_t n = qp.axisScaleOffsetEncoding.numScaleOffsets;
+    scales.resize(n);
+    offsets.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+      scales[i] = qp.axisScaleOffsetEncoding.scaleOffset[i].scale;
+      offsets[i] = qp.axisScaleOffsetEncoding.scaleOffset[i].offset;
+    }
+  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+    RETURN_IF_NOT(qp.bwAxisScaleOffsetEncoding.scales != nullptr &&
+                      qp.bwAxisScaleOffsetEncoding.offsets != nullptr &&
+                      qp.bwAxisScaleOffsetEncoding.numElements > 0,
+                  "Invalid BW_AXIS_SCALE_OFFSET bias quant params");
+    axis = qp.bwAxisScaleOffsetEncoding.axis;
+    const size_t n = qp.bwAxisScaleOffsetEncoding.numElements;
+    scales.resize(n);
+    offsets.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+      scales[i] = qp.bwAxisScaleOffsetEncoding.scales[i];
+      offsets[i] = qp.bwAxisScaleOffsetEncoding.offsets[i];
+    }
+  } else {
+    return MAKE_EP_FAIL("Unsupported bias quantization encoding for requantization.");
+  }
+
+  return Ort::Status();
+}
+
 Ort::Status QuantizeFloatBiasTensor(gsl::span<const float> float_bias_data,
                                     gsl::span<const float> weights_scales,
                                     float activation_scale,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1976,6 +1976,31 @@ std::string PtrToString(const void* const ptr) {
   return (std::ostringstream() << ptr).str();
 }
 
+Ort::Status DequantizeInt32BiasToFp16(gsl::span<const uint8_t> raw_int32_bytes,
+                                       gsl::span<const float> scales,
+                                       std::vector<uint8_t>& fp16_bytes) {
+  RETURN_IF_NOT(raw_int32_bytes.size() % sizeof(int32_t) == 0,
+                "raw_int32_bytes size must be a multiple of sizeof(int32_t)");
+  const size_t num_elems = raw_int32_bytes.size() / sizeof(int32_t);
+  RETURN_IF_NOT(scales.empty() || scales.size() == 1 || scales.size() == num_elems,
+                "scales must be empty (all 1.0f), per-tensor (size 1), or per-channel (size num_elems)");
+
+  const bool is_per_channel = (scales.size() == num_elems);
+  fp16_bytes.resize(num_elems * sizeof(uint16_t));
+
+  const auto* i32_ptr = reinterpret_cast<const int32_t*>(raw_int32_bytes.data());
+  auto* u16_ptr = reinterpret_cast<uint16_t*>(fp16_bytes.data());
+
+  for (size_t i = 0; i < num_elems; ++i) {
+    const float scale = scales.empty() ? 1.0f : (is_per_channel ? scales[i] : scales[0]);
+    const float f = static_cast<float>(i32_ptr[i]) * scale;
+    const Ort::Float16_t fp16_val(f);
+    std::memcpy(&u16_ptr[i], &fp16_val.val, sizeof(uint16_t));
+  }
+
+  return Ort::Status();
+}
+
 }  // namespace utils
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1742,7 +1742,6 @@ bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation
 }
 
 Ort::Status GetWeightQuantScales(const QnnQuantParamsWrapper& weight_quant_param,
-                                 uint32_t num_output_channels,
                                  std::vector<float>& weights_scales) {
   const auto& qp = weight_quant_param.Get();
 
@@ -1768,9 +1767,10 @@ Ort::Status GetWeightQuantScales(const QnnQuantParamsWrapper& weight_quant_param
     }
   } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) {
     RETURN_IF_NOT(qp.blockwiseExpansion != nullptr &&
-                      qp.blockwiseExpansion->scaleOffsets != nullptr,
+                      qp.blockwiseExpansion->scaleOffsets != nullptr &&
+                      weight_quant_param.GetPerChannelScalesSize() > 0,
                   "Invalid BLOCKWISE_EXPANSION weight quant params");
-    for (size_t c = 0; c < num_output_channels; ++c) {
+    for (size_t c = 0; c < weight_quant_param.GetPerChannelScalesSize(); ++c) {
       weights_scales.push_back(qp.blockwiseExpansion->scaleOffsets[c].scale);
     }
   } else {

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -868,8 +868,8 @@ std::string PtrToString(const void* const ptr);
  * @param fp16_bytes       Output: FP16 bytes (num_elems * sizeof(uint16_t) bytes).
  */
 Ort::Status DequantizeInt32BiasToFp16(gsl::span<const uint8_t> raw_int32_bytes,
-                                       gsl::span<const float> scales,
-                                       std::vector<uint8_t>& fp16_bytes);
+                                      gsl::span<const float> scales,
+                                      std::vector<uint8_t>& fp16_bytes);
 
 }  // namespace utils
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -33,6 +33,7 @@ namespace onnxruntime {
 namespace qnn {
 class QnnOpConfigWrapper;
 class QnnModelWrapper;
+class QnnQuantParamsWrapper;
 
 namespace utils {
 /**
@@ -652,6 +653,21 @@ uint64_t GetTimeStampInUs();
 // Returns true if they match within a tolerance, false otherwise
 bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale,
                          float tolerance = 1e-5f);
+
+// Extracts weight scales from a QnnQuantParamsWrapper.
+// Supports per-tensor (SCALE_OFFSET, BW_SCALE_OFFSET), per-channel (AXIS_SCALE_OFFSET,
+// BW_AXIS_SCALE_OFFSET), and LPBQ (BLOCKWISE_EXPANSION).
+Ort::Status GetWeightQuantScales(const QnnQuantParamsWrapper& weight_quant_param,
+                                 uint32_t num_output_channels,
+                                 std::vector<float>& weights_scales);
+
+// Extracts current scales, offsets, and axis from a bias's quant params.
+// Supports SCALE_OFFSET, BW_SCALE_OFFSET, AXIS_SCALE_OFFSET, BW_AXIS_SCALE_OFFSET.
+// Returns failure for unsupported encodings.
+Ort::Status GetBiasQuantScalesAndOffsets(const QnnQuantParamsWrapper& bias_quant_param,
+                                         std::vector<float>& scales,
+                                         std::vector<int32_t>& offsets,
+                                         int32_t& axis);
 
 // Quantizes a float bias tensor to int32 using bias_scale = activation_scale * weight_scale.
 // Used when the bias is provided as float (no quantization info) but activation and weight are quantized.

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -658,7 +658,6 @@ bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation
 // Supports per-tensor (SCALE_OFFSET, BW_SCALE_OFFSET), per-channel (AXIS_SCALE_OFFSET,
 // BW_AXIS_SCALE_OFFSET), and LPBQ (BLOCKWISE_EXPANSION).
 Ort::Status GetWeightQuantScales(const QnnQuantParamsWrapper& weight_quant_param,
-                                 uint32_t num_output_channels,
                                  std::vector<float>& weights_scales);
 
 // Extracts current scales, offsets, and axis from a bias's quant params.

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -131,6 +131,12 @@ Ort::Status GetQnnDataType(const bool is_quantized_tensor,
                            Qnn_DataType_t& tensor_data_type,
                            QnnBackendType backend_type = QnnBackendType::CPU);
 
+// Returns true if the QNN data type is a 16-bit fixed-point quantized type.
+inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
+  return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 ||
+         qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
+}
+
 // Name generator that produces unique QNN node names by appending a counter suffix,
 // (e.g., "_2") when the same base + suffix combination is requested more than once.
 class UniqueNameGeneratorImpl {
@@ -667,6 +673,19 @@ Ort::Status GetBiasQuantScalesAndOffsets(const QnnQuantParamsWrapper& bias_quant
                                          std::vector<float>& scales,
                                          std::vector<int32_t>& offsets,
                                          int32_t& axis);
+
+// Quantizes a float bias tensor to int32 using bias_scale = activation_scale * weight_scale.
+// Used when the bias is provided as float (no quantization info) but activation and weight are quantized.
+// If weights_scales has a single element, per-tensor bias quantization is used (all channels share one scale).
+// Otherwise, per-channel bias quantization is used (one scale per output channel).
+// The output quantized_bias_bytes contains packed int32 values (4 bytes per channel).
+// bias_offsets is always all-zeros (symmetric quantization).
+Ort::Status QuantizeFloatBiasTensor(gsl::span<const float> float_bias_data,
+                                    gsl::span<const float> weights_scales,
+                                    float activation_scale,
+                                    /*out*/ std::vector<uint8_t>& quantized_bias_bytes,
+                                    /*out*/ std::vector<float>& bias_scales,
+                                    /*out*/ std::vector<int32_t>& bias_offsets);
 
 // Requantizes a static bias tensor with new quantization parameters
 // This function:

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -668,19 +668,6 @@ Ort::Status GetBiasQuantScalesAndOffsets(const QnnQuantParamsWrapper& bias_quant
                                          std::vector<int32_t>& offsets,
                                          int32_t& axis);
 
-// Quantizes a float bias tensor to int32 using bias_scale = activation_scale * weight_scale.
-// Used when the bias is provided as float (no quantization info) but activation and weight are quantized.
-// If weights_scales has a single element, per-tensor bias quantization is used (all channels share one scale).
-// Otherwise, per-channel bias quantization is used (one scale per output channel).
-// The output quantized_bias_bytes contains packed int32 values (4 bytes per channel).
-// bias_offsets is always all-zeros (symmetric quantization).
-Ort::Status QuantizeFloatBiasTensor(gsl::span<const float> float_bias_data,
-                                    gsl::span<const float> weights_scales,
-                                    float activation_scale,
-                                    /*out*/ std::vector<uint8_t>& quantized_bias_bytes,
-                                    /*out*/ std::vector<float>& bias_scales,
-                                    /*out*/ std::vector<int32_t>& bias_offsets);
-
 // Requantizes a static bias tensor with new quantization parameters
 // This function:
 // 1. Dequantizes the bias tensor to float using current parameters
@@ -871,6 +858,18 @@ Ort::Status UnpackInitializerData(const OrtApi& ort_api,
    Intended for ORT logging
 */
 std::string PtrToString(const void* const ptr);
+
+/**
+ * Dequantizes a packed INT32 bias tensor to FP16 bytes.
+ * Each element is computed as: fp16(int32[i] * scale[i or 0]).
+ * @param raw_int32_bytes  Packed INT32 data (num_elems * sizeof(int32_t) bytes).
+ * @param scales           Per-tensor (size 1) or per-channel (size num_elems) float scales.
+ *                         Empty means all scales are 1.0f.
+ * @param fp16_bytes       Output: FP16 bytes (num_elems * sizeof(uint16_t) bytes).
+ */
+Ort::Status DequantizeInt32BiasToFp16(gsl::span<const uint8_t> raw_int32_bytes,
+                                       gsl::span<const float> scales,
+                                       std::vector<uint8_t>& fp16_bytes);
 
 }  // namespace utils
 }  // namespace qnn

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3635,7 +3635,7 @@ TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithBiasPerChannel_BS32) {
 }
 
 // LPBQ: 1x1 Conv, INT4 weight, block_size=8, float (unquantized) bias.
-TEST_F(QnnHTPBackendTests, DISABLED_ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                       /*weight=*/{4, 32, 1, 1},
@@ -3651,7 +3651,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
 }
 
 // LPBQ: 1x1 Conv, INT4 weight, block_size=32, float (unquantized) bias.
-TEST_F(QnnHTPBackendTests, DISABLED_ConvLPBQ_U16Int4_1x1_WithFloatBias_BS32) {
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS32) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
                                       /*weight=*/{8, 64, 1, 1},

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -784,7 +784,7 @@ static void RunQDQBlockQuantConv2DOpTest(
     int64_t block_size,
     int64_t weight_quant_axis,
     bool quantize_bias,
-    bool bias_per_channel
+    bool bias_per_channel,
     QDQTolerance tolerance = QDQTolerance(),
     ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
     int opset = 21,

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3635,7 +3635,7 @@ TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithBiasPerChannel_BS32) {
 }
 
 // LPBQ: 1x1 Conv, INT4 weight, block_size=8, float (unquantized) bias.
-TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
+TEST_F(QnnHTPBackendTests, DISABLED_ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
                                       /*weight=*/{4, 32, 1, 1},
@@ -3651,7 +3651,7 @@ TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
 }
 
 // LPBQ: 1x1 Conv, INT4 weight, block_size=32, float (unquantized) bias.
-TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS32) {
+TEST_F(QnnHTPBackendTests, DISABLED_ConvLPBQ_U16Int4_1x1_WithFloatBias_BS32) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
                                       /*weight=*/{8, 64, 1, 1},

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -650,169 +650,6 @@ static void RunHTPConvOpPerChannelTest(const std::string& conv_op_type, const Te
   TestQDQModelAccuracy(f32_fn, qdq_fn, provider_options, opset, expected_ep_assignment, tolerance);
 }
 
-template <typename ActivationQType, typename WeightQType>
-static GetTestQDQModelFn<ActivationQType> BuildQDQBlockQuantConv2DTestCase(
-    const TestInputDef<float>& input_def,
-    const TestInputDef<float>& weights_def,
-    const TestInputDef<float>& bias_def,
-    int64_t block_size,
-    int64_t weight_quant_axis,
-    const std::vector<int64_t>& strides,
-    const std::vector<int64_t>& pads,
-    const std::vector<int64_t>& dilations,
-    std::optional<int64_t> group,
-    bool quantize_bias,
-    bool bias_per_channel,
-    bool use_contrib_qdq = false) {
-  return [input_def, weights_def, bias_def, block_size, weight_quant_axis, strides, pads, dilations, group,
-          quantize_bias, bias_per_channel, use_contrib_qdq](
-             ModelTestBuilder& builder, std::vector<QuantParams<ActivationQType>>& output_qparams) {
-    QNN_ASSERT(weights_def.IsInitializer() && weights_def.IsRawData());
-
-    std::vector<std::string> conv_input_names;
-
-    MakeTestInput<float>(builder, "input", input_def);
-    const QuantParams<ActivationQType> input_qparams = GetTestInputQuantParams<ActivationQType>(input_def);
-    conv_input_names.push_back(AddQDQNodePair<ActivationQType>(
-        builder, "qdq_input", "input", input_qparams.scale, input_qparams.zero_point, use_contrib_qdq));
-
-    const auto& weight_shape = weights_def.GetShape();
-    int64_t pos_weight_quant_axis = weight_quant_axis;
-    if (pos_weight_quant_axis < 0) {
-      pos_weight_quant_axis += static_cast<int64_t>(weight_shape.size());
-    }
-
-    std::vector<float> weight_scales;
-    std::vector<WeightQType> weight_zero_points;
-    GetTestInputQuantParamsBlockQuant<WeightQType>(weights_def, weight_scales, weight_zero_points,
-                                                   block_size, pos_weight_quant_axis, true);
-
-    size_t num_weight_storage_elems = SizeOfShape(weight_shape);
-    if constexpr (std::is_same_v<WeightQType, Int4x2> || std::is_same_v<WeightQType, UInt4x2>) {
-      num_weight_storage_elems = Int4x2::CalcNumInt4Pairs(num_weight_storage_elems);
-    }
-
-    std::vector<WeightQType> quantized_weights(num_weight_storage_elems);
-    QuantizeValuesBlockQuant<float, WeightQType>(
-        weights_def.GetRawData(), quantized_weights, weight_shape,
-        weight_scales, weight_zero_points, block_size, pos_weight_quant_axis);
-
-    builder.MakeInitializer<WeightQType>("weights", weight_shape, quantized_weights);
-
-    std::vector<int64_t> scale_shape = weight_shape;
-    scale_shape[static_cast<size_t>(pos_weight_quant_axis)] =
-        (scale_shape[static_cast<size_t>(pos_weight_quant_axis)] + block_size - 1) / block_size;
-
-    builder.MakeInitializer<float>("weights_scale", scale_shape, weight_scales);
-    builder.MakeInitializer<WeightQType>("weights_zp", scale_shape, weight_zero_points);
-
-    builder.AddNode("weights_dq", "DequantizeLinear",
-                    {"weights", "weights_scale", "weights_zp"},
-                    {"weights_dq"},
-                    "",
-                    {builder.MakeScalarAttribute("axis", weight_quant_axis),
-                     builder.MakeScalarAttribute("block_size", block_size)});
-    conv_input_names.push_back("weights_dq");
-
-    if (!bias_def.GetShape().empty()) {
-      if (quantize_bias) {
-        if (bias_per_channel) {
-          const auto& bias_shape = bias_def.GetShape();
-          const size_t output_channels = static_cast<size_t>(bias_shape[0]);
-          const size_t num_blocks_per_output_channel = weight_scales.size() / output_channels;
-          QNN_ASSERT(weight_scales.size() == output_channels * num_blocks_per_output_channel);
-
-          std::vector<float> bias_scales(output_channels);
-          std::vector<int32_t> bias_zero_points(output_channels, 0);
-
-          for (size_t i = 0; i < bias_scales.size(); ++i) {
-            bias_scales[i] = input_qparams.scale * weight_scales[i * num_blocks_per_output_channel];
-          }
-
-          std::vector<int32_t> quantized_biases(SizeOfShape(bias_def.GetShape()));
-          QuantizeValues<float, int32_t>(bias_def.GetRawData(), quantized_biases,
-                                         bias_def.GetShape(), bias_scales, bias_zero_points,
-                                         0 /* axis */);
-
-          builder.MakeInitializer<int32_t>("bias_quant", bias_def.GetShape(), quantized_biases);
-          builder.MakeInitializer<float>("bias_scale", {static_cast<int64_t>(bias_scales.size())}, bias_scales);
-          builder.MakeInitializer<int32_t>("bias_zp", {static_cast<int64_t>(bias_zero_points.size())}, bias_zero_points);
-
-          builder.AddNode("BiasDQ",
-                          "DequantizeLinear",
-                          {"bias_quant", "bias_scale", "bias_zp"},
-                          {"bias_dq"},
-                          use_contrib_qdq ? kMSDomain : kOnnxDomain,
-                          {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
-          conv_input_names.push_back("bias_dq");
-        } else {
-          const float bias_scale = input_qparams.scale * weight_scales[0];
-          conv_input_names.push_back(MakeTestQDQBiasInput(builder, "bias", bias_def, bias_scale, use_contrib_qdq));
-        }
-      } else {
-        MakeTestInput<float>(builder, "bias", bias_def);
-        conv_input_names.push_back("bias");
-      }
-    }
-
-    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
-    if (group.has_value()) {
-      conv_attrs.push_back(builder.MakeScalarAttribute("group", group.value()));
-    }
-    if (!pads.empty()) {
-      conv_attrs.push_back(builder.MakeIntsAttribute("pads", pads));
-    }
-    if (!strides.empty()) {
-      conv_attrs.push_back(builder.MakeIntsAttribute("strides", strides));
-    }
-    if (!dilations.empty()) {
-      conv_attrs.push_back(builder.MakeIntsAttribute("dilations", dilations));
-    }
-
-    builder.AddNode("Conv", "Conv", conv_input_names, {"Y"}, kOnnxDomain, conv_attrs);
-
-    AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(
-        builder, "qdq_out", "Y", output_qparams[0].scale, output_qparams[0].zero_point, use_contrib_qdq);
-  };
-}
-
-template <typename ActivationQType, typename WeightQType>
-static void RunQDQBlockQuantConv2DOpTest(
-    const std::vector<int64_t>& input_shape,
-    const std::vector<int64_t>& weight_shape,
-    const std::vector<int64_t>& bias_shape,
-    int64_t block_size,
-    int64_t weight_quant_axis,
-    bool quantize_bias,
-    bool bias_per_channel,
-    QDQTolerance tolerance = QDQTolerance(),
-    ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
-    int opset = 21,
-    bool use_contrib_qdq = false) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "htp";
-  provider_options["offload_graph_io_quantization"] = "0";
-  provider_options["enable_block_quant_weight_optimization"] = "1";
-
-  TestInputDef<float> input_def(input_shape, false,
-                                GetFloatDataInRange(-10.0f, 10.0f, SizeOfShape(input_shape)));
-  TestInputDef<float> weight_def(weight_shape, true,
-                                 GetFloatDataInRange(-0.1f, 0.1f, SizeOfShape(weight_shape)));
-  TestInputDef<float> bias_def;
-  if (!bias_shape.empty()) {
-    bias_def = TestInputDef<float>(bias_shape, true,
-                                   GetFloatDataInRange(-0.1f, 0.1f, SizeOfShape(bias_shape)));
-  }
-
-  TestQDQModelAccuracy(
-      BuildF32ConvTestCase("Conv", input_def, weight_def, bias_def,
-                           {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, "NOTSET"),
-      BuildQDQBlockQuantConv2DTestCase<ActivationQType, WeightQType>(
-          input_def, weight_def, bias_def, block_size, weight_quant_axis,
-          {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, quantize_bias, bias_per_channel, use_contrib_qdq),
-      provider_options, opset, expected_ep_assignment, tolerance);
-}
-
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.
 // Tests bias as a dynamic input.
 // TODO: Segfaults when calling graphFinalize(). v2.13
@@ -3354,9 +3191,10 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
                                      bool include_bias = false,
                                      int weight_bits = 4,
                                      bool weight_is_unsigned = false,
-                                     bool bias_per_channel = false) {
+                                     bool bias_per_channel = false,
+                                     bool is_bias_quantized = true) {
   return [input_shape, weight_shape, block_size, include_bias, weight_bits,
-          weight_is_unsigned, bias_per_channel](ModelTestBuilder& builder) -> void {
+          weight_is_unsigned, bias_per_channel, is_bias_quantized](ModelTestBuilder& builder) -> void {
     const int64_t OC = weight_shape[0];
     const int64_t IC = weight_shape[1];
     const int64_t kH = weight_shape.size() >= 4 ? weight_shape[2] : 1;
@@ -3432,10 +3270,15 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
     // ── Conv ─────────────────────────────────────────────────────────────────
     std::vector<std::string> conv_inputs{act_dql_out, "weight_dql_out"};
     if (include_bias) {
-      // Use INT32-quantized bias directly (no QL node — avoids ORT QL opset validation for INT32).
-      // OrtConvNodeGroupSelector requires bias DQL input type == INT32 (qnn_ep_utils.cc:741).
-      if (bias_per_channel) {
-        // Per-channel bias: distinct quantized value and scale per output channel (DQ axis=0).
+      if (!is_bias_quantized) {
+        // Float bias: pass directly as a float initializer (no DQ node).
+        std::vector<float> bias_data(static_cast<size_t>(OC), 0.01f);
+        builder.Make1DInitializer<float>("bias", bias_data);
+        conv_inputs.push_back("bias");
+      } else if (bias_per_channel) {
+        // Per-channel quantized bias: distinct quantized value and scale per output channel (DQ axis=0).
+        // Use INT32-quantized bias directly (no QL node — avoids ORT QL opset validation for INT32).
+        // OrtConvNodeGroupSelector requires bias DQL input type == INT32 (qnn_ep_utils.cc:741).
         // Non-zero quant values ensure the per-channel scale indexing is actually exercised.
         // Omit zero_point (symmetric): ORT per-axis DQ requires zp be null or 1D of size OC.
         std::vector<int32_t> bias_quant(static_cast<size_t>(OC));
@@ -3449,15 +3292,17 @@ GetQDQTestCaseFn BuildBQConvTestCase(const std::vector<int64_t>& input_shape,
         builder.AddNode("bias_dql", "DequantizeLinear",
                         {"bias_quant", "bias_scale"}, {"bias_dql_out"}, "",
                         {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+        conv_inputs.push_back("bias_dql_out");
       } else {
+        // Per-tensor quantized bias.
         const float bias_scale = act_scale * 0.03f;
         builder.MakeScalarInitializer<float>("bias_scale", bias_scale);
         builder.MakeScalarInitializer<int32_t>("bias_zp", 0);
         builder.Make1DInitializer<int32_t>("bias_quant", std::vector<int32_t>(static_cast<size_t>(OC), 0));
         builder.AddNode("bias_dql", "DequantizeLinear",
                         {"bias_quant", "bias_scale", "bias_zp"}, {"bias_dql_out"});
+        conv_inputs.push_back("bias_dql_out");
       }
-      conv_inputs.push_back("bias_dql_out");
     }
     builder.AddNode("conv", "Conv",
                     conv_inputs, {"conv_out"}, kOnnxDomain,
@@ -3480,6 +3325,19 @@ ProviderOptions GetBQConvProviderOptions() {
 #if defined(__linux__) && !defined(__aarch64__)
   // On the x86_64 Linux HTP simulator, specify SM8850 to enable BW_FLOAT_BLOCK support.
   // On real ARM64 hardware, the SoC model is auto-detected by QNN EP.
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return opts;
+}
+
+// Provider options for the LPBQ (BLOCKWISE_EXPANSION) path.
+// enable_block_quant_weight_optimization=1 triggers BQ -> LPBQ conversion.
+ProviderOptions GetLPBQConvProviderOptions() {
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["enable_block_quant_weight_optimization"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
   opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
   return opts;
@@ -3690,6 +3548,124 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt8_1x1_BlockSize4) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
 }
 
+// Tests Conv2D with ONNX block-quantized (BQ) weights using the BQ -> QNN LPBQ conversion path.
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=8, no bias. IC=16, 2 blocks/OC.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_NoBias_BS8) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 16, 4, 4},
+                                      /*weight=*/{4, 16, 1, 1},
+                                      /*block_size=*/8,
+                                      /*include_bias=*/false),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=16, no bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_NoBias_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
+                                      /*weight=*/{4, 64, 1, 1},
+                                      /*block_size=*/16,
+                                      /*include_bias=*/false),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=16, with per-tensor quantized bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithBias_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
+                                      /*weight=*/{4, 64, 1, 1},
+                                      /*block_size=*/16,
+                                      /*include_bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/false),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=64, with per-tensor quantized bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithBias_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 128, 1, 1},
+                                      /*weight=*/{4, 128, 1, 1},
+                                      /*block_size=*/64,
+                                      /*include_bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/false),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=16, with per-channel quantized bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithBiasPerChannel_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/16,
+                                      /*include_bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/true),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=32, with per-channel quantized bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithBiasPerChannel_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 128, 4, 4},
+                                      /*weight=*/{4, 128, 1, 1},
+                                      /*block_size=*/32,
+                                      /*include_bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/true),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=8, float (unquantized) bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS8) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                      /*weight=*/{4, 32, 1, 1},
+                                      /*block_size=*/8,
+                                      /*include_bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/false,
+                                      /*is_bias_quantized=*/false),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// LPBQ: 1x1 Conv, INT4 weight, block_size=32, float (unquantized) bias.
+TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunQnnModelTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
+                                      /*weight=*/{8, 64, 1, 1},
+                                      /*block_size=*/32,
+                                      /*include_bias=*/true,
+                                      /*weight_bits=*/4,
+                                      /*weight_is_unsigned=*/false,
+                                      /*bias_per_channel=*/false,
+                                      /*is_bias_quantized=*/false),
+                  GetLPBQConvProviderOptions(),
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).
 // Conv2d: reuse_sparse_indices should be added to the QNN node parameters.
 TEST_F(QnnHTPBackendTests, Conv2D_ReuseSparseIndices) {
@@ -3760,23 +3736,6 @@ TEST_F(QnnHTPBackendTests, ConvTranspose2D_NoReuseSparseIndices) {
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
-
-#if defined(__linux__)
-
-// Tests Conv2D with ONNX block-quantized (BQ) weights using the BQ -> QNN LPBQ conversion path.
-// Currently BQ -> LPBQ conversion is only supported on Linux. It will be later enabled for Windows as well.
-TEST_F(QnnHTPBackendTests, Conv2DOp_QDQ_BlockQuant) {
-  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 16, 4, 4}, {4, 16, 1, 1}, {}, 8, 1, false, false, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 64, 4, 4}, {4, 64, 1, 1}, {}, 16, 1, false, false, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 128, 4, 4}, {4, 128, 1, 1}, {4}, 32, 1, true, false, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 256, 4, 4}, {4, 256, 1, 1}, {4}, 64, 1, true, false, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 64, 4, 4}, {4, 64, 1, 1}, {4}, 16, 1, true, true, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 64, 4, 4}, {4, 64, 1, 1}, {4}, 32, 1, true, true, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 16, 4, 4}, {4, 16, 1, 1}, {4}, 8, 1, false, false, QDQTolerance(0.02f));
-  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 64, 4, 4}, {8, 64, 1, 1}, {8}, 32, 1, false, false, QDQTolerance(0.02f));
-}
-
-#endif  // defined(__linux__)
 
 #if defined(_M_ARM64)
 //

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -650,6 +650,169 @@ static void RunHTPConvOpPerChannelTest(const std::string& conv_op_type, const Te
   TestQDQModelAccuracy(f32_fn, qdq_fn, provider_options, opset, expected_ep_assignment, tolerance);
 }
 
+template <typename ActivationQType, typename WeightQType>
+static GetTestQDQModelFn<ActivationQType> BuildQDQBlockQuantConv2DTestCase(
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weights_def,
+    const TestInputDef<float>& bias_def,
+    int64_t block_size,
+    int64_t weight_quant_axis,
+    const std::vector<int64_t>& strides,
+    const std::vector<int64_t>& pads,
+    const std::vector<int64_t>& dilations,
+    std::optional<int64_t> group,
+    bool quantize_bias,
+    bool bias_per_channel,
+    bool use_contrib_qdq = false) {
+  return [input_def, weights_def, bias_def, block_size, weight_quant_axis, strides, pads, dilations, group,
+          quantize_bias, bias_per_channel, use_contrib_qdq](
+             ModelTestBuilder& builder, std::vector<QuantParams<ActivationQType>>& output_qparams) {
+    QNN_ASSERT(weights_def.IsInitializer() && weights_def.IsRawData());
+
+    std::vector<std::string> conv_input_names;
+
+    MakeTestInput<float>(builder, "input", input_def);
+    const QuantParams<ActivationQType> input_qparams = GetTestInputQuantParams<ActivationQType>(input_def);
+    conv_input_names.push_back(AddQDQNodePair<ActivationQType>(
+        builder, "qdq_input", "input", input_qparams.scale, input_qparams.zero_point, use_contrib_qdq));
+
+    const auto& weight_shape = weights_def.GetShape();
+    int64_t pos_weight_quant_axis = weight_quant_axis;
+    if (pos_weight_quant_axis < 0) {
+      pos_weight_quant_axis += static_cast<int64_t>(weight_shape.size());
+    }
+
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zero_points;
+    GetTestInputQuantParamsBlockQuant<WeightQType>(weights_def, weight_scales, weight_zero_points,
+                                                   block_size, pos_weight_quant_axis, true);
+
+    size_t num_weight_storage_elems = SizeOfShape(weight_shape);
+    if constexpr (std::is_same_v<WeightQType, Int4x2> || std::is_same_v<WeightQType, UInt4x2>) {
+      num_weight_storage_elems = Int4x2::CalcNumInt4Pairs(num_weight_storage_elems);
+    }
+
+    std::vector<WeightQType> quantized_weights(num_weight_storage_elems);
+    QuantizeValuesBlockQuant<float, WeightQType>(
+        weights_def.GetRawData(), quantized_weights, weight_shape,
+        weight_scales, weight_zero_points, block_size, pos_weight_quant_axis);
+
+    builder.MakeInitializer<WeightQType>("weights", weight_shape, quantized_weights);
+
+    std::vector<int64_t> scale_shape = weight_shape;
+    scale_shape[static_cast<size_t>(pos_weight_quant_axis)] =
+        (scale_shape[static_cast<size_t>(pos_weight_quant_axis)] + block_size - 1) / block_size;
+
+    builder.MakeInitializer<float>("weights_scale", scale_shape, weight_scales);
+    builder.MakeInitializer<WeightQType>("weights_zp", scale_shape, weight_zero_points);
+
+    builder.AddNode("weights_dq", "DequantizeLinear",
+                    {"weights", "weights_scale", "weights_zp"},
+                    {"weights_dq"},
+                    "",
+                    {builder.MakeScalarAttribute("axis", weight_quant_axis),
+                     builder.MakeScalarAttribute("block_size", block_size)});
+    conv_input_names.push_back("weights_dq");
+
+    if (!bias_def.GetShape().empty()) {
+      if (quantize_bias) {
+        if (bias_per_channel) {
+          const auto& bias_shape = bias_def.GetShape();
+          const size_t output_channels = static_cast<size_t>(bias_shape[0]);
+          const size_t num_blocks_per_output_channel = weight_scales.size() / output_channels;
+          QNN_ASSERT(weight_scales.size() == output_channels * num_blocks_per_output_channel);
+
+          std::vector<float> bias_scales(output_channels);
+          std::vector<int32_t> bias_zero_points(output_channels, 0);
+
+          for (size_t i = 0; i < bias_scales.size(); ++i) {
+            bias_scales[i] = input_qparams.scale * weight_scales[i * num_blocks_per_output_channel];
+          }
+
+          std::vector<int32_t> quantized_biases(SizeOfShape(bias_def.GetShape()));
+          QuantizeValues<float, int32_t>(bias_def.GetRawData(), quantized_biases,
+                                         bias_def.GetShape(), bias_scales, bias_zero_points,
+                                         0 /* axis */);
+
+          builder.MakeInitializer<int32_t>("bias_quant", bias_def.GetShape(), quantized_biases);
+          builder.MakeInitializer<float>("bias_scale", {static_cast<int64_t>(bias_scales.size())}, bias_scales);
+          builder.MakeInitializer<int32_t>("bias_zp", {static_cast<int64_t>(bias_zero_points.size())}, bias_zero_points);
+
+          builder.AddNode("BiasDQ",
+                          "DequantizeLinear",
+                          {"bias_quant", "bias_scale", "bias_zp"},
+                          {"bias_dq"},
+                          use_contrib_qdq ? kMSDomain : kOnnxDomain,
+                          {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+          conv_input_names.push_back("bias_dq");
+        } else {
+          const float bias_scale = input_qparams.scale * weight_scales[0];
+          conv_input_names.push_back(MakeTestQDQBiasInput(builder, "bias", bias_def, bias_scale, use_contrib_qdq));
+        }
+      } else {
+        MakeTestInput<float>(builder, "bias", bias_def);
+        conv_input_names.push_back("bias");
+      }
+    }
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    if (group.has_value()) {
+      conv_attrs.push_back(builder.MakeScalarAttribute("group", group.value()));
+    }
+    if (!pads.empty()) {
+      conv_attrs.push_back(builder.MakeIntsAttribute("pads", pads));
+    }
+    if (!strides.empty()) {
+      conv_attrs.push_back(builder.MakeIntsAttribute("strides", strides));
+    }
+    if (!dilations.empty()) {
+      conv_attrs.push_back(builder.MakeIntsAttribute("dilations", dilations));
+    }
+
+    builder.AddNode("Conv", "Conv", conv_input_names, {"Y"}, kOnnxDomain, conv_attrs);
+
+    AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(
+        builder, "qdq_out", "Y", output_qparams[0].scale, output_qparams[0].zero_point, use_contrib_qdq);
+  };
+}
+
+template <typename ActivationQType, typename WeightQType>
+static void RunQDQBlockQuantConv2DOpTest(
+    const std::vector<int64_t>& input_shape,
+    const std::vector<int64_t>& weight_shape,
+    const std::vector<int64_t>& bias_shape,
+    int64_t block_size,
+    int64_t weight_quant_axis,
+    bool quantize_bias,
+    bool bias_per_channel
+    QDQTolerance tolerance = QDQTolerance(),
+    ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
+    int opset = 21,
+    bool use_contrib_qdq = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_block_quant_weight_optimization"] = "1";
+
+  TestInputDef<float> input_def(input_shape, false,
+                                GetFloatDataInRange(-10.0f, 10.0f, SizeOfShape(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, true,
+                                 GetFloatDataInRange(-0.1f, 0.1f, SizeOfShape(weight_shape)));
+  TestInputDef<float> bias_def;
+  if (!bias_shape.empty()) {
+    bias_def = TestInputDef<float>(bias_shape, true,
+                                   GetFloatDataInRange(-0.1f, 0.1f, SizeOfShape(bias_shape)));
+  }
+
+  TestQDQModelAccuracy(
+      BuildF32ConvTestCase("Conv", input_def, weight_def, bias_def,
+                           {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, "NOTSET"),
+      BuildQDQBlockQuantConv2DTestCase<ActivationQType, WeightQType>(
+          input_def, weight_def, bias_def, block_size, weight_quant_axis,
+          {1, 1}, {0, 0, 0, 0}, {1, 1}, 1, quantize_bias, bias_per_channel, use_contrib_qdq),
+      provider_options, opset, expected_ep_assignment, tolerance);
+}
+
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.
 // Tests bias as a dynamic input.
 // TODO: Segfaults when calling graphFinalize(). v2.13
@@ -3597,6 +3760,23 @@ TEST_F(QnnHTPBackendTests, ConvTranspose2D_NoReuseSparseIndices) {
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+#if defined(__linux__)
+
+// Tests Conv2D with ONNX block-quantized (BQ) weights using the BQ -> QNN LPBQ conversion path.
+// Currently BQ -> LPBQ conversion is only supported on Linux. It will be later enabled for Windows as well.
+TEST_F(QnnHTPBackendTests, Conv2DOp_QDQ_BlockQuant) {
+  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 16, 4, 4}, {4, 16, 1, 1}, {}, 8, 1, false, false, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 64, 4, 4}, {4, 64, 1, 1}, {}, 16, 1, false, false, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 128, 4, 4}, {4, 128, 1, 1}, {4}, 32, 1, true, false, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 256, 4, 4}, {4, 256, 1, 1}, {4}, 64, 1, true, false, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 64, 4, 4}, {4, 64, 1, 1}, {4}, 16, 1, true, true, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 64, 4, 4}, {4, 64, 1, 1}, {4}, 32, 1, true, true, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<int16_t, Int4x2>({1, 16, 4, 4}, {4, 16, 1, 1}, {4}, 8, 1, false, false, QDQTolerance(0.02f));
+  RunQDQBlockQuantConv2DOpTest<uint16_t, Int4x2>({1, 64, 4, 4}, {8, 64, 1, 1}, {8}, 32, 1, false, false, QDQTolerance(0.02f));
+}
+
+#endif  // defined(__linux__)
 
 #if defined(_M_ARM64)
 //


### PR DESCRIPTION
### Description
This PR adds support for the LPBQ (BLOCKWISE_EXPANSION) encoding path in the QNN EP Conv operator builder.

Route block-quantized weights to the HTP LPBQ encodings (`QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION`) when supported enabling the HTP backend to use its native low-precision block quantization kernel.
+ conv_op_builder: Selects the encoding based on the weight and activation datatype and other necessary conditions for LPBQ. Also adds the support for quantization of bias when float bias is present, but weight and activations are quantized.
+ conv_test: Adds lpbq tests for conv op.


### Motivation and Context
Previously, the QNN EP Conv builder only supported the BW_FLOAT_BLOCK path (FP16 activation + block-quantized INT4 weight) alongside per-tensor and per-channel quantization. This PR adds the LPBQ path that is triggered when:

1. The activation is INT16-quantized (uint16 or int16)
2. The weight is 4-bit signed and symmetric and has ONNX block quantization (`block_size` attribute on DQ node)
3. The provider option `enable_block_quant_weight_optimization=1` is set
