### PR TITLE
[QNN EP] Framework op tracing follow-up: source->optimized ONNX matcher

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -21,6 +21,7 @@ ONNX Runtime QNN EP can be used on Windows devices with Qualcomm Snapdragon SOC'
 - [Running an LLM model with QNN EP's Genie backend](#running-an-llm-model-with-qnn-eps-genie-backend)
 - [QNN context binary cache feature](#qnn-context-binary-cache-feature)
 - [QNN EP Framework Op Tracing](#qnn-ep-framework-op-tracing)
+- [QNN EP Input Graph Dump](#qnn-ep-input-graph-dump)
 - [QNN EP Profiling](#qnn-ep-profiling)
 - [QNN EP weight sharing](#qnn-ep-weight-sharing)
 - [Usage](#usage)
@@ -234,6 +235,15 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 |`"json_qnn_graph_dir"`|Description|
 |---|---|
 |Directory path (string)|Directory path for dumping QNN JSON graphs. Only effective when `dump_json_qnn_graph` is enabled.|
+
+|`"dump_qnn_ep_input_graph"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Dump the ONNX graph the QNN EP receives at compile time (after ORT Level 1 optimizations, before partitioning) as a JSON file. The output uses the same schema as `dump_json_qnn_graph`, so it opens in QNN Netron. Unlike `dump_json_qnn_graph` (which dumps the post-compile QNN graph), this captures the pre-compile ONNX graph. See `dump_qnn_ep_input_graph_dir` to control the output location.|
+
+|`"dump_qnn_ep_input_graph_dir"`|Description|
+|---|---|
+|Directory path (string)|Directory path for the QNN EP input graph dump. Only effective when `dump_qnn_ep_input_graph` is `'1'`. Defaults to the current working directory if not set. The directory is created automatically if it does not exist. If the directory cannot be created or written to, the dump is disabled with a WARNING log. Output files use the pattern `<graph_name>.<n>_qnn_ep_input_graph.json`, where `<n>` is a per-EP counter that increments for each dumped graph. When the source graph has no name, `<graph_name>` is the literal `graph`.|
 
 |`"dump_qnn_ir_dlc"`|Description|
 |---|---|
@@ -806,6 +816,89 @@ ort.unregister_execution_provider_library(ep_registration_name)
 ```
 
 For an out-of-the-box example, see [`qcom/samples/test_genie.py`](../../qcom/samples/test_genie.py).
+
+## QNN EP Input Graph Dump
+
+Setting `dump_qnn_ep_input_graph` to `'1'` writes the ONNX graph the QNN EP
+receives at compile time — after ORT Level 1 optimizations, before partitioning
+and EP compile — to a JSON file (one per graph, named
+`<graph_name>.<n>_qnn_ep_input_graph.json`, where `<n>` is a per-EP counter
+that disambiguates collisions when two graph names sanitize to the same
+string). Use `dump_qnn_ep_input_graph_dir` to
+choose the output directory (defaults to the current working directory).
+
+This is useful for inspecting exactly what the EP sees: that graph is **not** the
+user's source `.onnx` (ORT has run constant folding, QDQ duplication via
+`EnsureUniqueDQForNodeUnit`, Transpose optimization, etc.), and it is otherwise
+hard to observe — `SessionOptions::optimized_model_filepath` refuses to serialize
+a graph once an EP has compiled part of it into opaque compiled nodes ("Unable to
+serialize model as it contains compiled nodes").
+
+### Why the dump is QNN-Netron JSON, not an ONNX model
+
+The dump deliberately uses the same JSON schema as `dump_json_qnn_graph` rather
+than emitting a real `.onnx`. The QNN EP ships as a **standalone ABI plugin** that
+links only the public ONNX Runtime C/C++ API, Abseil, and nlohmann/json — it does
+**not** link protobuf or the ONNX proto definitions. Constructing or serializing
+an `onnx::ModelProto` therefore is not possible from the EP without adding a
+protobuf dependency to every shipped `onnxruntime_providers_qnn` binary, which
+would break the plugin's minimal-dependency contract.
+
+Reusing the QNN-Netron JSON schema instead means:
+
+- **No new dependencies** — nlohmann/json is already used by the EP.
+- **Opens directly in QNN Netron** — same schema Netron already understands.
+- **One graph-dump format** across the EP: `dump_json_qnn_graph` for the
+  post-compile QNN graph, `dump_qnn_ep_input_graph` for the pre-compile ONNX graph.
+- **Consumable by tooling** — the offline `qcom/tools/op_trace_matcher/source_to_optimized_matcher.py`
+  reads this JSON directly as its `--optimized-model`, recovering
+  `original ONNX -> EP-input -> QNN op` provenance.
+
+The schema carries node name/op_type/input_names/output_names and a tensor table
+flagging each tensor's role (graph input / output / intermediate / initializer),
+which is everything downstream consumers need.
+
+**Known limitation:** the dump does **not** include initializer tensor data
+bytes. Only the tensor name, dtype, shape, and role are recorded. Tools
+consuming the dump (for example `source_to_optimized_matcher.py`'s
+`--optimized-model` input) must therefore rely on initializer **names** or
+graph **topology** — not data hashes — when correlating tensors across the
+source and the EP-input graph. The matcher uses a name-derived sentinel hash
+for initializers from this input so name-based and topology-based matching
+work unchanged.
+
+### Multiple dumps per graph name
+
+A single inference session can produce **more than one** dump for the same
+graph name, because ORT may invoke `GetCapability` more than once:
+
+- **Layout transformation 2-pass cycle.** When the graph contains
+  layout-sensitive ops (Conv, Resize, Pool, …), ORT runs a 1st pass to
+  collect EP claims, applies an NCHW->NHWC rewrite for nodes the EP
+  accepted, and runs a 2nd pass on the transformed graph. The two dumps
+  differ — the 2nd has Conv in `kMSInternalNHWCDomain` and includes
+  inserted Transpose ops.
+- **Control-flow subgraphs.** Each `If` / `Loop` / `Scan` subgraph is a
+  separate `OrtGraph*` and gets its own `GetCapability` invocation, so
+  models with control flow legitimately produce multiple dumps with
+  different graph names.
+- **EPContext model loads.** Loading a previously-cached EPContext model
+  triggers another `GetCapability` pass on that context graph.
+
+Filenames append a per-EP atomic counter (`<graph_name>.<n>_…json`) so each
+pass gets a distinct file, and an explicit overwrite warning is logged if
+the same name is ever about to be rewritten.
+
+**Rule for the offline matcher (`source_to_optimized_matcher.py`):** for
+each unique `<graph_name>` in the dump directory, feed the file with the
+**highest `<n>`** as `--optimized-model`. That is the graph the EP actually
+compiled, and its node names are exactly the names that appear in
+`qnn_op_trace.json`'s `sources[]`. Lower-numbered files are intermediate
+snapshots (useful for debugging the layout transformer itself, not for
+matcher input).
+
+If a model has subgraphs (different graph names), pick the highest-numbered
+file *per unique graph name* and run the matcher per graph.
 
 ## QNN context binary cache feature
 There's a QNN context which contains QNN graphs after converting, compiling, finalizing the model. QNN can serialize the context into binary file, so that user can use it for futher inference directly (without the QDQ model) to improve the model loading cost.

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -836,8 +836,15 @@ serialize model as it contains compiled nodes").
 
 ### Why the dump is QNN-Netron JSON, not an ONNX model
 
-The dump deliberately uses the same JSON schema as `dump_json_qnn_graph` rather
-than emitting a real `.onnx`. The QNN EP ships as a **standalone ABI plugin** that
+Netron is the open-source neural-net viewer that already understands the
+JSON shape produced by QNN's existing `dump_json_qnn_graph`
+(the post-compile QNN graph). The schema is not formally specified,
+but it is stable and observable in this repository at
+`onnxruntime/core/providers/qnn/builder/qnn_utils.cc` (`QnnJSONGraph`). The
+EP-input dump deliberately reuses that schema rather than emitting a real
+`.onnx`.
+
+The QNN EP ships as a **standalone ABI plugin** that
 links only the public ONNX Runtime C/C++ API, Abseil, and nlohmann/json — it does
 **not** link protobuf or the ONNX proto definitions. Constructing or serializing
 an `onnx::ModelProto` therefore is not possible from the EP without adding a

--- a/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.cc
@@ -1,0 +1,304 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_ep_input_graph_dumper.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "QnnTypes.h"
+
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+// QNN tensor-type integers Netron uses to classify a tensor. Mirrors the
+// values emitted by the post-compile QnnJSONGraph path (qnn_utils.cc), which
+// serializes the raw Qnn_TensorType_t enum.
+constexpr int kQnnTensorTypeAppWrite = QNN_TENSOR_TYPE_APP_WRITE;  // graph input  = 0
+constexpr int kQnnTensorTypeAppRead = QNN_TENSOR_TYPE_APP_READ;    // graph output = 1
+constexpr int kQnnTensorTypeNative = QNN_TENSOR_TYPE_NATIVE;       // intermediate = 3
+constexpr int kQnnTensorTypeStatic = QNN_TENSOR_TYPE_STATIC;       // initializer  = 4
+
+// Assigns a stable, incrementing integer id per tensor name. The public
+// ValueInfo API exposes no per-value id, and Netron only needs uniqueness, so
+// a name->int allocator suffices.
+class TensorIdAllocator {
+ public:
+  TensorIdAllocator() = default;
+
+  int GetOrAdd(const std::string& name) {
+    auto it = ids_.find(name);
+    if (it != ids_.end()) {
+      return it->second;
+    }
+    int id = next_id_++;
+    ids_.emplace(name, id);
+    return id;
+  }
+
+ private:
+  std::unordered_map<std::string, int> ids_;
+  int next_id_ = 0;
+
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(TensorIdAllocator);
+};
+
+// Classify a value info into the QNN tensor-type integer Netron expects.
+// Order matters: an initializer that is also an optional graph input is
+// classified as STATIC (its data is what Netron should show).
+int ClassifyTensorType(const Ort::ConstValueInfo& value_info) {
+  if (value_info.IsConstantInitializer()) {
+    return kQnnTensorTypeStatic;
+  }
+  if (value_info.IsRequiredGraphInput() || value_info.IsOptionalGraphInput()) {
+    return kQnnTensorTypeAppWrite;
+  }
+  if (value_info.IsGraphOutput()) {
+    return kQnnTensorTypeAppRead;
+  }
+  return kQnnTensorTypeNative;
+}
+
+// Build the per-tensor JSON entry. `raw_value_info` may be null (an optional,
+// not-provided node input); the caller skips those before calling this.
+// `type_info_failures` is incremented when the value's type info cannot be
+// read; the dumper logs a single aggregated WARNING at the end so silent
+// degradation (every tensor reported as FLOAT_32 + empty dims) is observable.
+nlohmann::json BuildTensorJson(const Ort::ConstValueInfo& value_info, int id,
+                               size_t& type_info_failures) {
+  using json = nlohmann::json;
+  json tensor_json = json::object();
+
+  tensor_json["id"] = id;
+  tensor_json["type"] = ClassifyTensorType(value_info);
+  tensor_json["dataFormat"] = 0;
+  tensor_json["src_axis_format"] = "NOT_YET_DEFINED";
+  tensor_json["axis_format"] = "NOT_YET_DEFINED";
+
+  // Non-quantized placeholder: this dumper records ONNX-level structure, not
+  // QDQ scale/zero-point, so the encoding is reported as undefined.
+  tensor_json["quant_params"] = {
+      {"definition", QNN_DEFINITION_UNDEFINED},
+      {"encoding", QNN_QUANTIZATION_ENCODING_UNDEFINED},
+      {"scale_offset", {{"scale", 0.0}, {"offset", 0}}},
+  };
+
+  // data_type + dims are read from the value's type info, which may be absent.
+  // Default to FLOAT_32 + empty dims when unavailable, and treat dynamic dims
+  // as "no shape" (empty array) rather than emitting negative sizes.
+  int data_type = QNN_DATATYPE_FLOAT_32;
+  json dims = json::array();
+
+  const OrtValueInfo* raw = value_info;
+  if (raw != nullptr) {
+    try {
+      Ort::ConstTypeInfo type_info = value_info.TypeInfo();
+      Ort::ConstTensorTypeAndShapeInfo shape_info = type_info.GetTensorTypeAndShapeInfo();
+
+      ONNXTensorElementDataType elem_type = shape_info.GetElementType();
+      Qnn_DataType_t qnn_dt = QNN_DATATYPE_FLOAT_32;
+      if (utils::OnnxDataTypeToQnnDataType(elem_type, qnn_dt, /*is_quantized=*/false)) {
+        data_type = qnn_dt;
+      } else {
+        // The mapping helper does not yet cover this ONNX dtype (e.g. some
+        // 4-bit / brain-float variants). Reuse the same accumulator as the
+        // type-info exception path so the user still sees a single
+        // aggregated WARNING from the dumper instead of a silent FLOAT_32
+        // substitution in the JSON.
+        ++type_info_failures;
+      }
+
+      if (shape_info.HasShape()) {
+        std::vector<int64_t> shape = shape_info.GetShape();
+        bool has_dynamic = false;
+        for (int64_t s : shape) {
+          if (s < 0) {
+            has_dynamic = true;
+            break;
+          }
+        }
+        if (!has_dynamic) {
+          for (int64_t s : shape) {
+            dims.push_back(s);
+          }
+        }
+      }
+    } catch (const Ort::Exception&) {
+      ++type_info_failures;
+    }
+  }
+
+  tensor_json["data_type"] = data_type;
+  tensor_json["dims"] = std::move(dims);
+  return tensor_json;
+}
+
+// Collect the input/output tensor-name array for a node, recording each tensor
+// in `tensors_json` (deduped) and skipping null optional inputs.
+nlohmann::json CollectNodeTensorNames(const std::vector<Ort::ConstValueInfo>& value_infos,
+                                      TensorIdAllocator& id_alloc,
+                                      std::unordered_set<std::string>& seen_tensors,
+                                      nlohmann::json& tensors_json,
+                                      size_t& type_info_failures) {
+  nlohmann::json names = nlohmann::json::array();
+  for (const Ort::ConstValueInfo& vi : value_infos) {
+    const OrtValueInfo* raw = vi;
+    if (raw == nullptr) {
+      continue;  // optional input not provided
+    }
+    std::string name = std::string(vi.GetName());
+    if (name.empty()) {
+      continue;
+    }
+    names.push_back(name);
+    if (!seen_tensors.count(name)) {
+      seen_tensors.insert(name);
+      tensors_json[name] = BuildTensorJson(vi, id_alloc.GetOrAdd(name), type_info_failures);
+    }
+  }
+  return names;
+}
+
+}  // namespace
+
+bool DumpQnnEpInputGraphToJson(const OrtGraph* graph,
+                               const std::filesystem::path& output_path,
+                               const Ort::Logger& logger) {
+  using json = nlohmann::json;
+
+  json root = {
+      // Dummy model.cpp / model.bin: not required for Netron visualization.
+      {"model.cpp", "N/A"},
+      {"model.bin", "N/A"},
+      {"converter_command", ""},
+      {"copyright_str", "Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries."},
+      {"op_types", json::array()},
+      {"Total parameters", ""},
+      {"Total MACs per inference", ""},
+      {"graph", {{"tensors", json::object()}, {"nodes", json::object()}}},
+  };
+
+  json& tensors_json = root["graph"]["tensors"];
+  json& nodes_json = root["graph"]["nodes"];
+
+  TensorIdAllocator id_alloc;
+  std::unordered_set<std::string> seen_tensors;
+  // Sorted set so the serialized op_types array order is stable across runs
+  // and platforms (downstream diff/hash tools will not see hash-iteration
+  // noise).
+  std::set<std::string> seen_op_types;
+  size_t type_info_failures = 0;
+
+  Ort::ConstGraph ort_graph{graph};
+
+  // Nodes: one entry per ONNX node, keyed by node name (fall back to
+  // op_type + index when unnamed so the JSON object key stays unique).
+  std::vector<Ort::ConstNode> nodes = ort_graph.GetNodes();
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    const Ort::ConstNode& node = nodes[i];
+
+    std::string op_type = std::string(node.GetOperatorType());
+    std::string node_name = std::string(node.GetName());
+    if (node_name.empty()) {
+      node_name = op_type + "_" + std::to_string(i);
+    }
+
+    json node_json = json::object();
+    node_json["package"] = "onnx";
+    node_json["type"] = op_type;
+    node_json["input_names"] =
+        CollectNodeTensorNames(node.GetInputs(), id_alloc, seen_tensors, tensors_json, type_info_failures);
+    node_json["output_names"] =
+        CollectNodeTensorNames(node.GetOutputs(), id_alloc, seen_tensors, tensors_json, type_info_failures);
+    node_json["tensor_params"] = json::object();
+    node_json["scalar_params"] = json::object();
+    node_json["macs_per_inference"] = "";
+
+    nodes_json[node_name] = std::move(node_json);
+    seen_op_types.insert(op_type);
+  }
+
+  // Initializers may not be referenced as a node input via GetInputs() in all
+  // cases; gather them explicitly so weights still appear in Netron.
+  for (const Ort::ConstValueInfo& init : ort_graph.GetInitializers()) {
+    const OrtValueInfo* raw = init;
+    if (raw == nullptr) {
+      continue;
+    }
+    std::string name = std::string(init.GetName());
+    if (name.empty() || seen_tensors.count(name)) {
+      continue;
+    }
+    seen_tensors.insert(name);
+    tensors_json[name] = BuildTensorJson(init, id_alloc.GetOrAdd(name), type_info_failures);
+  }
+
+  json op_types = json::array();
+  for (const auto& t : seen_op_types) {
+    op_types.push_back(t);
+  }
+  root["op_types"] = std::move(op_types);
+
+  if (type_info_failures > 0) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("QNN EP input graph dump: " + std::to_string(type_info_failures) +
+                 " tensor(s) had unreadable type info; their data_type/dims fell back to FLOAT_32 / empty.")
+                    .c_str());
+  }
+
+  // File write: create parent dir, warn-on-overwrite, fail soft. Mirrors
+  // WriteTraceToFile in op_tracing/qnn_op_tracing.cc.
+  std::error_code ec;
+  auto parent = output_path.parent_path();
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("Failed to create QNN EP input graph dump directory: " + parent.string() +
+                   " error: " + ec.message())
+                      .c_str());
+      return false;
+    }
+  }
+
+  if (std::filesystem::exists(output_path)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("Overwriting existing QNN EP input graph dump: " + output_path.string()).c_str());
+  }
+
+  std::ofstream ofs(output_path);
+  if (!ofs.is_open()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("Could not open QNN EP input graph dump file: " + output_path.string()).c_str());
+    return false;
+  }
+
+  ofs << root.dump(2);
+  ofs.close();
+  if (!ofs) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("QNN EP input graph dump write failed (disk full / I/O error): " + output_path.string()).c_str());
+    std::error_code rm_ec;
+    std::filesystem::remove(output_path, rm_ec);
+    return false;
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO,
+              ("QNN EP input graph dumped to: " + output_path.string()).c_str());
+  return true;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.cc
@@ -3,8 +3,6 @@
 
 #include "core/providers/qnn/builder/qnn_ep_input_graph_dumper.h"
 
-#include <algorithm>
-#include <cctype>
 #include <fstream>
 #include <set>
 #include <string>
