### PR TITLE
[QNN EP] Negotiate ORT API version at plugin load

### DIFF
--- a/onnxruntime/core/providers/qnn/ort_api_version_parser.h
+++ b/onnxruntime/core/providers/qnn/ort_api_version_parser.h
@@ -27,12 +27,12 @@ inline uint32_t ParseRuntimeOrtApiVersion(const char* version_str) {
     return 0;
   }
 
-  int minor = 0;
+  uint32_t minor = 0;
   auto [p2, ec2] = std::from_chars(p1 + 1, end, minor);
-  if (ec2 != std::errc{} || minor < 0) {
+  if (ec2 != std::errc{}) {
     return 0;
   }
-  return static_cast<uint32_t>(minor);
+  return minor;
 }
 
 }  // namespace onnxruntime::qnn::detail

--- a/onnxruntime/core/providers/qnn/ort_api_version_parser.h
+++ b/onnxruntime/core/providers/qnn/ort_api_version_parser.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/onnxruntime/core/providers/qnn/ort_api_version_parser.h
+++ b/onnxruntime/core/providers/qnn/ort_api_version_parser.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <string_view>
+#include <system_error>
+
+namespace onnxruntime::qnn::detail {
+
+// Parse the host ORT version string ("1.X.Y") and return the API version (the
+// minor component). Returns 0 if the string is null, malformed, or major != 1.
+// The "minor == API version" contract is documented for ORT 1.x; rejecting
+// non-1 majors keeps a hypothetical ORT 2.x from being silently misparsed.
+inline uint32_t ParseRuntimeOrtApiVersion(const char* version_str) {
+  if (version_str == nullptr) {
+    return 0;
+  }
+  std::string_view sv{version_str};
+  const char* end = sv.data() + sv.size();
+
+  int major = 0;
+  auto [p1, ec1] = std::from_chars(sv.data(), end, major);
+  if (ec1 != std::errc{} || p1 == end || *p1 != '.' || major != 1) {
+    return 0;
+  }
+
+  int minor = 0;
+  auto [p2, ec2] = std::from_chars(p1 + 1, end, minor);
+  if (ec2 != std::errc{} || minor < 0) {
+    return 0;
+  }
+  return static_cast<uint32_t>(minor);
+}
+
+}  // namespace onnxruntime::qnn::detail

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -348,6 +348,7 @@ QnnEp::QnnEp(QnnEpFactory& factory,
       name_{name},
       logger_{Ort::Logger(logger)},
       session_options_{session_options} {
+  ort_version_supported = ORT_API_VERSION;  // set to the ORT version we were compiled with.
   GetName = GetNameImpl;
   GetCapability = GetCapabilityImpl;
   Compile = CompileImpl;

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -3,7 +3,10 @@
 
 #include "core/providers/qnn/qnn_provider_factory.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cstdint>
+#include <cstdio>
 #include <iostream>
 #include <optional>
 
@@ -465,6 +468,27 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetHardwareDeviceIncompatibilityDetailsImp
 
 }  // namespace onnxruntime
 
+namespace {
+// Parse the host ORT version string ("1.X.Y") and return the API version (the
+// minor component). Returns 0 if the string is null, malformed, or major != 1.
+// The "minor == API version" contract is documented for ORT 1.x; rejecting
+// non-1 majors keeps a hypothetical ORT 2.x from being silently misparsed.
+uint32_t ParseRuntimeOrtApiVersion(const char* version_str) {
+  if (version_str == nullptr) {
+    return 0;
+  }
+  int major = 0;
+  int minor = 0;
+  if (std::sscanf(version_str, "%d.%d", &major, &minor) < 2) {
+    return 0;
+  }
+  if (major != 1 || minor < 0) {
+    return 0;
+  }
+  return static_cast<uint32_t>(minor);
+}
+}  // namespace
+
 extern "C" {
 //
 // Public symbols
@@ -476,12 +500,38 @@ OrtStatus* CreateEpFactories(const char* registration_name,
                              size_t max_factories,
                              size_t* num_factories) {
   if (ort_api_base == nullptr) {
-    return nullptr;  // Cannot create status without API base
+    return nullptr;
   }
 
-  const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
+  // kMinOrtApiVersion must equal the highest \since version of any ORT API
+  // method this EP calls. Below this floor, GetApi() returns a function table
+  // that lacks members the EP would dereference.
+  constexpr uint32_t kMinOrtApiVersion = 24;
+
+  const char* version_str = ort_api_base->GetVersionString();
+  const uint32_t runtime_api_version = ParseRuntimeOrtApiVersion(version_str);
+
+  if (runtime_api_version < kMinOrtApiVersion) {
+    const uint32_t fallback_version = runtime_api_version > 0 ? runtime_api_version : 1;
+    const OrtApi* fallback_api = ort_api_base->GetApi(fallback_version);
+    if (fallback_api == nullptr) {
+      return nullptr;
+    }
+    char msg[256];
+    std::snprintf(msg, sizeof(msg),
+                  "QNN EP requires ORT >= 1.%u (API %u). "
+                  "Host ORT is %s (API %u).",
+                  kMinOrtApiVersion, kMinOrtApiVersion,
+                  version_str != nullptr ? version_str : "unknown",
+                  runtime_api_version);
+    return fallback_api->CreateStatus(ORT_FAIL, msg);
+  }
+
+  const uint32_t requested_api_version =
+      std::min(runtime_api_version, static_cast<uint32_t>(ORT_API_VERSION));
+  const OrtApi* ort_api = ort_api_base->GetApi(requested_api_version);
   if (ort_api == nullptr) {
-    return nullptr;  // Cannot create status without ORT API
+    return nullptr;
   }
 
   // Manual init for the C++ API

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -5,10 +5,13 @@
 
 #include <algorithm>
 #include <cassert>
+#include <charconv>
 #include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <optional>
+#include <string_view>
+#include <system_error>
 
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_ep_device_ep_metadata_keys.h"
@@ -477,12 +480,18 @@ uint32_t ParseRuntimeOrtApiVersion(const char* version_str) {
   if (version_str == nullptr) {
     return 0;
   }
+  std::string_view sv{version_str};
+  const char* end = sv.data() + sv.size();
+
   int major = 0;
-  int minor = 0;
-  if (std::sscanf(version_str, "%d.%d", &major, &minor) < 2) {
+  auto [p1, ec1] = std::from_chars(sv.data(), end, major);
+  if (ec1 != std::errc{} || p1 == end || *p1 != '.' || major != 1) {
     return 0;
   }
-  if (major != 1 || minor < 0) {
+
+  int minor = 0;
+  auto [p2, ec2] = std::from_chars(p1 + 1, end, minor);
+  if (ec2 != std::errc{} || minor < 0) {
     return 0;
   }
   return static_cast<uint32_t>(minor);

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -487,6 +487,8 @@ OrtStatus* CreateEpFactories(const char* registration_name,
   // the newest ORT API method this EP calls. Below this floor, GetApi()
   // returns a function table missing members the EP would dereference.
   constexpr uint32_t kMinOrtApiVersion = 24;
+  static_assert(kMinOrtApiVersion <= ORT_API_VERSION,
+                "kMinOrtApiVersion must not exceed ORT_API_VERSION");
 
   const char* version_str = ort_api_base->GetVersionString();
   const uint32_t runtime_api_version = onnxruntime::qnn::detail::ParseRuntimeOrtApiVersion(version_str);

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -5,19 +5,17 @@
 
 #include <algorithm>
 #include <cassert>
-#include <charconv>
 #include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <optional>
-#include <string_view>
-#include <system_error>
 
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_ep_device_ep_metadata_keys.h"
 #include "QnnCommon.h"
 
 #include "core/providers/qnn/ort_api.h"
+#include "core/providers/qnn/ort_api_version_parser.h"
 #include "core/providers/qnn/qnn_allocator.h"
 #include "core/providers/qnn/soc_utils.h"
 
@@ -471,33 +469,6 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetHardwareDeviceIncompatibilityDetailsImp
 
 }  // namespace onnxruntime
 
-namespace {
-// Parse the host ORT version string ("1.X.Y") and return the API version (the
-// minor component). Returns 0 if the string is null, malformed, or major != 1.
-// The "minor == API version" contract is documented for ORT 1.x; rejecting
-// non-1 majors keeps a hypothetical ORT 2.x from being silently misparsed.
-uint32_t ParseRuntimeOrtApiVersion(const char* version_str) {
-  if (version_str == nullptr) {
-    return 0;
-  }
-  std::string_view sv{version_str};
-  const char* end = sv.data() + sv.size();
-
-  int major = 0;
-  auto [p1, ec1] = std::from_chars(sv.data(), end, major);
-  if (ec1 != std::errc{} || p1 == end || *p1 != '.' || major != 1) {
-    return 0;
-  }
-
-  int minor = 0;
-  auto [p2, ec2] = std::from_chars(p1 + 1, end, minor);
-  if (ec2 != std::errc{} || minor < 0) {
-    return 0;
-  }
-  return static_cast<uint32_t>(minor);
-}
-}  // namespace
-
 extern "C" {
 //
 // Public symbols
@@ -512,17 +483,29 @@ OrtStatus* CreateEpFactories(const char* registration_name,
     return nullptr;
   }
 
-  // kMinOrtApiVersion must equal the highest \since version of any ORT API
-  // method this EP calls. Below this floor, GetApi() returns a function table
-  // that lacks members the EP would dereference.
+  // kMinOrtApiVersion must be at least the ORT API version that introduced
+  // the newest ORT API method this EP calls. Below this floor, GetApi()
+  // returns a function table missing members the EP would dereference.
   constexpr uint32_t kMinOrtApiVersion = 24;
 
   const char* version_str = ort_api_base->GetVersionString();
-  const uint32_t runtime_api_version = ParseRuntimeOrtApiVersion(version_str);
+  const uint32_t runtime_api_version = onnxruntime::qnn::detail::ParseRuntimeOrtApiVersion(version_str);
+
+  if (runtime_api_version == 0) {
+    const OrtApi* fallback_api = ort_api_base->GetApi(1);
+    if (fallback_api == nullptr) {
+      return nullptr;
+    }
+    char msg[256];
+    std::snprintf(msg, sizeof(msg),
+                  "QNN EP could not parse host ORT version string \"%s\" "
+                  "(expected \"1.X.Y\" with major == 1).",
+                  version_str != nullptr ? version_str : "(null)");
+    return fallback_api->CreateStatus(ORT_FAIL, msg);
+  }
 
   if (runtime_api_version < kMinOrtApiVersion) {
-    const uint32_t fallback_version = runtime_api_version > 0 ? runtime_api_version : 1;
-    const OrtApi* fallback_api = ort_api_base->GetApi(fallback_version);
+    const OrtApi* fallback_api = ort_api_base->GetApi(runtime_api_version);
     if (fallback_api == nullptr) {
       return nullptr;
     }
@@ -531,8 +514,7 @@ OrtStatus* CreateEpFactories(const char* registration_name,
                   "QNN EP requires ORT >= 1.%u (API %u). "
                   "Host ORT is %s (API %u).",
                   kMinOrtApiVersion, kMinOrtApiVersion,
-                  version_str != nullptr ? version_str : "unknown",
-                  runtime_api_version);
+                  version_str, runtime_api_version);
     return fallback_api->CreateStatus(ORT_FAIL, msg);
   }
 

--- a/onnxruntime/test/providers/qnn/ort_api_version_parser_test.cc
+++ b/onnxruntime/test/providers/qnn/ort_api_version_parser_test.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "gtest/gtest.h"
 

--- a/onnxruntime/test/providers/qnn/ort_api_version_parser_test.cc
+++ b/onnxruntime/test/providers/qnn/ort_api_version_parser_test.cc
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+
+#include "core/providers/qnn/ort_api_version_parser.h"
+
+namespace onnxruntime {
+namespace test {
+
+using onnxruntime::qnn::detail::ParseRuntimeOrtApiVersion;
+
+TEST(QnnOrtApiVersionParserTest, NullPointerReturnsZero) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion(nullptr), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, EmptyStringReturnsZero) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion(""), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, MissingMinorReturnsZero) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1"), 0u);
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1."), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, ValidTwoComponent) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.24"), 24u);
+}
+
+TEST(QnnOrtApiVersionParserTest, ValidThreeComponent) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.24.0"), 24u);
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.26.5"), 26u);
+}
+
+TEST(QnnOrtApiVersionParserTest, PrereleaseSuffixIgnoredAfterMinor) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.24.5-rc1"), 24u);
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.24-rc1"), 24u);
+}
+
+TEST(QnnOrtApiVersionParserTest, MajorNotOneReturnsZero) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("2.0.0"), 0u);
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("0.99.0"), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, NonNumericReturnsZero) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("abc"), 0u);
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.x"), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, LeadingPlusOrSpaceRejected) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion(" 1.24"), 0u);
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("+1.24"), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, NegativeMinorRejected) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("1.-1"), 0u);
+}
+
+TEST(QnnOrtApiVersionParserTest, MissingDotAfterMajorRejected) {
+  EXPECT_EQ(ParseRuntimeOrtApiVersion("124"), 0u);
+}
+
+}  // namespace test
+}  // namespace onnxruntime


### PR DESCRIPTION
### Description

`CreateEpFactories` in `qnn_provider_factory.cc` now negotiates the ORT API version with the host at plugin load instead of demanding `ORT_API_VERSION`

Verified locally with four venvs against the same EP wheel (and a second wheel built with a simulated lower ceiling)

### Motivation and Context

QNN EP is deployed into fixed host environments. The old code crashed (null deref) or emitted an opaque host message when the host ORT was older than the EP was compiled against. This converts that into a clear, actionable error.
