### PR TITLE
[CI] Reduce unnecessary CI workload on PRs

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test-single-os.yml
@@ -10,6 +10,14 @@ permissions:
 on:
   workflow_call:
     inputs: &common_inputs
+      has_code_changes:
+        description: |
+          If false, the job runs checkout + (skipped) steps only and skips ALL heavy work
+          (submodule init, build, tests, uploads), reporting success so required status checks
+          stay green on PRs that don't touch code. Defaults to true so release callers
+          (build-artifacts.yml) and direct workflow_dispatch are unaffected.
+        default: true
+        type: boolean
       target_os:
         description: "The OS for which to build: windows or linux"
         default: windows
@@ -139,10 +147,14 @@ jobs:
         shell: "${{ inputs.target_os == 'windows' && 'cmd' || 'bash' }}"
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        # Submodules omitted here; initialized below only when a heavy build is needed, so
+        # has_code_changes=false jobs skip the expensive recursive fetch while still reporting green.
+      - name: Initialize submodules
+        if: ${{ inputs.has_code_changes }}
+        run: git submodule update --init --recursive
 
       - name: Build ${{inputs.target_os}} ${{ inputs.target_arch }} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
+        if: ${{ inputs.has_code_changes }}
         run: >
           "${{ inputs.target_os == 'windows' && 'python.exe' || 'python3' }}"
           qcom/build_and_test.py
@@ -154,7 +166,7 @@ jobs:
           ${{inputs.upload_test_archive == true && 'archive' || 'build'}}_ort_${{inputs.target_os}}_${{ inputs.target_arch }}
 
       - name: Test ${{inputs.target_os}} ${{ inputs.target_arch }} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
-        if: ${{ inputs.run_tests && inputs.build_test_same_runner }}
+        if: ${{ inputs.has_code_changes && inputs.run_tests && inputs.build_test_same_runner }}
         run: >
           "${{ inputs.target_os == 'windows' && 'python.exe' || 'python3' }}"
           qcom/build_and_test.py
@@ -165,7 +177,7 @@ jobs:
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         # Skipped on fork PRs: the action creates a check run, which the fork-PR GITHUB_TOKEN cannot do.
-        if: ${{ always() && inputs.run_tests && inputs.build_test_same_runner && github.event.pull_request.head.repo.fork != true }}
+        if: ${{ always() && inputs.has_code_changes && inputs.run_tests && inputs.build_test_same_runner && github.event.pull_request.head.repo.fork != true }}
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}-test-results
           group_reports: false
@@ -177,7 +189,7 @@ jobs:
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v7
-        if: ${{ always() && inputs.run_tests && inputs.build_test_same_runner }} # always run even if the previous step fails
+        if: ${{ always() && inputs.has_code_changes && inputs.run_tests && inputs.build_test_same_runner }} # always run even if the previous step fails
         with:
           name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Test Results
           retention-days: 7
@@ -186,7 +198,7 @@ jobs:
 
       # Artifactory steps are no-ops on fork PRs (secrets unavailable). The build/in-runner tests still validate the change.
       - name: Setup JFrog CLI