@@ -199,12 +197,16 @@ bool DumpQnnEpInputGraphToJson(const OrtGraph* graph,
   // and platforms (downstream diff/hash tools will not see hash-iteration
   // noise).
   std::set<std::string> seen_op_types;
+  // Tracks node names already used as JSON object keys so a collision does
+  // not silently overwrite an earlier node.
+  std::unordered_set<std::string> seen_node_names;
   size_t type_info_failures = 0;
 
   Ort::ConstGraph ort_graph{graph};
 
-  // Nodes: one entry per ONNX node, keyed by node name (fall back to
-  // op_type + index when unnamed so the JSON object key stays unique).
+  // Nodes: one entry per ONNX node, keyed by node name (fall back to a
+  // synthesized `unnamed_{op_type}_{index}` form when unnamed so the JSON
+  // object key stays unique and matches the offline matcher's convention).
   std::vector<Ort::ConstNode> nodes = ort_graph.GetNodes();
   for (size_t i = 0; i < nodes.size(); ++i) {
     const Ort::ConstNode& node = nodes[i];
@@ -212,11 +214,30 @@ bool DumpQnnEpInputGraphToJson(const OrtGraph* graph,
     std::string op_type = std::string(node.GetOperatorType());
     std::string node_name = std::string(node.GetName());
     if (node_name.empty()) {
-      node_name = op_type + "_" + std::to_string(i);
+      // Synthesize a name for an unnamed node.
+      node_name = "unnamed_" + op_type + "_" + std::to_string(i);
+    }
+    // Disambiguate a name that has already been emitted (ONNX does not
+    // guarantee unique node names; the synthesized fallback above can also
+    // collide with an explicit name). Suffix with `__dup{i}` using the node's
+    // position index, matching the offline matcher's convention.
+    if (!seen_node_names.insert(node_name).second) {
+      node_name = node_name + "__dup" + std::to_string(i);
+      seen_node_names.insert(node_name);
     }
 
+    // `package` distinguishes contrib / internal-domain ops (e.g.
+    // `com.microsoft`, `com.ms.internal.nhwc` introduced by ORT's layout
+    // transformer) from the default ONNX op set. Empty / `ai.onnx` is
+    // normalized to "onnx" so the field matches what the post-compile
+    // `dump_json_qnn_graph` path emits for native ONNX nodes.
+    std::string node_domain = std::string(node.GetDomain());
     json node_json = json::object();
-    node_json["package"] = "onnx";
+    if (node_domain.empty() || node_domain == "ai.onnx") {
+      node_json["package"] = "onnx";
+    } else {
+      node_json["package"] = std::move(node_domain);
+    }
     node_json["type"] = op_type;
     node_json["input_names"] =
         CollectNodeTensorNames(node.GetInputs(), id_alloc, seen_tensors, tensors_json, type_info_failures);

--- a/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.h
@@ -1,0 +1,91 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+// EP-internal helper that serializes the ONNX graph the QNN EP receives in
+// GetCapabilityImpl (compile-time, before partitioning) into a JSON file using
+// the same schema as the post-compile `dump_json_qnn_graph` output, so the
+// result can be opened in QNN Netron and consumed by the offline
+// source->optimized op-trace matcher.
+//
+// This captures the graph AFTER ORT Level 1 optimizations (QDQ preserved,
+// `/duplicated` DQ copies, Transpose rearrangements) but BEFORE the QNN EP
+// compiles its partition, which is otherwise not observable: the ORT optimized-
+// model serializer refuses graphs containing compiled nodes.
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <string>
+#include <unordered_set>
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Walks the EP-input OrtGraph and writes a QNN-Netron-schema JSON description
+// to `output_path`. Returns true on success; logs a WARNING and returns false
+// on any failure (the caller treats the dump as a best-effort diagnostic and
+// continues compilation regardless).
+bool DumpQnnEpInputGraphToJson(const OrtGraph* graph,
+                               const std::filesystem::path& output_path,
+                               const Ort::Logger& logger);
+
+// Returns a filename-safe form of `graph_name`: any character outside
+// [A-Za-z0-9._-] is replaced with `_`, leading dots/hyphens are stripped (so
+// the result is never `..` or a hidden-file form), and trailing dots and
+// spaces are dropped (a Windows-reserved suffix). Windows reserved device
+// names (CON, PRN, AUX, NUL, COM1..9, LPT1..9, case-insensitive) are
+// suffixed with `_` so they no longer match the device-name pattern. An
+// input that sanitizes to the empty string returns "graph", giving callers a
+// non-empty fallback they can disambiguate further.
+//
+// Defined inline so the unit tests in onnxruntime_provider_test (which does
+// not link onnxruntime_providers_qnn) can call it directly.
+inline std::string SanitizeGraphNameForFilename(const std::string& graph_name) {
+  std::string result;
+  result.reserve(graph_name.size());
+  for (char c : graph_name) {
+    unsigned char uc = static_cast<unsigned char>(c);
+    bool safe = (uc >= '0' && uc <= '9') ||
+                (uc >= 'A' && uc <= 'Z') ||
+                (uc >= 'a' && uc <= 'z') ||
+                uc == '.' || uc == '_' || uc == '-';
+    result.push_back(safe ? static_cast<char>(uc) : '_');
+  }
+
+  size_t first = 0;
+  while (first < result.size() && (result[first] == '.' || result[first] == '-')) {
+    ++first;
+  }
+  if (first > 0) {
+    result.erase(0, first);
+  }
+
+  while (!result.empty() && (result.back() == '.' || result.back() == ' ')) {
+    result.pop_back();
+  }
+
+  if (result.empty()) {
+    return "graph";
+  }
+
+  std::string stem = result.substr(0, result.find('.'));
+  std::string upper_stem = stem;
+  std::transform(upper_stem.begin(), upper_stem.end(), upper_stem.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+  static const std::unordered_set<std::string> kReserved = {
+      "CON", "PRN", "AUX", "NUL",
+      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
+  if (kReserved.count(upper_stem)) {
+    result.insert(stem.size(), "_");
+  }
+
+  return result;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_ep_input_graph_dumper.h
@@ -14,11 +14,7 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cctype>
 #include <filesystem>
-#include <string>
-#include <unordered_set>
 
 #include "core/providers/qnn/ort_api.h"
 
@@ -32,60 +28,6 @@ namespace qnn {
 bool DumpQnnEpInputGraphToJson(const OrtGraph* graph,
                                const std::filesystem::path& output_path,
                                const Ort::Logger& logger);
-
-// Returns a filename-safe form of `graph_name`: any character outside
-// [A-Za-z0-9._-] is replaced with `_`, leading dots/hyphens are stripped (so
-// the result is never `..` or a hidden-file form), and trailing dots and
-// spaces are dropped (a Windows-reserved suffix). Windows reserved device
-// names (CON, PRN, AUX, NUL, COM1..9, LPT1..9, case-insensitive) are
-// suffixed with `_` so they no longer match the device-name pattern. An
-// input that sanitizes to the empty string returns "graph", giving callers a
-// non-empty fallback they can disambiguate further.
-//
-// Defined inline so the unit tests in onnxruntime_provider_test (which does
-// not link onnxruntime_providers_qnn) can call it directly.
-inline std::string SanitizeGraphNameForFilename(const std::string& graph_name) {
-  std::string result;
-  result.reserve(graph_name.size());
-  for (char c : graph_name) {
-    unsigned char uc = static_cast<unsigned char>(c);
-    bool safe = (uc >= '0' && uc <= '9') ||
-                (uc >= 'A' && uc <= 'Z') ||
-                (uc >= 'a' && uc <= 'z') ||
-                uc == '.' || uc == '_' || uc == '-';
-    result.push_back(safe ? static_cast<char>(uc) : '_');
-  }
-
-  size_t first = 0;
-  while (first < result.size() && (result[first] == '.' || result[first] == '-')) {
-    ++first;
-  }
-  if (first > 0) {
-    result.erase(0, first);
-  }
-
-  while (!result.empty() && (result.back() == '.' || result.back() == ' ')) {
-    result.pop_back();
-  }
-
-  if (result.empty()) {
-    return "graph";
-  }
-
-  std::string stem = result.substr(0, result.find('.'));
-  std::string upper_stem = stem;
-  std::transform(upper_stem.begin(), upper_stem.end(), upper_stem.begin(),
-                 [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
-  static const std::unordered_set<std::string> kReserved = {
-      "CON", "PRN", "AUX", "NUL",
-      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
-  if (kReserved.count(upper_stem)) {
-    result.insert(stem.size(), "_");
-  }
-
-  return result;
-}
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_ep_sanitize_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_ep_sanitize_utils.h
@@ -1,0 +1,85 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+// Pure-STL filename sanitizer extracted from qnn_ep_input_graph_dumper.h so
+// callers can use it without dragging in the QNN EP private API surface
+// (`core/providers/qnn/ort_api.h`). Used by both the dumper itself and the
+// dumper unit tests.
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <unordered_set>
+
+namespace onnxruntime {
+namespace qnn {
+
+// Returns a filename-safe form of `graph_name`: any character outside
+// [A-Za-z0-9._-] is replaced with `_` (so spaces and path separators become
+// `_`), leading dots/hyphens are stripped (so the result is never `..` or a
+// hidden-file form), and trailing dots are dropped (Windows treats a trailing
+// dot as ignorable). Windows reserved device names (CON, PRN, AUX, NUL,
+// COM1..9, LPT1..9, case-insensitive) are suffixed with `_` so they no longer
+// match the device-name pattern. An input that sanitizes to the empty string
+// returns "graph", giving callers a non-empty fallback they can disambiguate
+// further.
+//
+// Defined inline so the unit tests in onnxruntime_provider_test (which does
+// not link libonnxruntime_providers_qnn.so) can call it directly.
+inline std::string SanitizeGraphNameForFilename(const std::string& graph_name) {
+  std::string result;
+  result.reserve(graph_name.size());
+  for (char c : graph_name) {
+    unsigned char uc = static_cast<unsigned char>(c);
+    bool safe = (uc >= '0' && uc <= '9') ||
+                (uc >= 'A' && uc <= 'Z') ||
+                (uc >= 'a' && uc <= 'z') ||
+                uc == '.' || uc == '_' || uc == '-';
+    result.push_back(safe ? static_cast<char>(uc) : '_');
+  }
+
+  size_t first = 0;
+  while (first < result.size() && (result[first] == '.' || result[first] == '-')) {
+    ++first;
+  }
+  if (first > 0) {
+    result.erase(0, first);
+  }
+
+  // Trailing dot strip. Windows treats trailing dots as ignorable when
+  // resolving filenames (`foo.` and `foo` open the same file), so dropping
+  // them avoids ambiguity. Trailing spaces are already replaced with `_` by
+  // the safe-set pass above and so cannot reach this loop.
+  while (!result.empty() && result.back() == '.') {
+    result.pop_back();
+  }
+
+  if (result.empty()) {
+    return "graph";
+  }
+
+  // Windows reserves a small set of device names regardless of extension:
+  // creating a file named `CON`, `CON.json`, `nul`, etc. fails with
+  // ERROR_ACCESS_DENIED. The check is case-insensitive and applies to the
+  // stem only (the portion before the first `.`). On Linux/macOS these are
+  // ordinary filenames, but we suffix unconditionally to keep dump output
+  // portable across hosts.
+  std::string stem = result.substr(0, result.find('.'));
+  std::string upper_stem = stem;
+  std::transform(upper_stem.begin(), upper_stem.end(), upper_stem.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+  static const std::unordered_set<std::string> kReserved = {
+      "CON", "PRN", "AUX", "NUL",
+      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
+  if (kReserved.count(upper_stem)) {
+    result.insert(stem.size(), "_");
+  }
+
+  return result;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -28,6 +28,7 @@
 #include "core/providers/qnn/qnn_allocator.h"
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_backend_manager.h"
+#include "core/providers/qnn/builder/qnn_ep_input_graph_dumper.h"
 #include "core/providers/qnn/genie/genie_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_cache_compatibility_manager.h"
 #include "core/providers/qnn/builder/qnn_configs_helper.h"
@@ -1030,6 +1031,59 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                 "Provided a directory for framework op trace, but did not enable framework op tracing.");
   }
 
+  // QNN EP input graph dump options. Emits the ONNX graph the EP receives in
+  // GetCapabilityImpl (compile-time, pre-partition) as a QNN-Netron-schema JSON.
+  static constexpr const char* kDumpQnnEpInputGraph = "dump_qnn_ep_input_graph";
+  static constexpr const char* kDumpQnnEpInputGraphDir = "dump_qnn_ep_input_graph_dir";
+
+  dump_qnn_ep_input_graph_ = ParseBoolOption(ort_api,
+                                             session_options_,
+                                             FormatEPConfigKey(kDumpQnnEpInputGraph),
+                                             false,
+                                             logger_);
+
+  if (dump_qnn_ep_input_graph_) {
+    // Resolve the dump directory only when the dump itself is enabled. The
+    // session-config entry overrides the default; an unset/empty value falls
+    // back to the current working directory so the option is usable without
+    // a separate path config.
+    std::string ep_input_graph_dir_str;
+    GetSessionConfigEntryOrDefault(ort_api,
+                                   session_options_,
+                                   FormatEPConfigKey(kDumpQnnEpInputGraphDir),
+                                   "",
+                                   ep_input_graph_dir_str);
+    if (ep_input_graph_dir_str.empty()) {
+      ep_input_graph_dir_str = std::filesystem::current_path().string();
+    }
+    dump_qnn_ep_input_graph_dir_ = std::move(ep_input_graph_dir_str);
+
+    // Probe writability up-front so a non-writable path disables the feature
+    // before the per-graph walk runs.
+    std::filesystem::path probe_dir(dump_qnn_ep_input_graph_dir_);
+    std::error_code ec;
+    std::filesystem::create_directories(probe_dir, ec);
+    bool probe_ok = !ec;
+    if (probe_ok) {
+      std::filesystem::path probe_file = probe_dir / ".qnn_ep_input_graph_probe";
+      {
+        std::ofstream ofs(probe_file);
+        probe_ok = ofs.is_open() && (ofs << "1").good();
+      }
+      std::filesystem::remove(probe_file, ec);
+    }
+    if (!probe_ok) {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                  ("QNN EP input graph dump directory not writable: " + probe_dir.string() +
+                   "; the dump will be disabled.")
+                      .c_str());
+      dump_qnn_ep_input_graph_ = false;
+    } else {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+                  ("QNN EP input graph dump enabled. Output dir: " + dump_qnn_ep_input_graph_dir_).c_str());
+    }
+  }
+
   static const std::string QNN_HTP_EXTENDED_UDMA_MODE = "extended_udma";
   enable_htp_extended_udma_mode_ = ParseBoolOption(ort_api,
                                                    session_options_,
@@ -1687,6 +1741,28 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     if (!ep->onnx_graph_io_names_.has_value()) {
       ep->onnx_graph_io_names_.emplace(std::move(input_order), std::move(output_order));
     }
+  }
+
+  // Dump the EP-input ONNX graph (pre-partition) as a QNN-Netron-schema JSON.
+  // Best-effort diagnostic: failures are logged inside the dumper and never
+  // abort compilation. The filename always carries a per-EP counter so two
+  // graphs whose names sanitize to the same string produce two distinct
+  // files; the sanitized name (when present) is used as a human-readable
+  // prefix.
+  if (ep->dump_qnn_ep_input_graph_) {
+    Ort::ConstGraph dump_graph{graph};
+    std::string raw_name = std::string(dump_graph.GetName());
+    std::string graph_name;
+    if (raw_name.empty()) {
+      graph_name = "graph";
+    } else {
+      graph_name = qnn::SanitizeGraphNameForFilename(raw_name);
+    }
+    size_t count = ep->dump_qnn_ep_input_graph_count_.fetch_add(1, std::memory_order_relaxed);
+    std::filesystem::path out_path =
+        std::filesystem::path(ep->dump_qnn_ep_input_graph_dir_) /
+        (graph_name + "." + std::to_string(count) + "_qnn_ep_input_graph.json");
+    qnn::DumpQnnEpInputGraphToJson(graph, out_path, ep->logger_);
   }
 
   // Get node units for the ABI layer

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -29,6 +29,7 @@
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_ep_input_graph_dumper.h"
+#include "core/providers/qnn/builder/qnn_ep_sanitize_utils.h"
 #include "core/providers/qnn/genie/genie_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_cache_compatibility_manager.h"
 #include "core/providers/qnn/builder/qnn_configs_helper.h"
@@ -252,6 +253,43 @@ static bool ParseBoolOption(const OrtApi& ort_api,
   ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Using " + key + ": " + (result ? "1" : "0")).c_str());
 
   return result;
+}
+
+// Creates `dir` (and any missing parents) and verifies it is writable by
+// round-tripping a small probe file. Returns true on success. On failure,
+// logs a WARNING tagged with `feature_name` so callers can disable the
+// associated feature flag with a clear log trail. Used by every
+// QNN-EP-side dump option whose output is written incrementally during
+// session run (so a non-writable directory should disable the feature at
+// session-start rather than mid-inference).
+static bool ProbeDumpDirectoryWritable(const std::string& dir,
+                                       const std::string& feature_name,
+                                       const Ort::Logger& logger) {
+  std::filesystem::path probe_dir(dir);
+  std::error_code ec;
+  std::filesystem::create_directories(probe_dir, ec);
+  if (ec) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                (feature_name + " directory could not be created: " + probe_dir.string() +
+                 " (" + ec.message() + "); the feature will be disabled.")
+                    .c_str());
+    return false;
+  }
+  std::filesystem::path probe_file = probe_dir / ".qnn_ep_dump_probe";
+  bool ok = false;
+  {
+    std::ofstream ofs(probe_file);
+    ok = ofs.is_open() && (ofs << "1").good();
+  }
+  std::filesystem::remove(probe_file, ec);
+  if (!ok) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                (feature_name + " directory not writable: " + probe_dir.string() +
+                 "; the feature will be disabled.")
+                    .c_str());
+    return false;
+  }
+  return true;
 }
 
 #ifdef _WIN32
@@ -966,7 +1004,11 @@ QnnEp::QnnEp(QnnEpFactory& factory,
   if (!json_graph_dir_str.empty()) {
     json_qnn_graph_dir_ = json_graph_dir_str;
     if (dump_json_qnn_graph_) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, ("JSON graphs directory: " + json_qnn_graph_dir_).c_str());
+      if (ProbeDumpDirectoryWritable(json_qnn_graph_dir_, "QNN JSON graph dump", logger_)) {
+        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO, ("JSON graphs directory: " + json_qnn_graph_dir_).c_str());
+      } else {
+        dump_json_qnn_graph_ = false;
+      }
     } else {
       ORT_CXX_LOG(logger_,
                   ORT_LOGGING_LEVEL_WARNING,
@@ -1003,27 +1045,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     // surface as a WARNING after the entire compile + in-memory trace build
     // finishes. Disabling tracing here lets us skip all the per-graph collection
     // work when the trace can never be written.
-    std::filesystem::path probe_dir(framework_op_trace_dir_);
-    std::error_code ec;
-    std::filesystem::create_directories(probe_dir, ec);
-    bool probe_ok = !ec;
-    if (probe_ok) {
-      std::filesystem::path probe_file = probe_dir / ".qnn_op_trace_probe";
-      {
-        std::ofstream ofs(probe_file);
-        probe_ok = ofs.is_open() && (ofs << "1").good();
-      }
-      std::filesystem::remove(probe_file, ec);
-    }
-    if (!probe_ok) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
-                  ("Framework op trace directory not writable: " + probe_dir.string() +
-                   "; framework op tracing will be disabled.")
-                      .c_str());
-      enable_framework_op_trace_ = false;
-    } else {
+    if (ProbeDumpDirectoryWritable(framework_op_trace_dir_,
+                                   "Framework op trace",
+                                   logger_)) {
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
                   ("Framework op tracing enabled. Output dir: " + framework_op_trace_dir_).c_str());
+    } else {
+      enable_framework_op_trace_ = false;
     }
   } else if (!framework_op_trace_dir_.empty()) {
     ORT_CXX_LOG(logger_,
@@ -1060,27 +1088,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
 
     // Probe writability up-front so a non-writable path disables the feature
     // before the per-graph walk runs.
-    std::filesystem::path probe_dir(dump_qnn_ep_input_graph_dir_);
-    std::error_code ec;
-    std::filesystem::create_directories(probe_dir, ec);
-    bool probe_ok = !ec;
-    if (probe_ok) {
-      std::filesystem::path probe_file = probe_dir / ".qnn_ep_input_graph_probe";
-      {
-        std::ofstream ofs(probe_file);
-        probe_ok = ofs.is_open() && (ofs << "1").good();
-      }
-      std::filesystem::remove(probe_file, ec);
-    }
-    if (!probe_ok) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
-                  ("QNN EP input graph dump directory not writable: " + probe_dir.string() +
-                   "; the dump will be disabled.")
-                      .c_str());
-      dump_qnn_ep_input_graph_ = false;
-    } else {
+    if (ProbeDumpDirectoryWritable(dump_qnn_ep_input_graph_dir_,
+                                   "QNN EP input graph dump",
+                                   logger_)) {
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
                   ("QNN EP input graph dump enabled. Output dir: " + dump_qnn_ep_input_graph_dir_).c_str());
+    } else {
+      dump_qnn_ep_input_graph_ = false;
     }
   }
 
@@ -1612,6 +1626,29 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
                                                  OrtEpGraphSupportInfo* graph_support_info) noexcept {
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
+  // Best-effort diagnostic dump of the ONNX graph the EP just received.
+  // Fires before any subgraph / EPContext / Genie / backend-setup early
+  // return below so every GetCapability invocation produces a dump file —
+  // including subgraphs and sessions that later fail to set up a backend
+  // (precisely the cases where a "what did the EP see?" artifact is most
+  // useful). Filename is sanitized graph name + per-EP counter; the
+  // matcher's recommended consumption is "highest counter per unique
+  // sanitized name" (see docs/execution_providers/QNN-ExecutionProvider.md).
+  if (ep->dump_qnn_ep_input_graph_) {
+    Ort::ConstGraph dump_graph{graph};
+    // SanitizeGraphNameForFilename returns "graph" when the input is empty
+    // or sanitizes to empty, so a single call covers both the present-name
+    // and missing-name paths.
+    std::string graph_name = qnn::SanitizeGraphNameForFilename(std::string(dump_graph.GetName()));
+    size_t count = ep->dump_qnn_ep_input_graph_count_++;
+    std::filesystem::path out_path =
+        std::filesystem::path(ep->dump_qnn_ep_input_graph_dir_) /
+        (graph_name + "." + std::to_string(count) + "_qnn_ep_input_graph.json");
+    // Best-effort diagnostic: failures are already logged inside the dumper,
+    // so the bool return is intentionally discarded.
+    qnn::DumpQnnEpInputGraphToJson(graph, out_path, ep->logger_);
+  }
+
   const OrtNode* parent_node = nullptr;
   RETURN_IF_NOT_NULL(ep->ort_api.Graph_GetParentNode(graph, &parent_node));
   if (parent_node != nullptr) {
@@ -1741,28 +1778,6 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     if (!ep->onnx_graph_io_names_.has_value()) {
       ep->onnx_graph_io_names_.emplace(std::move(input_order), std::move(output_order));
     }
-  }
-
-  // Dump the EP-input ONNX graph (pre-partition) as a QNN-Netron-schema JSON.
-  // Best-effort diagnostic: failures are logged inside the dumper and never
-  // abort compilation. The filename always carries a per-EP counter so two
-  // graphs whose names sanitize to the same string produce two distinct
-  // files; the sanitized name (when present) is used as a human-readable
-  // prefix.
-  if (ep->dump_qnn_ep_input_graph_) {
-    Ort::ConstGraph dump_graph{graph};
-    std::string raw_name = std::string(dump_graph.GetName());
-    std::string graph_name;
-    if (raw_name.empty()) {
-      graph_name = "graph";
-    } else {
-      graph_name = qnn::SanitizeGraphNameForFilename(raw_name);
-    }
-    size_t count = ep->dump_qnn_ep_input_graph_count_.fetch_add(1, std::memory_order_relaxed);
-    std::filesystem::path out_path =
-        std::filesystem::path(ep->dump_qnn_ep_input_graph_dir_) /
-        (graph_name + "." + std::to_string(count) + "_qnn_ep_input_graph.json");
-    qnn::DumpQnnEpInputGraphToJson(graph, out_path, ep->logger_);
   }
 
   // Get node units for the ABI layer

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -216,6 +217,17 @@ class QnnEp : public OrtEp, public ApiPtrs {
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";
+
+  // === Qnn Ep Input Graph ===
+  // Dumps the ONNX graph the EP receives in GetCapabilityImpl (compile-time,
+  // pre-partition) as a QNN-Netron-schema JSON. Distinct from
+  // dump_json_qnn_graph_ above, which dumps the post-compile QNN graph.
+  bool dump_qnn_ep_input_graph_ = false;
+  std::string dump_qnn_ep_input_graph_dir_;
+  // Per-EP counter that disambiguates output filenames. Always appended to
+  // the filename so two graphs whose names sanitize to the same string still
+  // produce two distinct files.
+  std::atomic<size_t> dump_qnn_ep_input_graph_count_{0};
 
   // === Framework op trace ===
   bool enable_framework_op_trace_ = false;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -226,8 +226,9 @@ class QnnEp : public OrtEp, public ApiPtrs {
   std::string dump_qnn_ep_input_graph_dir_;
   // Per-EP counter that disambiguates output filenames. Always appended to
   // the filename so two graphs whose names sanitize to the same string still
-  // produce two distinct files.
-  std::atomic<size_t> dump_qnn_ep_input_graph_count_{0};
+  // produce two distinct files. ORT calls GetCapabilityImpl sequentially
+  // from a single thread today, so plain size_t is sufficient.
+  size_t dump_qnn_ep_input_graph_count_ = 0;
 
   // === Framework op trace ===
   bool enable_framework_op_trace_ = false;

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -14,7 +14,7 @@
 #include "onnxruntime_session_options_config_keys.h"
 
 #include "core/providers/qnn/builder/op_package/op_package_parser.h"
-#include "core/providers/qnn/builder/qnn_ep_input_graph_dumper.h"
+#include "core/providers/qnn/builder/qnn_ep_sanitize_utils.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/util/include/api_asserts.h"
 
@@ -2897,10 +2897,11 @@ TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_StripsLeadingDotsAndDashes) {
   EXPECT_EQ(qnn::SanitizeGraphNameForFilename("."), "graph");
 }
 
-TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_DropsTrailingDotAndSpace) {
-  // Trailing space is replaced with `_` by the safe-set pass (so the result
-  // does not end in space, satisfying the Windows constraint). Trailing
-  // dots are explicitly stripped because Windows treats them as ignorable.
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_DropsTrailingDot) {
+  // Trailing dots are explicitly stripped because Windows treats them as
+  // ignorable. Trailing space is already replaced with `_` by the safe-set
+  // pass before the trim runs, so it never reaches the trim — the
+  // `"foo. "` case below documents that contract.
   EXPECT_EQ(qnn::SanitizeGraphNameForFilename("foo. "), "foo._");
   EXPECT_EQ(qnn::SanitizeGraphNameForFilename("foo.bar."), "foo.bar");
   EXPECT_EQ(qnn::SanitizeGraphNameForFilename("foo..."), "foo");

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -14,6 +14,7 @@
 #include "onnxruntime_session_options_config_keys.h"
 
 #include "core/providers/qnn/builder/op_package/op_package_parser.h"
+#include "core/providers/qnn/builder/qnn_ep_input_graph_dumper.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/util/include/api_asserts.h"
 
@@ -2836,6 +2837,268 @@ TEST_F(QnnHTPBackendTests, ExtendedUdmaModeTest) {
                   0.008f);
 }
 #endif  // defined(_WIN32)
+
+// ============================ QNN EP input graph dump ============================
+//
+// `dump_qnn_ep_input_graph` writes the ONNX graph the EP receives at compile
+// time (after ORT Level 1 optimizations, before partitioning) as a JSON file in
+// the same QNN-Netron schema used by `dump_json_qnn_graph`. These tests run a
+// small model on the CPU backend, then parse and validate the emitted JSON.
+//
+// Why JSON (QNN Netron schema) and not a real .onnx: the QNN EP is a standalone
+// ABI plugin that links only the public ORT C/C++ API + Abseil + nlohmann/json
+// (see cmake/onnxruntime_providers_qnn.cmake) and intentionally does NOT link
+// protobuf / onnx proto, so it cannot construct or serialize an onnx::ModelProto.
+// nlohmann/json is already a plugin dependency and the schema is Netron-openable,
+// so reusing it adds zero dependencies. (The test binary itself DOES link onnx
+// proto, which is why these tests can build real models to feed the EP.)
+
+namespace {
+
+// Returns the first "*_qnn_ep_input_graph.json" file in `dir`, or {} if none.
+std::filesystem::path FindQnnEpInputGraphDump(const std::filesystem::path& dir) {
+  if (!std::filesystem::exists(dir)) return {};
+  for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+    if (entry.path().extension() == ".json" &&
+        entry.path().stem().string().find("_qnn_ep_input_graph") != std::string::npos) {
+      return entry.path();
+    }
+  }
+  return {};
+}
+
+}  // namespace
+
+// Pure-function tests for SanitizeGraphNameForFilename. These do not need to
+// drive the EP because the helper is exposed in the dumper header. The intent
+// is to lock down: (a) path-separator characters cannot escape the dump
+// directory, (b) Windows-illegal characters are replaced, (c) parent-dir
+// references (`..`) cannot survive, (d) Windows-reserved device names get
+// suffixed so they do not collide with the device-name handler, and
+// (e) sanitized output combined with `<dump_dir> / sanitized` always lands
+// inside `<dump_dir>` (lexical containment check).
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_ReplacesPathSeparators) {
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("model/encoder/layer.0/Add"),
+            "model_encoder_layer.0_Add");
+}
+
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_ReplacesWindowsIllegal) {
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("a:b*c?d|e<f>g\"h"),
+            "a_b_c_d_e_f_g_h");
+}
+
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_StripsLeadingDotsAndDashes) {
+  // `..foo` must not survive as a parent-dir reference. Leading `-` is
+  // stripped so the result cannot resemble an argument flag if it ever
+  // round-trips through a CLI.
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("..foo"), "foo");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("-rf"), "rf");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename(".."), "graph");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("."), "graph");
+}
+
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_DropsTrailingDotAndSpace) {
+  // Trailing space is replaced with `_` by the safe-set pass (so the result
+  // does not end in space, satisfying the Windows constraint). Trailing
+  // dots are explicitly stripped because Windows treats them as ignorable.
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("foo. "), "foo._");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("foo.bar."), "foo.bar");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("foo..."), "foo");
+}
+
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_AvoidsWindowsReservedNames) {
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("CON"), "CON_");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("nul"), "nul_");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("COM1"), "COM1_");
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("CON.json"), "CON_.json");
+  // A reserved-looking stem inside a longer name is fine.
+  EXPECT_EQ(qnn::SanitizeGraphNameForFilename("CONSOLE"), "CONSOLE");
+}
+
+TEST(QnnEpInputGraphDumperTest, SanitizeGraphName_LandsInsideDumpDir) {
+  // For any sanitized name N, `dump_dir / (N + suffix)`.lexically_normal()
+  // must remain a child of `dump_dir`. This is the containment invariant
+  // the dumper relies on so a hostile graph name (path separators, parent
+  // refs, drive prefixes) cannot redirect output outside the configured
+  // dump directory.
+  std::filesystem::path dump_dir = std::filesystem::temp_directory_path() / "qnn_dump_root";
+  for (const char* raw : {"model/encoder/Add",
+                          "../../etc/passwd",
+                          "C:\\Windows\\System32",
+                          "..",
+                          "CON",
+                          "graph.with.dots",
+                          ""}) {
+    std::string sanitized = qnn::SanitizeGraphNameForFilename(raw);
+    std::filesystem::path joined =
+        (dump_dir / (sanitized + "_qnn_ep_input_graph.json")).lexically_normal();
+    auto dump_root = dump_dir.lexically_normal();
+    auto joined_str = joined.string();
+    auto root_str = dump_root.string();
+    EXPECT_EQ(joined_str.rfind(root_str, 0), 0u)
+        << "graph name '" << raw << "' produced path '" << joined_str
+        << "' which escapes dump root '" << root_str << "'";
+    EXPECT_EQ(joined.parent_path().lexically_normal(), dump_root)
+        << "graph name '" << raw << "' produced parent != dump root";
+  }
+}
+
+// Run a tiny float model with the dump enabled and validate the emitted JSON
+// structure: the 8 top-level QNN-Netron keys, node entries keyed by name with
+// type/input_names/output_names, and tensor entries keyed by name with
+// id/type/data_type/dims.
+TEST_F(QnnCPUBackendTests, DumpQnnEpInputGraph_BasicStructure) {
+  const std::filesystem::path dump_dir =
+      std::filesystem::temp_directory_path() / "qnn_ep_input_graph_basic";
+  std::error_code ec;
+  std::filesystem::remove_all(dump_dir, ec);
+  std::filesystem::create_directories(dump_dir);
+
+  ProviderOptions options;
+  options["backend_type"] = "cpu";
+  options["offload_graph_io_quantization"] = "0";
+  options["dump_qnn_ep_input_graph"] = "1";
+  options["dump_qnn_ep_input_graph_dir"] = dump_dir.string();
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  RunQnnModelTest(BuildOpTestCase<float>("add_node", "Add",
+                                         {TestInputDef<float>({1, 2, 3}, false, data),
+                                          TestInputDef<float>({1, 2, 3}, false, data)},
+                                         {}, {}, kOnnxDomain),
+                  options, 13, ExpectedEPNodeAssignment::All);
+
+  if (::testing::UnitTest::GetInstance()->current_test_info()->result()->Skipped()) {
+    std::filesystem::remove_all(dump_dir, ec);
+    return;
+  }
+
+  std::filesystem::path dump_file = FindQnnEpInputGraphDump(dump_dir);
+  ASSERT_FALSE(dump_file.empty()) << "No *_qnn_ep_input_graph.json written in " << dump_dir;
+
+  std::ifstream ifs(dump_file);
+  ASSERT_TRUE(ifs.is_open());
+  nlohmann::json j = nlohmann::json::parse(ifs, nullptr, false);
+  ASSERT_FALSE(j.is_discarded()) << "dump is not valid JSON: " << dump_file;
+
+  // 8 top-level QNN-Netron keys.
+  for (const char* key : {"model.cpp", "model.bin", "converter_command", "copyright_str",
+                          "op_types", "Total parameters", "Total MACs per inference", "graph"}) {
+    EXPECT_TRUE(j.contains(key)) << "missing top-level key: " << key;
+  }
+  ASSERT_TRUE(j["graph"].contains("nodes"));
+  ASSERT_TRUE(j["graph"].contains("tensors"));
+  EXPECT_GE(j["graph"]["nodes"].size(), 1u);
+  EXPECT_GE(j["graph"]["tensors"].size(), 1u);
+
+  // Every node entry carries the Netron-required fields.
+  for (auto it = j["graph"]["nodes"].begin(); it != j["graph"]["nodes"].end(); ++it) {
+    const auto& node = it.value();
+    EXPECT_TRUE(node.contains("type"));
+    EXPECT_TRUE(node.contains("input_names"));
+    EXPECT_TRUE(node.contains("output_names"));
+    EXPECT_TRUE(node["input_names"].is_array());
+    EXPECT_TRUE(node["output_names"].is_array());
+  }
+
+  // Every tensor entry carries id/type/data_type/dims.
+  for (auto it = j["graph"]["tensors"].begin(); it != j["graph"]["tensors"].end(); ++it) {
+    const auto& tensor = it.value();
+    EXPECT_TRUE(tensor.contains("id"));
+    EXPECT_TRUE(tensor.contains("type"));
+    EXPECT_TRUE(tensor.contains("data_type"));
+    EXPECT_TRUE(tensor.contains("dims"));
+    EXPECT_TRUE(tensor["dims"].is_array());
+  }
+
+  std::filesystem::remove_all(dump_dir, ec);
+}
+
+// Validate that graph inputs, outputs, and initializers are classified with the
+// QNN tensor-type integers Netron expects (APP_WRITE=0, APP_READ=1, STATIC=4).
+TEST_F(QnnCPUBackendTests, DumpQnnEpInputGraph_TensorClassification) {
+  const std::filesystem::path dump_dir =
+      std::filesystem::temp_directory_path() / "qnn_ep_input_graph_classify";
+  std::error_code ec;
+  std::filesystem::remove_all(dump_dir, ec);
+  std::filesystem::create_directories(dump_dir);
+
+  ProviderOptions options;
+  options["backend_type"] = "cpu";
+  options["offload_graph_io_quantization"] = "0";
+  options["dump_qnn_ep_input_graph"] = "1";
+  options["dump_qnn_ep_input_graph_dir"] = dump_dir.string();
+
+  // Add with a constant initializer as the second input, so the dump contains
+  // a graph input (APP_WRITE), a graph output (APP_READ), and an initializer
+  // (STATIC).
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  std::vector<float> init_data = GetFloatDataInRange(-1.0f, 1.0f, 6);
+  RunQnnModelTest(BuildOpTestCase<float, float>("add_node", "Add",
+                                                {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                                                {TestInputDef<float>({1, 2, 3}, true, init_data)},
+                                                {}, kOnnxDomain),
+                  options, 13, ExpectedEPNodeAssignment::All);
+
+  if (::testing::UnitTest::GetInstance()->current_test_info()->result()->Skipped()) {
+    std::filesystem::remove_all(dump_dir, ec);
+    return;
+  }
+
+  std::filesystem::path dump_file = FindQnnEpInputGraphDump(dump_dir);
+  ASSERT_FALSE(dump_file.empty()) << "No dump written in " << dump_dir;
+  std::ifstream ifs(dump_file);
+  nlohmann::json j = nlohmann::json::parse(ifs, nullptr, false);
+  ASSERT_FALSE(j.is_discarded());
+
+  // Collect the set of tensor-type integers present. We expect at least one
+  // graph input (0), one graph output (1), and one initializer (4).
+  std::unordered_set<int> seen_types;
+  for (auto it = j["graph"]["tensors"].begin(); it != j["graph"]["tensors"].end(); ++it) {
+    seen_types.insert(it.value()["type"].get<int>());
+  }
+  EXPECT_TRUE(seen_types.count(0)) << "expected an APP_WRITE (graph input) tensor";
+  EXPECT_TRUE(seen_types.count(1)) << "expected an APP_READ (graph output) tensor";
+  EXPECT_TRUE(seen_types.count(4)) << "expected a STATIC (initializer) tensor";
+
+  std::filesystem::remove_all(dump_dir, ec);
+}
+
+// With the option disabled (default), no dump file is written.
+TEST_F(QnnCPUBackendTests, DumpQnnEpInputGraph_DisabledByDefault) {
+  const std::filesystem::path dump_dir =
+      std::filesystem::temp_directory_path() / "qnn_ep_input_graph_disabled";
+  std::error_code ec;
+  std::filesystem::remove_all(dump_dir, ec);
+  std::filesystem::create_directories(dump_dir);
+
+  ProviderOptions options;
+  options["backend_type"] = "cpu";
+  options["offload_graph_io_quantization"] = "0";
+  // Pin the dump directory to a scoped temp dir while leaving
+  // dump_qnn_ep_input_graph unset. Setting only the directory makes the
+  // assertion below catch a regression that flips the default to enabled:
+  // such a regression would write into this directory and trip the empty()
+  // check, instead of silently writing into the test's CWD where the helper
+  // would never look.
+  options["dump_qnn_ep_input_graph_dir"] = dump_dir.string();
+
+  std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
+  RunQnnModelTest(BuildOpTestCase<float>("add_node", "Add",
+                                         {TestInputDef<float>({1, 2, 3}, false, data),
+                                          TestInputDef<float>({1, 2, 3}, false, data)},
+                                         {}, {}, kOnnxDomain),
+                  options, 13, ExpectedEPNodeAssignment::All);
+
+  if (::testing::UnitTest::GetInstance()->current_test_info()->result()->Skipped()) {
+    std::filesystem::remove_all(dump_dir, ec);
+    return;
+  }
+
+  EXPECT_TRUE(FindQnnEpInputGraphDump(dump_dir).empty())
+      << "dump file written even though dump_qnn_ep_input_graph was not enabled";
+
+  std::filesystem::remove_all(dump_dir, ec);
+}
 
 #endif  // !defined(ORT_MINIMAL_BUILD)
 

--- a/qcom/tools/op_trace_matcher/README.md
+++ b/qcom/tools/op_trace_matcher/README.md
@@ -23,8 +23,11 @@ code changes.
 ## `source_to_optimized_matcher.py`
 
 Offline tool that computes a structural correspondence between a user-supplied
-ONNX model (`source.onnx`) and an ORT-optimized ONNX model (`optimized.onnx`,
-saved via `SessionOptions::optimized_model_filepath`). Output JSON aligns with
+ONNX model (`source.onnx`) and an ORT-optimized graph. The optimized side is
+either an ONNX model (`optimized.onnx`, saved via
+`SessionOptions::optimized_model_filepath`) or a QNN-Netron-schema JSON dumped
+by the QNN EP's `dump_qnn_ep_input_graph` option (the exact graph the EP saw;
+see the QNN EP workflow section below). Output JSON aligns with
 the QNN EP `FrameworkOpTrace` schema's `original_sources` extension and can be
 stitched together with the existing QNN EP op trace to produce end-to-end
 provenance: original ONNX node -> optimized ONNX node -> QNN op.
