### PR TITLE
Add DqlDqFusion: fuse DynamicQuantizeLinear+DequantizeLinear into identity Transpose

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.cc
@@ -75,9 +75,10 @@ std::unique_ptr<IQnnNodeGroup> DqlDqFusion::TryFusion(
     return reject("DQL.output[0] is not exclusively consumed by a standalone DequantizeLinear");
   }
 
-  // y_scale must have exactly one consumer and it must be the fused DQ node.
-  // y_zero_point is optional (DQ may omit it); if present it must also belong solely to this DQ.
-  // These checks prevent fusion when a second DQ node shares y_scale or y_zp: in that case the
+  // y_scale and y_zero_point must each have exactly one consumer and it must be the fused DQ node.
+  // y_zero_point must not be absent: DQL's y_zp is dynamic and typically non-zero, so allowing DQ
+  // to omit it (defaulting to zero_point=0) would break the identity round-trip.
+  // These checks also prevent fusion when a second DQ node shares y_scale or y_zp: in that case the
   // second DQ would lose its producer after fusion, corrupting the graph.
   {
     auto has_single_dq_consumer = [&](const Ort::ConstValueInfo& vi) -> bool {
@@ -91,12 +92,18 @@ std::unique_ptr<IQnnNodeGroup> DqlDqFusion::TryFusion(
       return reject("DQL.y_scale is not exclusively consumed by the fused DQ");
     }
 
-    // y_zero_point: 0 consumers is allowed; if present, must belong to the same DQ.
+    // y_zero_point: must be consumed exclusively by the same DQ.
+    // DQL computes a dynamic y_zp (typically non-zero for float32 inputs; e.g. ~128 for
+    // inputs in [-1, 1]).  If DQ omits zero_point it defaults to 0, making
+    // DQ(y, y_scale, 0) != x and breaking the identity round-trip.
     std::vector<Ort::ValueInfoConsumerProducerInfo> zp_consumers = dql_outs[2].GetConsumers();
-    if (!zp_consumers.empty()) {
-      if (zp_consumers.size() != 1 || zp_consumers[0].node == nullptr) {
-        return reject("DQL.y_zero_point has unexpected multiple consumers");
-      }
+    if (zp_consumers.empty()) {
+      return reject("DQL.y_zero_point has no consumers; DQ would use zero_point=0 which breaks the identity round-trip");
+    }
+    if (zp_consumers.size() != 1 || zp_consumers[0].node == nullptr) {
+      return reject("DQL.y_zero_point has unexpected multiple consumers");
+    }
+    {
       const auto it = node_to_node_unit.find(zp_consumers[0].node);
       if (it == node_to_node_unit.end() || it->second != dq) {
         return reject("DQL.y_zero_point consumer is not the fused DQ");
@@ -126,9 +133,13 @@ std::unique_ptr<IQnnNodeGroup> DqlDqFusion::TryFusion(
     return reject("DQ.scale does not match DQL.y_scale");
   }
 
-  // If DQ has a zero_point, it must come from DQL's y_zero_point (output[2]).
-  if (dq_inputs[0].quant_param->zero_point != nullptr &&
-      Ort::ConstValueInfo(dq_inputs[0].quant_param->zero_point).GetName() != dql_outputs[2].name) {
+  // DQ's zero_point must be present and come from DQL's y_zero_point (output[2]).
+  // DQL's y_zp is dynamic and typically non-zero; allowing DQ to omit it (defaulting
+  // to 0) would break the identity round-trip.
+  if (dq_inputs[0].quant_param->zero_point == nullptr) {
+    return reject("DQ is missing zero_point quant_param");
+  }
+  if (Ort::ConstValueInfo(dq_inputs[0].quant_param->zero_point).GetName() != dql_outputs[2].name) {
     return reject("DQ.zero_point does not match DQL.y_zero_point");
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.cc
@@ -1,0 +1,237 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.h"
+
+#include <gsl/gsl>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// ---------------------------------------------------------------------------
+// TryFusion
+// ---------------------------------------------------------------------------
+std::unique_ptr<IQnnNodeGroup> DqlDqFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& dql_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  auto reject = [&logger](std::string_view reason) -> std::unique_ptr<IQnnNodeGroup> {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                (std::string("DqlDqFusion rejected: ").append(reason)).c_str());
+    return nullptr;
+  };
+
+  if (dql_node_unit.OpType() != kOpDynamicQuantizeLinear ||
+      dql_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return reject("not a DynamicQuantizeLinear SingleNode");
+  }
+
+  const auto& dql_inputs = dql_node_unit.Inputs();
+  const auto& dql_outputs = dql_node_unit.Outputs();
+  if (dql_inputs.size() != 1 || dql_outputs.size() != 3) {
+    return reject("DQL input/output count mismatch (expected 1 input, 3 outputs)");
+  }
+
+  // DQL input must be float32.
+  TensorInfo input_info{};
+  if (!qnn_model_wrapper.GetTensorInfo(dql_inputs[0], input_info).IsOK() ||
+      input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32) {
+    return reject("DQL input is not float32");
+  }
+
+  // All 3 DQL outputs must be consumed exclusively by DequantizeLinear nodes.
+  // ConsumersAreAllOfType returns true vacuously for 0 consumers; GetOnlyChildOfOutput below
+  // handles the uniqueness check.
+  const std::vector<Ort::ConstValueInfo> dql_outs =
+      Ort::ConstNode(&dql_node_unit.GetNode()).GetOutputs();
+  if (dql_outs.size() != 3) {
+    return reject("DQL node does not have 3 output value_infos");
+  }
+  if (!ConsumersAreAllOfType(dql_outs[0], DEQUANTIZE_LINEAR, node_to_node_unit) ||
+      !ConsumersAreAllOfType(dql_outs[1], DEQUANTIZE_LINEAR, node_to_node_unit) ||
+      !ConsumersAreAllOfType(dql_outs[2], DEQUANTIZE_LINEAR, node_to_node_unit)) {
+    return reject("not all DQL outputs are consumed exclusively by DequantizeLinear");
+  }
+
+  // Find the single DQ consuming DQL.output[0]; it must not already belong to another group.
+  const OrtNodeUnit* dq = GetOnlyChildOfOutput(
+      qnn_model_wrapper, dql_node_unit, dql_outputs[0],
+      node_to_node_unit, node_unit_to_qnn_node_group);
+  if (dq == nullptr || dq->OpType() != DEQUANTIZE_LINEAR ||
+      dq->UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return reject("DQL.output[0] is not exclusively consumed by a standalone DequantizeLinear");
+  }
+
+  // y_scale must have exactly one consumer and it must be the fused DQ node.
+  // y_zero_point is optional (DQ may omit it); if present it must also belong solely to this DQ.
+  // These checks prevent fusion when a second DQ node shares y_scale or y_zp: in that case the
+  // second DQ would lose its producer after fusion, corrupting the graph.
+  {
+    auto has_single_dq_consumer = [&](const Ort::ConstValueInfo& vi) -> bool {
+      std::vector<Ort::ValueInfoConsumerProducerInfo> consumers = vi.GetConsumers();
+      if (consumers.size() != 1 || consumers[0].node == nullptr) return false;
+      const auto it = node_to_node_unit.find(consumers[0].node);
+      return it != node_to_node_unit.end() && it->second == dq;
+    };
+
+    if (!has_single_dq_consumer(dql_outs[1])) {
+      return reject("DQL.y_scale is not exclusively consumed by the fused DQ");
+    }
+
+    // y_zero_point: 0 consumers is allowed; if present, must belong to the same DQ.
+    std::vector<Ort::ValueInfoConsumerProducerInfo> zp_consumers = dql_outs[2].GetConsumers();
+    if (!zp_consumers.empty()) {
+      if (zp_consumers.size() != 1 || zp_consumers[0].node == nullptr) {
+        return reject("DQL.y_zero_point has unexpected multiple consumers");
+      }
+      const auto it = node_to_node_unit.find(zp_consumers[0].node);
+      if (it == node_to_node_unit.end() || it->second != dq) {
+        return reject("DQL.y_zero_point consumer is not the fused DQ");
+      }
+    }
+  }
+
+  // OrtNodeUnit::Inputs() wraps scale/zero_point as quant_param, so DQ has 1 logical input.
+  const auto& dq_inputs = dq->Inputs();
+  const auto& dq_outputs = dq->Outputs();
+  if (dq_inputs.size() != 1 || dq_outputs.size() != 1) {
+    return reject(("DQ has unexpected input/output count: " + std::to_string(dq_inputs.size()) +
+                   " inputs, " + std::to_string(dq_outputs.size()) + " outputs")
+                      .c_str());
+  }
+
+  // DQ's x must come from DQL's y (output[0]).
+  if (dq_inputs[0].name != dql_outputs[0].name) {
+    return reject("DQ.x does not match DQL.y");
+  }
+
+  // DQ's scale must be present and come from DQL's y_scale (output[1]).
+  if (!dq_inputs[0].quant_param.has_value() || dq_inputs[0].quant_param->scale == nullptr) {
+    return reject("DQ is missing scale quant_param");
+  }
+  if (Ort::ConstValueInfo(dq_inputs[0].quant_param->scale).GetName() != dql_outputs[1].name) {
+    return reject("DQ.scale does not match DQL.y_scale");
+  }
+
+  // If DQ has a zero_point, it must come from DQL's y_zero_point (output[2]).
+  if (dq_inputs[0].quant_param->zero_point != nullptr &&
+      Ort::ConstValueInfo(dq_inputs[0].quant_param->zero_point).GetName() != dql_outputs[2].name) {
+    return reject("DQ.zero_point does not match DQL.y_zero_point");
+  }
+
+  // DQ output must be float32.
+  TensorInfo dq_output_info{};
+  if (!qnn_model_wrapper.GetTensorInfo(dq_outputs[0], dq_output_info).IsOK() ||
+      dq_output_info.qnn_data_type != QNN_DATATYPE_FLOAT_32) {
+    return reject("DQ output is not float32");
+  }
+
+  auto fusion = std::unique_ptr<DqlDqFusion>(
+      new DqlDqFusion(&dql_node_unit, dq, dql_inputs[0].name, dq_outputs[0].name));
+
+  if (Ort::Status status = fusion->CreateOrValidateOnQnn(qnn_model_wrapper, /*validate=*/true);
+      !status.IsOK()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("DqlDqFusion rejected by QNN validate: " + status.GetErrorMessage()).c_str());
+    return nullptr;
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, "DqlDqFusion matched and validated");
+  return fusion;
+}
+
+// ---------------------------------------------------------------------------
+// Constructor / IQnnNodeGroup plumbing
+// ---------------------------------------------------------------------------
+DqlDqFusion::DqlDqFusion(const OrtNodeUnit* dql, const OrtNodeUnit* dq,
+                         std::string float_input_name, std::string float_output_name)
+    : dql_(dql),
+      node_units_({dql, dq}),
+      float_input_name_(std::move(float_input_name)),
+      float_output_name_(std::move(float_output_name)) {}
+
+Ort::Status DqlDqFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  return CreateOrValidateOnQnn(qmw, /*validate=*/true);
+}
+
+Ort::Status DqlDqFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const {
+  ORT_UNUSED_PARAMETER(logger);
+  return CreateOrValidateOnQnn(qmw, /*validate=*/false);
+}
+
+gsl::span<const OrtNodeUnit* const> DqlDqFusion::GetNodeUnits() const {
+  return gsl::make_span(node_units_);
+}
+
+// ---------------------------------------------------------------------------
+// Emission
+// ---------------------------------------------------------------------------
+Ort::Status DqlDqFusion::CreateOrValidateOnQnn(QnnModelWrapper& qmw, bool validate) const {
+  // Get the shape of the float input (DQL's single input tensor).
+  TensorInfo input_info{};
+  RETURN_IF_ERROR(qmw.GetTensorInfo(dql_->Inputs()[0], input_info));
+  const std::vector<uint32_t> shape(input_info.shape.begin(), input_info.shape.end());
+  const uint32_t rank = static_cast<uint32_t>(shape.size());
+  RETURN_IF_NOT(rank >= 1, "DQL input must have rank >= 1");
+
+  // Identity permutation: [0, 1, ..., rank-1].
+  std::vector<uint32_t> perm(rank);
+  for (uint32_t i = 0; i < rank; ++i) perm[i] = i;
+
+  const std::string node_name = utils::UniqueNameGenerator().New(*dql_);
+
+  const Qnn_TensorType_t in_type =
+      qmw.IsGraphInput(float_input_name_) ? QNN_TENSOR_TYPE_APP_WRITE : QNN_TENSOR_TYPE_NATIVE;
+  const Qnn_TensorType_t out_type =
+      qmw.IsGraphOutput(float_output_name_) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  QnnTensorWrapper in_tw(float_input_name_, in_type, QNN_DATATYPE_FLOAT_32,
+                         QnnQuantParamsWrapper(), std::vector<uint32_t>(shape));
+  QnnTensorWrapper out_tw(float_output_name_, out_type, QNN_DATATYPE_FLOAT_32,
+                          QnnQuantParamsWrapper(), std::vector<uint32_t>(shape));
+  QnnParamWrapper perm_param(dql_->Index(), node_name, QNN_OP_TRANSPOSE_PARAM_PERM,
+                             std::vector<uint32_t>{rank}, std::move(perm));
+
+  if (validate) {
+    RETURN_IF_ERROR(qmw.ValidateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                        QNN_OP_TRANSPOSE,
+                                        {in_tw.GetQnnTensor()},
+                                        {out_tw.GetQnnTensor()},
+                                        {perm_param.GetQnnParam()}));
+  } else {
+    if (!qmw.IsQnnTensorWrapperExist(float_input_name_)) {
+      RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(in_tw)),
+                    "DqlDqFusion: failed to add float input tensor");
+    }
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(out_tw)),
+                  "DqlDqFusion: failed to add float output tensor");
+
+    std::vector<std::string> param_names = {perm_param.GetParamTensorName()};
+    qmw.AddParamWrapper(std::move(perm_param));
+
+    RETURN_IF_NOT(qmw.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                    QNN_OP_TRANSPOSE,
+                                    {float_input_name_}, {float_output_name_},
+                                    std::move(param_names), /*do_op_validation=*/false),
+                  "DqlDqFusion: failed to create identity Transpose node");
+  }
+
+  return Ort::Status();
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.h
@@ -1,0 +1,71 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <gsl/gsl>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+/// <summary>
+/// Fuses the DynamicQuantizeLinear + DequantizeLinear pair into a QNN identity Transpose.
+///
+/// Pattern (ONNX):
+///   x (float32) --> DynamicQuantizeLinear --> (y_uint8, y_scale, y_zp)
+///                   ALL 3 outputs exclusively --> DequantizeLinear --> x_approx (float32)
+///
+/// Condition: all three DQL outputs must feed exclusively into the same DequantizeLinear, and
+/// the DequantizeLinear output must be float32.  This is the "fake-quantize" identity pattern:
+/// the round-trip DQL -> DQ leaves x_approx numerically close to x (quantized then restored to
+/// float), so the entire sub-graph can be bypassed on QNN without meaningful accuracy loss.
+///
+/// Rewrite (QNN):
+///   x --> Transpose(identity permutation) --> x_approx
+///
+/// QNN has no native Identity op; an identity-permutation Transpose compiles to zero cycles on
+/// HTP.
+/// </summary>
+class DqlDqFusion : public IQnnNodeGroup {
+ public:
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(DqlDqFusion);
+
+  static constexpr std::string_view kType = "DqlDqFusion";
+
+  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return dql_; }
+  std::string_view Type() const override { return kType; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& dql_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  DqlDqFusion(const OrtNodeUnit* dql, const OrtNodeUnit* dq,
+              std::string float_input_name, std::string float_output_name);
+
+  Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qmw, bool validate) const;
+
+  const OrtNodeUnit* dql_;
+  std::array<const OrtNodeUnit*, 2> node_units_;
+  std::string float_input_name_;   // DQL's input[0]: the original float activation
+  std::string float_output_name_;  // DQ's output[0]: passed through to downstream ops
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.h
@@ -25,7 +25,9 @@ class QnnModelWrapper;
 ///   x (float32) --> DynamicQuantizeLinear --> (y_uint8, y_scale, y_zp)
 ///                   ALL 3 outputs exclusively --> DequantizeLinear --> x_approx (float32)
 ///