-        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -196,49 +208,49 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Upload Test Archive to Artifactory
-        if: ${{ inputs.upload_test_archive && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_test_archive && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-tests"
           src_pattern: "onnxruntime-tests-${{inputs.target_os}}-${{ inputs.target_arch }}.${{ env.TEST_ARCHIVE_EXT }}"
 
       - name: Upload Wheel to Artifactory
-        if: ${{ inputs.upload_wheel && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_wheel && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-wheels"
           src_pattern: "${{ inputs.target_os }}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime_qnn*.whl"
 
       - name: Upload NuGet to Artifactory
-        if: ${{ inputs.upload_nuget && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_nuget && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-nuget"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/Qualcomm.ML.OnnxRuntime.QNN*.nupkg"
 
       - name: Upload Archive to Artifactory
-        if: ${{ inputs.upload_archive && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_archive && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-${{ inputs.build_config != 'Release' && format('{0}-', inputs.build_config) || '' }}${{ inputs.target_os == 'linux' && 'tgz' || 'zip' }}"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/dist/onnxruntime-qnn*.${{ inputs.target_os == 'linux' && 'tgz' || 'zip' }}"
 
       - name: Upload AAR to Artifactory
-        if: ${{ inputs.upload_aar && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_aar && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{inputs.target_os}}-${{ inputs.target_arch }}-aar"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.aar"
 
       - name: Upload POM to Artifactory
-        if: ${{ inputs.upload_aar && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_aar && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{inputs.target_os}}-${{ inputs.target_arch }}-pom"
           src_pattern: "${{inputs.target_os}}-${{ inputs.target_arch }}/${{ env.BUILD_CONFIG_DIR }}/java/build/android-qnn-ep/outputs/aar/onnxruntime-android-qnn.pom"
 
       - name: Build Windows ${{ inputs.target_arch }} PDB Archive
-        if: ${{ inputs.build_pdb_archive && inputs.target_os == 'windows' }}
+        if: ${{ inputs.has_code_changes && inputs.build_pdb_archive && inputs.target_os == 'windows' }}
         run: >
           python.exe tools/ci_build/pkg_assets.py
           --source_dir ${{ github.workspace }}
@@ -250,7 +262,7 @@ jobs:
           ${{ env.ORT_VERSION_SUFFIX != '' && format('--version_suffix {0}', env.ORT_VERSION_SUFFIX) || '' }}
 
       - name: Upload PDB Archive to Artifactory
-        if: ${{ inputs.upload_pdb_archive && inputs.target_os == 'windows' && env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ inputs.has_code_changes && inputs.upload_pdb_archive && inputs.target_os == 'windows' && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{ inputs.target_py_vsn }}-pdb-zip"
@@ -267,10 +279,13 @@ jobs:
         shell: "${{ inputs.target_os == 'windows' && 'cmd' || 'bash' }}"
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        # Submodules omitted here; initialized below only when a heavy test run is needed.
+      - name: Initialize submodules
+        if: ${{ inputs.has_code_changes }}
+        run: git submodule update --init --recursive
 
       - name: Setup JFrog CLI
+        if: ${{ inputs.has_code_changes }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -280,17 +295,19 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Download Tests from Artifactory
+        if: ${{ inputs.has_code_changes }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-tests"
 
       - name: Download testdata from Artifactory
-        if: ${{ inputs.testdata_archive_artifact_name != '' }}
+        if: ${{ inputs.has_code_changes && inputs.testdata_archive_artifact_name != '' }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: ${{ inputs.testdata_archive_artifact_name }}
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}
+        if: ${{ inputs.has_code_changes }}
         run: >
           "${{ inputs.target_os == 'windows' && 'python.exe' || 'python3' }}"
           qcom/build_and_test.py
@@ -301,7 +318,7 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
-        if: always() # always run even if the previous step fails
+        if: ${{ always() && inputs.has_code_changes }} # always run even if the previous step fails
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}}-test-results
           group_reports: false
@@ -313,7 +330,7 @@ jobs:
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v7
-        if: always() # always run even if the previous step fails
+        if: ${{ always() && inputs.has_code_changes }} # always run even if the previous step fails
         with:
           name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Test Results
           retention-days: 7
@@ -331,10 +348,13 @@ jobs:
         shell: "${{ inputs.target_os == 'windows' && 'cmd' || 'bash' }}"
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        # Submodules omitted here; initialized below only when a heavy wheel smoke test is needed.
+      - name: Initialize submodules
+        if: ${{ inputs.has_code_changes }}
+        run: git submodule update --init --recursive
 
       - name: Setup JFrog CLI
+        if: ${{ inputs.has_code_changes }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -344,11 +364,13 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Download Wheel from Artifactory
+        if: ${{ inputs.has_code_changes }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-py${{inputs.target_py_vsn}}-wheels"
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} py${{ inputs.target_py_vsn != 'None' && inputs.target_py_vsn || 'none'}} Wheel
+        if: ${{ inputs.has_code_changes }}
         run: >
           "${{ inputs.target_os == 'windows' && 'python.exe' || 'python3' }}"
           qcom/build_and_test.py

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -41,12 +41,63 @@ jobs:
     uses: ./.github/workflows/qualcomm-internal-archive-testdata.yml
     secrets: inherit
 
+  # Single change-detection gate (DRY): computes whether the diff touches code that needs a
+  # real build/test. Downstream required jobs consume this via the `has_code_changes` input and stay
+  # green even when it's false (they cannot be job-skipped without blocking the PR); non-required
+  # jobs gate at the job level. Mirrors the git-diff idiom already used by coverage.yml/asan.yml.
+  path-filter:
+    name: path-filter
+    runs-on: ["self-hosted", "X64", "Linux", "Build"]
+    outputs:
+      code: ${{ steps.gate.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # No submodules: the gate only needs git history, not the working tree.
+      - name: Detect changed paths
+        id: gate
+        run: |
+          set -euo pipefail
+
+          # Non-PR events (push to main/rel-*, merge_group, workflow_dispatch) always do a full
+          # build. merge_group has no usable base_ref, so short-circuit before the diff.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          base_ref="${{ github.base_ref }}"
+          if [ -z "${base_ref}" ]; then
+            echo "::error::github.base_ref is empty (event_name=${{ github.event_name }})"
+            exit 1
+          fi
+
+          if ! changed=$(git diff --name-only "origin/${base_ref}...HEAD"); then
+            echo "::error::git diff against origin/${base_ref}...HEAD failed"
+            exit 1
+          fi
+
+          # Build needed when any changed path is code-bearing. We invert a small docs-only
+          # allowlist: if any changed path is NOT docs (grep -qv), do a full build. This fails
+          # safe toward building (unknown/new paths build) and means CI workflow edits, qcom/
+          # scripts, cmake, sources, etc. all trigger a build without an explicit per-dir list.
+          if echo "${changed}" | grep -qvE \
+              -e '^docs/' \
+              -e '^[^/]+\.md$' \
+              -e '^LICENSE$'; then
+            echo "code=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "code=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   build-and-test-linux-x86_64:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: x86_64
@@ -58,10 +109,11 @@ jobs:
 
   build-linux-aarch64-oe-gcc11_2:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: aarch64_oe_gcc11_2
@@ -74,20 +126,22 @@ jobs:
   test-linux-aarch64-oe-gcc11_2:
     # Downstream tests need the Artifactory upload from build-linux-aarch64-oe-gcc11_2; skip on fork PRs.
     if: ${{ inputs.do_all && github.event.pull_request.head.repo.fork != true }}
-    needs: [build-linux-aarch64-oe-gcc11_2]
+    needs: [build-linux-aarch64-oe-gcc11_2, path-filter]
     uses: ./.github/workflows/qualcomm-internal-qdc-test.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       target_os: linux
       target_arch: aarch64_oe_gcc11_2
       testdata_archive_artifact_name: testdata-tarbz2
 
   build-and-test-linux-x86_64-ubuntu-22-04:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: x86_64_ubuntu_22_04
@@ -100,10 +154,11 @@ jobs:
 
   build-and-test-linux-arm64:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       nightly_build: ${{ inputs.nightly_build }}
       target_os: linux
       target_arch: aarch64_manylinux_2_34
@@ -118,10 +173,11 @@ jobs:
 
   build-and-test-windows-arm64:
     if: ${{ inputs.do_all || inputs.do_windows_arm64 }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       target_arch: arm64
       testdata_archive_artifact_name: testdata-zip
       build_runner_arch: ${{ inputs.windows_arm64_runner_arch }}
@@ -134,10 +190,11 @@ jobs:
 
   build-and-test-windows-arm64ec:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       nightly_build: ${{ inputs.nightly_build }}
       target_arch: arm64ec
       testdata_archive_artifact_name: testdata-zip
@@ -149,10 +206,11 @@ jobs:
 
   build-and-test-windows-x86_64:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     uses: ./.github/workflows/qualcomm-internal-build-and-test-single-os.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       nightly_build: ${{ inputs.nightly_build }}
       target_arch: x86_64
       testdata_archive_artifact_name: testdata-zip
@@ -172,16 +230,18 @@ jobs:
 
   build-android-aarch64:
     if: ${{ inputs.do_all }}
-    needs: [archive-testdata]
+    needs: [archive-testdata, path-filter]
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        # Submodules omitted here; initialized below only when a build is needed.
+      - name: Initialize submodules
+        if: ${{ needs['path-filter'].outputs.code == 'true' }}
+        run: git submodule update --init --recursive
 
       # Artifactory steps are no-ops on fork PRs (secrets unavailable). The build still validates the change.
       - name: Setup JFrog CLI
-        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ needs['path-filter'].outputs.code == 'true' && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -191,11 +251,12 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Build Android
+        if: ${{ needs['path-filter'].outputs.code == 'true' }}
         run: |
           python3 qcom/build_and_test.py archive_ort_android_aarch64
 
       - name: Upload Test Archive to Artifactory
-        if: ${{ env.BUILD_ARTIFACTORY_REPO != '' }}
+        if: ${{ needs['path-filter'].outputs.code == 'true' && env.BUILD_ARTIFACTORY_REPO != '' }}
         uses: ./.github/actions/upload-ci-artifact
         with:
           name: "android-aarch64-pyNone-tests"
@@ -204,10 +265,11 @@ jobs:
   test-android-aarch64:
     # Downstream tests need the Artifactory upload from build-android-aarch64; skip on fork PRs.
     if: ${{ inputs.do_all && github.event.pull_request.head.repo.fork != true }}
-    needs: [build-android-aarch64]
+    needs: [build-android-aarch64, path-filter]
     uses: ./.github/workflows/qualcomm-internal-qdc-test.yml
     secrets: inherit
     with:
+      has_code_changes: ${{ needs['path-filter'].outputs.code == 'true' }}
       target_os: android
       target_arch: aarch64
       testdata_archive_artifact_name: testdata-zip

--- a/.github/workflows/qualcomm-internal-ci-trigger.yml
+++ b/.github/workflows/qualcomm-internal-ci-trigger.yml
@@ -1,0 +1,64 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+# Lets developers trigger CI on a draft PR by commenting "/ci" on the PR.
+# Useful because draft PRs don't auto-trigger CI (see qualcomm-internal-ci.yml).
+#
+# Any collaborator with write access (COLLABORATOR, MEMBER, OWNER) may trigger.
+# Fork contributors (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, etc.) are rejected to
+# prevent unprivileged access to internal runners and secrets.
+
+name: Qualcomm Internal CI Trigger
+
+permissions:
+  contents: read
+  pull-requests: write  # to post the acknowledgement comment
+  actions: write        # to dispatch qualcomm-internal-ci.yml via createWorkflowDispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger:
+    name: Trigger CI from PR comment
+    # Only act on PR comments (not issue comments) containing "/ci".
+    # Require write-level association so fork contributors cannot trigger builds.
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/ci') &&
+      contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'),
+               github.event.comment.author_association)
+    runs-on: ["self-hosted", "X64", "Linux", "Build"]
+    steps:
+      - name: Dispatch CI workflow on PR branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Fetch the PR to get its head branch and draft status.
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const branch = pr.data.head.ref;
+            const isDraft = pr.data.draft;
+            const prUrl = pr.data.html_url;
+
+            // Dispatch the main CI workflow on the PR's head branch.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'qualcomm-internal-ci.yml',
+              ref: branch,
+            });
+
+            // Post an acknowledgement comment so the developer has a clear signal.
+            const draftNote = isDraft ? ' (draft PR — CI was skipped on push)' : '';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🔄 CI triggered on \`${branch}\`${draftNote} by @${context.actor}. Check the [Actions tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions) for progress.`,
+            });

--- a/.github/workflows/qualcomm-internal-ci-trigger.yml
+++ b/.github/workflows/qualcomm-internal-ci-trigger.yml
@@ -22,11 +22,13 @@ on:
 jobs:
   trigger:
     name: Trigger CI from PR comment
-    # Only act on PR comments (not issue comments) containing "/ci".
+    # Only act on PR comments whose body is exactly "/ci" or starts with "/ci " or "/ci\n".
     # Require write-level association so fork contributors cannot trigger builds.
     if: |
       github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '/ci') &&
+      (github.event.comment.body == '/ci' ||
+       startsWith(github.event.comment.body, '/ci ') ||
+       startsWith(github.event.comment.body, '/ci\n')) &&
       contains(fromJSON('["COLLABORATOR", "MEMBER", "OWNER"]'),
                github.event.comment.author_association)
     runs-on: ["self-hosted", "X64", "Linux", "Build"]

--- a/.github/workflows/qualcomm-internal-ci.yml
+++ b/.github/workflows/qualcomm-internal-ci.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches: [main, rel-*, rel/**/*]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, rel-*, rel/**/*]
   merge_group:
     types: [checks_requested]
@@ -28,17 +29,21 @@ concurrency:
 jobs:
   build-and-test-all:
     name: Build & Test
+    # Draft PRs don't auto-trigger CI: push to a draft runs nothing. CI fires when the PR is
+    # marked ready-for-review, or on manual workflow_dispatch. Drafts can't merge, so skipping
+    # their (required) checks blocks nothing. Non-PR events (push/merge_group/dispatch) always run.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     uses: ./.github/workflows/qualcomm-internal-build-and-test.yml
     secrets: inherit
     with:
       do_all: true
 
   coverage:
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     uses: ./.github/workflows/qualcomm-internal-coverage.yml
     secrets: inherit
 
   asan:
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     uses: ./.github/workflows/qualcomm-internal-asan.yml
     secrets: inherit

--- a/.github/workflows/qualcomm-internal-qdc-test.yml
+++ b/.github/workflows/qualcomm-internal-qdc-test.yml
@@ -10,6 +10,14 @@ permissions:
 on:
   workflow_call:
     inputs:
+      has_code_changes:
+        description: |
+          If false, the job runs checkout only and skips ALL heavy work (submodule init,
+          Artifactory downloads, the QDC device test), reporting success so the required status
+          check stays green on PRs that don't touch code and no QDC device slot is consumed.
+          Defaults to true so release callers and direct workflow_dispatch are unaffected.
+        default: true
+        type: boolean
       target_os:
         default: android
         type: string
@@ -52,10 +60,13 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        # Submodules omitted here; initialized below only when a heavy QDC run is needed.
+      - name: Initialize submodules
+        if: ${{ inputs.has_code_changes }}
+        run: git submodule update --init --recursive
 
       - name: Setup JFrog CLI
+        if: ${{ inputs.has_code_changes }}
         uses: jfrog/setup-jfrog-cli@v5
         with:
           disable-auto-build-publish: true
@@ -65,17 +76,19 @@ jobs:
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
       - name: Download Tests from Artifactory
+        if: ${{ inputs.has_code_changes }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: "${{ inputs.target_os }}-${{ inputs.target_arch }}-pyNone-tests"
 
       - name: Download testdata from Artifactory
-        if: ${{ inputs.testdata_archive_artifact_name != '' }}
+        if: ${{ inputs.has_code_changes && inputs.testdata_archive_artifact_name != '' }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: ${{ inputs.testdata_archive_artifact_name }}
 
       - name: Test ${{inputs.target_os}} ${{inputs.target_arch}} pynone
+        if: ${{ inputs.has_code_changes }}
         env:
           QDC_API_TOKEN: ${{ secrets.QDC_API_TOKEN }}
         # Use exec so that workflow cancel signals are sent directly to build_and_test.py, which will then
@@ -87,14 +100,14 @@ jobs:
           test_ort_qdc_${{inputs.target_os}}_${{inputs.target_arch}} --only
 
       - name: Cleanup QDC Runner tmp files
-        if: always()
+        if: ${{ always() && inputs.has_code_changes }}
         run: |
           echo "Cleaning $TMPDIR/QdcRunner-*"
           rm -fr $TMPDIR/QdcRunner-*
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
-        if: always() # always run even if the previous step fails
+        if: ${{ always() && inputs.has_code_changes }} # always run even if the previous step fails
         with:
           check_name: ${{inputs.target_os}}-${{inputs.target_arch}}-pynone-test-results
           group_reports: false
@@ -105,7 +118,7 @@ jobs:
             ${{ github.workspace }}/build/qdc-${{ env.QDC_RESULTS_ARCH }}/*.results.xml
 
       - uses: actions/upload-artifact@v7
-        if: always() # always run even if the previous step fails
+        if: ${{ always() && inputs.has_code_changes }} # always run even if the previous step fails
         with:
           name: ORT ${{inputs.target_os}} ${{inputs.target_arch}} pynone Test Results
           path: |


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Three levers to cut wasted runner compute:

- Path filter: a new `path-filter` gate job computes whether the diff
   touches code (any path outside docs/*.md / top-level *.md / LICENSE).
   All build/test jobs (required and non-required alike) always start and
   report green, but skip all heavy work (submodule init, build, test,
   Artifactory uploads, QDC device slot) when no code-bearing paths
   changed, via a new `has_code_changes` boolean input threaded through
   the reusable workflows.
- Draft PRs: pushes to a draft PR no longer auto-trigger CI. CI fires
   when the PR is marked ready-for-review, on push to main/rel-*, in the
   merge queue, or via manual dispatch. `ready_for_review` is added to
   the PR trigger types so converting a draft fires CI automatically.

- /ci comment trigger: a new `qualcomm-internal-ci-trigger.yml`
   workflow lets developers comment `/ci` on a draft PR to dispatch CI
   without leaving the PR page. Restricted to collaborators/members/
   owners; fork contributors are rejected.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Reduce CI workload