@@ -76,6 +79,138 @@ The tool produces both **node-level** and **tensor-level** mappings.
 3. **First-version scope.** Patterns currently encoded: `MatMul+Add -> Gemm`, the Erf-form `Gelu`, Tanh-form `FastGelu`, `QuickGelu`, `BiasGelu`, `BiasSoftmax`, `SkipLayerNormalization`, `FusedMatMul`. Branching fusions (LayerNormalization, EmbedLayerNormalization, Attention, GroupQueryAttention) are not in the pattern table because the matcher's walk-back is linear; the matcher will report partial matches for those via initializer anchoring instead.
 4. **Fusion tensor attribution.** For fused nodes, the optimized output tensor is attributed to the **last** source node (deepest in topological order). This matches the semantics of most ORT fusions; the explanatory note in the JSON makes the heuristic explicit.
 5. **No guarantees on attribute equivalence.** The matcher checks op_type and I/O structure but does not verify node attributes (kernel size, strides, etc.) are consistent between source and optimized.
+
+#### QNN EP / QDQ-direct workflow
+
+**Why QNN EP sees the QDQ source graph, not a QLinear-fused graph**
+
+When QNN EP is registered, ORT applies Level 1 optimizations to the graph
+before handing it to the EP. The Level 2 `QDQSelectorActionTransformer`
+— which converts `DQ -> op -> Q` clusters into QLinear* fused ops — does not
+apply to QNN EP's partition because QNN EP does not support QLinear*
+operators; it handles QDQ natively. As a result, **the graph the QNN EP
+receives is structurally very close to the user-supplied source ONNX**, with
+only the following Level 1 changes:
+
+| Level 1 transformation | Visible effect |
+|---|---|
+| `EnsureUniqueDQForNodeUnit` | Each DQ with multiple consumers gets its own copy, named with a `/duplicated` suffix |
+| `TransposeOptimizer` | May add or rearrange Transpose nodes |
+| `ConstantFolding` (DQ preserved) | Some constants folded, but DQ nodes kept intact |
+| `DoubleQDQPairsRemover`, `QDQPropagationTransformer` | Minor QDQ structural cleanup |
+
+**`-o 1` as an approximation of the EP-input graph**
+
+Running `onnxruntime_perf_test -o 1 -u ep_approx.onnx` (basic optimization
+only, no QNN EP) produces a file that is a close approximation of what QNN EP
+sees.  The gap between `-o 1` output and the true EP-input is small — a
+second pass of `MatMulAddFusion` and `QDQFinalCleanupTransformer` from Level
+2 may make minor structural changes — but for typical QDQ models the
+difference is negligible. The crucial Level 2 `QDQSelectorActionTransformer`
+(QDQ->QLinear) is not in that gap: it doesn't apply to QNN EP's partition
+regardless of the optimization level used.
+
+**Obtaining the `--optimized-model` for this workflow**
+
+`SessionOptions::SetOptimizedModelFilePath` (`-u` in perf_test) fails when
+QNN EP is active because the serialization happens after the EP has compiled
+its partition into opaque compiled nodes, and the ORT plugin EP API does not
+expose a graph-serialization interface. The practical alternatives, best first:
+
+1. **QNN EP `dump_qnn_ep_input_graph` (exact)** — the QNN EP can dump the
+   ONNX graph it actually receives at compile time (after ORT Level 1
+   optimizations, before partitioning) as a QNN-Netron-schema JSON. This is
+   the true EP-input graph, not an approximation:
+
+   ```bash
+   onnxruntime_perf_test ... \
+       -i "... dump_qnn_ep_input_graph|1 dump_qnn_ep_input_graph_dir|./"
+   # writes <graph_name>.<n>_qnn_ep_input_graph.json
+   ```
+
+   `--optimized-model` accepts this JSON directly (detected by the `.json`
+   extension) — no `onnx` load is needed for the optimized side:
+
+   ```bash
+   python source_to_optimized_matcher.py \
+       --source-model    model.onnx \
+       --optimized-model graph.0_qnn_ep_input_graph.json \
+       --qnn-trace       qnn_op_trace.json \
+       ...
+   ```
+
+   The dump carries node name/op_type/inputs/outputs and a tensor table that
+   flags initializers (tensor `type == 4`). It does not carry initializer data
+   bytes, so data-hash matching (renamed-weight detection) is inert for this
+   input — name-based and topology-based matching are unaffected, which is what
+   the QNN-EP-direct workflow needs.
+
+   **Multiple dumps for the same graph name — which file to feed.** A single
+   session can produce more than one dump per graph because ORT may invoke
+   `GetCapability` more than once: once before its NHWC layout transform and
+   once after on the rewritten graph; once per `If`/`Loop`/`Scan` subgraph;
+   and once again on EPContext model loads. The atomic counter in the
+   filename (`<graph_name>.<n>_…json`) gives each pass a distinct file, with
+   an overwrite warning logged if the same `<n>` is ever about to be reused.
+
+   For each unique `<graph_name>`, feed the file with the **highest `<n>`**
+   as `--optimized-model`. That is the graph the QNN EP actually compiled,
+   and its node names are the names that appear in `qnn_op_trace.json`'s
+   `sources[]` — the join `source -> optimized -> QNN op` only closes if you
+   feed the post-transform graph. Lower-numbered files are intermediate
+   snapshots and useful for debugging the layout transformer itself, not for
+   matcher input. Models with subgraphs need one matcher run per unique
+   graph name, each pointed at that graph's highest-numbered dump.
+
+2. **`-o 1 -u` without QNN EP** — a close approximation when the dump is not
+   available. Run the model through ORT with only Level 1 optimizations (no
+   QNN EP) and save:
+
+   ```bash
+   onnxruntime_perf_test.exe -o 1 -u ep_approx.onnx -r 0 model.onnx
+   # (omit --plugin_ep_libs / --plugin_eps so QNN EP is not registered)
+   ```
+
+   This applies the same Level 1 passes that QNN EP sees, including
+   `EnsureUniqueDQForNodeUnit` (which adds `/duplicated` DQ copies).
+   The gap is a second pass of `MatMulAddFusion` and
+   `QDQFinalCleanupTransformer` from Level 2 — both are negligible for
+   typical QDQ models. Crucially, `QDQSelectorActionTransformer` (the
+   QDQ->QLinear fusion) does **not** run in either case.
+
+   ```bash
+   python source_to_optimized_matcher.py \
+       --source-model    model.onnx \
+       --optimized-model ep_approx.onnx \
+       --qnn-trace       qnn_op_trace.json \
+       ...
+   ```
+
+3. **Pass the source ONNX as both arguments** — adequate for most QDQ models
+   because the EP-input is structurally very close to the source (Level 1
+   changes are mostly node copies and Transpose rearrangements, not renames):
+
+   ```bash
+   python source_to_optimized_matcher.py \
+       --source-model    model.onnx \
+       --optimized-model model.onnx \
+       --qnn-trace       qnn_op_trace.json \
+       ...
+   ```
+
+The matcher has an identity fallback in `join_qnn_trace`: if a node name
+from `sources[]` is not in the matcher's `node_mappings` but is a node in
+the source ONNX, it is passed through unchanged. This covers the common case
+where source ≈ EP-input, without requiring a precise EP-input dump.
+
+EP-synthesized node names (`_token_N` suffixes, `/duplicated` copies, bare
+`DequantizeLinear` without a namespace) have no user-authored ONNX counterpart
+and remain unresolved; this is correct behaviour.
+
+If you use a file saved with CPU EP or full ORT optimization
+(`SessionOptions::optimized_model_filepath` from a default session), it will
+contain QLinear* fused nodes that do not match what QNN EP consumed; most
+`original_sources[]` entries will be empty.
 
 ### Usage
 

--- a/qcom/tools/op_trace_matcher/README.md
+++ b/qcom/tools/op_trace_matcher/README.md
@@ -75,10 +75,9 @@ The tool produces both **node-level** and **tensor-level** mappings.
 #### Honest caveats
 
 1. **The matcher does not run ORT.** It operates on saved ONNX files. If your downstream consumer needs a runtime (in-process) mapping rather than an offline one over saved files, this tool is not the right choice.
-2. **Pattern table is hand-curated.** New ORT fusion passes need to be added to `FUSION_PATTERNS` to be recognized. The matcher will not crash on unknown patterns; it will just leave the optimized node in `unmapped_optimized_nodes`.
-3. **First-version scope.** Patterns currently encoded: `MatMul+Add -> Gemm`, the Erf-form `Gelu`, Tanh-form `FastGelu`, `QuickGelu`, `BiasGelu`, `BiasSoftmax`, `SkipLayerNormalization`, `FusedMatMul`. Branching fusions (LayerNormalization, EmbedLayerNormalization, Attention, GroupQueryAttention) are not in the pattern table because the matcher's walk-back is linear; the matcher will report partial matches for those via initializer anchoring instead.
-4. **Fusion tensor attribution.** For fused nodes, the optimized output tensor is attributed to the **last** source node (deepest in topological order). This matches the semantics of most ORT fusions; the explanatory note in the JSON makes the heuristic explicit.
-5. **No guarantees on attribute equivalence.** The matcher checks op_type and I/O structure but does not verify node attributes (kernel size, strides, etc.) are consistent between source and optimized.
+2. **Pattern table is hand-curated and lives in one place.** The authoritative list is the `FUSION_PATTERNS` dict in `source_to_optimized_matcher.py`; adding a new ORT fusion means adding one entry there and nowhere else. The matcher will not crash on unknown patterns — it just leaves the optimized node in `unmapped_optimized_nodes`. Branching fusions (LayerNormalization, EmbedLayerNormalization, Attention, GroupQueryAttention) are deliberately absent because the walk-back is linear; the matcher reports partial matches for those via initializer anchoring instead.
+3. **Fusion tensor attribution.** For fused nodes, the optimized output tensor is attributed to the **last** source node (deepest in topological order). This matches the semantics of most ORT fusions; the explanatory note in the JSON makes the heuristic explicit.
+4. **No guarantees on attribute equivalence.** The matcher checks op_type and I/O structure but does not verify node attributes (kernel size, strides, etc.) are consistent between source and optimized.
 
 #### QNN EP / QDQ-direct workflow
 
