### PR TITLE
[QNN EP] Minor CI Chore

### DIFF
--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -76,7 +76,6 @@ jobs:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
-      # We only publish this for AI Hub to use and they only want x86_64 Linux
       - name: Download x86_64 Linux 3.10 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -139,112 +138,112 @@ jobs:
       # Download wheels
       # ---------------
 
-      - name: Download x86_64 Linux 3.10 Wheel from Artifactory
+      - name: Download Linux x86_64 3.10 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.10-wheels
 
-      - name: Download x86_64 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.12-wheels
 
-      - name: Download aarch64 manylinux_2_34 Linux 3.11 Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-wheels
 
-      - name: Download aarch64 manylinux_2_34 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.12-wheels
 
-      - name: Download aarch64 manylinux_2_34 Linux 3.13 Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.13-wheels
 
-      - name: Download aarch64 manylinux_2_34 Linux 3.14 Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.12-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.13-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.14-wheels
 
-      - name: Download arm64 Windows 3.11 Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-wheels
 
-      - name: Download x86_64 Windows 3.11 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.11-wheels
-
-      - name: Download arm64ec Windows 3.11 Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.11 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.11-wheels
 
-      - name: Download arm64 Windows 3.12 Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.11-wheels
+
+      - name: Download Windows ARM64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.12-wheels
 
-      - name: Download arm64ec Windows 3.12 Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.12-wheels
 
-      - name: Download x86_64 Windows 3.12 Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.12-wheels
 
-      - name: Download arm64 Windows 3.13 Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.13 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.13-wheels
 
-      - name: Download arm64ec Windows 3.13 Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.13-wheels
 
-      - name: Download x86_64 Windows 3.13 Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.13-wheels
 
-      - name: Download arm64 Windows 3.14 Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.14-wheels
 
-      - name: Download arm64ec Windows 3.14 Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.14-wheels
 
-      - name: Download x86_64 Windows 3.14 Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.14 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.14-wheels
@@ -253,42 +252,42 @@ jobs:
       # Download test archives
       # ----------------------
 
-      - name: Download aarch64 manylinux_2_34 Linux Tests from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tests
 
-      - name: Download x86_64 Ubuntu 22.04 Linux Tests from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-tests
 
-      - name: Download aarch64 Android Tests from Artifactory
+      - name: Download Android Aarch64 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: android-aarch64-pyNone-tests
 
-      - name: Download aarch64 OE GCC 11.2 Linux Tests from Artifactory
+      - name: Download Linux Aarch64 OE GCC 11.2 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_oe_gcc11_2-pyNone-tests
 
-      - name: Download x86_64 Linux Tests from Artifactory
+      - name: Download Linux x86_64 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.10-tests
 
-      - name: Download arm64 Windows Tests from Artifactory
+      - name: Download Windows ARM64 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-tests
 
-      - name: Download arm64ec Windows Tests from Artifactory
+      - name: Download Windows ARM64EC Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.11-tests
 
-      - name: Download x86_64 Windows Tests from Artifactory
+      - name: Download Windows x86_64 Tests from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.11-tests
@@ -321,39 +320,39 @@ jobs:
         with:
           name: android-aarch64-pom
 
-      - name: Download ARM64 (ARM64x) Windows NuGet Package from Artifactory
+      - name: Download Windows ARM64 (ARM64x) NuGet Package from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64x-py3.11-nuget
 
-      - name: Download ARM64 Windows Zip Package
+      - name: Download Windows ARM64 Zip Package
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-zip
 
-      - name: Download ARM64 (ARM64x) Windows Zip Package
+      - name: Download Windows ARM64 (ARM64x) Zip Package
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64x-py3.11-zip
 
