### PR TITLE
[QNN EP] Framework op tracing follow-up: profiling integration and AOT sidecar

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -20,6 +20,7 @@ ONNX Runtime QNN EP can be used on Windows devices with Qualcomm Snapdragon SOC'
 - [Running a model with QNN EP's GPU backend](#running-a-model-with-qnn-eps-gpu-backend)
 - [Running an LLM model with QNN EP's Genie backend](#running-an-llm-model-with-qnn-eps-genie-backend)
 - [QNN context binary cache feature](#qnn-context-binary-cache-feature)
+- [QNN EP Framework Op Tracing](#qnn-ep-framework-op-tracing)
 - [QNN EP Profiling](#qnn-ep-profiling)
 - [QNN EP weight sharing](#qnn-ep-weight-sharing)
 - [Usage](#usage)
@@ -917,6 +918,22 @@ If `num_graph_prepare_threads` is never set or set to a value outside of the all
 
 If `std::thread::hardware_concurrency` returns a value less than 8, then the default number of threads will be the lower value rather than 8. This applies when `num_graph_prepare_threads` is set to an invalid value.
 
+## QNN EP Framework Op Tracing
+
+Framework op tracing records the mapping between ONNX operators and the QNN operators they compile to. It is useful for debugging accuracy issues, understanding node-group fusions, and diagnosing why certain operators fall back to CPU EP.
+
+Enable tracing by setting `enable_framework_op_trace` to `'1'` and optionally `framework_op_trace_dir` to choose the output directory.
+
+### Output File Naming
+
+The trace is written as `{framework_op_trace_dir}/qnn_op_trace.json`.
+
+### Sidecar for Pre-compiled Context Models
+
+When loading a pre-compiled context model with `profiling_level=detailed` or `optrace`, the EP looks for a sidecar trace file to annotate profiling output with ONNX source op names. The sidecar path is `qnn_op_trace.json` in the same directory as the context model.
+
+Because AOT context-binary generation (`ep.context_enable=1`) also writes `qnn_op_trace.json`, no manual rename is needed. The only prerequisite is that the Phase 1 (context-generation) run must set `framework_op_trace_dir` to the directory where the context model is saved (i.e. the parent directory of `ep.context_file_path`), so the sidecar lands next to the context model. If the two directories differ, copy `qnn_op_trace.json` next to the context model before the Phase 2 run.
+
 ## QNN EP Profiling
 Profiling data is available with the HTP backend. Enabling QNN profiling will generate a user-readable .csv file that will contain information from initialization, execution, and de-initialization.
 
@@ -975,6 +992,10 @@ With the example above, a file "output.csv" will be generated containing the pro
 The above will output basic information, such as the profiling data for the fastest and slowest execution as well as the average case. A .csv file can also be generated this way, too, though the information will likely not differ from the "output.csv".
 
 Additionally, if the profiling_level is set to "detailed" or "optrace", additional data will be shown per-network-layer.
+
+> **Combining profiling with framework op tracing:** When `profiling_level` is `detailed` or `optrace` **and** `enable_framework_op_trace` is `'1'`, the profiling CSV gains an extra `ONNX Source Ops` column. For each per-layer `NODE` event row, this column lists the originating ONNX operator name(s) (semicolon-separated for fused groups). This makes it easy to correlate QNN-level hardware profiling data back to the original ONNX model operators without manual lookup.
+>
+> At `profiling_level=basic` the `ONNX Source Ops` column is **not** added because basic profiling does not emit per-layer `NODE` events.
 
 ### Optrace-Level Profiling
 [Optrace-level profiling](https://docs.qualcomm.com/doc/80-63442-10/topic/htp_backend.html#qnn-htp-profiling) generates a profiling .log file that contains [Qualcomm Hexagon Tensor Processor Analaysis Summary (QHAS)](https://docs.qualcomm.com/doc/80-63442-10/topic/htp_backend.html#qnn-htp-analysis-summary-qhas-) data. This data can be used to generate chrometraces and provide a web browser-friendly UI to visualize data.

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.cc
@@ -126,7 +126,10 @@ void OpTraceCollector::RecordOpMapping(const std::string& qnn_op_name, const std
   op_mappings_.push_back(std::move(mapping));
 }
 
-void OpTraceCollector::Finalize(const std::string& graph_name, const QnnModelWrapper& wrapper, OpTraceInfo& out) {
+void OpTraceCollector::Finalize(const std::string& graph_name,
+                                const QnnModelWrapper& wrapper,
+                                OpTraceInfo& out_info,
+                                OpTraceLookup& out_lookup) {
   // Records the direct ONNX<->QNN tensor correspondence when a tensor was
   // renamed by an op builder (onnx_name != qnn_name).
   //
@@ -183,9 +186,14 @@ void OpTraceCollector::Finalize(const std::string& graph_name, const QnnModelWra
     recorded_tensor_names_.insert(qnn_name);
   }
 
-  out.graph_name = graph_name;
-  out.op_mappings = std::move(op_mappings_);
-  out.tensor_mappings = std::move(tensor_mappings_);
+  out_info.graph_name = graph_name;
+  out_info.op_mappings = std::move(op_mappings_);
+  out_info.tensor_mappings = std::move(tensor_mappings_);
+
+  // Build the dst_name->sources lookup used for profiling enrichment at execute time.
+  for (const auto& mapping : out_info.op_mappings) {
+    out_lookup[mapping.dst_name] = mapping.sources;
+  }
 }
 
 bool WriteTraceToFile(const FrameworkOpTrace& trace,
@@ -235,6 +243,42 @@ bool WriteTraceToFile(const FrameworkOpTrace& trace,
   ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO,
               ("Framework op trace written to: " + output_path.string()).c_str());
   return true;
+}
+
+bool LoadTraceLookupFromFile(const std::filesystem::path& trace_path,
+                             OpTraceLookup& out_lookup,
+                             const Ort::Logger& logger) {
+  // Parsing lives in the logger-free ParseTraceLookupFromFile (test-safe
+  // translation unit); this wrapper adds the EP logger, turning each load
+  // status into a log line.
+  size_t skipped_entries = 0;
+  switch (ParseTraceLookupFromFile(trace_path, out_lookup, &skipped_entries)) {
+    case TraceLoadStatus::kCannotOpen:
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("Cannot open op trace sidecar: " + trace_path.string()).c_str());
+      return false;
+    case TraceLoadStatus::kParseError:
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("Failed to parse op trace sidecar JSON: " + trace_path.string()).c_str());
+      return false;
+    case TraceLoadStatus::kMissingSubgraphTraces:
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("Op trace sidecar missing required `subgraph_traces` key: " + trace_path.string()).c_str());
+      return false;
+    case TraceLoadStatus::kOk:
+      if (skipped_entries > 0) {
+        ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                    ("Op trace sidecar had " + std::to_string(skipped_entries) +
+                     " malformed op_mappings entries (missing dst_name or sources) "
+                     "that were skipped: " +
+                     trace_path.string())
+                        .c_str());
+      }
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO,
+                  ("Loaded op trace sidecar for profiling enrichment: " + trace_path.string()).c_str());
+      return true;
+  }
+  return false;  // unreachable; silences -Wreturn-type on some compilers
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.h
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.h
@@ -1,7 +1,10 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MIT
 
-// EP-internal header: OpTraceCollector class definition and WriteTraceToFile.
+// EP-internal header: OpTraceCollector / NodeGroupGuard, and the
+// EP-side wrappers WriteTraceToFile and LoadTraceLookupFromFile (the latter
+// adds Ort logger plumbing on top of the test-safe ParseTraceLookupFromFile
+// declared in qnn_op_tracing_types.h).
 // Test TUs should include qnn_op_tracing_types.h (which also declares
 // SerializeFrameworkOpTrace via nlohmann/json_fwd.hpp) and add
 // nlohmann/json.hpp directly if they use the return value.
@@ -34,10 +37,15 @@ class OpTraceCollector {
   void RecordOpMapping(const std::string& qnn_op_name, const std::string& qnn_op_type,
                        gsl::span<const std::string> output_tensor_names);
 
-  // Finalize the subgraph trace: record tensor mappings from the wrapper and
-  // populate `out` with the collected op_mappings, tensor_mappings, and the
-  // graph name. Call once after ComposeQnnGraph().
-  void Finalize(const std::string& graph_name, const QnnModelWrapper& wrapper, OpTraceInfo& out);
+  // Finalize the subgraph trace: record tensor mappings from the wrapper, populate
+  // `out_info` with the collected op_mappings, tensor_mappings, and graph name,
+  // and also populate `out_lookup` with the dst_name->sources projection of
+  // op_mappings (used for profiling enrichment at execute time).
+  // Call once after ComposeQnnGraph().
+  void Finalize(const std::string& graph_name,
+                const QnnModelWrapper& wrapper,
+                OpTraceInfo& out_info,
+                OpTraceLookup& out_lookup);
 
  private:
   // Set/clear the current node group context. Only NodeGroupGuard may call these
@@ -79,6 +87,13 @@ class NodeGroupGuard {
 bool WriteTraceToFile(const FrameworkOpTrace& trace,
                       const std::filesystem::path& output_path,
                       const Ort::Logger& logger);
+
+// Loads an OpTraceLookup from a trace JSON sidecar file.
+// Iterates all subgraph_traces[*].op_mappings and builds a flat dst_name->sources map.
+// Returns true on success; logs a warning and returns false on any parse error.
+bool LoadTraceLookupFromFile(const std::filesystem::path& trace_path,
+                             OpTraceLookup& out_lookup,
+                             const Ort::Logger& logger);
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc
@@ -1,7 +1,8 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: MIT
 
-// Implementations of ComputeTraceSummary and SerializeFrameworkOpTrace.
+// Implementations of ComputeTraceSummary and SerializeFrameworkOpTrace,
+// and DeriveTracePathFromContextModel.
 //
 // This translation unit (.cc file) is compiled directly into the test binary
 // (via cmake) so that unit tests can call these functions without linking
@@ -11,6 +12,7 @@
 
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 
+#include <fstream>
 #include <unordered_set>
 
 #include "nlohmann/json.hpp"
@@ -138,6 +140,51 @@ nlohmann::json SerializeFrameworkOpTrace(const FrameworkOpTrace& trace) {
   j["summary"] = std::move(summary);
 
   return j;
+}
+
+std::filesystem::path DeriveTracePathFromContextModel(const std::filesystem::path& ctx_model_path) {
+  return ctx_model_path.parent_path() / "qnn_op_trace.json";
+}
+
+TraceLoadStatus ParseTraceLookupFromFile(const std::filesystem::path& trace_path,
+                                         OpTraceLookup& out_lookup,
+                                         size_t* skipped_entries) {
+  std::ifstream ifs(trace_path);
+  if (!ifs.is_open()) {
+    return TraceLoadStatus::kCannotOpen;
+  }
+  auto j = nlohmann::json::parse(ifs, nullptr, /*allow_exceptions=*/false);
+  if (j.is_discarded()) {
+    return TraceLoadStatus::kParseError;
+  }
+  if (!j.contains("subgraph_traces")) {
+    return TraceLoadStatus::kMissingSubgraphTraces;
+  }
+  size_t skipped = 0;
+  for (const auto& sg : j.at("subgraph_traces")) {
+    if (!sg.contains("op_mappings")) {
+      continue;
+    }
+    for (const auto& m : sg.at("op_mappings")) {
+      std::string dst_name = m.value("dst_name", "");
+      if (dst_name.empty() || !m.contains("sources")) {
+        ++skipped;
+        continue;
+      }
+      std::vector<TraceSourcePair> sources;
+      for (const auto& src : m.at("sources")) {
+        std::string name = src.value("name", "");
+        std::string type_str = src.value("type", "OP");
+        sources.push_back({std::move(name),
+                           type_str == "OP" ? TraceTargetType::kOp : TraceTargetType::kTensor});
+      }
+      out_lookup[std::move(dst_name)] = std::move(sources);
+    }
+  }
+  if (skipped_entries != nullptr) {
+    *skipped_entries = skipped;
+  }
+  return TraceLoadStatus::kOk;
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h
@@ -16,8 +16,10 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "nlohmann/json_fwd.hpp"
@@ -98,6 +100,42 @@ void ComputeTraceSummary(FrameworkOpTrace& trace);
 // Defined in qnn_op_tracing_serialization.cc.  Call sites that use the return value must
 // include nlohmann/json.hpp separately.
 nlohmann::json SerializeFrameworkOpTrace(const FrameworkOpTrace& trace);
+
+// Derives the AOT Phase 2 sidecar trace JSON path from a context model path.
+// Returns {parent_dir}/qnn_op_trace.json - the same filename Phase 1 writes when
+// framework_op_trace_dir is set to the context model's directory, so Phase 2
+// discovery is automatic without a manual rename step.
+// E.g. "/path/model_ctx.onnx" -> "/path/qnn_op_trace.json"
+// Defined in qnn_op_tracing_serialization.cc (test-safe translation unit).
+std::filesystem::path DeriveTracePathFromContextModel(const std::filesystem::path& ctx_model_path);
+
+// Lookup map: QNN op name -> ONNX source pairs.
+// Populated by OpTraceCollector at compile time;
+// persists in QnnModel for profiling enrichment at execute time.
+using OpTraceLookup = std::unordered_map<std::string, std::vector<TraceSourcePair>>;
+
+// Outcome of ParseTraceLookupFromFile, so callers can map each failure mode to
+// an appropriate log message without the parser needing a logger dependency.
+enum class TraceLoadStatus {
+  kOk,                     // parsed successfully (out_lookup populated)
+  kCannotOpen,             // file could not be opened
+  kParseError,             // file is not valid JSON
+  kMissingSubgraphTraces,  // valid JSON but missing the required top-level key
+};
+
+// Parses a trace JSON sidecar into a flat dst_name->sources lookup, iterating
+// all subgraph_traces[*].op_mappings. Defined in qnn_op_tracing_serialization.cc
+// with no Ort/logger dependency (the LoadTraceLookupFromFile wrapper supplies
+// logging). On any non-kOk status `out_lookup` is left unmodified.
+//
+// `skipped_entries` (optional) accumulates a count of malformed `op_mappings`
+// entries (empty `dst_name`, missing `sources`) that were silently skipped to
+// keep the loader forward-compatible with future schema additions. The wrapper
+// can use this to surface a warning when nonzero, distinguishing "empty
+// lookup because schema mismatch" from "empty lookup because no trace data".
+TraceLoadStatus ParseTraceLookupFromFile(const std::filesystem::path& trace_path,
+                                         OpTraceLookup& out_lookup,
+                                         size_t* skipped_entries = nullptr);
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -2293,6 +2293,15 @@ Ort::Status QnnBackendManager::ExtractBackendProfilingInfo(qnn::profile::Profili
     profiling_info.num_events = num_events;
 #endif
 
+    // When framework op tracing is enabled, attach the lookup so InitCsvFile()
+    // emits the `ONNX Source Ops` column header and ProcessEvent() annotates each
+    // NODE row with the originating ONNX op names. The lookup is read by pointer
+    // and continues to fill as later graphs compose; only DETAILED/OPTRACE
+    // profiling produces the per-NODE events this column annotates.
+    if (enable_framework_op_trace_ && HasNodeLevelProfiling()) {
+      profiling_info.op_trace_lookup = &op_trace_lookup_;
+    }
+
     profile::Serializer profile_writer(profiling_info,
                                        qnn_sys_interface_,
                                        tracelogging_provider_ep_enabled);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -2298,7 +2298,9 @@ Ort::Status QnnBackendManager::ExtractBackendProfilingInfo(qnn::profile::Profili
     // NODE row with the originating ONNX op names. The lookup is read by pointer
     // and continues to fill as later graphs compose; only DETAILED/OPTRACE
     // profiling produces the per-NODE events this column annotates.
-    if (enable_framework_op_trace_ && HasNodeLevelProfiling()) {
+    const bool has_node_level_profiling = profiling_level_merge_ == ProfilingLevel::DETAILED ||
+                                          profiling_level_merge_ == ProfilingLevel::OPTRACE;
+    if (enable_framework_op_trace_ && has_node_level_profiling) {
       profiling_info.op_trace_lookup = &op_trace_lookup_;
     }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -31,6 +31,7 @@
 #include "core/providers/qnn/rpcmem_library.h"
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/op_package/op_package.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 #include "core/providers/qnn/builder/qnn_context_mem_handle_manager.h"
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_htp_power_config_manager.h"
@@ -122,6 +123,11 @@ struct QnnBackendManagerConfig {
   uint32_t soc_model;
   std::vector<OpPackage> op_packages;
   bool skip_qnn_version_check;
+  // When true, framework op tracing is active for the session and the profiling
+  // CSV gains the `ONNX Source Ops` column. Provided here alongside the other
+  // profiling settings so it is set once at backend-manager construction and
+  // remains constant for the manager's lifetime.
+  bool enable_framework_op_trace = false;
 };
 
 class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager> {
@@ -146,6 +152,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
         profiling_level_etw_(config.profiling_level_etw),
         profiling_level_(config.profiling_level),
         profiling_file_path_(config.profiling_file_path),
+        enable_framework_op_trace_(config.enable_framework_op_trace),
         context_priority_(config.context_priority),
         qnn_serializer_config_(config.qnn_serializer_config),
         device_id_(config.device_id),
@@ -231,6 +238,25 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   Ort::Status ExtractBackendProfilingInfo(qnn::profile::ProfilingInfo& profiling_info);
 
+  // Framework op tracing: profiling enrichment lookup, shared across all
+  // QnnModels in this session. Populated by:
+  //   - JIT path:  ComposeGraph() merges each per-graph lookup via
+  //                MergeOpTraceLookup() after the trace collector finalizes.
+  //   - AOT path:  CompileContextModel() loads the sidecar JSON via
+  //                SetOpTraceLookup() before any context binary is loaded.
+  // Self-attached to the local ProfilingInfo inside ExtractBackendProfilingInfo
+  // when HasNodeLevelProfiling() is true and op tracing is enabled.
+  void SetOpTraceLookup(qnn::OpTraceLookup lookup) { op_trace_lookup_ = std::move(lookup); }
+  // Merges `other` into the session-wide lookup. On key collision the entry
+  // from `other` wins (last-write-wins), matching the operator[] semantics
+  // already used by OpTraceCollector::Finalize and LoadTraceLookupFromFile
+  // when they populate a lookup. `other` is consumed.
+  void MergeOpTraceLookup(qnn::OpTraceLookup&& other) {
+    for (auto& kv : other) {
+      op_trace_lookup_[kv.first] = std::move(kv.second);
+    }
+  }
+
   Ort::Status ExtractProfilingSubEvents(QnnProfile_EventId_t profile_event_id, profile::Serializer& profile_writer,
                                         bool backendSupportsExtendedEventData);
 
@@ -295,6 +321,14 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   bool ProfilingEnabled() { return profiling_enabled_; }
 #endif
+
+  // Returns true when profiling is at DETAILED or OPTRACE level, meaning per-node
+  // (QNN_PROFILE_EVENTTYPE_NODE) events are generated. Used to gate ONNX source
+  // annotation in the profiling CSV.
+  bool HasNodeLevelProfiling() const {
+    return profiling_level_merge_ == ProfilingLevel::DETAILED ||
+           profiling_level_merge_ == ProfilingLevel::OPTRACE;
+  }
 
   bool IsBackendSetup() { return backend_setup_completed_; }
   bool FileMappingIsEnabled() {
@@ -636,6 +670,13 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   ProfilingLevel profiling_level_;
   ProfilingLevel profiling_level_merge_;
   const std::string profiling_file_path_;
+  // Framework op trace -> profiling enrichment lookup. See accessor comments
+  // for population rules.
+  qnn::OpTraceLookup op_trace_lookup_;
+  // True when framework op tracing is active for the session. Fixed at
+  // construction, so the profiling CSV's `ONNX Source Ops` column is present
+  // for every graph's events and its header matches all NODE rows.
+  const bool enable_framework_op_trace_ = false;
   bool system_lib_loaded_ = false;
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -247,7 +247,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // Self-attached to the local ProfilingInfo inside ExtractBackendProfilingInfo
   // when profiling is at DETAILED/OPTRACE level (per-NODE events) and op
   // tracing is enabled.
-  void SetOpTraceLookup(OpTraceLookup lookup) { op_trace_lookup_ = std::move(lookup); }
+  void SetOpTraceLookup(OpTraceLookup&& lookup) { op_trace_lookup_ = std::move(lookup); }
   // Merges `other` into the session-wide lookup. On key collision the entry
   // from `other` wins (last-write-wins), matching the operator[] semantics
   // already used by OpTraceCollector::Finalize and LoadTraceLookupFromFile

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -236,7 +236,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // NOTE: This function locks the internal `logger_recursive_mutex_`.
   Ort::Status ResetQnnLogLevel(std::optional<OrtLoggingLevel> ort_log_level = std::nullopt);
 
-  Ort::Status ExtractBackendProfilingInfo(qnn::profile::ProfilingInfo& profiling_info);
+  Ort::Status ExtractBackendProfilingInfo(profile::ProfilingInfo& profiling_info);
 
   // Framework op tracing: profiling enrichment lookup, shared across all
   // QnnModels in this session. Populated by:
@@ -245,13 +245,14 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   //   - AOT path:  CompileContextModel() loads the sidecar JSON via
   //                SetOpTraceLookup() before any context binary is loaded.
   // Self-attached to the local ProfilingInfo inside ExtractBackendProfilingInfo
-  // when HasNodeLevelProfiling() is true and op tracing is enabled.
-  void SetOpTraceLookup(qnn::OpTraceLookup lookup) { op_trace_lookup_ = std::move(lookup); }
+  // when profiling is at DETAILED/OPTRACE level (per-NODE events) and op
+  // tracing is enabled.
+  void SetOpTraceLookup(OpTraceLookup lookup) { op_trace_lookup_ = std::move(lookup); }
   // Merges `other` into the session-wide lookup. On key collision the entry
   // from `other` wins (last-write-wins), matching the operator[] semantics
   // already used by OpTraceCollector::Finalize and LoadTraceLookupFromFile
   // when they populate a lookup. `other` is consumed.
-  void MergeOpTraceLookup(qnn::OpTraceLookup&& other) {
+  void MergeOpTraceLookup(OpTraceLookup&& other) {
     for (auto& kv : other) {
       op_trace_lookup_[kv.first] = std::move(kv.second);
     }
@@ -321,14 +322,6 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   bool ProfilingEnabled() { return profiling_enabled_; }
 #endif
-
-  // Returns true when profiling is at DETAILED or OPTRACE level, meaning per-node
-  // (QNN_PROFILE_EVENTTYPE_NODE) events are generated. Used to gate ONNX source
-  // annotation in the profiling CSV.
-  bool HasNodeLevelProfiling() const {
-    return profiling_level_merge_ == ProfilingLevel::DETAILED ||
-           profiling_level_merge_ == ProfilingLevel::OPTRACE;
-  }
 
   bool IsBackendSetup() { return backend_setup_completed_; }
   bool FileMappingIsEnabled() {
@@ -670,14 +663,20 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   ProfilingLevel profiling_level_;
   ProfilingLevel profiling_level_merge_;
   const std::string profiling_file_path_;
-  // Framework op trace -> profiling enrichment lookup. See accessor comments
-  // for population rules.
-  qnn::OpTraceLookup op_trace_lookup_;
-  // True when framework op tracing is active for the session. Fixed at
-  // construction, so the profiling CSV's `ONNX Source Ops` column is present
-  // for every graph's events and its header matches all NODE rows.
-  const bool enable_framework_op_trace_ = false;
   bool system_lib_loaded_ = false;
+
+  // ----------------------------------------------------------------------
+  // Framework op tracing (profiling CSV enrichment).
+  //
+  // Session-scoped state used to annotate the profiling CSV's `ONNX Source Ops`
+  // column. Read by ExtractBackendProfilingInfo() via &op_trace_lookup_.
+  //   - enable_framework_op_trace_: fixed at construction so the CSV header
+  //     and per-NODE rows agree across every graph's events.
+  //   - op_trace_lookup_: populated by SetOpTraceLookup (AOT sidecar) /
+  //     MergeOpTraceLookup (JIT, per-graph). See those accessor comments.
+  // ----------------------------------------------------------------------
+  const bool enable_framework_op_trace_ = false;
+  OpTraceLookup op_trace_lookup_;
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   bool profiling_enabled_ = false;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -308,7 +308,11 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
 
   // Collect framework op trace after graph composition
   if (trace_collector) {
-    trace_collector->Finalize(graph_name, qnn_model_wrapper, *context.op_trace_output);
+    qnn::OpTraceLookup per_graph_lookup;
+    trace_collector->Finalize(graph_name, qnn_model_wrapper, *context.op_trace_output, per_graph_lookup);
+    // Hand the per-graph lookup off to the backend manager, which holds the
+    // session-wide lookup that ExtractBackendProfilingInfo reads from.
+    qnn_backend_manager_->MergeOpTraceLookup(std::move(per_graph_lookup));
   }
 
   LogTensorDetails(qnn_model_wrapper, graph_name, context.json_qnn_graph_path, logger);

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -308,7 +308,7 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
 
   // Collect framework op trace after graph composition
   if (trace_collector) {
-    qnn::OpTraceLookup per_graph_lookup;
+    OpTraceLookup per_graph_lookup;
     trace_collector->Finalize(graph_name, qnn_model_wrapper, *context.op_trace_output, per_graph_lookup);
     // Hand the per-graph lookup off to the backend manager, which holds the
     // session-wide lookup that ExtractBackendProfilingInfo reads from.

--- a/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.cc
@@ -4,6 +4,7 @@
 #include "core/providers/qnn/builder/qnn_profile_serializer.h"
 
 #include <filesystem>
+#include <string_view>
 
 #include "core/providers/qnn/qnn_telemetry.h"
 
@@ -116,6 +117,30 @@ void Serializer::LogQnnProfileEventAsTraceLogging(
 }
 #endif
 
+std::string Serializer::LookupOnnxSources(const char* identifier) const {
+  if (!profiling_info_.op_trace_lookup || !identifier) return "";
+  // HTP profiling events may append ":OpId_{N} ({unit})" to the op name
+  // (e.g. "add_node:OpId_17 (cycles)"). Strip that suffix to recover the base
+  // op name used as the lookup key. A string_view does the trimming; the key is
+  // materialized only for the find() call, since the map is keyed by std::string.
+  std::string_view id_view(identifier);
+  auto colon_pos = id_view.find(":OpId_");
+  if (colon_pos != std::string_view::npos) id_view = id_view.substr(0, colon_pos);
+  auto it = profiling_info_.op_trace_lookup->find(std::string(id_view));
+  if (it == profiling_info_.op_trace_lookup->end()) return "";
+  // The column lists the ONNX op names a QNN op was fused from, so only
+  // OP-typed sources are emitted; TENSOR-typed sources are skipped. An entry
+  // with no OP-typed sources produces an empty cell.
+  std::string result;
+  for (const auto& src : it->second) {
+    if (src.type == TraceTargetType::kOp) {
+      if (!result.empty()) result += ';';
+      result += src.name;
+    }
+  }
+  return result;
+}
+
 Ort::Status Serializer::ProcessEvent(const QnnProfile_EventId_t event_id, const std::string& event_level,
                                      const QnnProfile_EventData_t& event_data) {
   const std::string& message = GetEventTypeString(event_data.type);
@@ -132,7 +157,11 @@ Ort::Status Serializer::ProcessEvent(const QnnProfile_EventId_t event_id, const 
              << "BACKEND"
              << ","
              << event_level << ","
-             << (event_data.identifier ? event_data.identifier : "NULL") << "\n";
+             << (event_data.identifier ? event_data.identifier : "NULL");
+    if (profiling_info_.op_trace_lookup) {
+      outfile_ << "," << LookupOnnxSources(event_data.identifier);
+    }
+    outfile_ << "\n";
   }
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   QnnSystemProfile_ProfileEventV1_t* created_event = nullptr;
@@ -180,8 +209,11 @@ Ort::Status Serializer::ProcessExtendedEvent(const QnnProfile_EventId_t event_id
                << "BACKEND"
                << ","
                << event_level << ","
-               << (event_data.v1.identifier ? event_data.v1.identifier : "NULL")
-               << "\n";
+               << (event_data.v1.identifier ? event_data.v1.identifier : "NULL");
+      if (profiling_info_.op_trace_lookup) {
+        outfile_ << "," << LookupOnnxSources(event_data.v1.identifier);
+      }
+      outfile_ << "\n";
     }
   }
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
@@ -224,9 +256,15 @@ Ort::Status Serializer::InitCsvFile() {
 
   outfile_.open(output_filepath.c_str(), std::ios_base::app);
   RETURN_IF(!outfile_.is_open(), ("Failed to open profiling file: " + output_filepath).c_str());
-  // If file didn't exist before, write the header
+  // If file didn't exist before, write the header. The header gains the
+  // `ONNX Source Ops` column when a trace lookup is attached, matching the
+  // per-event row layout written by ProcessEvent.
   if (!exists) {
-    outfile_ << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier\n";
+    if (profiling_info_.op_trace_lookup) {
+      outfile_ << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier,ONNX Source Ops\n";
+    } else {
+      outfile_ << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier\n";
+    }
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.h
@@ -11,6 +11,7 @@
 #include <System/QnnSystemInterface.h>
 
 #include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 #include "core/providers/qnn/ort_api.h"
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
@@ -30,6 +31,10 @@ namespace profile {
 struct ProfilingInfo {
   std::string graph_name = "";
   std::string csv_output_filepath = "";
+  // Optional trace lookup for NODE event annotation.
+  // Non-null when enable_framework_op_trace_ is true and tracing data exists.
+  // Pointer lifetime is owned by QnnBackendManager and outlasts the Serializer.
+  const OpTraceLookup* op_trace_lookup = nullptr;
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   uint64_t start_time = 0;
@@ -104,6 +109,11 @@ class Serializer {
       const std::string& eventLevel,
       const char* eventIdentifier);
 #endif
+
+  // Returns a semicolon-separated list of ONNX source op names for a QNN op
+  // identifier, or an empty string when tracing is disabled or the op is not
+  // in the lookup. Strips the ":OpId_{N}" HTP profiling suffix before lookup.
+  std::string LookupOnnxSources(const char* identifier) const;
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
   class ManagedSerializationTargetHandle {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1068,7 +1068,8 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                      htp_arch,
                                      soc_model,
                                      op_packages,
-                                     skip_qnn_version_check},
+                                     skip_qnn_version_check,
+                                     enable_framework_op_trace_},
         ApiPtrs{ort_api, ep_api, model_editor_api}, logger_);
     if (htp_share_resource_optimization_ == 1) {
       SharedContext::GetInstance().SetSharedQnnBackendManager(qnn_backend_manager_);
@@ -1880,6 +1881,28 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
   std::basic_string<ORTCHAR_T> model_path = GetModelPathString(graphs[0], ort_api);
   std::basic_string<ORTCHAR_T> context_model_path;
   GetContextOnnxModelFilePath(context_cache_path_cfg_, model_path, context_model_path);
+
+  // AOT Phase 2 sidecar discovery for profiling enrichment. Loaded here
+  // (before any context binary is restored) so the lookup is on the backend
+  // manager when the first profile extraction runs, ensuring InitCsvFile()
+  // emits the `ONNX Source Ops` column and every NODE event row is annotated.
+  if (enable_framework_op_trace_) {
+    auto trace_path = qnn::DeriveTracePathFromContextModel(std::filesystem::path(context_model_path));
+    std::error_code ec;
+    if (std::filesystem::exists(trace_path, ec) && !ec) {
+      qnn::OpTraceLookup loaded;
+      if (qnn::LoadTraceLookupFromFile(trace_path, loaded, logger_)) {
+        qnn_backend_manager_->SetOpTraceLookup(std::move(loaded));
+      }
+    } else {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+                  ("No sidecar op trace found at: " + trace_path.string() +
+                   " - the `ONNX Source Ops` profiling CSV column will be present "
+                   "(framework op trace was requested) but every NODE row's annotation "
+                   "will be empty.")
+                      .c_str());
+    }
+  }
 
   for (auto main_context_pos : main_context_pos_list) {
     // Create QNN context from the cached binary, deserialize the QNN graph from the binary

--- a/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
+++ b/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
@@ -3,10 +3,12 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "nlohmann/json.hpp"
 #include "gtest/gtest.h"
@@ -287,6 +289,141 @@ TEST_F(QnnFrameworkOpTraceUnit, SrcInfoMixedOpTensor) {
   const auto& relu_sources = trace.subgraph_traces[0].op_mappings[1].sources;
   ASSERT_EQ(relu_sources.size(), 1u);
   EXPECT_EQ(relu_sources[0].type, qnn::TraceTargetType::kOp);
+}
+
+// Test DeriveTracePathFromContextModel path derivation (test-safe: no backend needed).
+// Phase 1 writes qnn_op_trace.json; Phase 2 looks in the same directory.
+TEST_F(QnnFrameworkOpTraceUnit, DeriveTracePathFromContextModel_Basic) {
+  // Any context model path → {parent}/qnn_op_trace.json (constant filename)
+  {
+    fs::path ctx = fs::path("/some/dir") / "model_ctx.onnx";
+    fs::path expected = fs::path("/some/dir") / "qnn_op_trace.json";
+    EXPECT_EQ(qnn::DeriveTracePathFromContextModel(ctx), expected);
+  }
+  // Stem-only (no directory component): sibling of the ctx file
+  {
+    fs::path ctx = "mymodel.onnx";
+    fs::path derived = qnn::DeriveTracePathFromContextModel(ctx);
+    EXPECT_EQ(derived.filename().string(), "qnn_op_trace.json");
+  }
+  // No extension — still returns qnn_op_trace.json in the same directory
+  {
+    fs::path ctx = fs::path("/tmp") / "model_ctx";
+    fs::path derived = qnn::DeriveTracePathFromContextModel(ctx);
+    EXPECT_EQ(derived.filename().string(), "qnn_op_trace.json");
+  }
+  // Underscore in stem — filename is always constant, stem of ctx is irrelevant
+  {
+    fs::path ctx = fs::path("/out") / "my_model_ctx.onnx";
+    fs::path expected = fs::path("/out") / "qnn_op_trace.json";
+    EXPECT_EQ(qnn::DeriveTracePathFromContextModel(ctx), expected);
+  }
+}
+
+// ParseTraceLookupFromFile is the test-safe core of LoadTraceLookupFromFile.
+// These tests exercise every TraceLoadStatus branch and the OP/TENSOR type decode
+// without linking the EP library or needing a backend.
+TEST_F(QnnFrameworkOpTraceUnit, ParseTraceLookupFromFile_CannotOpen) {
+  ScopedTempDir tmp;
+  qnn::OpTraceLookup lookup;
+  EXPECT_EQ(qnn::ParseTraceLookupFromFile(tmp.path() / "does_not_exist.json", lookup),
+            qnn::TraceLoadStatus::kCannotOpen);
+  EXPECT_TRUE(lookup.empty());
+}
+
+TEST_F(QnnFrameworkOpTraceUnit, ParseTraceLookupFromFile_ParseError) {
+  ScopedTempDir tmp;
+  fs::path p = tmp.path() / "malformed.json";
+  {
+    std::ofstream ofs(p);
+    ofs << "{ this is not valid json ]";
+  }
+  qnn::OpTraceLookup lookup;
+  EXPECT_EQ(qnn::ParseTraceLookupFromFile(p, lookup), qnn::TraceLoadStatus::kParseError);
+  EXPECT_TRUE(lookup.empty());
+}
+
+TEST_F(QnnFrameworkOpTraceUnit, ParseTraceLookupFromFile_MissingSubgraphTraces) {
+  ScopedTempDir tmp;
+  fs::path p = tmp.path() / "no_key.json";
+  {
+    std::ofstream ofs(p);
+    ofs << R"({"model_name": "m.onnx", "summary": {}})";
+  }
+  qnn::OpTraceLookup lookup;
+  EXPECT_EQ(qnn::ParseTraceLookupFromFile(p, lookup),
+            qnn::TraceLoadStatus::kMissingSubgraphTraces);
+  EXPECT_TRUE(lookup.empty());
+}
+
+TEST_F(QnnFrameworkOpTraceUnit, ParseTraceLookupFromFile_OkWithOpAndTensorSources) {
+  ScopedTempDir tmp;
+  fs::path p = tmp.path() / "trace.json";
+  {
+    // dst "qnn_add" has one OP source and one TENSOR source; dst "qnn_mul"
+    // has a single OP source and the "type" field omitted (defaults to OP).
+    std::ofstream ofs(p);
+    ofs << R"({
+      "subgraph_traces": [
+        {
+          "op_mappings": [
+            {"dst_name": "qnn_add",
+             "sources": [
+               {"name": "onnx_add", "type": "OP"},
+               {"name": "tensor_x", "type": "TENSOR"}
+             ]},
+            {"dst_name": "qnn_mul",
+             "sources": [{"name": "onnx_mul"}]}
+          ]
+        }
+      ]
+    })";
+  }
+  qnn::OpTraceLookup lookup;
+  EXPECT_EQ(qnn::ParseTraceLookupFromFile(p, lookup), qnn::TraceLoadStatus::kOk);
+  ASSERT_EQ(lookup.size(), 2u);
+
+  ASSERT_EQ(lookup.count("qnn_add"), 1u);
+  const auto& add_sources = lookup.at("qnn_add");
+  ASSERT_EQ(add_sources.size(), 2u);
+  EXPECT_EQ(add_sources[0].name, "onnx_add");
+  EXPECT_EQ(add_sources[0].type, qnn::TraceTargetType::kOp);
+  EXPECT_EQ(add_sources[1].name, "tensor_x");
+  EXPECT_EQ(add_sources[1].type, qnn::TraceTargetType::kTensor);
+
+  ASSERT_EQ(lookup.count("qnn_mul"), 1u);
+  const auto& mul_sources = lookup.at("qnn_mul");
+  ASSERT_EQ(mul_sources.size(), 1u);
+  EXPECT_EQ(mul_sources[0].name, "onnx_mul");
+  EXPECT_EQ(mul_sources[0].type, qnn::TraceTargetType::kOp)
+      << "omitted `type` field must default to OP";
+}
+
+TEST_F(QnnFrameworkOpTraceUnit, ParseTraceLookupFromFile_SkipsMalformedEntries) {
+  ScopedTempDir tmp;
+  fs::path p = tmp.path() / "trace.json";
+  {
+    // One subgraph lacks op_mappings (skipped); entries with empty/absent
+    // dst_name or absent sources are skipped; one valid entry survives.
+    std::ofstream ofs(p);
+    ofs << R"({
+      "subgraph_traces": [
+        {"graph_name": "no_op_mappings_here"},
+        {
+          "op_mappings": [
+            {"dst_name": "", "sources": [{"name": "x", "type": "OP"}]},
+            {"dst_name": "missing_sources"},
+            {"dst_name": "good", "sources": [{"name": "onnx_good", "type": "OP"}]}
+          ]
+        }
+      ]
+    })";
+  }
+  qnn::OpTraceLookup lookup;
+  EXPECT_EQ(qnn::ParseTraceLookupFromFile(p, lookup), qnn::TraceLoadStatus::kOk);
+  ASSERT_EQ(lookup.size(), 1u);
+  ASSERT_EQ(lookup.count("good"), 1u);
+  EXPECT_EQ(lookup.at("good").at(0).name, "onnx_good");
 }
 
 // ========================= CPU Backend Integration Tests =========================
@@ -809,7 +946,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase1_TraceWritten) {
   EXPECT_EQ(j["backend_type"], "htp");
 
   // Phase 1 writes only to framework_op_trace_dir; no sidecar alongside the context model.
-  fs::path sidecar_path = ctx_file.parent_path() / "model_ctx_op_trace.json";
+  fs::path sidecar_path = ctx_file.parent_path() / "qnn_op_trace.json";
   EXPECT_FALSE(fs::exists(sidecar_path)) << "No sidecar should be written alongside context model";
 }
 
@@ -844,7 +981,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase1_DisabledNoTrace) {
 
   // No trace file should exist (no trace_dir created, no sidecar)
   EXPECT_TRUE(FindTraceFile(trace_dir).empty()) << "Trace file should not be generated when tracing disabled";
-  fs::path sidecar_path = ctx_file.parent_path() / "model_ctx_op_trace.json";
+  fs::path sidecar_path = ctx_file.parent_path() / "qnn_op_trace.json";
   EXPECT_FALSE(fs::exists(sidecar_path)) << "Sidecar should not be written when tracing disabled";
 }
 
@@ -906,6 +1043,126 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase1_MatchesJIT) {
   // Summary should match
   EXPECT_EQ(jit_j["summary"]["total_qnn_ops"], aot_j["summary"]["total_qnn_ops"]);
   EXPECT_EQ(jit_j["summary"]["supported_nodes"], aot_j["summary"]["supported_nodes"]);
+}
+
+// Test AOT Phase 2 sidecar discovery:
+// when a Phase 1 trace JSON exists alongside the context model,
+// Phase 2 loads it into op_trace_lookup_ without crashing.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase2_SidecarDiscovery) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+  // DeriveTracePathFromContextModel returns {parent}/qnn_op_trace.json — use the
+  // production filename so CompileContextModel actually finds the sidecar.
+  fs::path sidecar_path = tmp.path() / "qnn_op_trace.json";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  // Phase 1: generate context model + trace JSON
+  fs::path phase1_trace_dir = tmp.path() / "phase1_trace";
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = phase1_trace_dir.string();
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file)) << "Context model not generated in Phase 1";
+  auto phase1_trace_file = FindTraceFile(phase1_trace_dir);
+  ASSERT_FALSE(phase1_trace_file.empty()) << "No Phase 1 trace file found";
+
+  // Place sidecar trace file alongside context model (DeriveTracePathFromContextModel convention)
+  std::error_code ec;
+  fs::copy_file(phase1_trace_file, sidecar_path, ec);
+  ASSERT_FALSE(ec) << "Failed to copy trace sidecar: " << ec.message();
+  ASSERT_TRUE(fs::exists(sidecar_path));
+
+  // Phase 2: load context model with tracing enabled; the sidecar is discovered
+  // and loaded. framework_op_trace_dir points at a dedicated, initially-empty
+  // directory so the "no new trace file" check below is unambiguous — tmp.path()
+  // already holds the sidecar (qnn_op_trace.json), whose stem FindTraceFile matches.
+  fs::path phase2_trace_dir = tmp.path() / "phase2_trace";
+  fs::create_directories(phase2_trace_dir);
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = phase2_trace_dir.string();
+    opts["disable_file_mapped_weights"] = "1";
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    // Should not throw — sidecar is found and loaded without error
+    ASSERT_NO_THROW(Ort::Session session(*ort_env, ctx_file.c_str(), so));
+  }
+
+  // Loading a pre-compiled context model runs no ComposeGraph, so Phase 2 writes
+  // no new trace file. The dedicated Phase 2 directory therefore stays empty.
+  EXPECT_TRUE(FindTraceFile(phase2_trace_dir).empty())
+      << "Phase 2 (context-model load) should not write a new trace file";
+}
+
+// Test AOT Phase 2 with tracing enabled but NO sidecar file — should work fine (no crash).
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase2_NoSidecar_StillWorks) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  // Phase 1: generate context model WITHOUT trace
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file));
+  // Verify no sidecar was auto-created
+  fs::path sidecar_path = tmp.path() / "qnn_op_trace.json";
+  ASSERT_FALSE(fs::exists(sidecar_path)) << "No sidecar should exist when Phase 1 had tracing disabled";
+
+  // Phase 2: load context model with tracing enabled but no sidecar present
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["disable_file_mapped_weights"] = "1";
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    // Should not throw even though no sidecar exists
+    ASSERT_NO_THROW(Ort::Session session(*ort_env, ctx_file.c_str(), so));
+  }
 }
 
 // ========================= Mixed EPContext Model Integration Tests =========================
@@ -1410,6 +1667,450 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_ReshapeEinsumReshape) {
         << "Each N:M fusion entry should reference all 3 ONNX source ops "
            "(reshape1, einsum, reshape2)";
   }
+}
+
+// ========================= Profiling + Tracing Combination Tests =========================
+//
+// These tests verify the interaction between qnn.profiling_level and qnn.enable_framework_op_trace.
+//
+// Design notes:
+// - The ONNX Source Ops field only appears in the CSV when profiling_level is
+//   DETAILED or OPTRACE (HasNodeLevelProfiling() == true) AND tracing is on.
+// - At BASIC level profiling, no QNN_PROFILE_EVENTTYPE_NODE events are emitted,
+//   so annotation would always be empty — the field is suppressed entirely.
+// - CSV header is written once when the file is first created; its field count
+//   is the reliable indicator because it is set unconditionally at file creation.
+
+// Helper: return the first line (header) of a CSV file.
+static std::string ReadCsvHeader(const fs::path& csv_path) {
+  std::ifstream ifs(csv_path);
+  if (!ifs.is_open()) return {};
+  std::string line;
+  std::getline(ifs, line);
+  return line;
+}
+
+// Helper: count comma-separated fields in a CSV line.
+static size_t CountCsvColumns(const std::string& csv_line) {
+  if (csv_line.empty()) return 0;
+  return static_cast<size_t>(std::count(csv_line.begin(), csv_line.end(), ',')) + 1;
+}
+
+// Helper: count rows (excluding header) of a given event type string.
+static size_t CountCsvRowsByMessage(const fs::path& csv_path, const std::string& message) {
+  std::ifstream ifs(csv_path);
+  if (!ifs.is_open()) return 0;
+  std::string line;
+  std::getline(ifs, line);  // skip header
+  size_t count = 0;
+  while (std::getline(ifs, line)) {
+    if (line.find(message) != std::string::npos) ++count;
+  }
+  return count;
+}
+
+// Helper: collect non-empty ONNX Source Ops values from NODE rows.
+static std::vector<std::string> CollectOnnxSourcesFromNodeRows(const fs::path& csv_path) {
+  std::vector<std::string> result;
+  std::ifstream ifs(csv_path);
+  if (!ifs.is_open()) return result;
+  std::string header;
+  std::getline(ifs, header);
+  // Check for "ONNX Source Ops" field in header
+  if (header.find("ONNX Source Ops") == std::string::npos) return result;
+  std::string line;
+  while (std::getline(ifs, line)) {
+    if (line.find("NODE") == std::string::npos) continue;
+    // Last field (after the last comma)
+    auto pos = line.rfind(',');
+    if (pos == std::string::npos) continue;
+    std::string onnx_col = line.substr(pos + 1);
+    if (!onnx_col.empty()) result.push_back(onnx_col);
+  }
+  return result;
+}
+
+// Test: profiling_level=detailed + enable_framework_op_trace=1
+// Expect: CSV header includes "ONNX Source Ops" field.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_Detailed_With_Trace) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path csv_path = tmp.path() / "profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["profiling_level"] = "detailed";
+  opts["profiling_file_path"] = csv_path.string();
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data),
+                              TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+
+  ASSERT_TRUE(fs::exists(csv_path)) << "Profiling CSV not created";
+  std::string header = ReadCsvHeader(csv_path);
+  EXPECT_FALSE(header.empty()) << "CSV header is empty";
+  EXPECT_EQ(CountCsvColumns(header), 8u)
+      << "Expected 8 columns (with ONNX Source Ops) but got: " << header;
+  EXPECT_NE(header.find("ONNX Source Ops"), std::string::npos)
+      << "ONNX Source Ops column missing from header: " << header;
+}
+
+// Test: profiling_level=basic + enable_framework_op_trace=1
+// Expect: CSV header has no "ONNX Source Ops" field — basic has no NODE events.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_Basic_With_Trace) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path csv_path = tmp.path() / "profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["profiling_level"] = "basic";
+  opts["profiling_file_path"] = csv_path.string();
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data),
+                              TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+
+  ASSERT_TRUE(fs::exists(csv_path)) << "Profiling CSV not created";
+  std::string header = ReadCsvHeader(csv_path);
+  EXPECT_FALSE(header.empty()) << "CSV header is empty";
+  EXPECT_EQ(CountCsvColumns(header), 7u)
+      << "Expected 7 columns (no ONNX Source Ops at basic level) but got: " << header;
+  EXPECT_EQ(header.find("ONNX Source Ops"), std::string::npos)
+      << "ONNX Source Ops column should not appear at basic level";
+}
+
+// Test: profiling_level=detailed WITHOUT enable_framework_op_trace
+// Expect: CSV header has no "ONNX Source Ops" field — tracing disabled.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_Detailed_Without_Trace) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path csv_path = tmp.path() / "profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["profiling_level"] = "detailed";
+  opts["profiling_file_path"] = csv_path.string();
+  // enable_framework_op_trace intentionally NOT set
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data),
+                              TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+
+  ASSERT_TRUE(fs::exists(csv_path)) << "Profiling CSV not created";
+  std::string header = ReadCsvHeader(csv_path);
+  EXPECT_FALSE(header.empty()) << "CSV header is empty";
+  EXPECT_EQ(CountCsvColumns(header), 7u)
+      << "Expected 7 columns (no tracing) but got: " << header;
+  EXPECT_EQ(header.find("ONNX Source Ops"), std::string::npos)
+      << "ONNX Source Ops column should not appear when tracing is disabled";
+}
+
+// Test: profiling_level=detailed + enable_framework_op_trace=1 + inference run
+// Expect: NODE rows in the CSV have ONNX Source Ops populated (non-empty).
+// This verifies the end-to-end join: trace op name == profiling event identifier.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_Detailed_With_Trace_NodeRowsAnnotated) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path csv_path = tmp.path() / "profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["profiling_level"] = "detailed";
+  opts["profiling_file_path"] = csv_path.string();
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data),
+                              TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+
+  ASSERT_TRUE(fs::exists(csv_path)) << "Profiling CSV not created";
+
+  // Verify header has the ONNX annotation field.
+  std::string header = ReadCsvHeader(csv_path);
+  ASSERT_EQ(CountCsvColumns(header), 8u) << "Expected 8 columns: " << header;
+
+  // DETAILED profiling emits per-NODE events (HasNodeLevelProfiling() is true),
+  // and every NODE row carries an ONNX source annotation. Assert the NODE count
+  // is non-zero first, then that the rows are annotated.
+  size_t node_row_count = CountCsvRowsByMessage(csv_path, ",NODE,");
+  ASSERT_GT(node_row_count, 0u)
+      << "DETAILED profiling expected to emit NODE events but CSV has none";
+  auto annotated = CollectOnnxSourcesFromNodeRows(csv_path);
+  EXPECT_GT(annotated.size(), 0u)
+      << "NODE rows exist but none have ONNX Source Ops annotation";
+}
+
+// Test: profiling_level=optrace + enable_framework_op_trace=1
+// Expect: CSV header includes "ONNX Source Ops" field and NODE rows are annotated (same as detailed).
+// optrace is the highest-value profiling level: hardware-level cycles/bandwidth per op.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_OpTrace_With_Trace) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path csv_path = tmp.path() / "profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["profiling_level"] = "optrace";
+  opts["profiling_file_path"] = csv_path.string();
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = tmp.path().string();
+#if defined(__linux__) && !defined(__aarch64__)
+  opts["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data),
+                              TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain),
+      opts, 13, ExpectedEPNodeAssignment::All, 5e-3f);
+
+  ASSERT_TRUE(fs::exists(csv_path)) << "Profiling CSV not created";
+
+  // optrace triggers HasNodeLevelProfiling() == true, same as detailed.
+  std::string header = ReadCsvHeader(csv_path);
+  EXPECT_FALSE(header.empty()) << "CSV header is empty";
+  EXPECT_EQ(CountCsvColumns(header), 8u)
+      << "Expected 8 columns (ONNX Source Ops present) but got: " << header;
+  EXPECT_NE(header.find("ONNX Source Ops"), std::string::npos)
+      << "ONNX Source Ops column missing from header: " << header;
+
+  // OPTRACE profiling emits per-NODE events (HasNodeLevelProfiling() is true),
+  // and every NODE row carries an ONNX source annotation.
+  size_t node_row_count = CountCsvRowsByMessage(csv_path, ",NODE,");
+  ASSERT_GT(node_row_count, 0u)
+      << "OPTRACE profiling expected to emit NODE events but CSV has none";
+  auto annotated = CollectOnnxSourcesFromNodeRows(csv_path);
+  EXPECT_GT(annotated.size(), 0u)
+      << "NODE rows exist but none have ONNX Source Ops annotation";
+}
+
+// Test: AOT Phase 2 (pre-compiled context model) end-to-end profiling join.
+// In Phase 1 a context model and its sidecar (qnn_op_trace.json) are generated.
+// In Phase 2 the sidecar is discovered next to the context model, loaded via
+// LoadTraceLookupFromFile, and used to annotate the profiling CSV produced by an
+// inference run. With profiling_level=detailed + profiling_file_path set, the
+// test asserts the loaded sidecar annotates the NODE rows with ONNX sources.
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase2_SidecarAnnotatesProfiling) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+  fs::path csv_path = tmp.path() / "phase2_profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  // Phase 1: generate context model + sidecar trace. framework_op_trace_dir is
+  // set to the context model's directory so the sidecar is written as
+  // {tmp}/qnn_op_trace.json — exactly where DeriveTracePathFromContextModel
+  // looks in Phase 2 (no manual copy needed).
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = tmp.path().string();
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+
+  ASSERT_TRUE(fs::exists(ctx_file)) << "Context model not generated in Phase 1";
+  fs::path sidecar_path = tmp.path() / "qnn_op_trace.json";
+  ASSERT_TRUE(fs::exists(sidecar_path))
+      << "Phase 1 should write the sidecar next to the context model";
+
+  // Phase 2: load context model with tracing + detailed profiling, run inference.
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = tmp.path().string();
+    opts["profiling_level"] = "detailed";
+    opts["profiling_file_path"] = csv_path.string();
+    opts["disable_file_mapped_weights"] = "1";  // avoid DMA path crash with App Verifier
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, ctx_file.c_str(), so);
+
+    auto input_names = session.GetInputNames();
+    auto output_names = session.GetOutputNames();
+
+    std::vector<float> input_data(6, 1.0f);
+    std::vector<int64_t> input_shape = {1, 2, 3};
+
+    Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    std::vector<Ort::Value> inputs;
+    for (size_t i = 0; i < input_names.size(); ++i) {
+      inputs.push_back(Ort::Value::CreateTensor<float>(
+          mem_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size()));
+    }
+
+    std::vector<const char*> input_name_ptrs;
+    for (const auto& name : input_names) input_name_ptrs.push_back(name.c_str());
+    std::vector<const char*> output_name_ptrs;
+    for (const auto& name : output_names) output_name_ptrs.push_back(name.c_str());
+
+    auto outputs = session.Run(Ort::RunOptions{nullptr},
+                               input_name_ptrs.data(), inputs.data(), inputs.size(),
+                               output_name_ptrs.data(), output_name_ptrs.size());
+    EXPECT_GT(outputs.size(), 0u) << "Phase 2 inference should produce output";
+  }
+
+  // The sidecar must have been discovered and joined to the Phase 2 profiling CSV.
+  ASSERT_TRUE(fs::exists(csv_path)) << "Phase 2 profiling CSV not created";
+  std::string header = ReadCsvHeader(csv_path);
+  EXPECT_NE(header.find("ONNX Source Ops"), std::string::npos)
+      << "ONNX Source Ops column missing — sidecar lookup not applied: " << header;
+
+  size_t node_row_count = CountCsvRowsByMessage(csv_path, ",NODE,");
+  ASSERT_GT(node_row_count, 0u)
+      << "Detailed profiling expected to emit NODE events but Phase 2 CSV has none";
+  auto annotated = CollectOnnxSourcesFromNodeRows(csv_path);
+  EXPECT_GT(annotated.size(), 0u)
+      << "Phase 2 NODE rows exist but none annotated — sidecar→profiling join failed";
+}
+
+// AOT Phase 2 with framework op trace + detailed profiling enabled, but no
+// sidecar next to the context model. Verifies the column-stability contract:
+//   - the `ONNX Source Ops` column appears in the CSV header (the gate is the
+//     session-stable enable_framework_op_trace_ flag, not lookup emptiness, so
+//     header and per-row column counts always agree),
+//   - every NODE row's annotation cell is empty (the lookup is empty, so every
+//     LookupOnnxSources() returns ""),
+// distinguishing "trace requested but no source data" from "trace not requested".
+TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase2_NoSidecar_EmitsEmptyColumn) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ScopedTempDir tmp;
+  fs::path ctx_file = tmp.path() / "model_ctx.onnx";
+  fs::path csv_path = tmp.path() / "phase2_no_sidecar_profiling.csv";
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::string model_data = BuildModelData(
+      BuildOpTestCase<float>("add_node", "Add",
+                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {}, {}, kOnnxDomain));
+
+  // Phase 1: generate context model WITHOUT trace, so no sidecar is produced.
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_file.string().c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+  }
+  ASSERT_TRUE(fs::exists(ctx_file));
+  ASSERT_FALSE(fs::exists(tmp.path() / "qnn_op_trace.json"))
+      << "Phase 1 had tracing disabled, so no sidecar should exist";
+
+  // Phase 2: load context model with tracing + detailed profiling, run inference.
+  // No sidecar exists → lookup stays empty.
+  {
+    ProviderOptions opts;
+    opts["backend_type"] = "htp";
+    opts["offload_graph_io_quantization"] = "0";
+    opts["enable_framework_op_trace"] = "1";
+    opts["framework_op_trace_dir"] = tmp.path().string();
+    opts["profiling_level"] = "detailed";
+    opts["profiling_file_path"] = csv_path.string();
+    opts["disable_file_mapped_weights"] = "1";
+
+    Ort::SessionOptions so;
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, "QNNExecutionProvider", opts);
+    Ort::Session session(*ort_env, ctx_file.c_str(), so);
+
+    auto input_names = session.GetInputNames();
+    auto output_names = session.GetOutputNames();
+    std::vector<float> input_data(6, 1.0f);
+    std::vector<int64_t> input_shape = {1, 2, 3};
+    Ort::MemoryInfo mem_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    std::vector<Ort::Value> inputs;
+    for (size_t i = 0; i < input_names.size(); ++i) {
+      inputs.push_back(Ort::Value::CreateTensor<float>(
+          mem_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size()));
+    }
+    std::vector<const char*> input_name_ptrs;
+    for (const auto& name : input_names) input_name_ptrs.push_back(name.c_str());
+    std::vector<const char*> output_name_ptrs;
+    for (const auto& name : output_names) output_name_ptrs.push_back(name.c_str());
+    auto outputs = session.Run(Ort::RunOptions{nullptr},
+                               input_name_ptrs.data(), inputs.data(), inputs.size(),
+                               output_name_ptrs.data(), output_name_ptrs.size());
+    EXPECT_GT(outputs.size(), 0u);
+  }
+
+  ASSERT_TRUE(fs::exists(csv_path)) << "Phase 2 profiling CSV not created";
+  std::string header = ReadCsvHeader(csv_path);
+  // Column IS present — gate is session-stable enable_framework_op_trace_ flag.
+  EXPECT_NE(header.find("ONNX Source Ops"), std::string::npos)
+      << "ONNX Source Ops column should still be in header (column-stability invariant): " << header;
+
+  size_t node_row_count = CountCsvRowsByMessage(csv_path, ",NODE,");
+  ASSERT_GT(node_row_count, 0u)
+      << "Detailed profiling expected to emit NODE events but CSV has none";
+  // No sidecar means the lookup is empty → every NODE row's annotation cell is empty.
+  auto annotated = CollectOnnxSourcesFromNodeRows(csv_path);
+  EXPECT_EQ(annotated.size(), 0u)
+      << "Without a sidecar the annotation column should be present but every cell empty; "
+      << "got " << annotated.size() << " non-empty annotations";
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
+++ b/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
@@ -1675,7 +1675,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_ReshapeEinsumReshape) {
 //
 // Design notes:
 // - The ONNX Source Ops field only appears in the CSV when profiling_level is
-//   DETAILED or OPTRACE (HasNodeLevelProfiling() == true) AND tracing is on.
+//   DETAILED or OPTRACE (per-NODE events emitted) AND tracing is on.
 // - At BASIC level profiling, no QNN_PROFILE_EVENTTYPE_NODE events are emitted,
 //   so annotation would always be empty — the field is suppressed entirely.
 // - CSV header is written once when the file is first created; its field count
@@ -1867,7 +1867,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_Detailed_With_Trace_NodeRo
   std::string header = ReadCsvHeader(csv_path);
   ASSERT_EQ(CountCsvColumns(header), 8u) << "Expected 8 columns: " << header;
 
-  // DETAILED profiling emits per-NODE events (HasNodeLevelProfiling() is true),
+  // DETAILED profiling emits per-NODE events,
   // and every NODE row carries an ONNX source annotation. Assert the NODE count
   // is non-zero first, then that the rows are annotated.
   size_t node_row_count = CountCsvRowsByMessage(csv_path, ",NODE,");
@@ -1907,7 +1907,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_OpTrace_With_Trace) {
 
   ASSERT_TRUE(fs::exists(csv_path)) << "Profiling CSV not created";
 
-  // optrace triggers HasNodeLevelProfiling() == true, same as detailed.
+  // optrace triggers per-NODE events to be emitted, same as detailed.
   std::string header = ReadCsvHeader(csv_path);
   EXPECT_FALSE(header.empty()) << "CSV header is empty";
   EXPECT_EQ(CountCsvColumns(header), 8u)
@@ -1915,7 +1915,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_Profiling_OpTrace_With_Trace) {
   EXPECT_NE(header.find("ONNX Source Ops"), std::string::npos)
       << "ONNX Source Ops column missing from header: " << header;
 
-  // OPTRACE profiling emits per-NODE events (HasNodeLevelProfiling() is true),
+  // OPTRACE profiling emits per-NODE events,
   // and every NODE row carries an ONNX source annotation.
   size_t node_row_count = CountCsvRowsByMessage(csv_path, ",NODE,");
   ASSERT_GT(node_row_count, 0u)


### PR DESCRIPTION
Add two follow-up features to the framework op tracing implementation:

1. Profiling <-> trace auto-merge (JIT and AOT Phase 2)
   - Extend profiling output with onnx op column when the profiling level is detailed or optrace.

2. AOT Phase 2 sidecar discovery
   - Check and load a Phase 1 trace JSON placed alongside the context model.

Tests and documentation
 - Add unit tests.
 - New `## QNN EP Framework Op Tracing` section in `QNN-ExecutionProvider.md` covering output file naming and the zero-step Phase 1->2 sidecar workflow.