@@ -444,6 +443,8 @@ Msg Timestamp,...,Event Identifier,ONNX Source Ops,Original ONNX Source Ops
 
 - Python 3.9+ (PEP 604 union syntax in module-level annotations; `onnx` package floor).
 - `onnx` (any recent version, `pip install onnx`) — required for the matcher and for Mode B of the enrichment tool. Mode A of the enrichment tool is pure stdlib and does not need `onnx`.
+
+For convenience, this directory ships its own [`requirements.txt`](./requirements.txt) listing the runtime deps; install with `pip install -r qcom/tools/op_trace_matcher/requirements.txt`. The repo-wide `requirements-dev.txt` already covers these plus `pytest` for the unit tests.
 
 No ORT runtime dependency — both tools operate on saved `.onnx` files and JSON/CSV artifacts only.
 

--- a/qcom/tools/op_trace_matcher/README.md
+++ b/qcom/tools/op_trace_matcher/README.md
@@ -1,0 +1,321 @@
+# Op Trace Matcher Tools
+
+This directory contains two related offline tools that, together, deliver
+end-to-end provenance for QNN-EP-compiled models —
+`original ONNX -> optimized ONNX -> QNN op` — without any ORT-core or QNN-EP
+code changes.
+
+> **Dependency:** these tools consume the QNN EP framework-op-trace artifacts —
+> the `qnn_op_trace.json` sidecar and the `ONNX Source Ops` profiling-CSV column
+> produced by `Serializer::LookupOnnxSources()` / `Serializer::InitCsvFile()`.
+> That feature ships with the QNN EP framework op tracing support
+> (`qnn.enable_framework_op_trace`). The matcher and enricher consume those
+> artifacts as plain files and do not link against the EP, but a `qnn_op_trace.json`
+> from a build without framework op tracing will be absent.
+
+| Tool | Purpose |
+|------|---------|
+| [`source_to_optimized_matcher.py`](#source_to_optimized_matcherpy) | Compute source ONNX -> optimized ONNX node and tensor mappings. Optionally extend a QNN EP `qnn_op_trace.json` with `original_sources[]`. |
+| [`enrich_profiling_csv.py`](#enrich_profiling_csvpy) | Add original ONNX op names to a QNN EP profiling CSV by joining on the merged framework op trace. Adapts to the input: verbatim-copies BASIC profiling; appends one column when `ONNX Source Ops` is already present and populated; fills the empty column in place plus appends Original when the column is present but every NODE row's cell is empty (AOT-no-sidecar); synthesizes both columns when the column is missing. Mode A reads a pre-computed merged trace; Mode B invokes the matcher inline. |
+
+---
+
+## `source_to_optimized_matcher.py`
+
+Offline tool that computes a structural correspondence between a user-supplied
+ONNX model (`source.onnx`) and an ORT-optimized ONNX model (`optimized.onnx`,
+saved via `SessionOptions::optimized_model_filepath`). Output JSON aligns with
+the QNN EP `FrameworkOpTrace` schema's `original_sources` extension and can be
+stitched together with the existing QNN EP op trace to produce end-to-end
+provenance: original ONNX node -> optimized ONNX node -> QNN op.
+
+Approach: zero ORT core changes; relies on the public
+`optimized_model_filepath` session option to obtain the post-optimizer graph,
+then applies layered structural matching offline.
+
+### Feasibility Assessment
+
+The tool produces both **node-level** and **tensor-level** mappings.
+
+#### Node-level matching strategies
+
+| Case | Strategy | Confidence |
+|------|----------|-----------|
+| Unchanged 1:1 nodes (same name + op_type) | Exact-name match | High |
+| Renamed but topologically identical nodes | Exact I/O signature match | High |
+| Optimized node consumes initializer with same name as source consumer | Initializer-name anchoring | High |
+| Initializer renamed but data byte-identical | Initializer SHA-256 hash | High |
+| Multiple source nodes share initializers with one optimized node | Initializer-name anchoring -> fusion | Medium |
+| Source nodes folded into an upstream optimized node (Conv+BN, Conv+Relu) | Producer-preferred lineage extension | Medium |
+| Common known patterns (MatMul+Add -> Gemm; Gelu / FastGelu / QuickGelu / BiasGelu / BiasSoftmax / SkipLayerNormalization / FusedMatMul fusions) | Pattern matcher (extensible table) | Medium |
+
+#### Tensor-level matching strategies
+
+| Case | Strategy | Confidence |
+|------|----------|-----------|
+| Tensor name preserved (model I/O, surviving intermediates) | Exact-name match | High |
+| Initializer with same name in both graphs | Initializer-name match | High |
+| Initializer renamed but byte-identical | Initializer SHA-256 hash | High |
+| Output tensor of a 1:1 matched node | Node-output positional inheritance | High |
+| Output tensor of a fused node (multiple source nodes) | Node-output positional, attributed to last source | Medium |
+
+#### What this tool cannot do
+
+| Case | Why | Consequence in output |
+|------|-----|----------------------|
+| Constant folding (subgraph -> initializer) | Source node identity is destroyed at folding | Reported in `removed_original_nodes` with `likely_reason: "constant_folded"` |
+| Layout transposition (NHWC) when initializer data is repacked | Bytes change, names change, no anchor | Falls through to topology heuristic; flagged as low-confidence or unmatched |
+| Novel fusion patterns not in the pattern table | Pattern unknown to matcher | Optimized node reported in `unmapped_optimized_nodes`; user can add the pattern |
+| Multi-tenant initializer reuse (same weight consumed by multiple unrelated nodes) | Hash matches everyone | Multiple candidate matches reported as Medium-confidence with explanatory note |
+| Tensors introduced purely by optimization (e.g., new Transpose I/O) | No source counterpart | Not present in `tensor_mappings` |
+
+#### Honest caveats
+
+1. **The matcher does not run ORT.** It operates on saved ONNX files. If your downstream consumer needs a runtime (in-process) mapping rather than an offline one over saved files, this tool is not the right choice.
+2. **Pattern table is hand-curated.** New ORT fusion passes need to be added to `FUSION_PATTERNS` to be recognized. The matcher will not crash on unknown patterns; it will just leave the optimized node in `unmapped_optimized_nodes`.
+3. **First-version scope.** Patterns currently encoded: `MatMul+Add -> Gemm`, the Erf-form `Gelu`, Tanh-form `FastGelu`, `QuickGelu`, `BiasGelu`, `BiasSoftmax`, `SkipLayerNormalization`, `FusedMatMul`. Branching fusions (LayerNormalization, EmbedLayerNormalization, Attention, GroupQueryAttention) are not in the pattern table because the matcher's walk-back is linear; the matcher will report partial matches for those via initializer anchoring instead.
+4. **Fusion tensor attribution.** For fused nodes, the optimized output tensor is attributed to the **last** source node (deepest in topological order). This matches the semantics of most ORT fusions; the explanatory note in the JSON makes the heuristic explicit.
+5. **No guarantees on attribute equivalence.** The matcher checks op_type and I/O structure but does not verify node attributes (kernel size, strides, etc.) are consistent between source and optimized.
+
+### Usage
+
+#### Basic: produce the source->optimized mapping
+
+```bash
+# Step 1: Have ORT save the optimized model.
+#         In your inference code:
+#
+#         session_options.optimized_model_filepath = "optimized.onnx"
+#         # ... create session, run once
+#
+# Step 2: Run the matcher.
+python source_to_optimized_matcher.py \
+    --source-model path/to/source.onnx \
+    --optimized-model path/to/optimized.onnx \
+    --output mapping.json
+
+# Optional: --verbose for per-strategy match counts and unmapped diagnostics.
+```
+
+#### Combined: extend an existing QNN EP `qnn_op_trace.json`
+
+If the QNN EP's `qnn_op_trace.json`
+is also available, pass it via `--qnn-trace` and the matcher will produce an
+extended trace where each `op_mappings[]` and `tensor_mappings[]` entry gets
+a new `original_sources[]` field, populated by joining on the optimized node
+and tensor names. This yields the end-to-end `original ONNX -> QNN op` /
+`original ONNX tensor -> QNN tensor` provenance directly.
+
+```bash
+python source_to_optimized_matcher.py \
+    --source-model path/to/source.onnx \
+    --optimized-model path/to/optimized.onnx \
+    --output mapping.json \
+    --qnn-trace path/to/qnn_op_trace.json \
+    --joined-output path/to/qnn_op_trace.with_original_sources.json
+```
+
+If `--joined-output` is omitted, the joined file is written next to the input
+QNN trace as `<stem>.with_original_sources.json`.
+
+Both op-typed (`type="OP"`) and tensor-typed (`type="TENSOR"`) sources are resolved.
+`original_sources` entries follow the QNN EP `TraceSourcePair` schema
+(`{name, type}`), with an additional `op_type` field on op entries for human
+readability. Source references with no matcher counterpart are left without
+an `original_sources` field and reported in the warning counts.
+
+### Output schema
+
+`original_sources[]` (in `node_mappings`) and `original_tensors[]` (in
+`tensor_mappings`) follow the QNN EP `TraceSourcePair` schema (`{name, type}`,
+where `type` is the string `"OP"` or `"TENSOR"`). Op entries carry an extra
+`op_type` field for human readability. For multi-source matches (fusions),
+the chain is emitted in source-graph topological order with intermediate
+tensors woven between consecutive ops, matching the QNN EP convention
+(`op1, tensor_out1, op2, ..., opN`).
+
+```json
+{
+  "source_model": "...",
+  "optimized_model": "...",
+  "summary": {
+    "total_source_nodes": 7,
+    "total_optimized_nodes": 5,
+    "matched_optimized_nodes": 5,
+    "unmatched_optimized_nodes": 0,
+    "by_method": {
+      "exact_name": 4,
+      "initializer_name": 1
+    },
+    "total_optimized_tensors": 11,
+    "matched_tensors": 11,
+    "by_tensor_method": {
+      "exact_name": 6,
+      "initializer_name": 5
+    }
+  },
+  "node_mappings": [
+    {
+      "optimized_node": "Gemm_fused_42",
+      "optimized_op_type": "Gemm",
+      "original_sources": [
+        {"name": "matmul1", "type": "OP", "op_type": "MatMul"},
+        {"name": "mm_out",  "type": "TENSOR"},
+        {"name": "add1",    "type": "OP", "op_type": "Add"}
+      ],
+      "match_method": "initializer_name",
+      "confidence": "medium",
+      "notes": "Multiple source nodes share initializers — likely fusion"
+    }
+  ],
+  "tensor_mappings": [
+    {
+      "optimized_tensor": "y",
+      "original_tensors": [{"name": "y"}],
+      "match_method": "exact_name",
+      "confidence": "high"
+    }
+  ],
+  "unmapped_optimized_nodes": [
+    {"name": "...", "op_type": "...", "reason": "no_strategy_matched"}
+  ],
+  "removed_original_nodes": [
+    {"name": "...", "op_type": "Constant", "likely_reason": "constant_folded"}
+  ]
+}
+```
+
+### Extending
+
+To add a new fusion pattern, edit `FUSION_PATTERNS` in
+`source_to_optimized_matcher.py`. Each entry maps an optimized op type to a
+list of source op-type sequences. The matcher walks back from the optimized
+node's input tensors looking for a chain of source nodes matching the
+sequence.
+
+---
+
+## `enrich_profiling_csv.py`
+
+Companion tool for the QNN EP's profiling output. Joins a profiling CSV
+with the merged framework op trace to add **user-authored** (pre-optimization)
+ONNX op names to each NODE-level row, completing the original ONNX ->
+optimized ONNX -> QNN op chain in profiling output.
+
+Behavior adapts to the shape of the input CSV — there are four branches
+(BASIC verbatim copy, append one column, fill empty column + append one,
+synthesize two columns); see [Behavior](#behavior) and
+[Output schema](#output-schema-1) below for the exact rules. The QNN EP-side
+column this tool complements is written by `Serializer::InitCsvFile()` in
+`qnn_profile_serializer.cc`.
+
+### Workflow
+
+The tool accepts the merged trace either as a pre-computed JSON file
+(**Mode A**) or as raw ingredients that it joins inline by invoking the
+matcher as a library (**Mode B**). The two modes are mutually exclusive —
+exactly one input style must be selected.
+
+| | Mode A | Mode B |
+|---|--------|--------|
+| Inputs | `--merged-trace` | `--source-model` + `--optimized-model` + `--qnn-trace` |
+| Intermediate file | Pre-existing `*.merged.json` (from the matcher) | None — matcher runs in-process |
+| Best for | Iterating on enrichment, sharing the merged trace as a CI artifact, debugger workflows | One-shot profiling-only workflows |
+| Dependencies | Pure stdlib | Requires `onnx` package + sibling-importable `source_to_optimized_matcher.py` |
+
+```bash
+# Mode A — pre-computed merged trace.
+#
+# Step 1: extend the QNN trace with original_sources via the matcher.
+python source_to_optimized_matcher.py \
+    --source-model source.onnx \
+    --optimized-model optimized.onnx \
+    --output mapping.json \
+    --qnn-trace qnn_op_trace.json \
+    --joined-output qnn_op_trace.merged.json
+#
+# Step 2: enrich the profiling CSV.
+python enrich_profiling_csv.py \
+    --profiling-csv qnn_profile.csv \
+    --merged-trace qnn_op_trace.merged.json \
+    --output qnn_profile.with_originals.csv
+
+# Mode B — one-shot from raw ingredients (matcher runs inline).
+python enrich_profiling_csv.py \
+    --profiling-csv qnn_profile.csv \
+    --source-model source.onnx \
+    --optimized-model optimized.onnx \
+    --qnn-trace qnn_op_trace.json \
+    --output qnn_profile.with_originals.csv
+```
+
+### Behavior
+
+- The `Event Identifier` column is the lookup key. The HTP `:OpId_{N} (unit)`
+  suffix is stripped before lookup, mirroring `Serializer::LookupOnnxSources()`
+  at `qnn_profile_serializer.cc`.
+- Only op-typed entries (`type="OP"`) from `original_sources[]` are emitted in
+  the new column, semicolon-separated, mirroring the existing
+  `ONNX Source Ops` column format.
+- **The tool detects whether the input has NODE-level events** (any row with a
+  non-empty `Event Identifier`). If none — for example, a CSV from BASIC
+  profiling or any case where `HasNodeLevelProfiling()` was false at run time —
+  no columns are added and the file is copied byte-for-byte unchanged. There
+  is nothing to enrich.
+- **If NODE-level events are present and the input is missing the
+  `ONNX Source Ops` column** (DETAILED/OPTRACE profiling with
+  `qnn.enable_framework_op_trace=false` at run time), the tool synthesizes
+  both `ONNX Source Ops` and `Original ONNX Source Ops` from the merged
+  trace in a single pass. The synthesized `ONNX Source Ops` column matches
+  what QNN EP would have written natively when run-time tracing was on.
+- **If NODE-level events are present and the input has the `ONNX Source Ops`
+  column but every NODE row's cell in that column is empty** (AOT Phase 2
+  with framework op trace requested but no sidecar found next to the context
+  model — see `Serializer::InitCsvFile()`), the tool fills the existing
+  column in place from the merged trace and appends `Original ONNX Source
+  Ops`. The detection is conservative: only an entirely-empty column is
+  filled, so a CSV with mixed populated/empty cells preserves runtime data.
+- Non-NODE rows (SESSION/GRAPH events, no Event Identifier) get empty
+  cells in any new columns added.
+- QNN op names not present in the merged trace get empty cells and
+  are reported in the warning count — the tool does not fabricate provenance.
+- Mode A and Mode B produce byte-identical output for the same inputs (the
+  matcher logic and join logic are reused; only the input-resolution path
+  differs).
+
+### Output schema
+
+The output CSV preserves all original columns. The new columns appended
+depend on the input shape:
+
+| Input | Columns appended | Existing column overwritten? |
+|-------|------------------|------------------------------|
+| BASIC profiling (no NODE-level events) | None — output is a verbatim byte-for-byte copy of the input | n/a |
+| DETAILED/OPTRACE with `ONNX Source Ops` present and populated (framework op trace ran at run time) | `Original ONNX Source Ops` only | No — runtime values preserved |
+| DETAILED/OPTRACE with `ONNX Source Ops` present but every NODE row's cell empty (AOT Phase 2 with no sidecar found) | `Original ONNX Source Ops` only | Yes — existing column filled in place from the merged trace |
+| DETAILED/OPTRACE with `ONNX Source Ops` missing (run-time tracing off entirely) | `ONNX Source Ops`, then `Original ONNX Source Ops` | n/a |
+
+Example (DETAILED + run-time tracing off — both columns synthesized):
+
+```
+Msg Timestamp,...,Event Identifier,ONNX Source Ops,Original ONNX Source Ops
+...,qnn_conv_0:OpId_5 (cycles),conv1,conv1;bn1
+...,qnn_fc_3:OpId_8 (cycles),flat1;Gemm_fused_42,flat1;matmul1;add1
+```
+
+---
+
+## Requirements
+
+- Python 3.9+ (PEP 604 union syntax in module-level annotations; `onnx` package floor).
+- `onnx` (any recent version, `pip install onnx`) — required for the matcher and for Mode B of the enrichment tool. Mode A of the enrichment tool is pure stdlib and does not need `onnx`.
+
+No ORT runtime dependency — both tools operate on saved `.onnx` files and JSON/CSV artifacts only.
+
+## Output safety
+
+Both tools overwrite an existing output file (`--output`, and the matcher's
+`--joined-output`), printing a warning to stderr when they do. The enricher
+additionally refuses a `--profiling-csv` that already carries the
+`Original ONNX Source Ops` column, since that indicates a previously-enriched
+CSV — enrich the original QNN EP profiling CSV instead.

--- a/qcom/tools/op_trace_matcher/__init__.py
+++ b/qcom/tools/op_trace_matcher/__init__.py
@@ -4,4 +4,19 @@
 
 Marking this directory as a Python package allows package-style imports
 (`from qcom.tools.op_trace_matcher.source_to_optimized_matcher import ...`).
+
+Public APIs are intentionally exposed only on the submodules — each submodule
+defines its own ``__all__``. Import them directly:
+
+    from qcom.tools.op_trace_matcher.source_to_optimized_matcher import (
+        Matcher, build_output, join_qnn_trace,
+    )
+    from qcom.tools.op_trace_matcher.enrich_profiling_csv import (
+        build_lookups, enrich,
+    )
+
+The package itself does NOT re-export those names; this keeps the submodule
+boundary explicit and lets each tool be loaded in isolation (e.g. Mode A of
+``enrich_profiling_csv`` does not need ``onnx`` and only imports the
+matcher's stdlib-only schema constants on demand).
 """

--- a/qcom/tools/op_trace_matcher/__init__.py
+++ b/qcom/tools/op_trace_matcher/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+"""op_trace_matcher: source ONNX -> optimized ONNX -> QNN op trace tooling.
+
+Marking this directory as a Python package allows package-style imports
+(`from qcom.tools.op_trace_matcher.source_to_optimized_matcher import ...`).
+"""

--- a/qcom/tools/op_trace_matcher/enrich_profiling_csv.py
+++ b/qcom/tools/op_trace_matcher/enrich_profiling_csv.py
@@ -179,6 +179,7 @@ def enrich(profiling_csv: Path, merged_trace: dict, output_csv: Path) -> dict:
         "rows_enriched_optimized": 0,
         "rows_unresolved_qnn_op": 0,
         "added_optimized_column": False,
+        "filled_existing_onnx_column": False,
         "node_events_present": False,
     }
 

--- a/qcom/tools/op_trace_matcher/enrich_profiling_csv.py
+++ b/qcom/tools/op_trace_matcher/enrich_profiling_csv.py
@@ -40,35 +40,55 @@ import sys
 from pathlib import Path
 
 # Mode B (inline matcher) needs the `onnx` package and the sibling matcher
-# script. They are not required for Mode A (pre-computed merged trace),
-# which is pure-stdlib, so the imports are guarded — failing to load them
-# only disables Mode B and surfaces a helpful error at use time.
+# module. They are not required for Mode A (pre-computed merged trace), which
+# is pure-stdlib, so the imports are guarded — failing to load them only
+# disables Mode B and surfaces a helpful error at use time.
 #
-# Temporarily prepend this file's own directory to sys.path so the sibling
-# import resolves regardless of invocation method (direct run, `python -m`,
-# imported as a module, or a different CWD). The entry is removed in `finally`
-# so importing this file as a library does not permanently mutate sys.path.
-_THIS_DIR = str(Path(__file__).resolve().parent)
-sys.path.insert(0, _THIS_DIR)
-try:
-    # Schema constants come from the matcher to keep both tools in lock-step
-    # with the QNN EP's TraceSourcePair serialization. Stdlib-only — always
-    # imported so the Mode A path stays schema-aligned even without `onnx`.
-    from source_to_optimized_matcher import _TRACE_TYPE_OP
+# Predefine the availability flags so any import failure (sibling missing,
+# `onnx` missing, etc.) still leaves these names defined. Without this,
+# downstream references would raise a confusing NameError instead of a
+# diagnosable ImportError.
+_MATCHER_AVAILABLE = False
+_MATCHER_IMPORT_ERROR: str | None = None
+_TRACE_TYPE_OP: str | None = None
+Matcher = None  # type: ignore[assignment]
+join_qnn_trace = None  # type: ignore[assignment]
 
-    # Mode B (inline matcher) additionally requires `onnx`.
+# Try the package-relative import first (set when invoked via `python -m
+# qcom.tools.op_trace_matcher.enrich_profiling_csv`); fall back to a sibling
+# absolute import for direct-script invocation. The package's __init__.py
+# makes the relative path work without a sys.path mutation.
+try:
+    try:
+        from .source_to_optimized_matcher import _TRACE_TYPE_OP  # type: ignore[no-redef]
+    except ImportError:
+        # Direct-script invocation: ensure the file's own directory is on
+        # sys.path for the sibling lookup, then revert.
+        _THIS_DIR = str(Path(__file__).resolve().parent)
+        sys.path.insert(0, _THIS_DIR)
+        try:
+            from source_to_optimized_matcher import _TRACE_TYPE_OP  # type: ignore[no-redef]
+        finally:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(_THIS_DIR)
+
+    # Schema constants imported successfully. Now try the heavier Mode B
+    # imports (onnx + matcher classes).
     try:
         import onnx
-        from source_to_optimized_matcher import Matcher, join_qnn_trace
 
+        try:
+            from .source_to_optimized_matcher import Matcher, join_qnn_trace  # type: ignore[no-redef]
+        except ImportError:
+            from source_to_optimized_matcher import Matcher, join_qnn_trace  # type: ignore[no-redef]
         _MATCHER_AVAILABLE = True
-        _MATCHER_IMPORT_ERROR: str | None = None
     except ImportError as _e:
-        _MATCHER_AVAILABLE = False
         _MATCHER_IMPORT_ERROR = str(_e)
-finally:
-    with contextlib.suppress(ValueError):
-        sys.path.remove(_THIS_DIR)
+except ImportError as _e:
+    # Even the schema-constant import failed (sibling renamed / missing).
+    # _MATCHER_AVAILABLE stays False; record the error so use-time messages
+    # can point at the real cause instead of a NameError.
+    _MATCHER_IMPORT_ERROR = str(_e)
 
 
 # Public API for import-as-a-library use. Underscore-prefixed helpers
@@ -104,7 +124,14 @@ def _format_op_sources(sources: list[dict]) -> str:
     `Serializer::LookupOnnxSources()`. Reused for both `sources[]` (optimized)
     and `original_sources[]` (original), since both follow the same
     `TraceSourcePair` schema."""
-    return ";".join(name for s in sources or [] if s.get("type") == _TRACE_TYPE_OP and (name := s.get("name", "")))
+    parts = []
+    for s in sources or []:
+        if s.get("type") != _TRACE_TYPE_OP:
+            continue
+        name = s.get("name", "")
+        if name:
+            parts.append(name)
+    return ";".join(parts)
 
 
 def build_lookups(merged_trace: dict) -> tuple[dict[str, list[dict]], dict[str, list[dict]]]:

--- a/qcom/tools/op_trace_matcher/enrich_profiling_csv.py
+++ b/qcom/tools/op_trace_matcher/enrich_profiling_csv.py
@@ -1,0 +1,454 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+"""Profiling CSV enrichment tool.
+
+Takes a QNN EP profiling CSV and a merged framework op trace JSON
+(`qnn_op_trace.json` extended with `original_sources[]` by
+`source_to_optimized_matcher.py`), and produces a CSV that traces every QNN
+op back to the user-authored ONNX op names. Behavior adapts to the input:
+
+  - BASIC profiling (no NODE-level events) -> verbatim byte-for-byte copy
+    via shutil.copyfile; there is nothing to enrich.
+  - DETAILED/OPTRACE with `ONNX Source Ops` present and populated (run-time
+    `qnn.enable_framework_op_trace` was on, JIT trace landed) -> append a
+    parallel `Original ONNX Source Ops` column with the pre-optimization
+    ONNX op names; preserve the runtime-written cells.
+  - DETAILED/OPTRACE with `ONNX Source Ops` present but every NODE row's cell
+    empty (AOT Phase 2 with framework op trace requested but no sidecar
+    found) -> fill the existing column from the merged trace and append
+    `Original ONNX Source Ops`.
+  - DETAILED/OPTRACE with `ONNX Source Ops` missing (run-time tracing was
+    off entirely) -> synthesize both `ONNX Source Ops` and
+    `Original ONNX Source Ops` at the end of the row.
+
+The merged trace can be supplied either as a pre-computed JSON file
+(--merged-trace) or computed inline by invoking the matcher as a library
+(--source-model + --optimized-model + --qnn-trace).
+
+Column naming, semicolon delimiter, and the `:OpId_{N}` suffix-stripping
+behavior match `Serializer::LookupOnnxSources()` in qnn_profile_serializer.cc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# Mode B (inline matcher) needs the `onnx` package and the sibling matcher
+# script. They are not required for Mode A (pre-computed merged trace),
+# which is pure-stdlib, so the imports are guarded — failing to load them
+# only disables Mode B and surfaces a helpful error at use time.
+#
+# Temporarily prepend this file's own directory to sys.path so the sibling
+# import resolves regardless of invocation method (direct run, `python -m`,
+# imported as a module, or a different CWD). The entry is removed in `finally`
+# so importing this file as a library does not permanently mutate sys.path.
+_THIS_DIR = str(Path(__file__).resolve().parent)
+sys.path.insert(0, _THIS_DIR)
+try:
+    # Schema constants come from the matcher to keep both tools in lock-step
+    # with the QNN EP's TraceSourcePair serialization. Stdlib-only — always
+    # imported so the Mode A path stays schema-aligned even without `onnx`.
+    from source_to_optimized_matcher import _TRACE_TYPE_OP
+
+    # Mode B (inline matcher) additionally requires `onnx`.
+    try:
+        import onnx
+        from source_to_optimized_matcher import Matcher, join_qnn_trace
+
+        _MATCHER_AVAILABLE = True
+        _MATCHER_IMPORT_ERROR: str | None = None
+    except ImportError as _e:
+        _MATCHER_AVAILABLE = False
+        _MATCHER_IMPORT_ERROR = str(_e)
+finally:
+    with contextlib.suppress(ValueError):
+        sys.path.remove(_THIS_DIR)
+
+
+# Public API for import-as-a-library use. Underscore-prefixed helpers
+# (_format_op_sources, _strip_op_id_suffix, _COL_*) remain private; tests reach
+# for them by name but they are not part of the supported surface.
+__all__ = [
+    "build_lookups",
+    "enrich",
+]
+
+
+# CSV column names from `Serializer::InitCsvFile()` in
+# qnn_profile_serializer.cc. The QNN EP omits `ONNX Source Ops` when
+# `op_trace_lookup` is null (BASIC profiling, framework op trace disabled,
+# or AOT runs without a sidecar).
+_COL_EVENT_IDENTIFIER = "Event Identifier"
+_COL_ONNX_SOURCE_OPS = "ONNX Source Ops"
+_COL_ORIGINAL_ONNX_SOURCE_OPS = "Original ONNX Source Ops"
+
+
+def _strip_op_id_suffix(identifier: str) -> str:
+    """HTP profiling events may append `:OpId_{N} ({unit})` to the op name
+    (e.g. `add_node:OpId_17 (cycles)`). Strip this suffix to recover the
+    base op name used as the lookup key. Mirrors
+    `Serializer::LookupOnnxSources()` in qnn_profile_serializer.cc."""
+    pos = identifier.find(":OpId_")
+    return identifier[:pos] if pos != -1 else identifier
+
+
+def _format_op_sources(sources: list[dict]) -> str:
+    """Emit only op-typed entries with non-empty names, semicolon-separated,
+    mirroring the QNN EP's existing CSV serialization in
+    `Serializer::LookupOnnxSources()`. Reused for both `sources[]` (optimized)
+    and `original_sources[]` (original), since both follow the same
+    `TraceSourcePair` schema."""
+    return ";".join(name for s in sources or [] if s.get("type") == _TRACE_TYPE_OP and (name := s.get("name", "")))
+
+
+def build_lookups(merged_trace: dict) -> tuple[dict[str, list[dict]], dict[str, list[dict]]]:
+    """Return (originals_lookup, optimized_lookup), each keyed by QNN op name.
+
+    The optimized_lookup mirrors what the QNN EP's `Serializer::LookupOnnxSources()`
+    returns at runtime: the `sources[]` chain from the op_mapping. It is needed
+    when the input CSV is missing the `ONNX Source Ops` column (e.g. profiling
+    CSVs from BASIC level or runs without framework op trace enabled), so the
+    enrichment tool can synthesize that column from the merged trace alongside
+    the new `Original ONNX Source Ops` column.
+    """
+    originals: dict[str, list[dict]] = {}
+    optimized: dict[str, list[dict]] = {}
+    for sg in merged_trace.get("subgraph_traces", []):
+        for mapping in sg.get("op_mappings", []) or []:
+            dst = mapping.get("dst_name")
+            if not dst:
+                continue
+            # Store either chain only when present and non-empty; an empty list
+            # yields an empty cell at lookup time, so there is nothing to record.
+            if orig := mapping.get("original_sources"):
+                originals[dst] = orig
+            if src := mapping.get("sources"):
+                optimized[dst] = src
+    return originals, optimized
+
+
+def enrich(profiling_csv: Path, merged_trace: dict, output_csv: Path) -> dict:
+    """Read profiling_csv, append `Original ONNX Source Ops` column (and
+    `ONNX Source Ops` if missing from the input). Skipped entirely if the
+    input has no NODE-level events (BASIC profiling — nothing to enrich).
+    `merged_trace` is the parsed JSON dict (loaded from disk in Mode A,
+    computed in-memory in Mode B). Returns a stats dict.
+
+    Raises ValueError if the input CSV is empty, missing the
+    `Event Identifier` column, or already carries the `Original ONNX Source Ops`
+    column (i.e. is itself an enricher output)."""
+    originals_lookup, optimized_lookup = build_lookups(merged_trace)
+
+    stats = {
+        "rows_total": 0,
+        "rows_with_identifier": 0,
+        "rows_enriched_originals": 0,
+        "rows_enriched_optimized": 0,
+        "rows_unresolved_qnn_op": 0,
+        "added_optimized_column": False,
+        "node_events_present": False,
+    }
+
+    # Read input fully so we can detect NODE-level events before deciding
+    # the output column layout. Profiling CSVs are typically small (a few
+    # thousand rows at most) so buffering is fine.
+    with profiling_csv.open(newline="", encoding="utf-8") as fin:
+        reader = csv.reader(fin)
+        try:
+            header = next(reader)
+        except StopIteration as e:
+            raise ValueError(f"empty CSV: {profiling_csv}") from e
+
+        if _COL_EVENT_IDENTIFIER not in header:
+            raise ValueError(
+                f"input CSV is missing the `{_COL_EVENT_IDENTIFIER}` column "
+                f"(found: {header}). Is this a QNN EP profiling CSV?"
+            )
+        identifier_idx = header.index(_COL_EVENT_IDENTIFIER)
+        rows = list(reader)
+
+    stats["rows_total"] = len(rows)
+    has_node_events = any(identifier_idx < len(row) and row[identifier_idx] for row in rows)
+    stats["node_events_present"] = has_node_events
+    has_existing_onnx_col = _COL_ONNX_SOURCE_OPS in header
+    onnx_source_ops_idx = header.index(_COL_ONNX_SOURCE_OPS) if has_existing_onnx_col else -1
+
+    # When the `ONNX Source Ops` column is in the header, scan NODE rows to see
+    # whether it carries any data. The AOT-no-sidecar case (framework op trace
+    # is on but no sidecar exists next to the context model) emits the column
+    # because column gating is session-stable, yet leaves every cell empty —
+    # the merged trace passed to the enricher is then the authoritative source
+    # of optimized-name annotations, so the existing empty cells should be
+    # filled in instead of left next to a populated `Original ONNX Source Ops`.
+    existing_onnx_col_has_data = False
+    if has_existing_onnx_col:
+        for row in rows:
+            if (
+                identifier_idx < len(row)
+                and row[identifier_idx]
+                and onnx_source_ops_idx < len(row)
+                and row[onnx_source_ops_idx]
+            ):
+                existing_onnx_col_has_data = True
+                break
+
+    # Refuse to enrich a CSV that already carries the `Original ONNX Source Ops`
+    # column — that means it is already an enricher output, and appending a
+    # second identically-named column would silently produce a malformed CSV.
+    if _COL_ORIGINAL_ONNX_SOURCE_OPS in header:
+        raise ValueError(
+            f"input CSV already has the `{_COL_ORIGINAL_ONNX_SOURCE_OPS}` column "
+            f"({profiling_csv}); it looks like an enricher output. Enrich the original "
+            f"QNN EP profiling CSV instead of a previously-enriched one."
+        )
+
+    # Output column layout:
+    # - No NODE events (BASIC profiling, or HasNodeLevelProfiling()=false at
+    #   runtime) -> nothing to enrich; copy the CSV verbatim.
+    # - DETAILED/OPTRACE with `ONNX Source Ops` present and populated -> append
+    #   only `Original ONNX Source Ops`; preserve the runtime-written values.
+    # - DETAILED/OPTRACE with `ONNX Source Ops` missing -> synthesize both
+    #   columns at the end from the merged trace.
+    # - DETAILED/OPTRACE with `ONNX Source Ops` present but every NODE row's
+    #   cell empty (AOT-no-sidecar) -> fill the existing column in place from
+    #   the merged trace and append `Original ONNX Source Ops`.
+    if not has_node_events:
+        # Use shutil.copyfile so byte-level content (incl. line endings) is
+        # preserved exactly. Routing through csv.writer would normalize line
+        # endings to CRLF and silently change the output.
+        shutil.copyfile(profiling_csv, output_csv)
+        return stats
+
+    fill_existing_onnx_col = has_existing_onnx_col and not existing_onnx_col_has_data
+    if has_existing_onnx_col:
+        new_columns = [_COL_ORIGINAL_ONNX_SOURCE_OPS]
+        synthesize_optimized = False
+    else:
+        new_columns = [_COL_ONNX_SOURCE_OPS, _COL_ORIGINAL_ONNX_SOURCE_OPS]
+        synthesize_optimized = True
+    stats["added_optimized_column"] = synthesize_optimized
+    stats["filled_existing_onnx_column"] = fill_existing_onnx_col
+
+    with output_csv.open("w", newline="", encoding="utf-8") as fout:
+        writer = csv.writer(fout)
+        writer.writerow([*header, *new_columns])
+
+        for row in rows:
+            if identifier_idx < len(row) and row[identifier_idx]:
+                stats["rows_with_identifier"] += 1
+                qnn_op = _strip_op_id_suffix(row[identifier_idx])
+                originals = originals_lookup.get(qnn_op)
+                optimized = optimized_lookup.get(qnn_op)
+
+                # Either lookup may be unresolved if the merged trace doesn't
+                # include this QNN op (e.g. trace from a different model run).
+                # Count it once per row, not once per missing column.
+                if originals is None and optimized is None:
+                    stats["rows_unresolved_qnn_op"] += 1
+
+                originals_str = _format_op_sources(originals) if originals else ""
+                optimized_str = _format_op_sources(optimized) if optimized else ""
+                if originals_str:
+                    stats["rows_enriched_originals"] += 1
+                if (synthesize_optimized or fill_existing_onnx_col) and optimized_str:
+                    stats["rows_enriched_optimized"] += 1
+
+                if fill_existing_onnx_col:
+                    # Overwrite the all-empty existing cell at onnx_source_ops_idx.
+                    # Copy the row first so the original `rows` list stays intact,
+                    # and pad if the input row was shorter than the header.
+                    row_out = list(row)
+                    if onnx_source_ops_idx >= len(row_out):
+                        row_out.extend([""] * (onnx_source_ops_idx - len(row_out) + 1))
+                    row_out[onnx_source_ops_idx] = optimized_str
+                    writer.writerow([*row_out, originals_str])
+                else:
+                    appended = [optimized_str, originals_str] if synthesize_optimized else [originals_str]
+                    writer.writerow([*row, *appended])
+            else:
+                # Non-NODE rows (SESSION, GRAPH, etc.) get empty cells in any
+                # new columns we add, and their existing ONNX Source Ops cell
+                # (if any) was already empty — leave it untouched.
+                empty_appended = ["", ""] if synthesize_optimized else [""]
+                writer.writerow([*row, *empty_appended])
+
+    return stats
+
+
+def _resolve_merged_trace(args: argparse.Namespace) -> tuple[dict, str]:
+    """Return (merged_trace_dict, mode_label).
+
+    Mode A — load a pre-computed merged trace JSON from --merged-trace.
+    Mode B — run the matcher in-memory on (--source-model, --optimized-model,
+    --qnn-trace) and return the joined result dict.
+    """
+    if args.merged_trace is not None:
+        try:
+            return json.loads(args.merged_trace.read_text(encoding="utf-8")), "A (pre-computed merged trace)"
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"error: failed to parse {args.merged_trace}: {e}\n")
+            sys.exit(2)
+
+    # Mode B: import matcher as a library and compute in-memory.
+    # The matcher script lives next to this file; running this script puts
+    # its directory on sys.path automatically.
+    if not _MATCHER_AVAILABLE:
+        sys.stderr.write(
+            f"error: Mode B requires the `onnx` package and "
+            f"source_to_optimized_matcher.py in the same directory: "
+            f"{_MATCHER_IMPORT_ERROR}\n"
+        )
+        sys.exit(2)
+
+    source = onnx.load(str(args.source_model))
+    optimized = onnx.load(str(args.optimized_model))
+    matcher = Matcher(source, optimized)
+    matches, tensor_matches, mstats, _, _ = matcher.run()
+
+    try:
+        qnn_trace = json.loads(args.qnn_trace.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"error: failed to parse {args.qnn_trace}: {e}\n")
+        sys.exit(2)
+    merged, _ = join_qnn_trace(matches, tensor_matches, qnn_trace, matcher.src)
+
+    if args.verbose:
+        print(
+            f"Matcher (inline): {mstats.matched}/{mstats.total_optimized} optimized "
+            f"nodes, {mstats.matched_tensors}/{mstats.total_optimized_tensors} tensors"
+        )
+
+    return merged, "B (inline matcher)"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Append Original ONNX Source Ops column to a QNN EP profiling CSV.",
+        allow_abbrev=False,
+    )
+    ap.add_argument(
+        "--profiling-csv",
+        required=True,
+        type=Path,
+        help="Profiling CSV from QNN EP (any qnn.profiling_level — BASIC is "
+        "copied verbatim, DETAILED/OPTRACE is enriched).",
+    )
+    ap.add_argument("--output", required=True, type=Path, help="Output CSV path")
+
+    # Mode A: pre-computed merged trace.
+    ap.add_argument(
+        "--merged-trace",
+        type=Path,
+        default=None,
+        help="(Mode A) Merged framework op trace JSON, output of "
+        "source_to_optimized_matcher.py --qnn-trace --joined-output. "
+        "Mutually exclusive with the Mode B trio.",
+    )
+
+    # Mode B: raw inputs — matcher is run inline.
+    ap.add_argument("--source-model", type=Path, default=None, help="(Mode B) Original user-provided ONNX model")
+    ap.add_argument(
+        "--optimized-model",
+        type=Path,
+        default=None,
+        help="(Mode B) ORT-optimized ONNX model (saved via SessionOptions::optimized_model_filepath)",
+    )
+    ap.add_argument("--qnn-trace", type=Path, default=None, help="(Mode B) QNN EP qnn_op_trace.json")
+
+    ap.add_argument("--verbose", action="store_true", help="Print row-level diagnostics")
+    args = ap.parse_args()
+
+    # Validate mode selection.
+    mode_a = args.merged_trace is not None
+    mode_b_inputs = [args.source_model, args.optimized_model, args.qnn_trace]
+    mode_b_partial = any(x is not None for x in mode_b_inputs)
+    mode_b_complete = all(x is not None for x in mode_b_inputs)
+
+    if mode_a and mode_b_partial:
+        sys.stderr.write(
+            "error: --merged-trace (Mode A) is mutually exclusive with "
+            "--source-model/--optimized-model/--qnn-trace (Mode B)\n"
+        )
+        return 2
+    if not mode_a and not mode_b_complete:
+        if mode_b_partial:
+            sys.stderr.write("error: Mode B requires all three of --source-model, --optimized-model, --qnn-trace\n")
+        else:
+            sys.stderr.write(
+                "error: provide either --merged-trace (Mode A) or "
+                "--source-model + --optimized-model + --qnn-trace (Mode B)\n"
+            )
+        return 2
+
+    # Validate input file existence.
+    required_paths = [(args.profiling_csv, "profiling CSV")]
+    if mode_a:
+        required_paths.append((args.merged_trace, "merged trace"))
+    else:
+        required_paths.extend(
+            [
+                (args.source_model, "source model"),
+                (args.optimized_model, "optimized model"),
+                (args.qnn_trace, "QNN trace"),
+            ]
+        )
+    for path, label in required_paths:
+        if not path.is_file():
+            sys.stderr.write(f"error: {label} not found: {path}\n")
+            return 2
+
+    if args.output.exists():
+        sys.stderr.write(f"warning: overwriting existing output: {args.output}\n")
+
+    merged_trace, mode_label = _resolve_merged_trace(args)
+    if args.verbose:
+        print(f"Mode: {mode_label}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        stats = enrich(args.profiling_csv, merged_trace, args.output)
+    except ValueError as e:
+        sys.stderr.write(f"error: {e}\n")
+        return 2
+
+    if not stats["node_events_present"]:
+        print(
+            f"No NODE-level events in input CSV ({stats['rows_total']} rows; "
+            f"likely BASIC profiling or framework op trace not emitting per-node "
+            f"data). Output is a verbatim copy — nothing to enrich."
+        )
+    elif stats["added_optimized_column"]:
+        print(
+            f"Enriched {stats['rows_enriched_originals']}/{stats['rows_with_identifier']} rows "
+            f"with original ONNX sources, "
+            f"{stats['rows_enriched_optimized']}/{stats['rows_with_identifier']} rows "
+            f"with optimized ONNX sources "
+            f"(input CSV missing `ONNX Source Ops` column — both columns added; "
+            f"total rows: {stats['rows_total']}, "
+            f"unresolved QNN ops: {stats['rows_unresolved_qnn_op']})"
+        )
+    else:
+        print(
+            f"Enriched {stats['rows_enriched_originals']}/{stats['rows_with_identifier']} rows "
+            f"with original ONNX sources "
+            f"(total rows: {stats['rows_total']}, "
+            f"unresolved QNN ops: {stats['rows_unresolved_qnn_op']})"
+        )
+    if args.verbose and stats["rows_unresolved_qnn_op"]:
+        print(
+            f"  warning: {stats['rows_unresolved_qnn_op']} row(s) had a QNN op "
+            f"name not present in the merged trace. Make sure the trace was "
+            f"produced from the same model run as the profiling CSV."
+        )
+    print(f"Output: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qcom/tools/op_trace_matcher/requirements.txt
+++ b/qcom/tools/op_trace_matcher/requirements.txt
@@ -1,0 +1,12 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+
+# Runtime requirements for source_to_optimized_matcher.py and
+# enrich_profiling_csv.py. For unit tests, additionally `pip install pytest`
+# (or use the repo-wide requirements-dev.txt which already includes all three).
+#
+# Minimum versions: numpy floor matches the onnxruntime-qnn package
+# requirement; onnx 1.13 is the first release with the
+# numpy_helper.to_array / from_array APIs the matcher relies on.
+numpy >= 1.25.2
+onnx >= 1.13.0

--- a/qcom/tools/op_trace_matcher/source_to_optimized_matcher.py
+++ b/qcom/tools/op_trace_matcher/source_to_optimized_matcher.py
@@ -1,0 +1,1054 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+"""Source ONNX -> Optimized ONNX node and tensor mapping tool.
+
+Computes a structural correspondence between a user-supplied ONNX model
+(`source.onnx`) and an ORT-optimized ONNX model (`optimized.onnx`, saved via
+`SessionOptions::optimized_model_filepath`). Output JSON aligns with the QNN
+EP `FrameworkOpTrace` schema's `original_sources` extension; combined with
+the QNN EP's existing `qnn_op_trace.json`, this yields end-to-end
+provenance: original ONNX node -> optimized ONNX node -> QNN op.
+
+See ./README.md for the feasibility assessment, known limitations, and the
+output schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+# `onnx` is needed only to load the models at run time. Import lazily so that
+# `--help` and import-as-a-library (Mode B of enrich_profiling_csv.py guards its
+# own use) work without the package installed; the hard error is raised in
+# _require_onnx() at the point of actual use. `from __future__ import annotations`
+# keeps the ModelProto type hints as strings, so they need no import here.
+try:
+    import onnx
+    from onnx import ModelProto  # used in string annotations (ModelProto type hints)
+except ImportError:
+    onnx = None
+
+
+def _require_onnx() -> None:
+    if onnx is None:
+        sys.stderr.write("error: this tool requires the `onnx` package (`pip install onnx`)\n")
+        sys.exit(2)
+
+
+# Public API for import-as-a-library use (e.g. enrich_profiling_csv.py Mode B).
+__all__ = [
+    "Confidence",
+    "Match",
+    "MatchMethod",
+    "Matcher",
+    "MatcherStats",
+    "TensorMatch",
+    "build_output",
+    "join_qnn_trace",
+]
+
+
+# Maximum BFS hop count for the lineage-extension walks (producer-preferred
+# backward walk and consumer fallback forward walk). For any DAG the per-walk
+# `seen` set already bounds total work to O(|tensors|); this ceiling is a
+# defensive safety net for pathological or cyclic inputs, deliberately set
+# well above any practical model depth so it never trips on real graphs.
+_LINEAGE_WALK_MAX_HOPS = 1024
+
+
+# ---------------------------------------------------------------------------
+# Match result types
+# ---------------------------------------------------------------------------
+
+
+class MatchMethod(str, Enum):
+    EXACT_NAME = "exact_name"
+    EXACT_IO = "exact_io"
+    INITIALIZER_NAME = "initializer_name"
+    INITIALIZER_HASH = "initializer_hash"
+    FUSION_PATTERN = "fusion_pattern"
+    NODE_OUTPUT_POSITIONAL = "node_output_positional"
+
+
+class Confidence(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+
+
+@dataclass
+class Match:
+    optimized_node: str
+    optimized_op_type: str
+    source_nodes: list[str]
+    source_op_types: list[str]
+    method: MatchMethod
+    confidence: Confidence
+    pattern: str | None = None
+    notes: str | None = None
+
+
+@dataclass
+class TensorMatch:
+    optimized_tensor: str
+    original_tensors: list[str]
+    method: MatchMethod
+    confidence: Confidence
+    notes: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Graph index
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NodeRecord:
+    name: str
+    op_type: str
+    inputs: tuple[str, ...]
+    outputs: tuple[str, ...]
+    initializer_inputs: tuple[str, ...] = ()
+
+
+@dataclass
+class GraphIndex:
+    nodes: dict[str, NodeRecord]
+    by_output_tensor: dict[str, str]
+    by_input_tensor: dict[str, list[str]]
+    initializers: dict[str, bytes]
+    by_initializer_consumer: dict[str, list[str]]
+
+    @classmethod
+    def build(cls, model: ModelProto) -> GraphIndex:
+        graph = model.graph
+
+        initializers: dict[str, bytes] = {}
+        for init in graph.initializer:
+            # Hash raw_data when present; otherwise serialize the whole proto.
+            # raw_data is the common case for large weights and gives a stable
+            # identity that survives renaming.
+            if init.raw_data:
+                payload = init.raw_data
+            else:
+                payload = init.SerializeToString()
+            initializers[init.name] = hashlib.sha256(payload).digest()
+
+        nodes: dict[str, NodeRecord] = {}
+        by_output_tensor: dict[str, str] = {}
+        by_input_tensor: dict[str, list[str]] = defaultdict(list)
+        by_initializer_consumer: dict[str, list[str]] = defaultdict(list)
+
+        seen_names: set[str] = set()
+        for idx, node in enumerate(graph.node):
+            name = node.name or f"<unnamed_{node.op_type}_{idx}>"
+            if name in seen_names:
+                name = f"{name}__dup{idx}"
+            seen_names.add(name)
+
+            init_inputs = tuple(i for i in node.input if i in initializers)
+            record = NodeRecord(
+                name=name,
+                op_type=node.op_type,
+                inputs=tuple(node.input),
+                outputs=tuple(node.output),
+                initializer_inputs=init_inputs,
+            )
+            nodes[name] = record
+            for out in node.output:
+                if out:
+                    by_output_tensor[out] = name
+            for inp in node.input:
+                if inp:
+                    by_input_tensor[inp].append(name)
+            for init_name in init_inputs:
+                by_initializer_consumer[init_name].append(name)
+
+        return cls(
+            nodes=nodes,
+            by_output_tensor=by_output_tensor,
+            by_input_tensor=dict(by_input_tensor),
+            initializers=dict(initializers),
+            by_initializer_consumer=dict(by_initializer_consumer),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fusion patterns
+# ---------------------------------------------------------------------------
+
+# Each pattern: optimized op_type -> list of candidate source-op-type sequences.
+# Sequences are listed in source-graph topological order (input -> output),
+# which matches how the matcher walks back from the optimized node's input.
+#
+# Only LINEAR source chains can be expressed here — the walker follows one
+# input edge per step. Fusions with branching source patterns (LayerNorm,
+# EmbedLayerNorm, Attention, the Tanh-form FastGelu, …) typically rely on
+# the matcher's initializer-anchoring or lineage-extension strategies
+# instead. Patterns derived by reading the corresponding fusion files in
+# onnxruntime/core/optimizer/.
+FUSION_PATTERNS: dict[str, list[list[str]]] = {
+    # MatMul + Add  ->  Gemm                 (matmul_add_fusion)
+    "Gemm": [["MatMul", "Add"]],
+    # Div + Erf + Add + Mul + Mul  ->  Gelu  (gelu_fusion, Erf form)
+    "Gelu": [["Div", "Erf", "Add", "Mul", "Mul"]],
+    # Tanh-form approximation  ->  FastGelu  (fast_gelu_fusion)
+    # The full source pattern branches; this is the linear chain through
+    # the inner Mul·Tanh·Add expression. Best-effort.
+    "FastGelu": [["Mul", "Tanh", "Add", "Mul", "Mul", "Add", "Mul"]],
+    # Sigmoid + Mul  ->  QuickGelu           (quick_gelu_fusion)
+    "QuickGelu": [["Sigmoid", "Mul"]],
+    # Add + (Gelu | FastGelu)  ->  BiasGelu  (bias_gelu_fusion)
+    "BiasGelu": [
+        ["Add", "Gelu"],
+        ["Add", "FastGelu"],
+    ],
+    # Add + Softmax  ->  BiasSoftmax         (bias_softmax_fusion)
+    "BiasSoftmax": [["Add", "Softmax"]],
+    # Add + LayerNormalization  ->  SkipLayerNormalization
+    #                                       (skip_layer_norm_fusion)
+    "SkipLayerNormalization": [["Add", "LayerNormalization"]],
+    # Transpose + MatMul  ->  FusedMatMul    (matmul_transpose_fusion)
+    # Only one MatMul input is transposed; whether the linear walk finds
+    # Transpose depends on input ordering. Fallback strategies usually
+    # cover the case when this pattern misses.
+    "FusedMatMul": [["Transpose", "MatMul"]],
+}
+
+
+# ---------------------------------------------------------------------------
+# Matcher
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MatcherStats:
+    total_source: int = 0
+    total_optimized: int = 0
+    matched: int = 0
+    unmatched: int = 0
+    by_method: dict[str, int] = field(default_factory=dict)
+    # Tensor-level stats
+    total_optimized_tensors: int = 0
+    matched_tensors: int = 0
+    by_tensor_method: dict[str, int] = field(default_factory=dict)
+
+
+class Matcher:
+    def __init__(self, source: ModelProto, optimized: ModelProto):
+        self.src = GraphIndex.build(source)
+        self.opt = GraphIndex.build(optimized)
+        self.matches: dict[str, Match] = {}
+
+    def run(self) -> tuple[list[Match], list[TensorMatch], MatcherStats, list[str], list[str]]:
+        # Strategies are applied in confidence order. Each strategy only
+        # operates on optimized nodes that have not yet been matched.
+        self._exact_name_match()
+        self._exact_io_match()
+        self._initializer_name_match()
+        self._initializer_hash_match()
+        self._fusion_pattern_match()
+        self._lineage_extension()
+
+        # Tensor-level matching runs after node-level so it can derive
+        # output-position mappings from the node matches.
+        tensor_matches = self._match_tensors()
+
+        unmatched_opt = [n for n in self.opt.nodes if n not in self.matches]
+
+        claimed_src = self._collect_claimed_src()
+        removed_src = [n for n in self.src.nodes if n not in claimed_src]
+
+        stats = MatcherStats(
+            total_source=len(self.src.nodes),
+            total_optimized=len(self.opt.nodes),
+            matched=len(self.matches),
+            unmatched=len(unmatched_opt),
+            total_optimized_tensors=len(self._all_tensor_names(self.opt)),
+            matched_tensors=len(tensor_matches),
+        )
+        for m in self.matches.values():
+            stats.by_method[m.method.value] = stats.by_method.get(m.method.value, 0) + 1
+        for tm in tensor_matches:
+            stats.by_tensor_method[tm.method.value] = stats.by_tensor_method.get(tm.method.value, 0) + 1
+
+        return list(self.matches.values()), tensor_matches, stats, unmatched_opt, removed_src
+
+    def _collect_claimed_src(self) -> set[str]:
+        """Set of source node names already attributed by an earlier strategy.
+        Used to keep each source node attributed to at most one optimized node.
+        Strategies that build a multi-source chain (initializer anchoring,
+        fusion patterns) read this and either filter or skip accordingly."""
+        claimed: set[str] = set()
+        for m in self.matches.values():
+            claimed.update(m.source_nodes)
+        return claimed
+
+    # -- Strategy 1: exact name + op_type --------------------------------
+
+    def _exact_name_match(self) -> None:
+        for name, opt in self.opt.nodes.items():
+            if name in self.matches:
+                continue
+            src = self.src.nodes.get(name)
+            if src is None or src.op_type != opt.op_type:
+                continue
+            self._record(
+                opt,
+                source_nodes=[name],
+                method=MatchMethod.EXACT_NAME,
+                confidence=Confidence.HIGH,
+            )
+
+    # -- Strategy 2: exact I/O signature ---------------------------------
+
+    def _exact_io_match(self) -> None:
+        # Index source by (op_type, inputs, outputs) signature.
+        sig_to_src: dict[tuple, list[str]] = defaultdict(list)
+        for name, n in self.src.nodes.items():
+            sig_to_src[(n.op_type, n.inputs, n.outputs)].append(name)
+
+        already_claimed_singletons: set[str] = {
+            m.source_nodes[0] for m in self.matches.values() if len(m.source_nodes) == 1
+        }
+
+        for name, opt in self.opt.nodes.items():
+            if name in self.matches:
+                continue
+            sig = (opt.op_type, opt.inputs, opt.outputs)
+            candidates = [c for c in sig_to_src.get(sig, []) if c not in already_claimed_singletons]
+            if len(candidates) == 1:
+                src = candidates[0]
+                already_claimed_singletons.add(src)
+                self._record(
+                    opt,
+                    source_nodes=[src],
+                    method=MatchMethod.EXACT_IO,
+                    confidence=Confidence.HIGH,
+                )
+
+    # -- Strategy 3: initializer name anchoring --------------------------
+
+    def _initializer_name_match(self) -> None:
+        # Note: this strategy intentionally does NOT filter against
+        # _collect_claimed_src(). In QDQ models, a single source Q/DQ pair on a
+        # quantized boundary tensor legitimately participates in BOTH the
+        # upstream and downstream fused QLinear* ops' source sets — the same
+        # scale/zero_point initializer is shared across the boundary. Skipping
+        # already-claimed source nodes here would strip exactly those legitimate
+        # multi-attributions and produce incomplete provenance for QDQ patterns.
+        for name, opt in self.opt.nodes.items():
+            if name in self.matches:
+                continue
+            if not opt.initializer_inputs:
+                continue
+            candidates: set[str] = set()
+            for init_name in opt.initializer_inputs:
+                for src_consumer in self.src.by_initializer_consumer.get(init_name, []):
+                    candidates.add(src_consumer)
+            if not candidates:
+                continue
+            src_list = self._topo_sort_in_src(list(candidates))
+            confidence = Confidence.HIGH if len(src_list) == 1 else Confidence.MEDIUM
+            notes = None if len(src_list) == 1 else "Multiple source nodes share initializers — likely fusion"
+            self._record(
+                opt,
+                source_nodes=src_list,
+                method=MatchMethod.INITIALIZER_NAME,
+                confidence=confidence,
+                notes=notes,
+            )
+
+    # -- Strategy 4: initializer data hash -------------------------------
+
+    def _initializer_hash_match(self) -> None:
+        # hash -> set of source node names that consume an initializer with that hash
+        src_hash_to_consumers: dict[bytes, set[str]] = defaultdict(set)
+        for init_name, h in self.src.initializers.items():
+            for consumer in self.src.by_initializer_consumer.get(init_name, []):
+                src_hash_to_consumers[h].add(consumer)
+
+        # See _initializer_name_match: deliberately no claimed-source filter,
+        # because QDQ-boundary Q/DQ pairs are legitimately shared across
+        # adjacent fused QLinear ops.
+        for name, opt in self.opt.nodes.items():
+            if name in self.matches:
+                continue
+            if not opt.initializer_inputs:
+                continue
+            candidates: set[str] = set()
+            for init_name in opt.initializer_inputs:
+                h = self.opt.initializers.get(init_name)
+                if h is None:
+                    continue
+                candidates.update(src_hash_to_consumers.get(h, set()))
+            if not candidates:
+                continue
+            src_list = self._topo_sort_in_src(list(candidates))
+            confidence = Confidence.HIGH if len(src_list) == 1 else Confidence.MEDIUM
+            notes = (
+                None
+                if len(src_list) == 1
+                else "Renamed initializer matched by data hash; multiple consumers suggest fusion"
+            )
+            self._record(
+                opt,
+                source_nodes=src_list,
+                method=MatchMethod.INITIALIZER_HASH,
+                confidence=confidence,
+                notes=notes,
+            )
+
+    # -- Strategy 5: fusion pattern walk ---------------------------------
+
+    def _fusion_pattern_match(self) -> None:
+        # A fusion chain is a structural pattern (e.g. MatMul + Add -> Gemm)
+        # that requires every node in the chain. If any chain node is already
+        # attributed to a different optimized node, the fusion is incomplete
+        # for this candidate, so skip — unlike initializer anchoring, we
+        # cannot meaningfully drop the claimed node and keep the rest.
+        claimed_src = self._collect_claimed_src()
+
+        for name, opt in self.opt.nodes.items():
+            if name in self.matches:
+                continue
+            patterns = FUSION_PATTERNS.get(opt.op_type)
+            if not patterns:
+                continue
+            for pattern in patterns:
+                chain = self._walk_back_for_pattern(opt, pattern)
+                if chain and not any(s in claimed_src for s in chain):
+                    self._record(
+                        opt,
+                        source_nodes=chain,
+                        method=MatchMethod.FUSION_PATTERN,
+                        confidence=Confidence.MEDIUM,
+                        pattern="+".join(pattern),
+                    )
+                    claimed_src.update(chain)
+                    break
+
+    def _walk_back_for_pattern(self, opt: NodeRecord, pattern: list[str]) -> list[str] | None:
+        """Try to find a chain of source nodes matching `pattern` whose final
+        output tensor is one of `opt`'s inputs. Pattern is in source topological
+        order (input side first); we walk backward starting from the last op."""
+        for inp in opt.inputs:
+            producer_name = self.src.by_output_tensor.get(inp)
+            if producer_name is None:
+                continue
+            chain: list[str] = []
+            current: str | None = producer_name
+            for op_type in reversed(pattern):
+                if current is None:
+                    break
+                src = self.src.nodes.get(current)
+                if src is None or src.op_type != op_type:
+                    break
+                chain.append(current)
+                # Move to the producer of this node's first non-initializer input.
+                current = None
+                for src_inp in src.inputs:
+                    if src_inp in self.src.by_output_tensor:
+                        current = self.src.by_output_tensor[src_inp]
+                        break
+            if len(chain) == len(pattern):
+                return list(reversed(chain))  # source topological order
+        return None
+
+    # -- Strategy 6: lineage extension -----------------------------------
+
+    def _lineage_extension(self) -> None:
+        """For source nodes not yet claimed, attribute them to a matched
+        optimized node — preferring the *producer* (upstream) over the
+        *consumer* (downstream).
+
+        The producer-preferred rule reflects how ORT fusions actually work:
+        Conv+BN -> Conv folds BN into Conv, so unmatched `bn1` belongs with
+        `conv1` (its producer), not `relu1` (its consumer). MatMul+Add -> Gemm
+        is similar — `add1` belongs with the node that absorbed `matmul1`.
+
+        Iterates: a chain of unmatched nodes (e.g. BN -> Activation both folded)
+        is propagated outward until no more progress is possible.
+        """
+        claimed: set[str] = set()
+        src_to_opt: dict[str, str] = {}
+        for opt_name, m in self.matches.items():
+            for s in m.source_nodes:
+                claimed.add(s)
+                src_to_opt[s] = opt_name
+
+        progress = True
+        while progress:
+            progress = False
+            for src_name, src in self.src.nodes.items():
+                if src_name in claimed:
+                    continue
+                # Producer first (upstream).
+                target_opt = self._find_producer_match(src, src_to_opt)
+                # Fall back to consumer (downstream).
+                if target_opt is None:
+                    target_opt = self._find_lineage_target(src)
+                if target_opt is None:
+                    continue
+                opt_match = self.matches.get(target_opt)
+                if opt_match is None or src_name in opt_match.source_nodes:
+                    continue
+                # Insert and re-sort topologically by source-graph order.
+                merged = self._topo_sort_in_src([*opt_match.source_nodes, src_name])
+                opt_match.source_nodes = merged
+                opt_match.source_op_types = [self.src.nodes[n].op_type for n in merged]
+                opt_match.confidence = Confidence.MEDIUM
+                tag = f"lineage-extended: absorbed source node `{src_name}` ({src.op_type})"
+                opt_match.notes = f"{opt_match.notes}; {tag}" if opt_match.notes else tag
+                claimed.add(src_name)
+                src_to_opt[src_name] = target_opt
+                progress = True
+
+    def _find_producer_match(self, src: NodeRecord, src_to_opt: dict[str, str]) -> str | None:
+        """Walk *backward* in the source graph from `src.inputs` until we
+        reach a node already claimed by an optimized match. Returns the
+        optimized node's name."""
+        frontier: list[str] = [t for t in src.inputs if t]
+        seen: set[str] = set(frontier)
+        for _hop in range(_LINEAGE_WALK_MAX_HOPS):
+            if not frontier:
+                return None
+            new_frontier: list[str] = []
+            for tensor in frontier:
+                producer_in_src = self.src.by_output_tensor.get(tensor)
+                if producer_in_src is None:
+                    continue
+                if producer_in_src in src_to_opt:
+                    return src_to_opt[producer_in_src]
+                producer_node = self.src.nodes.get(producer_in_src)
+                if producer_node is None:
+                    continue
+                for inp in producer_node.inputs:
+                    if inp and inp not in seen:
+                        seen.add(inp)
+                        new_frontier.append(inp)
+            frontier = new_frontier
+        return None
+
+    def _topo_sort_in_src(self, node_names: list[str]) -> list[str]:
+        """Sort source-graph node names in topological order (a node A comes
+        before B if B transitively consumes A's output). Returns alphabetical
+        as a fallback if a cycle or disconnected case is detected."""
+        if len(node_names) <= 1:
+            return list(node_names)
+        name_set = set(node_names)
+        in_degree: dict[str, int] = dict.fromkeys(node_names, 0)
+        edges: dict[str, list[str]] = defaultdict(list)
+        for n in node_names:
+            node = self.src.nodes.get(n)
+            if node is None:
+                continue
+            for inp in node.inputs:
+                producer = self.src.by_output_tensor.get(inp)
+                if producer in name_set and producer != n:
+                    edges[producer].append(n)
+                    in_degree[n] += 1
+        queue: list[str] = sorted(n for n in node_names if in_degree[n] == 0)
+        result: list[str] = []
+        while queue:
+            cur = queue.pop(0)
+            result.append(cur)
+            promoted = []
+            for nxt in edges[cur]:
+                in_degree[nxt] -= 1
+                if in_degree[nxt] == 0:
+                    promoted.append(nxt)
+            queue.extend(sorted(promoted))
+        if len(result) != len(node_names):
+            return sorted(node_names)
+        return result
+
+    def _find_lineage_target(self, src: NodeRecord) -> str | None:
+        """Walk forward in the source graph from `src.outputs` until we reach a
+        tensor name that is an output of some optimized node we already
+        matched. Return that optimized node's name."""
+        frontier: list[str] = [o for o in src.outputs if o]
+        seen: set[str] = set(frontier)
+        # Bound the walk to avoid pathological runtime on deep graphs.
+        for _hop in range(_LINEAGE_WALK_MAX_HOPS):
+            if not frontier:
+                return None
+            new_frontier: list[str] = []
+            for tensor in frontier:
+                # Direct hit: tensor is an output of an optimized node we matched.
+                producer_in_opt = self.opt.by_output_tensor.get(tensor)
+                if producer_in_opt and producer_in_opt in self.matches:
+                    return producer_in_opt
+                # Otherwise expand: who consumes this tensor in the source graph?
+                for downstream in self.src.by_input_tensor.get(tensor, []):
+                    ds = self.src.nodes.get(downstream)
+                    if ds is None:
+                        continue
+                    for out in ds.outputs:
+                        if out and out not in seen:
+                            seen.add(out)
+                            new_frontier.append(out)
+            frontier = new_frontier
+        return None
+
+    # -- Tensor-level matching -------------------------------------------
+
+    @staticmethod
+    def _all_tensor_names(g: GraphIndex) -> set[str]:
+        """All non-empty tensor names that appear in a graph: node outputs,
+        node inputs (incl. model inputs), and initializers."""
+        names: set[str] = set()
+        names.update(t for t in g.by_output_tensor if t)
+        names.update(t for t in g.by_input_tensor if t)
+        names.update(g.initializers.keys())
+        return names
+
+    def _match_tensors(self) -> list[TensorMatch]:
+        """Build tensor-level mapping (optimized_tensor -> original_tensors).
+        Layered strategies, applied in confidence order:
+          1. Exact tensor name match (model I/O + surviving intermediate tensors)
+          2. Initializer name match
+          3. Initializer SHA-256 hash match (renamed initializers)
+          4. Node-output positional inheritance from node matches
+        """
+        out: dict[str, TensorMatch] = {}
+
+        def record(
+            opt_t: str, src_ts: list[str], method: MatchMethod, conf: Confidence, notes: str | None = None
+        ) -> None:
+            if not opt_t or opt_t in out:
+                return
+            out[opt_t] = TensorMatch(opt_t, list(src_ts), method, conf, notes)
+
+        src_tensors = self._all_tensor_names(self.src)
+        opt_tensors = self._all_tensor_names(self.opt)
+
+        # Phase 1: exact name match (covers model I/O + surviving intermediates).
+        for t in opt_tensors:
+            if t in src_tensors and t not in self.opt.initializers:
+                record(t, [t], MatchMethod.EXACT_NAME, Confidence.HIGH)
+
+        # Phase 2: initializer name match.
+        for init_name in self.opt.initializers:
+            if init_name in self.src.initializers:
+                record(init_name, [init_name], MatchMethod.INITIALIZER_NAME, Confidence.HIGH)
+
+        # Phase 3: initializer hash match (renamed but byte-identical).
+        src_hash_to_init: dict[bytes, list[str]] = defaultdict(list)
+        for src_name, h in self.src.initializers.items():
+            src_hash_to_init[h].append(src_name)
+        for init_name, h in self.opt.initializers.items():
+            if init_name in out:
+                continue
+            candidates = src_hash_to_init.get(h, [])
+            if not candidates:
+                continue
+            cands = sorted(candidates)
+            confidence = Confidence.HIGH if len(cands) == 1 else Confidence.MEDIUM
+            notes = None if len(cands) == 1 else "Multiple source initializers share data hash"
+            record(init_name, cands, MatchMethod.INITIALIZER_HASH, confidence, notes)
+
+        # Phase 4: node-output positional inheritance from node matches.
+        # Heuristic: optimized node X matched to source nodes [s1, ..., sN] —
+        # the LAST source node (sN) is the deepest in topological order, so its
+        # outputs are the most likely semantic match for X's outputs.
+        for opt_node_name, opt_node in self.opt.nodes.items():
+            node_match = self.matches.get(opt_node_name)
+            if node_match is None:
+                continue
+            target_src_name = node_match.source_nodes[-1]
+            src_node = self.src.nodes.get(target_src_name)
+            if src_node is None:
+                continue
+            for i, opt_out in enumerate(opt_node.outputs):
+                if not opt_out or opt_out in out:
+                    continue
+                if i >= len(src_node.outputs):
+                    continue
+                src_out = src_node.outputs[i]
+                if not src_out:
+                    continue
+                if len(node_match.source_nodes) == 1:
+                    confidence = Confidence.HIGH
+                    notes = None
+                else:
+                    confidence = Confidence.MEDIUM
+                    notes = (
+                        f"derived from fused node mapping "
+                        f"({len(node_match.source_nodes)} source nodes; "
+                        f"output attributed to last source `{target_src_name}`)"
+                    )
+                record(opt_out, [src_out], MatchMethod.NODE_OUTPUT_POSITIONAL, confidence, notes)
+
+        return list(out.values())
+
+    # -- helpers ---------------------------------------------------------
+
+    def _record(
+        self,
+        opt: NodeRecord,
+        *,
+        source_nodes: list[str],
+        method: MatchMethod,
+        confidence: Confidence,
+        pattern: str | None = None,
+        notes: str | None = None,
+    ) -> None:
+        self.matches[opt.name] = Match(
+            optimized_node=opt.name,
+            optimized_op_type=opt.op_type,
+            source_nodes=list(source_nodes),
+            source_op_types=[self.src.nodes[s].op_type for s in source_nodes],
+            method=method,
+            confidence=confidence,
+            pattern=pattern,
+            notes=notes,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Output classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_removal(src: NodeRecord, matcher: Matcher) -> str:
+    # Constant folding turns the source node's output tensors into initializers
+    # in the optimized graph. Require at least one real (non-empty) output name
+    # and require all real outputs to appear as optimized initializers — a node
+    # with only placeholder/empty output names cannot be classified as folded.
+    real_outputs = [o for o in src.outputs if o]
+    if real_outputs and all(o in matcher.opt.initializers for o in real_outputs):
+        return "constant_folded"
+    # If a downstream optimized match claims this src node via lineage extension,
+    # we'd already have moved it into matches. Reaching here means lineage
+    # extension didn't link it — most likely it was removed (e.g. NoOp dropout).
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_output(
+    args: argparse.Namespace,
+    matcher: Matcher,
+    matches: list[Match],
+    tensor_matches: list[TensorMatch],
+    stats: MatcherStats,
+    unmatched: list[str],
+    removed: list[str],
+) -> dict:
+    return {
+        "source_model": str(args.source_model),
+        "optimized_model": str(args.optimized_model),
+        "summary": {
+            "total_source_nodes": stats.total_source,
+            "total_optimized_nodes": stats.total_optimized,
+            "matched_optimized_nodes": stats.matched,
+            "unmatched_optimized_nodes": stats.unmatched,
+            "by_method": dict(stats.by_method),
+            "total_optimized_tensors": stats.total_optimized_tensors,
+            "matched_tensors": stats.matched_tensors,
+            "by_tensor_method": dict(stats.by_tensor_method),
+        },
+        "node_mappings": [
+            {
+                "optimized_node": m.optimized_node,
+                "optimized_op_type": m.optimized_op_type,
+                "original_sources": _build_original_chain(m.source_nodes, m.source_op_types, matcher.src),
+                "match_method": m.method.value,
+                "confidence": m.confidence.value,
+                **({"fusion_pattern": m.pattern} if m.pattern else {}),
+                **({"notes": m.notes} if m.notes else {}),
+            }
+            for m in matches
+        ],
+        "tensor_mappings": [
+            {
+                "optimized_tensor": tm.optimized_tensor,
+                "original_tensors": [{"name": n} for n in tm.original_tensors],
+                "match_method": tm.method.value,
+                "confidence": tm.confidence.value,
+                **({"notes": tm.notes} if tm.notes else {}),
+            }
+            for tm in tensor_matches
+        ],
+        "unmapped_optimized_nodes": [
+            {
+                "name": n,
+                "op_type": matcher.opt.nodes[n].op_type,
+                "reason": "no_strategy_matched",
+            }
+            for n in unmatched
+        ],
+        "removed_original_nodes": [
+            {
+                "name": n,
+                "op_type": matcher.src.nodes[n].op_type,
+                "likely_reason": _classify_removal(matcher.src.nodes[n], matcher),
+            }
+            for n in removed
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Join with QNN EP qnn_op_trace.json
+# ---------------------------------------------------------------------------
+
+# TraceTargetType string values as serialized by the QNN EP's
+# SerializeFrameworkOpTrace() in qnn_op_tracing_serialization.cc.
+_TRACE_TYPE_TENSOR = "TENSOR"
+_TRACE_TYPE_OP = "OP"
+
+
+def _connecting_tensor(src_index: GraphIndex, a: str, b: str) -> str | None:
+    """Return a tensor that's an output of source-graph node `a` and an input
+    of node `b` (the one that flows from a to b). Used to weave intermediate
+    tensors into a multi-op source chain."""
+    na = src_index.nodes.get(a)
+    nb = src_index.nodes.get(b)
+    if na is None or nb is None:
+        return None
+    b_inputs = set(nb.inputs)
+    for out in na.outputs:
+        if out and out in b_inputs:
+            return out
+    return None
+
+
+def _build_original_chain(
+    source_nodes: list[str],
+    source_op_types: list[str],
+    src_index: GraphIndex,
+) -> list[dict]:
+    """Build a QNN-EP-style source chain (`op1, tensor_out1, op2, ..., opN`)
+    from a list of source-graph node names. Intermediate tensors are looked
+    up via `_connecting_tensor` against the source graph. Tensor entries use
+    `{name, type="TENSOR"}`, op entries use `{name, type="OP", op_type}`."""
+    chain: list[dict] = []
+    for i, name in enumerate(source_nodes):
+        chain.append(
+            {
+                "name": name,
+                "type": _TRACE_TYPE_OP,
+                "op_type": source_op_types[i],
+            }
+        )
+        if i < len(source_nodes) - 1:
+            connecting = _connecting_tensor(src_index, name, source_nodes[i + 1])
+            if connecting:
+                chain.append({"name": connecting, "type": _TRACE_TYPE_TENSOR})
+    return chain
+
+
+def join_qnn_trace(
+    matches: list[Match],
+    tensor_matches: list[TensorMatch],
+    qnn_trace: dict,
+    src_index: GraphIndex,
+) -> tuple[dict, dict]:
+    """Extend a QNN EP qnn_op_trace.json with `original_sources` on each
+    TraceMapping. Resolves both op-typed sources (via node matches) and
+    tensor-typed sources (via tensor matches). Returns the extended trace plus
+    a stats dict.
+
+    The returned dict is a deep copy — `qnn_trace` is not mutated, so callers
+    can keep using their original input unchanged.
+
+    For multi-source op expansions (fusions), the source nodes are emitted in
+    source-graph topological order and intermediate tensors are woven between
+    consecutive ops, mirroring the QNN EP `op1, tensor1, op2, ..., opN`
+    convention.
+
+    Output entries follow the QNN EP `TraceSourcePair` schema (`{name, type}`),
+    with an additional `op_type` field on op entries for human readability.
+    """
+    qnn_trace = copy.deepcopy(qnn_trace)
+    node_index: dict[str, list[dict]] = {
+        m.optimized_node: _build_original_chain(m.source_nodes, m.source_op_types, src_index) for m in matches
+    }
+
+    tensor_index: dict[str, list[str]] = {tm.optimized_tensor: list(tm.original_tensors) for tm in tensor_matches}
+
+    stats = {
+        "op_mappings_total": 0,
+        "op_mappings_extended": 0,
+        "tensor_mappings_total": 0,
+        "tensor_mappings_extended": 0,
+        "op_sources_unresolved": 0,
+        "tensor_sources_unresolved": 0,
+    }
+
+    def lookup_originals(sources: list) -> list[dict]:
+        """Collect deduplicated original sources for entries in `sources`,
+        preserving QNN EP's `{name, type}` schema. Mutates `stats` counters
+        for unresolved references."""
+        seen: set[tuple[int, str]] = set()
+        result: list[dict] = []
+        for src in sources or []:
+            src_type = src.get("type")
+            src_name = src.get("name", "")
+            if src_type == _TRACE_TYPE_OP:
+                chain = node_index.get(src_name)
+                if chain is None:
+                    stats["op_sources_unresolved"] += 1
+                    continue
+                for entry in chain:
+                    key = (entry["type"], entry["name"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    result.append(dict(entry))
+            elif src_type == _TRACE_TYPE_TENSOR:
+                originals = tensor_index.get(src_name)
+                if originals is None:
+                    stats["tensor_sources_unresolved"] += 1
+                    continue
+                for tname in originals:
+                    key = (_TRACE_TYPE_TENSOR, tname)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    result.append({"name": tname, "type": _TRACE_TYPE_TENSOR})
+        return result
+
+    for sg in qnn_trace.get("subgraph_traces", []):
+        for mapping in sg.get("op_mappings", []) or []:
+            stats["op_mappings_total"] += 1
+            originals = lookup_originals(mapping.get("sources", []))
+            if originals:
+                mapping["original_sources"] = originals
+                stats["op_mappings_extended"] += 1
+        for mapping in sg.get("tensor_mappings", []) or []:
+            stats["tensor_mappings_total"] += 1
+            originals = lookup_originals(mapping.get("sources", []))
+            if originals:
+                mapping["original_sources"] = originals
+                stats["tensor_mappings_extended"] += 1
+
+    return qnn_trace, stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Match source ONNX nodes to ORT-optimized ONNX nodes.",
+        allow_abbrev=False,
+    )
+    ap.add_argument("--source-model", required=True, type=Path, help="Original user-provided ONNX model")
+    ap.add_argument(
+        "--optimized-model",
+        required=True,
+        type=Path,
+        help="ORT-optimized ONNX model (saved via SessionOptions::optimized_model_filepath)",
+    )
+    ap.add_argument("--output", required=True, type=Path, help="Output JSON path")
+    ap.add_argument(
+        "--qnn-trace",
+        type=Path,
+        default=None,
+        help="(Optional) QNN EP qnn_op_trace.json. When given, the trace is "
+        "extended with `original_sources` and written to --joined-output.",
+    )
+    ap.add_argument(
+        "--joined-output",
+        type=Path,
+        default=None,
+        help="(Optional) Output path for the extended QNN trace. Defaults to "
+        "<qnn-trace-stem>.with_original_sources.json next to --qnn-trace. "
+        "Only used when --qnn-trace is given.",
+    )
+    ap.add_argument("--verbose", action="store_true", help="Print per-strategy diagnostics")
+    args = ap.parse_args()
+
+    if not args.source_model.is_file():
+        sys.stderr.write(f"error: source model not found: {args.source_model}\n")
+        return 2
+    if not args.optimized_model.is_file():
+        sys.stderr.write(f"error: optimized model not found: {args.optimized_model}\n")
+        return 2
+    if args.qnn_trace is not None and not args.qnn_trace.is_file():
+        sys.stderr.write(f"error: QNN trace not found: {args.qnn_trace}\n")
+        return 2
+    if args.joined_output is not None and args.qnn_trace is None:
+        sys.stderr.write("error: --joined-output requires --qnn-trace\n")
+        return 2
+    if args.output.exists():
+        sys.stderr.write(f"warning: overwriting existing output: {args.output}\n")
+
+    _require_onnx()
+    source = onnx.load(str(args.source_model))
+    optimized = onnx.load(str(args.optimized_model))
+
+    matcher = Matcher(source, optimized)
+    matches, tensor_matches, stats, unmatched, removed = matcher.run()
+
+    output = build_output(args, matcher, matches, tensor_matches, stats, unmatched, removed)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2), encoding="utf-8")
+
+    print(
+        f"Matched {stats.matched}/{stats.total_optimized} optimized nodes "
+        f"(unmatched: {stats.unmatched}, source-removed: {len(removed)}); "
+        f"{stats.matched_tensors}/{stats.total_optimized_tensors} optimized tensors"
+    )
+    if args.verbose:
+        print(f"  by node method: {dict(stats.by_method)}")
+        print(f"  by tensor method: {dict(stats.by_tensor_method)}")
+        if unmatched:
+            print(f"  unmapped optimized nodes: {len(unmatched)}")
+            for n in unmatched[:10]:
+                print(f"    - {n} ({matcher.opt.nodes[n].op_type})")
+            if len(unmatched) > 10:
+                print(f"    ... and {len(unmatched) - 10} more")
+        if removed:
+            classified: dict[str, int] = defaultdict(int)
+            for n in removed:
+                classified[_classify_removal(matcher.src.nodes[n], matcher)] += 1
+            print(f"  source-removed by reason: {dict(classified)}")
+    print(f"Output: {args.output}")
+
+    if args.qnn_trace is not None:
+        joined_path = args.joined_output or (
+            args.qnn_trace.with_name(args.qnn_trace.stem + ".with_original_sources.json")
+        )
+        if joined_path.exists():
+            sys.stderr.write(f"warning: overwriting existing joined output: {joined_path}\n")
+        try:
+            qnn_trace = json.loads(args.qnn_trace.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"error: failed to parse {args.qnn_trace}: {e}\n")
+            return 2
+        extended, join_stats = join_qnn_trace(matches, tensor_matches, qnn_trace, matcher.src)
+        joined_path.parent.mkdir(parents=True, exist_ok=True)
+        joined_path.write_text(json.dumps(extended, indent=2), encoding="utf-8")
+        print(
+            f"Joined QNN trace: {join_stats['op_mappings_extended']}/"
+            f"{join_stats['op_mappings_total']} op_mappings extended, "
+            f"{join_stats['tensor_mappings_extended']}/"
+            f"{join_stats['tensor_mappings_total']} tensor_mappings extended"
+        )
+        if join_stats["op_sources_unresolved"]:
+            print(
+                f"  warning: {join_stats['op_sources_unresolved']} op-typed source "
+                f"reference(s) had no matcher entry (optimized node not in source->optimized mapping)"
+            )
+        if join_stats["tensor_sources_unresolved"]:
+            print(
+                f"  warning: {join_stats['tensor_sources_unresolved']} tensor-typed source "
+                f"reference(s) had no matcher entry (optimized tensor not in source->optimized mapping)"
+            )
+        print(f"Joined output: {joined_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qcom/tools/op_trace_matcher/source_to_optimized_matcher.py
+++ b/qcom/tools/op_trace_matcher/source_to_optimized_matcher.py
@@ -155,12 +155,14 @@ class GraphIndex:
             elif _onnx_numpy_helper is not None:
                 try:
                     payload = _onnx_numpy_helper.to_array(init).tobytes()
-                except Exception:
-                    # Fall back to proto serialization if the initializer cannot
-                    # be converted (unsupported type / external data not yet
-                    # resolved). The hash is still byte-stable within a single
-                    # protobuf process; cross-process stability is the only
-                    # property weakened.
+                except (ValueError, TypeError, RuntimeError):
+                    # numpy_helper raises ValueError for malformed tensor
+                    # field counts, TypeError for unsupported dtypes (BF16
+                    # variants on older onnx versions), and RuntimeError when
+                    # external_data is referenced but not yet resolved. Fall
+                    # back to proto serialization in those cases. The hash is
+                    # still byte-stable within a single protobuf process;
+                    # cross-process stability is the only property weakened.
                     payload = init.SerializeToString()
             else:
                 payload = init.SerializeToString()
@@ -173,7 +175,7 @@ class GraphIndex:
 
         seen_names: set[str] = set()
         for idx, node in enumerate(graph.node):
-            name = node.name or f"<unnamed_{node.op_type}_{idx}>"
+            name = node.name or f"unnamed_{node.op_type}_{idx}"
             if name in seen_names:
                 name = f"{name}__dup{idx}"
             seen_names.add(name)
@@ -237,7 +239,7 @@ class GraphIndex:
         seen_names: set[str] = set()
         for idx, (node_name, raw_ninfo) in enumerate(json_nodes.items()):
             ninfo = raw_ninfo or {}
-            name = node_name or f"<unnamed_{ninfo.get('type', 'op')}_{idx}>"
+            name = node_name or f"unnamed_{ninfo.get('type', 'op')}_{idx}"
             if name in seen_names:
                 name = f"{name}__dup{idx}"
             seen_names.add(name)
@@ -978,6 +980,24 @@ def join_qnn_trace(
 
     Output entries follow the QNN EP `TraceSourcePair` schema (`{name, type}`),
     with an additional `op_type` field on op entries for human readability.
+
+    Returns:
+        A tuple ``(extended_trace, stats)``.
+
+        ``extended_trace`` is a deep copy of ``qnn_trace`` with an
+        ``original_sources`` field added next to ``sources`` on every
+        op_mappings/tensor_mappings entry.
+
+        ``stats`` is a dict with the following integer keys:
+
+          - ``op_mappings_total`` / ``op_mappings_extended`` — count of
+            ``op_mappings[]`` entries traversed and how many had at least one
+            ``original_sources`` entry written.
+          - ``tensor_mappings_total`` / ``tensor_mappings_extended`` — same
+            counts for ``tensor_mappings[]``.
+          - ``op_sources_unresolved`` / ``tensor_sources_unresolved`` — count
+            of ``sources[]`` references (op-typed and tensor-typed) that
+            could not be resolved to an original-ONNX name.
     """
     qnn_trace = copy.deepcopy(qnn_trace)
     node_index: dict[str, list[dict]] = {

--- a/qcom/tools/op_trace_matcher/source_to_optimized_matcher.py
+++ b/qcom/tools/op_trace_matcher/source_to_optimized_matcher.py
@@ -3,11 +3,10 @@
 """Source ONNX -> Optimized ONNX node and tensor mapping tool.
 
 Computes a structural correspondence between a user-supplied ONNX model
-(`source.onnx`) and an ORT-optimized ONNX model (`optimized.onnx`, saved via
-`SessionOptions::optimized_model_filepath`). Output JSON aligns with the QNN
-EP `FrameworkOpTrace` schema's `original_sources` extension; combined with
-the QNN EP's existing `qnn_op_trace.json`, this yields end-to-end
-provenance: original ONNX node -> optimized ONNX node -> QNN op.
+(`source.onnx`) and an ORT-optimized graph. Output JSON aligns with
+the QNN EP `FrameworkOpTrace` schema's `original_sources` extension;
+combined with the QNN EP's existing `qnn_op_trace.json`, this yields
+end-to-end provenance: original ONNX node -> optimized ONNX node -> QNN op.
 
 See ./README.md for the feasibility assessment, known limitations, and the
 output schema.
@@ -33,8 +32,10 @@ from pathlib import Path
 try:
     import onnx
     from onnx import ModelProto  # used in string annotations (ModelProto type hints)
+    from onnx import numpy_helper as _onnx_numpy_helper
 except ImportError:
     onnx = None
+    _onnx_numpy_helper = None
 
 
 def _require_onnx() -> None:
@@ -54,6 +55,12 @@ __all__ = [
     "build_output",
     "join_qnn_trace",
 ]
+
+
+# QNN-Netron tensor-type integer for an initializer (weights/constants). Mirrors
+# `Qnn_TensorType_t::QNN_TENSOR_TYPE_STATIC` used by the QNN EP's
+# dump_qnn_ep_input_graph output (see qnn_ep_input_graph_dumper.cc).
+_QNN_TENSOR_TYPE_STATIC = 4
 
 
 # Maximum BFS hop count for the lineage-extension walks (producer-preferred
@@ -132,11 +139,29 @@ class GraphIndex:
 
         initializers: dict[str, bytes] = {}
         for init in graph.initializer:
-            # Hash raw_data when present; otherwise serialize the whole proto.
-            # raw_data is the common case for large weights and gives a stable
-            # identity that survives renaming.
+            # raw_data is the common case for large weights: hash it directly,
+            # decoupled from any protobuf encoding details.
+            #
+            # For non-raw_data initializers (small constants stored in
+            # field-typed lists like int32_data/float_data), hash the canonical
+            # numpy bytes via onnx.numpy_helper.to_array(...).tobytes() rather
+            # than init.SerializeToString(). The proto wire format is not
+            # guaranteed deterministic across re-serializations, but the
+            # underlying numpy buffer is — this keeps the hash stable when the
+            # source and optimized graphs were each round-tripped through
+            # different ONNX load/save passes.
             if init.raw_data:
                 payload = init.raw_data
+            elif _onnx_numpy_helper is not None:
+                try:
+                    payload = _onnx_numpy_helper.to_array(init).tobytes()
+                except Exception:
+                    # Fall back to proto serialization if the initializer cannot
+                    # be converted (unsupported type / external data not yet
+                    # resolved). The hash is still byte-stable within a single
+                    # protobuf process; cross-process stability is the only
+                    # property weakened.
+                    payload = init.SerializeToString()
             else:
                 payload = init.SerializeToString()
             initializers[init.name] = hashlib.sha256(payload).digest()
@@ -179,6 +204,71 @@ class GraphIndex:
             by_initializer_consumer=dict(by_initializer_consumer),
         )
 
+    @classmethod
+    def build_from_qnn_json(cls, doc: dict) -> GraphIndex:
+        """Build a GraphIndex from the QNN-Netron-schema JSON emitted by the
+        QNN EP's `dump_qnn_ep_input_graph` option (see qnn_ep_input_graph_dumper.cc).
+
+        That JSON is the ONNX graph the EP received at compile time. It carries
+        node name/op_type/inputs/outputs and a tensor table that flags each
+        tensor's role via an integer `type` (see _QNN_TENSOR_TYPE_STATIC for the
+        initializer value).
+        It does NOT carry initializer data bytes, so each initializer is given a
+        name-derived sentinel hash: name-based and topology-based matching work
+        unchanged, while data-hash matching (for renamed weights) is inert for
+        this input — acceptable because the QNN-EP-direct workflow keeps weight
+        names stable.
+        """
+        graph = doc.get("graph", {})
+        json_nodes = graph.get("nodes", {}) or {}
+        json_tensors = graph.get("tensors", {}) or {}
+
+        # Initializers: tensors flagged STATIC. Sentinel hash per name.
+        initializers: dict[str, bytes] = {}
+        for tname, tinfo in json_tensors.items():
+            if isinstance(tinfo, dict) and tinfo.get("type") == _QNN_TENSOR_TYPE_STATIC:
+                initializers[tname] = hashlib.sha256(tname.encode("utf-8")).digest()
+
+        nodes: dict[str, NodeRecord] = {}
+        by_output_tensor: dict[str, str] = {}
+        by_input_tensor: dict[str, list[str]] = defaultdict(list)
+        by_initializer_consumer: dict[str, list[str]] = defaultdict(list)
+
+        seen_names: set[str] = set()
+        for idx, (node_name, raw_ninfo) in enumerate(json_nodes.items()):
+            ninfo = raw_ninfo or {}
+            name = node_name or f"<unnamed_{ninfo.get('type', 'op')}_{idx}>"
+            if name in seen_names:
+                name = f"{name}__dup{idx}"
+            seen_names.add(name)
+
+            inputs = tuple(ninfo.get("input_names", []) or [])
+            outputs = tuple(ninfo.get("output_names", []) or [])
+            init_inputs = tuple(i for i in inputs if i in initializers)
+            nodes[name] = NodeRecord(
+                name=name,
+                op_type=ninfo.get("type", ""),
+                inputs=inputs,
+                outputs=outputs,
+                initializer_inputs=init_inputs,
+            )
+            for out in outputs:
+                if out:
+                    by_output_tensor[out] = name
+            for inp in inputs:
+                if inp:
+                    by_input_tensor[inp].append(name)
+            for init_name in init_inputs:
+                by_initializer_consumer[init_name].append(name)
+
+        return cls(
+            nodes=nodes,
+            by_output_tensor=by_output_tensor,
+            by_input_tensor=dict(by_input_tensor),
+            initializers=dict(initializers),
+            by_initializer_consumer=dict(by_initializer_consumer),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Fusion patterns
@@ -190,10 +280,10 @@ class GraphIndex:
 #
 # Only LINEAR source chains can be expressed here — the walker follows one
 # input edge per step. Fusions with branching source patterns (LayerNorm,
-# EmbedLayerNorm, Attention, the Tanh-form FastGelu, …) typically rely on
-# the matcher's initializer-anchoring or lineage-extension strategies
-# instead. Patterns derived by reading the corresponding fusion files in
-# onnxruntime/core/optimizer/.
+# EmbedLayerNorm, Attention, GroupQueryAttention, the Tanh-form FastGelu, …)
+# typically rely on the matcher's initializer-anchoring or lineage-extension
+# strategies instead. Patterns derived by reading the corresponding fusion
+# files in onnxruntime/core/optimizer/.
 FUSION_PATTERNS: dict[str, list[list[str]]] = {
     # MatMul + Add  ->  Gemm                 (matmul_add_fusion)
     "Gemm": [["MatMul", "Add"]],
@@ -242,9 +332,13 @@ class MatcherStats:
 
 
 class Matcher:
-    def __init__(self, source: ModelProto, optimized: ModelProto):
-        self.src = GraphIndex.build(source)
-        self.opt = GraphIndex.build(optimized)
+    def __init__(self, source, optimized):
+        """`source` and `optimized` may each be either an onnx ModelProto (built
+        via GraphIndex.build) or an already-constructed GraphIndex (e.g. from
+        GraphIndex.build_from_qnn_json). This lets the optimized side come from
+        the QNN EP's dump_qnn_ep_input_graph JSON instead of a saved .onnx."""
+        self.src = source if isinstance(source, GraphIndex) else GraphIndex.build(source)
+        self.opt = optimized if isinstance(optimized, GraphIndex) else GraphIndex.build(optimized)
         self.matches: dict[str, Match] = {}
 
     def run(self) -> tuple[list[Match], list[TensorMatch], MatcherStats, list[str], list[str]]:
@@ -438,7 +532,20 @@ class Matcher:
     def _walk_back_for_pattern(self, opt: NodeRecord, pattern: list[str]) -> list[str] | None:
         """Try to find a chain of source nodes matching `pattern` whose final
         output tensor is one of `opt`'s inputs. Pattern is in source topological
-        order (input side first); we walk backward starting from the last op."""
+        order (input side first); we walk backward starting from the last op.
+
+        Limitation for non-commutative fusions (MatMul+Add -> Gemm,
+        Conv+Add -> Conv-with-bias, …): when a node has more than one
+        op-output input, this walker takes the FIRST `inputs[]` entry that
+        has a producer in the source graph and stops. This relies on the
+        assumption that the chain entry sits at the lower input index — true
+        for all currently-supported fusions because their non-chain operand
+        is an initializer (bias / weight) that never appears in
+        `by_output_tensor`. Fusions whose chain entry sits at a higher input
+        index, or whose siblings are both op outputs, will require an
+        explicit per-pattern annotation (e.g. an `input_index` marker on
+        `FUSION_PATTERNS`).
+        """
         for inp in opt.inputs:
             producer_name = self.src.by_output_tensor.get(inp)
             if producer_name is None:
@@ -891,7 +998,14 @@ def join_qnn_trace(
     def lookup_originals(sources: list) -> list[dict]:
         """Collect deduplicated original sources for entries in `sources`,
         preserving QNN EP's `{name, type}` schema. Mutates `stats` counters
-        for unresolved references."""
+        for unresolved references.
+
+        When an OP-typed source name is not in `node_index` (i.e. the optimized
+        graph has no match for it in the source->optimized mapping), but the name
+        exists as a node in the source graph, it is assumed the EP consumed the
+        source ONNX directly without an intervening ORT optimization that would
+        have renamed or fused the node. In that case the source name is already
+        an original-ONNX name and is passed through unchanged (identity match)."""
         seen: set[tuple[int, str]] = set()
         result: list[dict] = []
         for src in sources or []:
@@ -900,6 +1014,21 @@ def join_qnn_trace(
             if src_type == _TRACE_TYPE_OP:
                 chain = node_index.get(src_name)
                 if chain is None:
+                    # Identity fallback: the EP processed this source node directly
+                    # from the user's ONNX (the source -> optimized step was a no-op
+                    # for this node, or the user passed the same file as both).
+                    src_node = src_index.nodes.get(src_name)
+                    if src_node is not None:
+                        entry = {
+                            "name": src_name,
+                            "type": _TRACE_TYPE_OP,
+                            "op_type": src_node.op_type,
+                        }
+                        key = (entry["type"], entry["name"])
+                        if key not in seen:
+                            seen.add(key)
+                            result.append(entry)
+                        continue
                     stats["op_sources_unresolved"] += 1
                     continue
                 for entry in chain:
@@ -948,7 +1077,9 @@ def main() -> int:
         "--optimized-model",
         required=True,
         type=Path,
-        help="ORT-optimized ONNX model (saved via SessionOptions::optimized_model_filepath)",
+        help="ORT-optimized graph the EP consumed. Either an ONNX model (saved via "
+        "SessionOptions::optimized_model_filepath) or a QNN-Netron-schema JSON dumped "
+        "by the QNN EP's `dump_qnn_ep_input_graph` option (detected by a .json extension).",
     )
     ap.add_argument("--output", required=True, type=Path, help="Output JSON path")
     ap.add_argument(
@@ -986,7 +1117,19 @@ def main() -> int:
 
     _require_onnx()
     source = onnx.load(str(args.source_model))
-    optimized = onnx.load(str(args.optimized_model))
+
+    # The optimized side may be a QNN-Netron-schema JSON (from the QNN EP's
+    # dump_qnn_ep_input_graph) instead of an .onnx; detect by extension and
+    # build the GraphIndex directly so no onnx proto load is needed for it.
+    if args.optimized_model.suffix.lower() == ".json":
+        try:
+            opt_doc = json.loads(args.optimized_model.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            sys.stderr.write(f"error: failed to parse {args.optimized_model}: {e}\n")
+            return 2
+        optimized = GraphIndex.build_from_qnn_json(opt_doc)
+    else:
+        optimized = onnx.load(str(args.optimized_model))
 
     matcher = Matcher(source, optimized)
     matches, tensor_matches, stats, unmatched, removed = matcher.run()

--- a/qcom/tools/op_trace_matcher/test_op_trace_matcher.py
+++ b/qcom/tools/op_trace_matcher/test_op_trace_matcher.py
@@ -1,0 +1,422 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+"""Unit tests for `source_to_optimized_matcher` and `enrich_profiling_csv`.
+
+The tests build minimal `onnx.ModelProto` graphs in memory (no real model
+needed) and exercise:
+
+  * each layered matching strategy (`MatchMethod` enum) at least once
+  * the linear-chain fusion walk (MatMul + Add -> Gemm)
+  * `join_qnn_trace`'s identity fallback when no real source ONNX is paired
+  * each of the four CSV adaptation modes in `enrich_profiling_csv.enrich`
+  * `build_lookups` on a degenerate empty trace
+
+Tests are stdlib-only except for `onnx`, which is also the matcher's only
+runtime dependency. Pytest is the runner; tests are self-contained so they
+can be invoked via `python -m pytest qcom/tools/op_trace_matcher/`.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the sibling module importable regardless of how pytest discovers the
+# file (rootdir / cwd / -m). The package's __init__.py also enables the
+# `qcom.tools.op_trace_matcher` import path when invoked via `python -m`.
+_THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_THIS_DIR))
+
+import enrich_profiling_csv as enr  # noqa: E402
+import source_to_optimized_matcher as m  # noqa: E402
+
+onnx = pytest.importorskip("onnx")
+import numpy as np  # noqa: E402
+from onnx import TensorProto, helper, numpy_helper  # noqa: E402
+
+sys.path.remove(str(_THIS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building tiny ONNX graphs
+# ---------------------------------------------------------------------------
+
+
+def _make_value_info(name: str, shape: list[int]) -> onnx.ValueInfoProto:
+    return helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+
+
+def _make_initializer(name: str, array: np.ndarray) -> onnx.TensorProto:
+    return numpy_helper.from_array(array, name=name)
+
+
+def _model_from_nodes(
+    nodes: list[onnx.NodeProto],
+    inputs: list[onnx.ValueInfoProto],
+    outputs: list[onnx.ValueInfoProto],
+    initializers: list[onnx.TensorProto] | None = None,
+    name: str = "test_graph",
+) -> onnx.ModelProto:
+    graph = helper.make_graph(
+        nodes=nodes,
+        name=name,
+        inputs=inputs,
+        outputs=outputs,
+        initializer=initializers or [],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 19)])
+    model.ir_version = 9
+    return model
+
+
+# ---------------------------------------------------------------------------
+# GraphIndex
+# ---------------------------------------------------------------------------
+
+
+class TestGraphIndex:
+    def test_build_records_initializers_and_consumers(self) -> None:
+        weight = _make_initializer("W", np.ones((2, 2), dtype=np.float32))
+        x = _make_value_info("X", [2, 2])
+        y = _make_value_info("Y", [2, 2])
+        node = helper.make_node("MatMul", ["X", "W"], ["Y"], name="matmul1")
+        model = _model_from_nodes([node], [x], [y], [weight])
+
+        idx = m.GraphIndex.build(model)
+
+        assert "matmul1" in idx.nodes
+        rec = idx.nodes["matmul1"]
+        assert rec.op_type == "MatMul"
+        assert rec.inputs == ("X", "W")
+        assert "W" in rec.initializer_inputs
+        assert "W" in idx.initializers
+        assert idx.by_output_tensor["Y"] == "matmul1"
+        assert "matmul1" in idx.by_initializer_consumer["W"]
+
+    def test_build_from_qnn_json_uses_static_type_for_initializers(self) -> None:
+        # The QNN-Netron schema emitted by the EP marks initializers via
+        # `type == _QNN_TENSOR_TYPE_STATIC`. Verify that GraphIndex picks
+        # them up under that contract.
+        doc = {
+            "graph": {
+                "nodes": {
+                    "n1": {"type": "MatMul", "input_names": ["X", "W"], "output_names": ["Y"]},
+                },
+                "tensors": {
+                    "X": {"type": 0},  # APP_WRITE
+                    "W": {"type": m._QNN_TENSOR_TYPE_STATIC},
+                    "Y": {"type": 1},  # APP_READ
+                },
+            },
+        }
+        idx = m.GraphIndex.build_from_qnn_json(doc)
+        assert "W" in idx.initializers
+        assert "X" not in idx.initializers
+        assert idx.nodes["n1"].op_type == "MatMul"
+
+
+# ---------------------------------------------------------------------------
+# Matcher strategies
+# ---------------------------------------------------------------------------
+
+
+class TestMatcherStrategies:
+    def _single_node_model(self, op_type: str, name: str, *, inputs=("X",), outputs=("Y",)) -> onnx.ModelProto:
+        node = helper.make_node(op_type, list(inputs), list(outputs), name=name)
+        return _model_from_nodes(
+            [node],
+            [_make_value_info(t, [2, 2]) for t in inputs],
+            [_make_value_info(t, [2, 2]) for t in outputs],
+        )
+
+    def test_exact_name_match(self) -> None:
+        # Same node name on both sides — should land EXACT_NAME with HIGH.
+        src = self._single_node_model("Relu", "relu1")
+        opt = self._single_node_model("Relu", "relu1")
+        matches, *_ = m.Matcher(src, opt).run()
+        assert len(matches) == 1
+        assert matches[0].method == m.MatchMethod.EXACT_NAME
+        assert matches[0].confidence == m.Confidence.HIGH
+        assert matches[0].source_nodes == ["relu1"]
+
+    def test_exact_io_match_on_renamed_node(self) -> None:
+        # Same input + output names, different node name — EXACT_IO.
+        src = self._single_node_model("Relu", "relu_orig")
+        opt = self._single_node_model("Relu", "relu_renamed")
+        matches, *_ = m.Matcher(src, opt).run()
+        assert len(matches) == 1
+        assert matches[0].method == m.MatchMethod.EXACT_IO
+        assert matches[0].source_nodes == ["relu_orig"]
+
+    def test_initializer_name_match(self) -> None:
+        # Same initializer name consumed by a node whose other inputs differ.
+        weight = _make_initializer("W", np.ones((2, 2), dtype=np.float32))
+        src = _model_from_nodes(
+            [helper.make_node("MatMul", ["X_src", "W"], ["Y_src"], name="m_src")],
+            [_make_value_info("X_src", [2, 2])],
+            [_make_value_info("Y_src", [2, 2])],
+            [weight],
+        )
+        opt = _model_from_nodes(
+            [helper.make_node("MatMul", ["X_opt", "W"], ["Y_opt"], name="m_opt")],
+            [_make_value_info("X_opt", [2, 2])],
+            [_make_value_info("Y_opt", [2, 2])],
+            [weight],
+        )
+        matches, *_ = m.Matcher(src, opt).run()
+        assert len(matches) == 1
+        assert matches[0].method == m.MatchMethod.INITIALIZER_NAME
+
+    def test_initializer_hash_match_on_renamed_initializer(self) -> None:
+        # Same bytes, different name — only INITIALIZER_HASH can recover this
+        # since names differ AND I/O tensor names differ.
+        arr = np.arange(4, dtype=np.float32).reshape(2, 2)
+        weight_src = _make_initializer("W_src", arr)
+        weight_opt = _make_initializer("W_opt", arr)
+        src = _model_from_nodes(
+            [helper.make_node("MatMul", ["X_src", "W_src"], ["Y_src"], name="m_src")],
+            [_make_value_info("X_src", [2, 2])],
+            [_make_value_info("Y_src", [2, 2])],
+            [weight_src],
+        )
+        opt = _model_from_nodes(
+            [helper.make_node("MatMul", ["X_opt", "W_opt"], ["Y_opt"], name="m_opt")],
+            [_make_value_info("X_opt", [2, 2])],
+            [_make_value_info("Y_opt", [2, 2])],
+            [weight_opt],
+        )
+        matches, *_ = m.Matcher(src, opt).run()
+        assert len(matches) == 1
+        assert matches[0].method == m.MatchMethod.INITIALIZER_HASH
+
+    def test_fusion_pattern_matmul_add_to_gemm(self) -> None:
+        # Source: MatMul -> Add(bias). Optimized: a single Gemm. Walker should
+        # link the Gemm node back to the MatMul + Add chain.
+        weight = _make_initializer("W", np.ones((2, 2), dtype=np.float32))
+        bias = _make_initializer("B", np.ones((2,), dtype=np.float32))
+        src = _model_from_nodes(
+            [
+                helper.make_node("MatMul", ["X", "W"], ["mm_out"], name="matmul1"),
+                helper.make_node("Add", ["mm_out", "B"], ["Y"], name="add1"),
+            ],
+            [_make_value_info("X", [2, 2])],
+            [_make_value_info("Y", [2, 2])],
+            [weight, bias],
+        )
+        opt = _model_from_nodes(
+            [helper.make_node("Gemm", ["X", "W", "B"], ["Y"], name="gemm1")],
+            [_make_value_info("X", [2, 2])],
+            [_make_value_info("Y", [2, 2])],
+            [weight, bias],
+        )
+        matches, *_ = m.Matcher(src, opt).run()
+        assert len(matches) == 1
+        # MatMul + Add -> Gemm via fusion pattern (HIGH); other strategies
+        # may also fire on shared initializers, so accept either path that
+        # produces the chain.
+        assert matches[0].source_op_types == ["MatMul", "Add"]
+
+
+# ---------------------------------------------------------------------------
+# join_qnn_trace identity fallback
+# ---------------------------------------------------------------------------
+
+
+class TestJoinQnnTraceIdentityFallback:
+    def test_identity_fallback_emits_dst_as_original(self) -> None:
+        # When the matcher produced no matches (e.g. EP-input == source ONNX
+        # in the QNN-direct workflow), join_qnn_trace falls back to identity:
+        # `dst_name` itself becomes the original-source entry.
+        weight = _make_initializer("W", np.ones((2, 2), dtype=np.float32))
+        src_model = _model_from_nodes(
+            [helper.make_node("MatMul", ["X", "W"], ["Y"], name="matmul1")],
+            [_make_value_info("X", [2, 2])],
+            [_make_value_info("Y", [2, 2])],
+            [weight],
+        )
+        src_index = m.GraphIndex.build(src_model)
+
+        qnn_trace = {
+            "subgraph_traces": [
+                {
+                    "op_mappings": [
+                        {
+                            "dst_name": "matmul1",
+                            "sources": [{"name": "matmul1", "type": m._TRACE_TYPE_OP}],
+                        }
+                    ]
+                }
+            ]
+        }
+        # No matches -> identity fallback fires for the op-typed source.
+        extended, _stats = m.join_qnn_trace([], [], qnn_trace, src_index)
+        mapping = extended["subgraph_traces"][0]["op_mappings"][0]
+        assert "original_sources" in mapping
+        names = [s["name"] for s in mapping["original_sources"]]
+        assert "matmul1" in names
+
+
+# ---------------------------------------------------------------------------
+# enrich_profiling_csv: four input modes
+# ---------------------------------------------------------------------------
+
+
+def _write_csv(path: Path, rows: list[list[str]]) -> None:
+    with path.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        for row in rows:
+            w.writerow(row)
+
+
+def _read_csv(path: Path) -> list[list[str]]:
+    with path.open(newline="") as fh:
+        return list(csv.reader(fh))
+
+
+def _merged_trace_one_mapping(qnn_op: str, original: str) -> dict:
+    return {
+        "subgraph_traces": [
+            {
+                "op_mappings": [
+                    {
+                        "dst_name": qnn_op,
+                        "sources": [{"name": "opt_" + qnn_op, "type": m._TRACE_TYPE_OP}],
+                        "original_sources": [{"name": original, "type": m._TRACE_TYPE_OP}],
+                    }
+                ]
+            }
+        ]
+    }
+
+
+class TestEnrichCsvModes:
+    def test_basic_no_node_events_copies_verbatim(self, tmp_path: Path) -> None:
+        # BASIC profiling has no NODE-level rows. Whatever the merged trace
+        # says, the CSV is copied byte-for-byte.
+        profiling_csv = tmp_path / "basic.csv"
+        _write_csv(
+            profiling_csv,
+            [
+                ["Event Identifier", "Time (us)"],  # header only — no NODE rows
+            ],
+        )
+        merged = _merged_trace_one_mapping("qnn_op", "orig_op")
+        out = tmp_path / "out.csv"
+        stats = enr.enrich(profiling_csv, merged, out)
+        assert stats["node_events_present"] is False
+        assert profiling_csv.read_bytes() == out.read_bytes()
+
+    def test_populated_existing_column_appends_only_originals(self, tmp_path: Path) -> None:
+        profiling_csv = tmp_path / "populated.csv"
+        _write_csv(
+            profiling_csv,
+            [
+                ["Event Identifier", "ONNX Source Ops"],
+                ["qnn_op:OpId_3 (cycles)", "runtime_written"],
+            ],
+        )
+        merged = _merged_trace_one_mapping("qnn_op", "orig_op")
+        out = tmp_path / "out.csv"
+        stats = enr.enrich(profiling_csv, merged, out)
+        # Already-populated `ONNX Source Ops` => do not synthesize, do not
+        # fill in place — only append `Original ONNX Source Ops`.
+        assert stats["added_optimized_column"] is False
+        assert stats["filled_existing_onnx_column"] is False
+        rows = _read_csv(out)
+        assert "Original ONNX Source Ops" in rows[0]
+        # Runtime-written value preserved.
+        assert "runtime_written" in rows[1]
+        # Original ONNX Source Ops column populated.
+        orig_idx = rows[0].index("Original ONNX Source Ops")
+        assert rows[1][orig_idx] == "orig_op"
+
+    def test_all_empty_existing_column_filled_in_place(self, tmp_path: Path) -> None:
+        # AOT-no-sidecar case: column is present but every NODE row's cell
+        # is empty. Enricher should fill that column from the merged trace
+        # AND append Original ONNX Source Ops.
+        profiling_csv = tmp_path / "aot.csv"
+        _write_csv(
+            profiling_csv,
+            [
+                ["Event Identifier", "ONNX Source Ops"],
+                ["qnn_op:OpId_5 (cycles)", ""],
+            ],
+        )
+        merged = _merged_trace_one_mapping("qnn_op", "orig_op")
+        out = tmp_path / "out.csv"
+        stats = enr.enrich(profiling_csv, merged, out)
+        assert stats["added_optimized_column"] is False
+        assert stats["filled_existing_onnx_column"] is True
+        rows = _read_csv(out)
+        onnx_idx = rows[0].index("ONNX Source Ops")
+        orig_idx = rows[0].index("Original ONNX Source Ops")
+        assert rows[1][onnx_idx] == "opt_qnn_op"
+        assert rows[1][orig_idx] == "orig_op"
+
+    def test_missing_column_synthesizes_both(self, tmp_path: Path) -> None:
+        profiling_csv = tmp_path / "synth.csv"
+        _write_csv(
+            profiling_csv,
+            [
+                ["Event Identifier", "Time (us)"],
+                ["qnn_op:OpId_7 (cycles)", "100"],
+            ],
+        )
+        merged = _merged_trace_one_mapping("qnn_op", "orig_op")
+        out = tmp_path / "out.csv"
+        stats = enr.enrich(profiling_csv, merged, out)
+        assert stats["added_optimized_column"] is True
+        rows = _read_csv(out)
+        assert "ONNX Source Ops" in rows[0]
+        assert "Original ONNX Source Ops" in rows[0]
+        onnx_idx = rows[0].index("ONNX Source Ops")
+        orig_idx = rows[0].index("Original ONNX Source Ops")
+        assert rows[1][onnx_idx] == "opt_qnn_op"
+        assert rows[1][orig_idx] == "orig_op"
+
+    def test_refuses_already_enriched_csv(self, tmp_path: Path) -> None:
+        profiling_csv = tmp_path / "already.csv"
+        _write_csv(
+            profiling_csv,
+            [
+                ["Event Identifier", "ONNX Source Ops", "Original ONNX Source Ops"],
+                ["qnn_op:OpId_1 (cycles)", "x", "y"],
+            ],
+        )
+        out = tmp_path / "out.csv"
+        with pytest.raises(ValueError):
+            enr.enrich(profiling_csv, {}, out)
+
+
+# ---------------------------------------------------------------------------
+# build_lookups
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLookups:
+    def test_empty_trace_returns_empty_lookups(self) -> None:
+        originals, optimized = enr.build_lookups({})
+        assert originals == {}
+        assert optimized == {}
+
+    def test_skips_mappings_without_dst_name(self) -> None:
+        trace = {
+            "subgraph_traces": [
+                {
+                    "op_mappings": [
+                        {"sources": [{"name": "a", "type": m._TRACE_TYPE_OP}]},  # no dst_name
+                        {
+                            "dst_name": "qnn_op",
+                            "sources": [{"name": "opt_a", "type": m._TRACE_TYPE_OP}],
+                            "original_sources": [{"name": "orig_a", "type": m._TRACE_TYPE_OP}],
+                        },
+                    ]
+                }
+            ]
+        }
+        originals, optimized = enr.build_lookups(trace)
+        assert list(optimized.keys()) == ["qnn_op"]
+        assert list(originals.keys()) == ["qnn_op"]


### PR DESCRIPTION
Closes the original-ONNX -> optimized-ONNX provenance gap left by the existing framework op trace. Combined with qnn_op_trace.json, gives end-to-end original ONNX -> optimized ONNX -> QNN op mappings.

Three pieces:

1.  dump_qnn_ep_input_graph session config — serializes the ONNX graph the EP receives in GetCapability (post-Level-1, pre-partition) as a QNN-Netron-schema JSON. Needed because optimized_model_filepath rejects graphs containing compiled nodes, and the plugin EP cannot link protobuf to write real .onnx.
2. source_to_optimized_matcher.py — six-strategy structural matcher (name / I/O / initializer name+hash / fusion pattern / lineage) between source.onnx and the EP-input dump (or an optimized.onnx). Optionally extends qnn_op_trace.json with original_sources[].
3. enrich_profiling_csv.py — appends an Original ONNX Source Ops column to the QNN EP profiling CSV; adapts to four input shapes.

Tests: add new tests.
Docs updated end-to-end, including the highest-<n>-wins rule for picking the right dump file when ORT runs GetCapability multiple times in one session.