-      - name: Download ARM64 Windows Debug Zip Package from Artifactory
+      - name: Download Windows ARM64 Debug Zip Package from Artifactory
         if: ${{ inputs.build_windows_arm64_debug }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-Debug-zip
 
-      - name: Download ARM64 Windows RelWithDebInfo Zip Package from Artifactory
+      - name: Download Windows ARM64 RelWithDebInfo Zip Package from Artifactory
         if: ${{ inputs.build_windows_arm64_relwithdebinfo }}
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-RelWithDebInfo-zip
 
-      - name: Download aarch64 manylinux_2_34 Linux TGZ Package from Artifactory
+      - name: Download Linux Arch64 manylinux_2_34 Linux TGZ Package from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
 
-      - name: Download x86_64 Ubuntu 22.04 Linux TGZ Package from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 TGZ Package from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-tgz
@@ -373,7 +372,7 @@ jobs:
         with:
           name: windows-x86_64-py3.11-pdb-zip
 
-      - name: Download Windows ARM64 (ARM64x) Windows PDB Archive from Artifactory
+      - name: Download Windows ARM64 (ARM64x) PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64x-py3.11-pdb-zip
@@ -398,9 +397,9 @@ jobs:
           find "${{ github.workspace }}/build/windows-arm64ec" -name "*.whl" -delete
           find "${{ github.workspace }}/build/windows-x86_64" -name "*.whl" -delete
 
-      - name: Verify wheel artifacts
+      - name: Verify Wheel artifacts
         run: |
-          # After merge: 2 linux x86_64 (py3.10, py3.12) + 4 linux aarch64 manylinux_2_34 + 4 linux x86_64 ubuntu 22.04 + 4 arm64 + 4 merged AMD = 18 wheels
+          # After merge: 2 Linux x86_64 (py3.10, py3.12) + 4 Linux Aarch64 manylinux_2_34 + 4 Linux x86_64 ubuntu 22.04 + 4 Windows ARM64 + 4 merged AMD = 18 wheels
           # (arm64ec and x86_64 originals are deleted by the merge step above)
           count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
           echo "Found $count wheel(s)"

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -138,12 +138,12 @@ jobs:
       # Download wheels
       # ---------------
 
-      - name: Download Linux x86_64 3.10 Wheel from Artifactory
+      - name: Download Linux x86_64 Python 3.10 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.10-wheels
 
-      - name: Download Linux x86_64 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.12-wheels
@@ -168,22 +168,22 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.12-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.13-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.14-wheels
@@ -193,55 +193,55 @@ jobs:
         with:
           name: windows-arm64-py3.11-wheels
 
-      - name: Download Windows ARM64EC Python 3.11 from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.11-wheels
-
-      - name: Download Windows x86_64 Python 3.11 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.11-wheels
-
       - name: Download Windows ARM64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.12-wheels
-
-      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.12-wheels
-
-      - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.12-wheels
-
+          
       - name: Download Windows ARM64 Python 3.13 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.13-wheels
-
-      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.13-wheels
-
-      - name: Download Windows x86_64 Python 3.13 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.13-wheels
 
       - name: Download Windows ARM64 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.14-wheels
 
+      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.13-wheels
+    
+      - name: Download Windows ARM64EC Python 3.11 from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.11-wheels
+
+      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.12-wheels
+
       - name: Download Windows ARM64EC Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.14-wheels
+
+      - name: Download Windows x86_64 Python 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.11-wheels
+          
+      - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.12-wheels
+
+      - name: Download Windows x86_64 Python 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.13-wheels
 
       - name: Download Windows x86_64 Python 3.14 from Artifactory
         uses: ./.github/actions/download-ci-artifact
@@ -347,16 +347,6 @@ jobs:
         with:
           name: windows-arm64-py3.11-RelWithDebInfo-zip
 
-      - name: Download Linux Arch64 manylinux_2_34 Linux TGZ Package from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: linux-aarch64_manylinux_2_34-py3.11-tgz
-
-      - name: Download Linux x86_64 Ubuntu 22.04 TGZ Package from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: linux-x86_64_ubuntu_22_04-py3.11-tgz
-
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -376,6 +366,16 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64x-py3.11-pdb-zip
+
+      - name: Download Linux Aarch64 manylinux_2_34 Linux TGZ Package from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-aarch64_manylinux_2_34-py3.11-tgz
+
+      - name: Download Linux x86_64 Ubuntu 22.04 TGZ Package from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: linux-x86_64_ubuntu_22_04-py3.11-tgz
 
       - name: Merge AMD Wheels
         run: |
@@ -399,7 +399,7 @@ jobs:
 
       - name: Verify Wheel artifacts
         run: |
-          # After merge: 2 Linux x86_64 (py3.10, py3.12) + 4 Linux Aarch64 manylinux_2_34 + 4 Linux x86_64 ubuntu 22.04 + 4 Windows ARM64 + 4 merged AMD = 18 wheels
+          # After merge: 2 Linux x86_64 (py3.10, py3.12) + 4 Linux Aarch64 manylinux_2_34 + 4 Linux x86_64 Ubuntu 22.04 + 4 Windows ARM64 + 4 merged AMD = 18 wheels
           # (arm64ec and x86_64 originals are deleted by the merge step above)
           count=$(find "${{ github.workspace }}/build" -name "*.whl" | wc -l)
           echo "Found $count wheel(s)"

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -76,12 +76,13 @@ jobs:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
-      - name: Download x86_64 Linux 3.10 Wheel from Artifactory
+      # We only publish this for AI Hub to use and they only want x86_64 Linux
+      - name: Download Linux x86_64 Python 3.10 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.10-wheels
 
-      - name: Download x86_64 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64-py3.12-wheels
@@ -197,8 +198,8 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.12-wheels
-          
-      - name: Download Windows ARM64 Python 3.13 from Artifactory
+
+      - name: Download Windows ARM64 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.13-wheels
@@ -212,7 +213,7 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.13-wheels
-    
+
       - name: Download Windows ARM64EC Python 3.11 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -232,7 +233,7 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.11-wheels
-          
+
       - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -325,12 +326,12 @@ jobs:
         with:
           name: windows-arm64x-py3.11-nuget
 
-      - name: Download Windows ARM64 Zip Package
+      - name: Download Windows ARM64 Zip Package from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-zip
 
-      - name: Download Windows ARM64 (ARM64x) Zip Package
+      - name: Download Windows ARM64 (ARM64x) Zip from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64x-py3.11-zip
@@ -367,7 +368,7 @@ jobs:
         with:
           name: windows-arm64x-py3.11-pdb-zip
 
-      - name: Download Linux Aarch64 manylinux_2_34 Linux TGZ Package from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 TGZ Package from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz

--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -209,20 +209,20 @@ jobs:
         with:
           name: windows-arm64-py3.14-wheels
 
-      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.13-wheels
-
-      - name: Download Windows ARM64EC Python 3.11 from Artifactory
+      - name: Download Windows ARM64EC Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.11-wheels
 
-      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.12 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.12-wheels
+
+      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.13-wheels
 
       - name: Download Windows ARM64EC Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -92,22 +92,22 @@ jobs:
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.12-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.13-wheels
 
-      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.14-wheels
@@ -117,55 +117,55 @@ jobs:
         with:
           name: windows-arm64-py3.11-wheels
 
-      - name: Download Windows ARM64EC Python 3.11 from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.11-wheels
-
-      - name: Download Windows x86_64 Python 3.11 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.11-wheels
-
       - name: Download Windows ARM64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.12-wheels
-
-      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.12-wheels
-
-      - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.12-wheels
-
+          
       - name: Download Windows ARM64 Python 3.13 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.13-wheels
-
-      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.13-wheels
-
-      - name: Download Windows x86_64 Python 3.13 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-x86_64-py3.13-wheels
 
       - name: Download Windows ARM64 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.14-wheels
 
+      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.13-wheels
+    
+      - name: Download Windows ARM64EC Python 3.11 from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.11-wheels
+
+      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.12-wheels
+
       - name: Download Windows ARM64EC Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.14-wheels
+
+      - name: Download Windows x86_64 Python 3.11 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.11-wheels
+          
+      - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.12-wheels
+
+      - name: Download Windows x86_64 Python 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-x86_64-py3.13-wheels
 
       - name: Download Windows x86_64 Python 3.14 from Artifactory
         uses: ./.github/actions/download-ci-artifact
@@ -203,7 +203,7 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 4 Linux aarch64 manylinux_2_34 + 4 Linux x86_64 ubuntu 22.04 + 4 Windows ARM64 + 4 merged AMD wheels in build/dist/
+          # After merge: 4 Linux Aarch64 manylinux_2_34 + 4 Linux x86_64 Ubuntu 22.04 + 4 Windows ARM64 + 4 merged AMD wheels in build/dist/
           count=$(find "${{ github.workspace }}/build/dist" -name "*.whl" | wc -l)
           echo "Found $count wheel(s) in build/dist"
           [ "$count" -eq 16 ] || { echo "ERROR: Expected 16 wheels in build/dist, found $count"; exit 1; }
@@ -345,17 +345,7 @@ jobs:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
-      - name: Download Windows ARM64 Zip from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64-py3.11-zip
-
-      - name: Download Windows ARM64 (ARM64x) Zip from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64x-py3.11-zip
-
-      - name: Download Linux aarch64 manylinux_2_34 TGZ from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 TGZ from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-tgz
@@ -365,6 +355,16 @@ jobs:
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-tgz
 
+      - name: Download Windows ARM64 Zip from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64-py3.11-zip
+
+      - name: Download Windows ARM64 (ARM64x) Zip from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64x-py3.11-zip
+          
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -121,7 +121,7 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.12-wheels
-          
+
       - name: Download Windows ARM64 Python 3.13 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -136,7 +136,7 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.13-wheels
-    
+
       - name: Download Windows ARM64EC Python 3.11 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -156,7 +156,7 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.11-wheels
-          
+
       - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
@@ -364,7 +364,7 @@ jobs:
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64x-py3.11-zip
-          
+
       - name: Download Windows ARM64 PDB Archive from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -56,7 +56,7 @@ jobs:
       windows_arm64_build_archive: true
 
   upload-wheel-workflow:
-    name: "Upload python wheel artifacts to Artifactory"
+    name: "Upload Python Wheel artifacts to Artifactory"
     runs-on: [Linux, self-hosted, Build]
     needs: [build-artifacts]
 
@@ -72,122 +72,115 @@ jobs:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
-      # Download Python wheels from Artifactory
-      - name: Download Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.11-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.12-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.13-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Linux Aarch64 manylinux_2_34 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-aarch64_manylinux_2_34-py3.14-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.11-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.12-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.13-wheels
 
-      - name: Download x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
+      - name: Download Linux x86_64 Ubuntu 22.04 Linux 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: linux-x86_64_ubuntu_22_04-py3.14-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.11-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.11 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.11-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.11-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.12-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.12-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.12 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.12-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.13 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.13-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.13-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.13 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.13-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64 Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64-py3.14-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.14-wheels
 
-      - name: Download Wheel from Artifactory
+      - name: Download Windows x86_64 Python 3.14 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-x86_64-py3.14-wheels
 
-      - name: Consolidate Wheels
+      - name: Consolidate Python Wheels
         run: |
           mkdir "${{ github.workspace }}/build/dist"
+          mkdir "${{ github.workspace }}/build/dist/arm64ec"
+          mkdir "${{ github.workspace }}/build/dist/x64"
           cp "${{ github.workspace }}/build/windows-arm64/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
           cp "${{ github.workspace }}/build/linux-aarch64_manylinux_2_34/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
           cp "${{ github.workspace }}/build/linux-x86_64_ubuntu_22_04/Release/dist/"*.whl "${{ github.workspace }}/build/dist"
-
-      - name: Consolidate Wheels
-        run: |
-          mkdir "${{ github.workspace }}/build/dist/arm64ec"
           cp "${{ github.workspace }}/build/windows-arm64ec/Release/Release/dist/"*.whl "${{ github.workspace }}/build/dist/arm64ec"
-
-      - name: Consolidate Wheels
-        run: |
-          mkdir "${{ github.workspace }}/build/dist/x64"
           cp "${{ github.workspace }}/build/windows-x86_64/Release/dist/"*.whl "${{ github.workspace }}/build/dist/x64"
 
       - name: Install Dependencies
@@ -210,12 +203,12 @@ jobs:
 
       - name: Verify wheel artifacts
         run: |
-          # After merge: 4 linux aarch64 manylinux_2_34 + 4 linux x86_64 ubuntu 22.04 + 4 arm64 + 4 merged AMD wheels in build/dist/
+          # After merge: 4 Linux aarch64 manylinux_2_34 + 4 Linux x86_64 ubuntu 22.04 + 4 Windows ARM64 + 4 merged AMD wheels in build/dist/
           count=$(find "${{ github.workspace }}/build/dist" -name "*.whl" | wc -l)
           echo "Found $count wheel(s) in build/dist"
           [ "$count" -eq 16 ] || { echo "ERROR: Expected 16 wheels in build/dist, found $count"; exit 1; }
 
-      - name: Check Wheels
+      - name: Check Python Wheels
         run: |
           source uplevel_venv/bin/activate
           twine check ${{ github.workspace }}/build/dist/*.whl
@@ -242,7 +235,7 @@ jobs:
             "wheels.zip" "$VERSION" "$NETRC_FILE"
           rm -f "$NETRC_FILE"
 
-      - name: Publish
+      - name: Publish Wheels
         if: ${{ !inputs.skip_publish }}
         env:
           TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -255,7 +248,7 @@ jobs:
             ${{ github.workspace }}/build/dist/*.whl
 
   upload-nuget-workflow:
-    name: "Upload nuget artifacts to Artifactory"
+    name: "Upload Nuget artifacts to Artifactory"
     runs-on: [Windows, self-hosted, Build, X64]
     needs: [build-artifacts]
 
@@ -316,7 +309,7 @@ jobs:
 
           Remove-Item -Path $netrcFile -Force
 
-      - name: Publish
+      - name: Publish NuGet
         if: ${{ !inputs.skip_publish }}
         shell: powershell
         env:
@@ -336,7 +329,7 @@ jobs:
             -InputDir "${{ github.workspace }}\build\windows-arm64x\Release"
 
   upload-zip-workflow:
-    name: "Upload zip artifacts to Artifactory"
+    name: "Upload Zip artifacts to Artifactory"
     runs-on: [Linux, self-hosted, Build]
     needs: [build-artifacts]
 
@@ -457,7 +450,7 @@ jobs:
             "zip.zip" "$VERSION" "$NETRC_FILE"
           rm -f "$NETRC_FILE"
 
-      - name: Publish
+      - name: Publish Zip
         if: ${{ !inputs.skip_publish }}
         run: |
           # Create temporary .netrc file with credentials

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -132,20 +132,20 @@ jobs:
         with:
           name: windows-arm64-py3.14-wheels
 
-      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
-        uses: ./.github/actions/download-ci-artifact
-        with:
-          name: windows-arm64ec-py3.13-wheels
-
-      - name: Download Windows ARM64EC Python 3.11 from Artifactory
+      - name: Download Windows ARM64EC Python 3.11 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.11-wheels
 
-      - name: Download Windows ARM64EC Python 3.12 Wheel from Artifactory
+      - name: Download Windows ARM64EC Python 3.12 from Artifactory
         uses: ./.github/actions/download-ci-artifact
         with:
           name: windows-arm64ec-py3.12-wheels
+
+      - name: Download Windows ARM64EC Python 3.13 Wheel from Artifactory
+        uses: ./.github/actions/download-ci-artifact
+        with:
+          name: windows-arm64ec-py3.13-wheels
 
       - name: Download Windows ARM64EC Python 3.14 Wheel from Artifactory
         uses: ./.github/actions/download-ci-artifact

--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -117,6 +117,8 @@ def _select_release_entries(release_dir: Path, rules: PerArchAcceptRules, repo_r
 def archive_linux(target_platform: str, config: str = "Release", repo_root: Path = REPO_ROOT) -> None:
     build_root = repo_root / "build"
     archive_path = build_root / f"onnxruntime-tests-{target_platform}.tar.bz2"
+    if config != "Release":
+        archive_path = build_root / f"onnxruntime-tests-{config}-{target_platform}.tar.bz2"
     release_dir = build_root / target_platform / config
     rules = PerArchAcceptRules()
 
@@ -132,6 +134,8 @@ def archive_linux(target_platform: str, config: str = "Release", repo_root: Path
 def archive_windows(target_platform: str, config: str = "Release", repo_root: Path = REPO_ROOT) -> None:
     build_root = repo_root / "build"
     archive_path = build_root / f"onnxruntime-tests-{target_platform}.zip"
+    if config != "Release":
+        archive_path = build_root / f"onnxruntime-tests-{config}-{target_platform}.zip"
     release_dir = build_root / target_platform / config
     rules = PerArchAcceptRules()
 

--- a/tools/ci_build/pkg_assets.py
+++ b/tools/ci_build/pkg_assets.py
@@ -105,7 +105,9 @@ def get_qnn_asset_file_list():
     return qnn_assets["windows"] if is_windows() else qnn_assets["others"]
 
 
-def _compute_archive_name(source_dir, version_suffix, archive_name_suffix, archive_ext, target_arch=None):
+def _compute_archive_name(
+    source_dir, version_suffix, archive_name_suffix, archive_ext, target_arch=None, config="Release"
+):
     """
     Build the archive filename using the shared naming rules.
 
@@ -119,6 +121,7 @@ def _compute_archive_name(source_dir, version_suffix, archive_name_suffix, archi
         target_arch: Optional explicit target architecture. When set, overrides
             platform.machine() — needed for cross-compile builds where the build
             host arch differs from the target arch (e.g. arm64ec on an x64 host).
+        config: Config for the build, default "Release"
     """
     sys_name = platform.system().lower()
     platform_name = "win" if sys_name == "windows" else sys_name
@@ -134,6 +137,8 @@ def _compute_archive_name(source_dir, version_suffix, archive_name_suffix, archi
         name += f"{version_suffix}"
     if archive_name_suffix:
         name += f"-{archive_name_suffix}"
+    if config != "Release":
+        name += f"-{config}"
     name += f"-{platform_name}-{arch}{archive_ext}"
     return name
 
@@ -187,7 +192,7 @@ def build_archive_asset(
 
         archive_ext = ".zip" if is_windows() else ".tgz"
         archive_name = _compute_archive_name(
-            source_dir, version_suffix, archive_name_suffix, archive_ext, target_arch=target_arch
+            source_dir, version_suffix, archive_name_suffix, archive_ext, target_arch=target_arch, config=config
         )
         archive_path = Path(dist_dir) / archive_name
 
@@ -320,7 +325,7 @@ def build_pdb_archive_asset(
         dist_dir = os.path.join(cwd, "dist")
         os.makedirs(dist_dir, exist_ok=True)
 
-        base_name = _compute_archive_name(source_dir, version_suffix, None, "", target_arch=target_arch)
+        base_name = _compute_archive_name(source_dir, version_suffix, None, "", target_arch=target_arch, config=config)
         archive_path = Path(dist_dir) / f"{base_name}-pdb.zip"
 
         found_files = []


### PR DESCRIPTION
### Description

This PR handles couple of minor chores in CI workflows

1. Reorder and rename jobs in the order according to the architecture
2. #325 introduced building Windows ARM64 Debug and RelWithDebInfo builds. Made changes in `tools/ci_build/pkg_assets.py` and `qcom/scripts/all/archive_tests.py` to add the config name in the archive names when uploading to Zip. Previously they were uploaded as just `onnxruntime-qnn-version-win-arm64.zip` which would have been difficult to differentiate with the Release config builds.