-/// Condition: all three DQL outputs must feed exclusively into the same DequantizeLinear, and
+/// Condition: all three DQL outputs must feed exclusively into the same DequantizeLinear
+/// (including y_zp — DQ must not omit zero_point, since DQL's y_zp is dynamic and typically
+/// non-zero; allowing DQ to default to zero_point=0 would break the identity round-trip), and
 /// the DequantizeLinear output must be float32.  This is the "fake-quantize" identity pattern:
 /// the round-trip DQL -> DQ leaves x_approx numerically close to x (quantized then restored to
 /// float), so the entire sub-graph can be bypassed on QNN without meaningful accuracy loss.

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -16,6 +16,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/dq_conv_integer_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/dq_matmul_integer_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/dq_q_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/dql_dq_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/gather_transpose_reshape_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/gelu_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/hardsigmoid_mul_fusion.h"
@@ -87,6 +88,7 @@ using FusionFunc = std::function<std::unique_ptr<IQnnNodeGroup>(QnnModelWrapper&
 // Maps a starting operator type to the fusion function.
 static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"DequantizeLinear", {DQQFusion::TryFusion}},
+    {"DynamicQuantizeLinear", {DqlDqFusion::TryFusion}},
     {"MatMulInteger", {DQMatMulIntegerFusion::TryFusion}},
     {"ConvInteger", {DQConvIntegerFusion::TryFusion}},
     {"Gather", {GatherTransposeReshapeFusion::TryFusion}},

--- a/onnxruntime/test/providers/qnn/qnn_node_group/dql_dq_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/dql_dq_fusion_test.cc
@@ -113,6 +113,33 @@ GetTestModelFn BuildDqlDqAddTestCase(const TestInputDef<float>& input_def,
   };
 }
 
+// Builds:
+//   input (float32) --> DynamicQuantizeLinear --> (y, y_scale, y_zp)
+//   DequantizeLinear(y, y_scale) --> dq_out (float32)   [y_zp not consumed]
+//   Relu(dq_out) --> output (float32)
+//
+// DQL.y_zp has zero consumers: DQ omits zero_point and defaults to 0. Because
+// DQL's y_zp is dynamic and typically non-zero (e.g. ~128 for inputs in [-1,1]),
+// DQ(y, y_scale, 0) != x and the round-trip is NOT identity. Fusion must be
+// rejected to avoid silently producing wrong results.
+GetTestModelFn BuildDqlDqNoZpTestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("dql_dq_no_zp_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("dql", "DynamicQuantizeLinear", {"input"},
+                    {"dql_y", "dql_y_scale", "dql_y_zp"});
+
+    // DQ omits y_zp (zero_point is optional per ONNX spec).
+    // DQL.y_zp has zero consumers after this.
+    builder.AddNode("dq", "DequantizeLinear",
+                    {"dql_y", "dql_y_scale"}, {"dq_out"});
+
+    builder.AddNode("relu", "Relu", {"dq_out"}, {"output"});
+    builder.MakeOutput("output");
+  };
+}
+
 // ---------------------------------------------------------------------------
 // No-fusion model builders
 // ---------------------------------------------------------------------------
@@ -277,6 +304,32 @@ TEST_F(QnnHTPBackendTests, DqlDqFusion_LargeActivation_Correctness) {
   AssertOpInQnnGraph(json_dir, "Relu", /*count=*/1);
   AssertOpInQnnGraph(json_dir, "DynamicQuantizeLinear", /*count=*/0);
   AssertOpInQnnGraph(json_dir, "Dequantize", /*count=*/0);
+}
+
+// DQL.y_zp has zero consumers (DQ omits zero_point, which is optional per ONNX
+// spec). DQL's y_zp is dynamic and typically non-zero, so DQ(y, y_scale, 0) != x:
+// the round-trip is NOT identity and fusion must be rejected.
+TEST_F(QnnHTPBackendTests, DqlDqFusion_NoZeroPoint_NoFusion) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::filesystem::path json_dir = "DqlDqFusion_NoZeroPoint_NoFusion";
+
+  // DQL has no standalone HTP op-builder, so at least some nodes must land on
+  // CPU EP when fusion does not fire.
+  RunFusionTest({json_dir,
+                 BuildDqlDqNoZpTestCase(
+                     TestInputDef<float>({1, 4, 4, 8}, /*is_initializer=*/false,
+                                         -1.0f, 1.0f)),
+                 /*opset_version=*/13,
+                 /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
+                 /*fp32_abs_err=*/1e-2f,
+                 /*log_severity=*/OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                 /*verify_outputs=*/false});  // graph is split across CPU/QNN EP
+
+  if (!HasQnnJsonGraph(json_dir)) return;
+
+  // The identity Transpose emitted by DqlDqFusion must be absent.
+  AssertOpInQnnGraph(json_dir, "Transpose", /*count=*/0);
 }
 
 // ==========================================================================

--- a/onnxruntime/test/providers/qnn/qnn_node_group/dql_dq_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/dql_dq_fusion_test.cc
@@ -1,0 +1,327 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <functional>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Helper: JSON graph directory setup / teardown
+// ---------------------------------------------------------------------------
+void ResetQnnGraphDir(const std::filesystem::path& dir) {
+  std::filesystem::remove_all(dir);
+  ASSERT_TRUE(std::filesystem::create_directory(dir));
+}
+
+// Returns true if at least one QNN JSON graph file exists in `dump_dir`.
+// Used to skip graph assertions when the test was not executed (e.g., FP32
+// HTP not available and no JSON dump is produced).
+bool HasQnnJsonGraph(const std::filesystem::path& dump_dir) {
+  if (!std::filesystem::exists(dump_dir)) return false;
+  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ProviderOptions GetHTPProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  // On x86-64 Linux the HTP emulator needs a concrete SoC model to run.
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return provider_options;
+}
+
+// ---------------------------------------------------------------------------
+// Happy-path model builders
+// ---------------------------------------------------------------------------
+
+// Builds:
+//   input (float32, shape) --> DynamicQuantizeLinear --> (y, y_scale, y_zp)
+//   DequantizeLinear(y, y_scale, y_zp) --> dq_out (float32)
+//   Relu(dq_out) --> output (float32)
+//
+// The fusion should replace DQL + DQ with an identity Transpose so the graph
+// visible to QNN contains only Transpose + Relu.
+GetTestModelFn BuildDqlDqReluTestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("dql_dq_relu_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // DynamicQuantizeLinear: input -> (y, y_scale, y_zp)
+    builder.AddNode("dql", "DynamicQuantizeLinear", {"input"},
+                    {"dql_y", "dql_y_scale", "dql_y_zp"});
+
+    // DequantizeLinear: (y, y_scale, y_zp) -> dq_out
+    builder.AddNode("dq", "DequantizeLinear",
+                    {"dql_y", "dql_y_scale", "dql_y_zp"}, {"dq_out"});
+
+    // Relu: dq_out -> output
+    builder.AddNode("relu", "Relu", {"dq_out"}, {"output"});
+    builder.MakeOutput("output");
+  };
+}
+
+// Builds the same DQL -> DQ pair but uses an Add instead of Relu so that we
+// can also verify 2D / flat tensor shapes go through the fusion.
+//
+//   input (float32) --> DQL --> DQ --> Add(const) --> output (float32)
+GetTestModelFn BuildDqlDqAddTestCase(const TestInputDef<float>& input_def,
+                                     float addend = 0.1f) {
+  return [input_def, addend](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("dql_dq_add_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("dql", "DynamicQuantizeLinear", {"input"},
+                    {"dql_y", "dql_y_scale", "dql_y_zp"});
+
+    builder.AddNode("dq", "DequantizeLinear",
+                    {"dql_y", "dql_y_scale", "dql_y_zp"}, {"dq_out"});
+
+    // Small constant addend so the downstream Add has a concrete initializer.
+    const std::vector<int64_t> shape = input_def.GetShape();
+    const size_t num_elems =
+        static_cast<size_t>(std::accumulate(shape.begin(), shape.end(), int64_t{1},
+                                            std::multiplies<int64_t>{}));
+    builder.MakeInitializer<float>("addend", shape,
+                                   std::vector<float>(num_elems, addend));
+
+    builder.AddNode("add", "Add", {"dq_out", "addend"}, {"output"});
+    builder.MakeOutput("output");
+  };
+}
+
+// ---------------------------------------------------------------------------
+// No-fusion model builders
+// ---------------------------------------------------------------------------
+
+// Builds a model where DQL.y (output[0]) is consumed by BOTH a
+// DequantizeLinear AND a direct Cast to float32.  This violates the
+// "all DQL outputs exclusively consumed by DQ" requirement, so
+// DqlDqFusion::TryFusion should return nullptr and the graph must fall
+// through to the regular op builders (DQL is not supported on HTP in
+// isolation, so at least some nodes land on CPU EP).
+//
+//   input --> DQL --> (y, y_scale, y_zp)
+//                y ----> DequantizeLinear(y, y_scale, y_zp) --> dq_out
+//                y ----> Cast (float32) --> cast_out
+//             Relu(dq_out) --> relu_out
+//             Add(cast_out, relu_out) --> output
+GetTestModelFn BuildDqlDqNoFusionTestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("dql_dq_no_fusion_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("dql", "DynamicQuantizeLinear", {"input"},
+                    {"dql_y", "dql_y_scale", "dql_y_zp"});
+
+    // DequantizeLinear consumes all three DQL outputs.
+    builder.AddNode("dq", "DequantizeLinear",
+                    {"dql_y", "dql_y_scale", "dql_y_zp"}, {"dq_out"});
+
+    // Extra consumer of dql_y: Cast uint8 -> float32.
+    // This makes ConsumersAreAllOfType(dql_outs[0], DEQUANTIZE_LINEAR) return
+    // false and the fusion should be rejected.
+    builder.AddNode("cast_y", "Cast", {"dql_y"}, {"cast_y_out"}, kOnnxDomain,
+                    {builder.MakeScalarAttribute(
+                        "to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType_FLOAT))});
+
+    builder.AddNode("relu", "Relu", {"dq_out"}, {"relu_out"});
+
+    builder.AddNode("add", "Add", {"cast_y_out", "relu_out"}, {"output"});
+    builder.MakeOutput("output");
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Common runner: runs the model, verifies outputs, and optionally checks the
+// QNN graph JSON.
+// ---------------------------------------------------------------------------
+struct FusionTestParams {
+  std::filesystem::path json_dir;
+  GetTestModelFn build_model;
+  int opset_version = 13;
+  ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All;
+  float fp32_abs_err = 1e-2f;
+  OrtLoggingLevel log_severity = OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR;
+  bool verify_outputs = true;
+};
+
+void RunFusionTest(const FusionTestParams& p) {
+  ResetQnnGraphDir(p.json_dir);
+  auto cleanup = gsl::finally([&p]() { std::filesystem::remove_all(p.json_dir); });
+
+  ProviderOptions provider_options = GetHTPProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = p.json_dir.string();
+
+  RunQnnModelTest(p.build_model,
+                  provider_options,
+                  p.opset_version,
+                  p.expected_ep_assignment,
+                  p.fp32_abs_err,
+                  p.log_severity,
+                  p.verify_outputs);
+}
+
+}  // namespace
+
+// ==========================================================================
+// Happy-path tests — fusion fires, QNN sees a Transpose instead of DQL+DQ
+// ==========================================================================
+
+// Basic 4-D input: DQL + DQ should be replaced by an identity Transpose; Relu
+// is the downstream consumer that keeps the graph alive.
+TEST_F(QnnHTPBackendTests, DqlDqFusion_4D_WithRelu) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::filesystem::path json_dir = "DqlDqFusion_4D_WithRelu";
+  RunFusionTest({json_dir,
+                 BuildDqlDqReluTestCase(
+                     TestInputDef<float>({1, 4, 4, 8}, /*is_initializer=*/false,
+                                         -1.0f, 1.0f))});
+
+  if (!HasQnnJsonGraph(json_dir)) return;
+
+  // The fused graph should contain exactly one Transpose (the identity
+  // placeholder for DQL+DQ) and one Relu; DQL and DQ must be absent.
+  AssertOpInQnnGraph(json_dir, "Transpose", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "Relu", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "DynamicQuantizeLinear", /*count=*/0);
+  AssertOpInQnnGraph(json_dir, "Dequantize", /*count=*/0);
+}
+
+// 2-D input — checks that the identity-permutation [0,1] is correctly emitted.
+TEST_F(QnnHTPBackendTests, DqlDqFusion_2D_WithRelu) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::filesystem::path json_dir = "DqlDqFusion_2D_WithRelu";
+  RunFusionTest({json_dir,
+                 BuildDqlDqReluTestCase(
+                     TestInputDef<float>({8, 16}, /*is_initializer=*/false,
+                                         -1.0f, 1.0f))});
+
+  if (!HasQnnJsonGraph(json_dir)) return;
+
+  AssertOpInQnnGraph(json_dir, "Transpose", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "Relu", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "DynamicQuantizeLinear", /*count=*/0);
+  AssertOpInQnnGraph(json_dir, "Dequantize", /*count=*/0);
+}
+
+// 3-D input with Add downstream — exercises the case where the fused Transpose
+// output feeds an Add with a constant initializer.
+TEST_F(QnnHTPBackendTests, DqlDqFusion_3D_WithAdd) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::filesystem::path json_dir = "DqlDqFusion_3D_WithAdd";
+  RunFusionTest({json_dir,
+                 BuildDqlDqAddTestCase(
+                     TestInputDef<float>({1, 4, 8}, /*is_initializer=*/false,
+                                         -1.0f, 1.0f),
+                     /*addend=*/0.05f),
+                 /*opset_version=*/13,
+                 ExpectedEPNodeAssignment::All,
+                 /*fp32_abs_err=*/1e-2f});
+
+  if (!HasQnnJsonGraph(json_dir)) return;
+
+  AssertOpInQnnGraph(json_dir, "Transpose", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "DynamicQuantizeLinear", /*count=*/0);
+  AssertOpInQnnGraph(json_dir, "Dequantize", /*count=*/0);
+}
+
+// Larger activation tensor similar to a typical transformer hidden-state shape.
+// Primarily a correctness check: output must be close to the CPU EP reference.
+// The DQL→DQ round-trip is a fake-quantize, so the approximation error is
+// bounded by the quantization step (|x_approx - x| <= scale/2), which for
+// inputs in [-1, 1] is at most ~0.004 with uint8.  We use 1e-2 as a safe
+// upper bound.
+TEST_F(QnnHTPBackendTests, DqlDqFusion_LargeActivation_Correctness) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::filesystem::path json_dir = "DqlDqFusion_LargeActivation";
+  RunFusionTest({json_dir,
+                 BuildDqlDqReluTestCase(
+                     TestInputDef<float>({1, 128, 768}, /*is_initializer=*/false,
+                                         -1.5f, 1.5f)),
+                 /*opset_version=*/13,
+                 ExpectedEPNodeAssignment::All,
+                 /*fp32_abs_err=*/1e-2f});
+
+  if (!HasQnnJsonGraph(json_dir)) return;
+
+  AssertOpInQnnGraph(json_dir, "Transpose", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "Relu", /*count=*/1);
+  AssertOpInQnnGraph(json_dir, "DynamicQuantizeLinear", /*count=*/0);
+  AssertOpInQnnGraph(json_dir, "Dequantize", /*count=*/0);
+}
+
+// ==========================================================================
+// No-fusion tests — guard conditions not met; graph must not crash
+// ==========================================================================
+
+// DQL.y is consumed by both DequantizeLinear AND a Cast node, which breaks the
+// "all DQL outputs exclusively consumed by DQ" guard.
+//
+// Primary no-fusion guard: ExpectedEPNodeAssignment::Some.
+//   If fusion incorrectly fired, DQL+DQ would become a Transpose on QNN EP and
+//   the downstream Cast/Relu/Add would also land on QNN EP, yielding an "All"
+//   assignment.  Asserting "Some" verifies that at least one node stayed on CPU
+//   EP — which can only happen when fusion did NOT fire.
+//
+// Secondary graph-content guard: Transpose count == 0.
+//   DqlDqFusion emits an identity-permutation Transpose as a placeholder.
+//   All ops in this graph are elementwise, so the layout optimizer will not
+//   insert its own Transpose; asserting count == 0 is therefore safe and
+//   directly checks that the fusion product is absent.
+TEST_F(QnnHTPBackendTests, DqlDqFusion_ExtraConsumer_NoFusion) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::filesystem::path json_dir = "DqlDqFusion_ExtraConsumer_NoFusion";
+
+  // Primary guard: DQL has no standalone QNN HTP op-builder, so at least some
+  // nodes must land on CPU EP when fusion does not fire.
+  RunFusionTest({json_dir,
+                 BuildDqlDqNoFusionTestCase(
+                     TestInputDef<float>({1, 4, 4, 8}, /*is_initializer=*/false, -1.0f, 1.0f)),
+                 /*opset_version=*/13,
+                 /*expected_ep_assignment=*/ExpectedEPNodeAssignment::Some,
+                 /*fp32_abs_err=*/1e-2f,
+                 /*log_severity=*/OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                 /*verify_outputs=*/false});  // graph is split across CPU/QNN EP; output comparison is not meaningful
+
+  if (!HasQnnJsonGraph(json_dir)) return;
+
+  // Secondary guard: the identity Transpose emitted by DqlDqFusion must be absent.
+  AssertOpInQnnGraph(json_dir, "Transpose", /*count=*/0);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
**Summary**

- Add DqlDqFusion to fuse DynamicQuantizeLinear + DequantizeLinear into an identity-permutation Transpose on QNN EP
- Fixes CPU fallback caused by QNN EP's lack of native DynamicQuantizeLinear support

**Background**

Some models contain a fake-quantize identity pattern where DynamicQuantizeLinear (DQL) computes dynamic quant params
that are immediately reversed by DequantizeLinear (DQ), with no integer kernel (e.g. MatMulInteger) ever consuming the
quantized tensor:

x (float32) ──► DynamicQuantizeLinear ──► (y_uint8, y_scale, y_zp)
				ALL 3 outputs exclusively ──► DequantizeLinear ──► x_approx (float32)
																	 └──► Gemm (float32)

This is a leftover artifact from an incomplete quantization conversion. Since QNN EP does not support
DynamicQuantizeLinear, the entire subgraph falls back to CPU, impacting performance.

**Solution**

Replace the DQL + DQ pair with an identity-permutation Transpose (zero cycles on HTP). The round-trip DQ(DQL(x)) ≈ x —
replacing it with identity actually improves numerical accuracy (removes quantization noise) since the downstream op
is float32.

Guard conditions (all must hold to fuse):
1. DQL is a SingleNode with 1 float32 input and 3 outputs
2. All 3 DQL outputs consumed exclusively by DequantizeLinear nodes
3. The DQ consuming DQL.y also receives DQL.y_scale (via quant_param) and optionally DQL.y_zero_point — same DQ node,
no other consumers
4. DQ output is float32
5. QNN validates the replacement Transpose

Files Changed

  - builder/qnn_node_group/dql_dq_fusion.h — New: DqlDqFusion class declaration
  - builder/qnn_node_group/dql_dq_fusion.cc — New: fusion implementation
  - builder/qnn_node_group/qnn_node_group.cc — Register DqlDqFusion::TryFusion for DynamicQuantizeLinear

Implementation Note

OrtNodeUnit::Inputs() embeds scale/zero_point in quant_param rather than exposing them as separate input entries. The
DQ verification therefore uses quant_param->scale and quant_param->zero_point instead of raw input indices.

