### PR TITLE
[QNN EP] Enable framework op trace for FCB multi-SoCs

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -284,6 +284,13 @@ Warning: Enabling HTP Monolithic LSTM may improve session creation time, but thi
 |---|---|
 |Directory path (string)|Directory path for framework op trace JSON files. Only effective when `enable_framework_op_trace` is `'1'`. Defaults to the current working directory if not set. The directory is created automatically if it does not exist. If the directory cannot be created or written to (e.g. read-only mount, missing permissions), framework op tracing is disabled with a WARNING log and no trace file is produced. Trace files use the pattern `qnn_op_trace.json`.|
 
+**Schema migration note:** The `qnn_op_trace.json` schema moves the `compilation_target` object out of the document root and into a new `soc_traces` array. Single-SoC sessions emit exactly one entry; multi-SoC FCB sessions emit one entry per `(htp_arch, soc_model)` pair. `subgraph_traces` (the ONNX-to-QNN op mapping) stays at the document root because op-builder output is SoC-agnostic. A new `summary.total_socs` field reports the entry count. A top-level `"schema_version"` field (currently `2`) is bumped on every breaking schema change so consumers can branch on it.
+
+- Old (legacy): `j["compilation_target"]["htp_arch"]`
+- New: `j["soc_traces"][0]["compilation_target"]["htp_arch"]`
+
+Consumers that read the compilation target must update the JSON path. Consumers of `subgraph_traces`, `unsupported_nodes`, and `summary` are unaffected.
+
 |`"qnn_ir_backend_path"`|Description|
 |---|---|
 |Backend path (string)|Path to the QNN IR backend library. Defaults to 'libQnnIr.so' or 'QnnIr.dll'. Only effective when `dump_qnn_ir_dlc` is enabled.|

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.cc
@@ -245,6 +245,31 @@ bool WriteTraceToFile(const FrameworkOpTrace& trace,
   return true;
 }
 
+void FrameworkOpTraceBuilder::AppendSoc(uint32_t htp_arch, uint32_t soc_model, uint32_t device_id) {
+  CompilationTarget target;
+  target.device_id = device_id;
+  if (soc_model != kSocUnknown) {
+    target.soc_model = soc_model;
+  }
+  target.htp_arch = EncodeHtpArch(htp_arch);  // "" when arch is unknown
+  trace_.soc_traces.push_back(SocTrace{std::move(target)});
+}
+
+bool FrameworkOpTraceBuilder::FinalizeAndWrite(const std::string& model_name,
+                                               const std::string& backend_type,
+                                               const std::filesystem::path& output_path,
+                                               const Ort::Logger& logger) {
+  trace_.model_name = model_name.empty() ? "<in-memory>" : model_name;
+  trace_.backend_type = backend_type;
+  ComputeTraceSummary(trace_);
+
+  // Skip a wholly-empty trace (e.g. an EPContext cached run with no fresh compile).
+  if (trace_.subgraph_traces.empty() && trace_.unsupported_nodes.empty()) {
+    return false;
+  }
+  return WriteTraceToFile(trace_, output_path, logger);
+}
+
 bool LoadTraceLookupFromFile(const std::filesystem::path& trace_path,
                              OpTraceLookup& out_lookup,
                              const Ort::Logger& logger) {

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.h
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing.h
@@ -88,6 +88,37 @@ bool WriteTraceToFile(const FrameworkOpTrace& trace,
                       const std::filesystem::path& output_path,
                       const Ort::Logger& logger);
 
+// Owns the session's FrameworkOpTrace. NewSubgraphSlot / UnsupportedNodes hand
+// out interior references valid only until the next mutating call.
+class FrameworkOpTraceBuilder {
+ public:
+  // GetCapability runs twice per graph; reset before each pass so pass 2 does
+  // not double-count.
+  void Reset() { trace_ = FrameworkOpTrace{}; }
+
+  // Record one SoC iteration. Raw ids (0 = unknown, omitted); uint32_t keeps
+  // this header SDK-header-free.
+  void AppendSoc(uint32_t htp_arch, uint32_t soc_model, uint32_t device_id);
+
+  // Reserve a subgraph slot for ComposeGraph to fill (valid until the next call).
+  OpTraceInfo* NewSubgraphSlot() {
+    trace_.subgraph_traces.push_back(OpTraceInfo{});
+    return &trace_.subgraph_traces.back();
+  }
+
+  // Out-param the support scan appends rejected nodes into.
+  std::vector<UnsupportedNodeInfo>& UnsupportedNodes() { return trace_.unsupported_nodes; }
+
+  // Compute the summary and write the file, skipping a wholly-empty trace.
+  bool FinalizeAndWrite(const std::string& model_name,
+                        const std::string& backend_type,
+                        const std::filesystem::path& output_path,
+                        const Ort::Logger& logger);
+
+ private:
+  FrameworkOpTrace trace_;
+};
+
 // Loads an OpTraceLookup from a trace JSON sidecar file.
 // Iterates all subgraph_traces[*].op_mappings and builds a flat dst_name->sources map.
 // Returns true on success; logs a warning and returns false on any parse error.

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_serialization.cc
@@ -12,6 +12,7 @@
 
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 
+#include <algorithm>
 #include <fstream>
 #include <unordered_set>
 
@@ -25,6 +26,7 @@ void ComputeTraceSummary(FrameworkOpTrace& trace) {
   summary.unsupported_nodes = trace.unsupported_nodes.size();
   summary.qnn_subgraphs = trace.subgraph_traces.size();
   summary.total_qnn_ops = 0;
+  summary.total_socs = static_cast<uint32_t>(trace.soc_traces.size());
   summary.fusion_count.clear();
 
   // An ONNX node is "supported" if it appears as an OP-typed source on any QNN
@@ -47,6 +49,91 @@ void ComputeTraceSummary(FrameworkOpTrace& trace) {
 
   summary.supported_nodes = supported_onnx_node_names.size();
   summary.total_onnx_nodes = summary.supported_nodes + summary.unsupported_nodes;
+}
+
+std::string EncodeHtpArch(uint32_t htp_arch) {
+  if (htp_arch == kSocUnknown) {
+    return {};
+  }
+  return "V" + std::to_string(htp_arch);
+}
+
+std::string MakeSocLabel(uint32_t htp_arch, uint32_t soc_model) {
+  std::string arch = EncodeHtpArch(htp_arch);
+  if (arch.empty()) {
+    return "soc_model=" + std::to_string(soc_model);
+  }
+  if (soc_model != kSocUnknown) {
+    return arch + "/soc_model=" + std::to_string(soc_model);
+  }
+  return arch;
+}
+
+std::vector<UnsupportedNodeInfo> MergePerSocUnsupportedNodes(
+    const std::vector<PerSocUnsupportedNodes>& per_soc) {
+  // One merged node: identity fields plus reasons (first-seen order), each with
+  // its contributing SoC labels. Label lists are tiny (<= SoC count), so dedup
+  // uses a linear find rather than a parallel set.
+  struct Merged {
+    std::string node_name;
+    std::string op_type;
+    size_t node_index = 0;
+    std::vector<std::string> reason_order;  // distinct reasons, first-seen
+    std::unordered_map<std::string, std::vector<std::string>> soc_labels_by_reason;
+  };
+
+  std::vector<size_t> node_order;  // first-seen node_index order
+  std::unordered_map<size_t, Merged> merged;
+
+  for (const auto& soc : per_soc) {
+    for (const auto& un : soc.nodes) {
+      auto it = merged.find(un.node_index);
+      if (it == merged.end()) {
+        node_order.push_back(un.node_index);
+        Merged m;
+        m.node_name = un.node_name;
+        m.op_type = un.op_type;
+        m.node_index = un.node_index;
+        it = merged.emplace(un.node_index, std::move(m)).first;
+      }
+      Merged& m = it->second;
+
+      // New reason for this node? Record its first-seen position.
+      auto& labels = m.soc_labels_by_reason[un.reason];
+      if (labels.empty()) {
+        m.reason_order.push_back(un.reason);
+      }
+      // Attribute this SoC to the reason, deduping identical (reason, label).
+      if (std::find(labels.begin(), labels.end(), soc.soc_label) == labels.end()) {
+        labels.push_back(soc.soc_label);
+      }
+    }
+  }
+
+  std::vector<UnsupportedNodeInfo> out;
+  out.reserve(node_order.size());
+  for (size_t node_index : node_order) {
+    const Merged& m = merged[node_index];
+    // Format: "<labels joined by ','>: <reason>" fragments joined by "; ".
+    std::string reason;
+    for (size_t r = 0; r < m.reason_order.size(); ++r) {
+      const std::string& reason_text = m.reason_order[r];
+      const std::vector<std::string>& labels = m.soc_labels_by_reason.at(reason_text);
+      if (r != 0) {
+        reason += "; ";
+      }
+      for (size_t l = 0; l < labels.size(); ++l) {
+        if (l != 0) {
+          reason += ",";
+        }
+        reason += labels[l];
+      }
+      reason += ": ";
+      reason += reason_text;
+    }
+    out.push_back({m.node_name, m.op_type, m.node_index, std::move(reason)});
+  }
+  return out;
 }
 
 namespace detail {
@@ -83,14 +170,22 @@ static nlohmann::json SerializeTraceMapping(const TraceMapping& mapping) {
 
 nlohmann::json SerializeFrameworkOpTrace(const FrameworkOpTrace& trace) {
   nlohmann::json j;
+  j["schema_version"] = kFrameworkOpTraceSchemaVersion;
   j["model_name"] = trace.model_name;
   j["backend_type"] = trace.backend_type;
 
-  nlohmann::json ct;
-  ct["htp_arch"] = trace.compilation_target.htp_arch;
-  ct["soc_model"] = trace.compilation_target.soc_model;
-  ct["device_id"] = trace.compilation_target.device_id;
-  j["compilation_target"] = std::move(ct);
+  // One entry per SoC iteration; compilation_target lives here, not at root.
+  nlohmann::json soc_traces = nlohmann::json::array();
+  for (const auto& soc : trace.soc_traces) {
+    nlohmann::json soc_json;
+    nlohmann::json ct;
+    ct["htp_arch"] = soc.compilation_target.htp_arch;
+    ct["soc_model"] = soc.compilation_target.soc_model;
+    ct["device_id"] = soc.compilation_target.device_id;
+    soc_json["compilation_target"] = std::move(ct);
+    soc_traces.push_back(std::move(soc_json));
+  }
+  j["soc_traces"] = std::move(soc_traces);
 
   nlohmann::json subgraphs = nlohmann::json::array();
   for (const auto& sg : trace.subgraph_traces) {
@@ -131,6 +226,7 @@ nlohmann::json SerializeFrameworkOpTrace(const FrameworkOpTrace& trace) {
   summary["unsupported_nodes"] = s.unsupported_nodes;
   summary["qnn_subgraphs"] = s.qnn_subgraphs;
   summary["total_qnn_ops"] = s.total_qnn_ops;
+  summary["total_socs"] = s.total_socs;
 
   nlohmann::json fc;
   for (const auto& [type, count] : s.fusion_count) {

--- a/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h
+++ b/onnxruntime/core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h
@@ -27,6 +27,13 @@
 namespace onnxruntime {
 namespace qnn {
 
+// Unknown-value sentinel for htp_arch/soc_model (mirrors the SDK's 0-valued
+// QNN_HTP_DEVICE_ARCH_NONE / QNN_SOC_MODEL_UNKNOWN; kept SDK-header-free here).
+inline constexpr uint32_t kSocUnknown = 0;
+
+// qnn_op_trace.json schema version; bumped on each breaking change (v2 = FCB soc_traces[]).
+inline constexpr int kFrameworkOpTraceSchemaVersion = 2;
+
 // Source target type: matches the integer encoding used by the QNN SDK
 // (TENSOR = 0, OP = 1, defined in QnnInterface.h).
 enum class TraceTargetType : uint8_t {
@@ -59,21 +66,21 @@ struct UnsupportedNodeInfo {
   std::string node_name;
   std::string op_type;
   size_t node_index;
+  // Single-SoC: raw QNN validator message. Multi-SoC: SoC-attributed by
+  // MergePerSocUnsupportedNodes, e.g. "V73: A; V81: B".
   std::string reason;
 };
 
 struct TraceSummary {
   size_t total_onnx_nodes = 0;
-  // Count of unique ONNX source nodes that appear as OP-typed sources across
-  // all op_mappings. Deduplicated by source name so an N:M fusion (which
-  // emits the same ONNX sources from multiple QNN op entries) is counted
-  // once per ONNX node rather than once per QNN op entry.
+  // Unique ONNX nodes appearing as OP-typed sources, deduped by source name.
   size_t supported_nodes = 0;
   size_t unsupported_nodes = 0;
   size_t qnn_subgraphs = 0;
   size_t total_qnn_ops = 0;
-  // std::map keeps keys in sorted order, which produces deterministic JSON
-  // output and makes trace files diff-friendly across runs.
+  // SoC iteration count (single-SoC = 1; multi-SoC FCB = N).
+  uint32_t total_socs = 0;
+  // std::map for deterministic, diff-friendly JSON key order.
   std::map<std::string, size_t> fusion_count;
 };
 
@@ -83,10 +90,17 @@ struct CompilationTarget {
   uint32_t device_id = 0;
 };
 
+// One SoC iteration's target. Single-SoC = one SocTrace; multi-SoC FCB = one per SoC.
+struct SocTrace {
+  CompilationTarget compilation_target;
+};
+
 struct FrameworkOpTrace {
   std::string model_name;
   std::string backend_type;
-  CompilationTarget compilation_target;
+  // One entry per SoC iteration.
+  std::vector<SocTrace> soc_traces;
+  // SoC-agnostic op mappings; stays at root and is collected once (not per SoC).
   std::vector<OpTraceInfo> subgraph_traces;
   std::vector<UnsupportedNodeInfo> unsupported_nodes;
   TraceSummary summary;
@@ -95,6 +109,40 @@ struct FrameworkOpTrace {
 // Compute summary statistics for a FrameworkOpTrace.
 // Defined in qnn_op_tracing_serialization.cc.
 void ComputeTraceSummary(FrameworkOpTrace& trace);
+
+// Encode a raw HTP arch number as "V<n>", or "" for 0 (QNN_HTP_DEVICE_ARCH_NONE).
+// Single source of truth for the arch-string form; SDK-header-free (uint32_t).
+std::string EncodeHtpArch(uint32_t htp_arch);
+
+// Build the SoC label attributing a per-SoC rejection. `htp_arch` / `soc_model`
+// are raw ids (0 = unknown). Format:
+//   - arch + soc_model: "V73/soc_model=60"
+//   - arch only:        "V73"
+//   - soc_model only:   "soc_model=60"
+std::string MakeSocLabel(uint32_t htp_arch, uint32_t soc_model);
+
+// One SoC's rejections, tagged with its SoC label (see MakeSocLabel).
+struct PerSocUnsupportedNodes {
+  std::string soc_label;
+  std::vector<UnsupportedNodeInfo> nodes;
+
+  PerSocUnsupportedNodes() = default;
+  // From a pre-built label.
+  PerSocUnsupportedNodes(std::string soc_label, std::vector<UnsupportedNodeInfo> nodes)
+      : soc_label(std::move(soc_label)), nodes(std::move(nodes)) {}
+  // From raw ids, so call sites pass (htp_arch, soc_model) directly.
+  PerSocUnsupportedNodes(uint32_t htp_arch, uint32_t soc_model, std::vector<UnsupportedNodeInfo> nodes)
+      : soc_label(MakeSocLabel(htp_arch, soc_model)), nodes(std::move(nodes)) {}
+};
+
+// Merge per-SoC rejections into one UnsupportedNodeInfo per ONNX node, so the row
+// count equals the distinct-node count. Each distinct reason is attributed to its
+// SoC(s), in first-seen order:
+//   - same reason on V73 and V81 -> "V73,V81: R"
+//   - different reasons          -> "V73: A; V81: B"
+// node_name/op_type come from the first SoC to report the node.
+std::vector<UnsupportedNodeInfo> MergePerSocUnsupportedNodes(
+    const std::vector<PerSocUnsupportedNodes>& per_soc);
 
 // Serialize a FrameworkOpTrace to JSON.
 // Defined in qnn_op_tracing_serialization.cc.  Call sites that use the return value must

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -16,6 +16,7 @@
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #ifdef _WIN32
@@ -1170,15 +1171,6 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     framework_op_trace_dir_ = trace_dir_str;
   }
 
-  // TODO: Re-enable framework op trace for multi-SoC preparation.
-  if (enable_framework_op_trace_ && enable_multi_soc_ep_context_) {
-    ORT_CXX_LOG(logger_,
-                ORT_LOGGING_LEVEL_WARNING,
-                "Option 'enable_framework_op_trace' is unsupported in multi-SoC EP context.");
-    enable_framework_op_trace_ = false;
-    framework_op_trace_dir_ = "";
-  }
-
   if (enable_framework_op_trace_) {
     if (framework_op_trace_dir_.empty()) {
       framework_op_trace_dir_ = std::filesystem::current_path().string();
@@ -1572,7 +1564,15 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
 OrtStatus* QnnEp::GetMultiSocSupportedNodes(const OrtGraph* graph,
                                             const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                             const size_t node_unit_size,
-                                            std::vector<const OrtNode*>& supported_nodes) const {
+                                            std::vector<const OrtNode*>& supported_nodes,
+                                            std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes) const {
+  // Collect each SoC's rejections tagged with its SoC label, then merge into one
+  // row per ONNX node via MergePerSocUnsupportedNodes.
+  std::vector<qnn::PerSocUnsupportedNodes> per_soc_unsupported;
+  if (enable_framework_op_trace_) {
+    per_soc_unsupported.reserve(htp_arch_per_soc_.size());
+  }
+
   // Iterate each SoC and intersect supported nodes.
   for (size_t idx = 0; idx < htp_arch_per_soc_.size(); ++idx) {
     ORT_CXX_LOG(logger_,
@@ -1585,15 +1585,22 @@ OrtStatus* QnnEp::GetMultiSocSupportedNodes(const OrtGraph* graph,
     ScopedPerSocQnnBackendSetup scoped_backend_setup(*this);
     RETURN_IF_NOT_OK(scoped_backend_setup.Init(idx));
 
-    // Get SoC-specific supported nodes.
+    // Get SoC-specific supported and unsupported nodes.
     std::vector<const OrtNode*> supported_nodes_per_soc;
-    // Dummy for now as framework op trace is temporarily disabled for multi-SoC preparation.
-    std::vector<qnn::UnsupportedNodeInfo> unsupported_nodes;
+    std::vector<qnn::UnsupportedNodeInfo> unsupported_nodes_per_soc;
     RETURN_IF_NOT_NULL(GetSupportedNodes(graph,
                                          node_unit_map,
                                          node_unit_size,
                                          supported_nodes_per_soc,
-                                         unsupported_nodes));
+                                         unsupported_nodes_per_soc));
+
+    // Tag this SoC's rejections with its (htp_arch, soc_model) label for merging.
+    // Identical (arch, soc_model) configs share a label and merge — acceptable,
+    // they are indistinguishable targets.
+    if (enable_framework_op_trace_) {
+      per_soc_unsupported.emplace_back(htp_arch_per_soc_[idx], soc_model_per_soc_[idx],
+                                       std::move(unsupported_nodes_per_soc));
+    }
 
     if (idx == 0) {
       // Directly move for the first SoC.
@@ -1612,6 +1619,13 @@ OrtStatus* QnnEp::GetMultiSocSupportedNodes(const OrtGraph* graph,
       supported_nodes.erase(std::remove_if(supported_nodes.begin(), supported_nodes.end(), not_contains),
                             supported_nodes.end());
     }
+  }
+
+  if (enable_framework_op_trace_) {
+    std::vector<qnn::UnsupportedNodeInfo> merged = qnn::MergePerSocUnsupportedNodes(per_soc_unsupported);
+    unsupported_nodes.insert(unsupported_nodes.end(),
+                             std::make_move_iterator(merged.begin()),
+                             std::make_move_iterator(merged.end()));
   }
 
   return nullptr;
@@ -2016,6 +2030,13 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     return nullptr;
   }
 
+  // GetCapability runs up to twice. Clear before pass 2 so its collection
+  // supersedes pass 1; pass 1's data is kept for the all-unsupported flush below
+  // (reached only on pass 1, since pass 2 doesn't run when nothing is supported).
+  if (ep->enable_framework_op_trace_ && ep->is_post_layout_transform_) {
+    ep->op_trace_builder_.Reset();
+  }
+
   // Store original graph I/O order for use in Compile.
   // The partitioning process may reorder inputs, so we capture the original order here.
   {
@@ -2052,9 +2073,13 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
                                              node_unit_map,
                                              node_unit_holder.size(),
                                              supported_nodes,
-                                             ep->trace_.unsupported_nodes));
+                                             ep->op_trace_builder_.UnsupportedNodes()));
   } else {
-    RETURN_IF_NOT_NULL(ep->GetMultiSocSupportedNodes(graph, node_unit_map, node_unit_holder.size(), supported_nodes));
+    RETURN_IF_NOT_NULL(ep->GetMultiSocSupportedNodes(graph,
+                                                     node_unit_map,
+                                                     node_unit_holder.size(),
+                                                     supported_nodes,
+                                                     ep->op_trace_builder_.UnsupportedNodes()));
   }
 
   // Helper function that returns a string that lists all unsupported nodes.
@@ -2084,8 +2109,15 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     // unsupported list collected in GetSupportedNodes would otherwise be
     // discarded. Flush a trace here so the diagnostic record (why every node
     // was rejected) is preserved.
-    if (ep->enable_framework_op_trace_ && !ep->trace_.unsupported_nodes.empty()) {
-      ep->CollectAndWriteFrameworkOpTrace(graph);
+    if (ep->enable_framework_op_trace_ && !ep->op_trace_builder_.UnsupportedNodes().empty()) {
+      // CompileImpl is skipped here, so record every configured SoC (multi-SoC)
+      // or the live target (single-SoC) before writing.
+      if (ep->enable_multi_soc_ep_context_) {
+        ep->AppendMultiSocTraces();
+      } else {
+        ep->AppendSingleSocTrace();
+      }
+      ep->WriteFrameworkOpTrace(graph);
     }
     return nullptr;
   }
@@ -2141,7 +2173,8 @@ OrtStatus* QnnEp::CompileOnnxModel(const OrtGraph** graphs,
                                    const OrtNode** fused_nodes,
                                    size_t count,
                                    OrtNodeComputeInfo** node_compute_infos,
-                                   const qnn::HtpGraphConfigs_t& htp_graph_configs) {
+                                   const qnn::HtpGraphConfigs_t& htp_graph_configs,
+                                   bool collect_subgraph_traces) {
 #if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
   // Initialize now for possible reuse in loop
   auto finalize_start = std::chrono::steady_clock::time_point::min();
@@ -2222,10 +2255,10 @@ OrtStatus* QnnEp::CompileOnnxModel(const OrtGraph** graphs,
         /*tensor_name_overrides=*/&tensor_name_overrides_,
         /*json_qnn_graph_path=*/std::string{}};
 
-    // Each ComposeGraph writes its mappings into a slot in trace_.subgraph_traces.
-    if (enable_framework_op_trace_) {
-      trace_.subgraph_traces.push_back(qnn::OpTraceInfo{});
-      context.op_trace_output = &trace_.subgraph_traces.back();
+    // subgraph_traces are SoC-agnostic, so the FCB multi-SoC loop collects them
+    // only on its first iteration (collect_subgraph_traces=false thereafter).
+    if (enable_framework_op_trace_ && collect_subgraph_traces) {
+      context.op_trace_output = op_trace_builder_.NewSubgraphSlot();
     }
 
     if (dump_json_qnn_graph_) {
@@ -2318,12 +2351,14 @@ OrtStatus* QnnEp::CompileMultiSocOnnxModel(const OrtGraph** graphs,
     ScopedPerSocQnnBackendSetup scoped_backend_setup(*this);
     RETURN_IF_NOT_OK(scoped_backend_setup.Init(idx));
 
-    // Compile for current SoC.
+    // Collect subgraph_traces once (on idx 0): the ONNX->QNN op mapping is the
+    // same across SoCs, since which QNN op a node lowers to does not depend on arch.
     RETURN_IF_NOT_NULL(CompileOnnxModel(graphs,
                                         fused_nodes,
                                         count,
                                         node_compute_infos,
-                                        htp_graph_configs_per_soc_[idx]));
+                                        htp_graph_configs_per_soc_[idx],
+                                        /*collect_subgraph_traces=*/idx == 0));
 
     if (idx != htp_arch_per_soc_.size() - 1) {
       // `qnn_models_` and `node_compute_infos` are repeatedly set in each `CompileOnnxModel` call, where previous
@@ -2685,38 +2720,31 @@ OrtStatus* QnnEp::CompileDlcContextModel(OrtEp* this_ptr,
   return nullptr;
 }
 
-void QnnEp::CollectAndWriteFrameworkOpTrace(const OrtGraph* primary_graph) {
-  trace_.model_name = std::filesystem::path(GetModelPathString(primary_graph, ort_api)).filename().u8string();
-  if (trace_.model_name.empty()) {
-    trace_.model_name = "<in-memory>";
-  }
-  trace_.backend_type = qnn::QnnBackendTypeToString(qnn_backend_manager_->GetQnnBackendType());
-  trace_.compilation_target.device_id = device_id_;
-
+void QnnEp::AppendSingleSocTrace() {
+  // Single-SoC path: encode from live backend state.
   if (qnn::IsNpuBackend(qnn_backend_manager_->GetQnnBackendType())) {
-    uint32_t soc_model = qnn_backend_manager_->GetSocModel();
-    if (soc_model != QNN_SOC_MODEL_UNKNOWN) {
-      trace_.compilation_target.soc_model = soc_model;
-    }
-    QnnHtpDevice_Arch_t htp_arch = qnn_backend_manager_->GetHtpArch();
-    if (htp_arch != QNN_HTP_DEVICE_ARCH_NONE) {
-      trace_.compilation_target.htp_arch = "V" + std::to_string(htp_arch);
-    }
+    op_trace_builder_.AppendSoc(qnn_backend_manager_->GetHtpArch(),
+                                qnn_backend_manager_->GetSocModel(),
+                                device_id_);
+  } else {
+    // Non-NPU backends have no arch/soc_model; pass the QNN "unknown" sentinels.
+    op_trace_builder_.AppendSoc(QNN_HTP_DEVICE_ARCH_NONE, QNN_SOC_MODEL_UNKNOWN, device_id_);
   }
+}
 
-  qnn::ComputeTraceSummary(trace_);
-
-  // Write when either compiled subgraphs or unsupported nodes are present.
-  // The unsupported-only branch covers the "entire model is unsupported"
-  // case, where ORT may not invoke CompileImpl at all but the trace still
-  // has diagnostic value (it records why every node was rejected).
-  // A wholly empty trace can still occur on EPContext cached runs
-  // - skip the file write there.
-  if (!trace_.subgraph_traces.empty() || !trace_.unsupported_nodes.empty()) {
-    qnn::WriteTraceToFile(trace_,
-                          std::filesystem::path(framework_op_trace_dir_) / "qnn_op_trace.json",
-                          logger_);
+void QnnEp::AppendMultiSocTraces() {
+  // One SocTrace per configured (htp_arch, soc_model) entry, from the member arrays.
+  for (size_t idx = 0; idx < htp_arch_per_soc_.size(); ++idx) {
+    op_trace_builder_.AppendSoc(htp_arch_per_soc_[idx], soc_model_per_soc_[idx], device_id_);
   }
+}
+
+void QnnEp::WriteFrameworkOpTrace(const OrtGraph* primary_graph) {
+  std::string model_name = std::filesystem::path(GetModelPathString(primary_graph, ort_api)).filename().u8string();
+  op_trace_builder_.FinalizeAndWrite(model_name,
+                                     qnn::QnnBackendTypeToString(qnn_backend_manager_->GetQnnBackendType()),
+                                     std::filesystem::path(framework_op_trace_dir_) / "qnn_op_trace.json",
+                                     logger_);
 }
 
 OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
@@ -2738,7 +2766,12 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
 #endif
 
   if (!ep->enable_multi_soc_ep_context_) {
-    RETURN_IF_NOT_NULL(ep->CompileOnnxModel(graphs, fused_nodes, count, node_compute_infos, ep->htp_graph_configs_));
+    RETURN_IF_NOT_NULL(ep->CompileOnnxModel(graphs,
+                                            fused_nodes,
+                                            count,
+                                            node_compute_infos,
+                                            ep->htp_graph_configs_,
+                                            /*collect_subgraph_traces=*/true));
   } else {
     RETURN_IF_NOT_NULL(ep->CompileMultiSocOnnxModel(graphs, fused_nodes, count, node_compute_infos));
   }
@@ -2748,10 +2781,14 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   // below to serialize the io_name_overrides attribute into the EPContext model.
   ep->onnx_graph_io_names_.reset();
 
-  // Framework op trace: serialize and write JSON.
-  // When multiple graphs are compiled, all subgraph traces are collected into a single file.
+  // Framework op trace: record SoC trace(s), then finalize and write.
   if (ep->enable_framework_op_trace_) {
-    ep->CollectAndWriteFrameworkOpTrace(graphs[0]);
+    if (ep->enable_multi_soc_ep_context_) {
+      ep->AppendMultiSocTraces();
+    } else {
+      ep->AppendSingleSocTrace();
+    }
+    ep->WriteFrameworkOpTrace(graphs[0]);
   }
 
   if (ep->context_cache_enabled_) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -19,6 +19,7 @@
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
 #include "core/providers/qnn/builder/onnx_ctx_model_helper.h"
 #include "core/providers/qnn/cache_compatibility/qnn_cache_compatibility_info.h"
@@ -104,7 +105,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
   OrtStatus* GetMultiSocSupportedNodes(const OrtGraph* graph,
                                        const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                        const size_t node_unit_size,
-                                       std::vector<const OrtNode*>& supported_nodes) const;
+                                       std::vector<const OrtNode*>& supported_nodes,
+                                       std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes) const;
 
   void PartitionCtxModel(const OrtGraph* graph, OrtEpGraphSupportInfo* graph_support_info);
 
@@ -112,7 +114,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
                               const OrtNode** fused_nodes,
                               size_t count,
                               OrtNodeComputeInfo** node_compute_infos,
-                              const qnn::HtpGraphConfigs_t& htp_graph_configs);
+                              const qnn::HtpGraphConfigs_t& htp_graph_configs,
+                              bool collect_subgraph_traces = true);
 
   OrtStatus* CompileMultiSocOnnxModel(const OrtGraph** graphs,
                                       const OrtNode** fused_nodes,
@@ -138,10 +141,11 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // Helper functions
   void ParsePerSocHtpConfigs();
 
-  // Framework op trace helpers. trace_ is populated incrementally during
-  // GetCapability (unsupported_nodes) and Compile (subgraph_traces); this
-  // function finalizes summary fields and writes the JSON file.
-  void CollectAndWriteFrameworkOpTrace(const OrtGraph* primary_graph);
+  // Append a SocTrace: from live backend state (single-SoC), or one per configured SoC.
+  void AppendSingleSocTrace();
+  void AppendMultiSocTraces();
+  // Feed EP-side inputs (model name, backend type, dir) to op_trace_builder_ and write.
+  void WriteFrameworkOpTrace(const OrtGraph* primary_graph);
 
   // Emit a one-shot WARNING when the QNN EP is running on the HTP user-driver (HNRD) fallback path.
   void WarnIfHnrdPathActive();
@@ -261,10 +265,8 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // === Framework op trace ===
   bool enable_framework_op_trace_ = false;
   std::string framework_op_trace_dir_;
-  // Accumulates the trace state for this session: unsupported nodes are pushed
-  // by GetSupportedNodes, per-subgraph mappings are pushed by CompileImpl, and
-  // CollectAndWriteFrameworkOpTrace finalizes/serializes.
-  qnn::FrameworkOpTrace trace_;
+  // Owns trace assembly; the EP only feeds it data during GetCapability/Compile.
+  qnn::FrameworkOpTraceBuilder op_trace_builder_;
 
   bool enable_htp_extended_udma_mode_ = false;
 

--- a/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
+++ b/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
@@ -18,6 +18,8 @@
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
+#define ORT_MODEL_FOLDER ORT_TSTR("testdata/")
+
 // Defined in test_main.cc
 extern std::unique_ptr<Ort::Env> ort_env;
 
@@ -119,11 +121,23 @@ static nlohmann::json RunModelWithTracing(const GetTestModelFn& build_fn,
 static void ValidateTraceStructure(const nlohmann::json& j) {
   ASSERT_TRUE(j.contains("backend_type"));
   ASSERT_TRUE(j.contains("subgraph_traces"));
-  ASSERT_TRUE(j.contains("compilation_target"));
+  // compilation_target lives under soc_traces[i] in the new schema; it is
+  // intentionally not at root anymore. Every caller of this validator runs a
+  // single backend (single-SoC), so soc_traces must have exactly one entry.
+  // Asserting == 1 (not >= 1) also guards the two-pass GetCapabilityImpl
+  // regression: without the trace_ reset, a second partitioner pass would
+  // append a duplicate soc_trace and this would catch it.
+  ASSERT_FALSE(j.contains("compilation_target"))
+      << "compilation_target must NOT be at root in the new schema; "
+         "consumers should read from soc_traces[i].compilation_target";
+  ASSERT_TRUE(j.contains("soc_traces"));
+  ASSERT_EQ(j["soc_traces"].size(), 1u);
+  ASSERT_TRUE(j["soc_traces"][0].contains("compilation_target"));
   ASSERT_TRUE(j.contains("unsupported_nodes"));
   ASSERT_TRUE(j.contains("summary"));
   ASSERT_GE(j["subgraph_traces"].size(), 1u);
   EXPECT_GT(j["summary"]["total_qnn_ops"].get<size_t>(), 0u);
+  EXPECT_EQ(j["summary"]["total_socs"].get<uint32_t>(), 1u);
 }
 
 // ========================= Unit Tests =========================
@@ -135,7 +149,8 @@ TEST_F(QnnFrameworkOpTraceUnit, SerializeDeserializeRoundTrip) {
   qnn::FrameworkOpTrace trace;
   trace.model_name = "test_model.onnx";
   trace.backend_type = "cpu";
-  trace.compilation_target = {"V73", 60, 0};
+  // Single-SoC: soc_traces has exactly one entry holding the CompilationTarget.
+  trace.soc_traces.push_back(qnn::SocTrace{{"V73", 60, 0}});
 
   qnn::OpTraceInfo sg;
   sg.graph_name = "QnnEP_graph_0";
@@ -158,8 +173,13 @@ TEST_F(QnnFrameworkOpTraceUnit, SerializeDeserializeRoundTrip) {
 
   nlohmann::json j = qnn::SerializeFrameworkOpTrace(trace);
   EXPECT_EQ(j["model_name"], "test_model.onnx");
-  EXPECT_EQ(j["compilation_target"]["htp_arch"], "V73");
-  EXPECT_EQ(j["compilation_target"]["soc_model"], 60);
+  // compilation_target is no longer at root - it lives under soc_traces[0].
+  EXPECT_FALSE(j.contains("compilation_target"));
+  ASSERT_TRUE(j.contains("soc_traces"));
+  ASSERT_EQ(j["soc_traces"].size(), 1u);
+  EXPECT_EQ(j["soc_traces"][0]["compilation_target"]["htp_arch"], "V73");
+  EXPECT_EQ(j["soc_traces"][0]["compilation_target"]["soc_model"], 60);
+  EXPECT_EQ(j["soc_traces"][0]["compilation_target"]["device_id"], 0);
   EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][0]["dst_name"], "Add_0");
   EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][0]["sources"][0]["type"], "OP");
   // Verify mixed OP+TENSOR sources in Conv_1 (DQ_Q_Fusion)
@@ -168,6 +188,7 @@ TEST_F(QnnFrameworkOpTraceUnit, SerializeDeserializeRoundTrip) {
   EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][1]["sources"][1]["type"], "TENSOR");
   EXPECT_EQ(j["subgraph_traces"][0]["op_mappings"][1]["sources"][1]["name"], "_out_dq");
   EXPECT_EQ(j["unsupported_nodes"][0]["node_name"], "custom_op_1");
+  EXPECT_EQ(j["summary"]["total_socs"], 1u);
 }
 
 TEST_F(QnnFrameworkOpTraceUnit, ComputeTraceSummary) {
@@ -226,6 +247,132 @@ TEST_F(QnnFrameworkOpTraceUnit, ComputeTraceSummary) {
   EXPECT_EQ(trace.summary.fusion_count["FusionB"], 1u);
   EXPECT_EQ(trace.summary.fusion_count["FusionC"], 1u);
   EXPECT_EQ(trace.summary.fusion_count["FusionD"], 2u);
+}
+
+// ---- MergePerSocUnsupportedNodes: FCB multi-SoC rejection merging ----
+
+// EncodeHtpArch / MakeSocLabel: the single source of truth for the label format.
+TEST_F(QnnFrameworkOpTraceUnit, MakeSocLabel_Format) {
+  // arch encoding: raw number -> "V<n>", 0 -> "".
+  EXPECT_EQ(qnn::EncodeHtpArch(73), "V73");
+  EXPECT_EQ(qnn::EncodeHtpArch(0), "");
+  // arch + soc_model known.
+  EXPECT_EQ(qnn::MakeSocLabel(73, 60), "V73/soc_model=60");
+  // arch known, soc_model unknown (0).
+  EXPECT_EQ(qnn::MakeSocLabel(73, 0), "V73");
+  // arch unknown, soc_model known.
+  EXPECT_EQ(qnn::MakeSocLabel(0, 60), "soc_model=60");
+  // both unknown: arch empty wins, emits the sentinel numeric.
+  EXPECT_EQ(qnn::MakeSocLabel(0, 0), "soc_model=0");
+}
+
+// A node rejected on multiple SoCs for the SAME reason collapses to one row
+// with the SoC labels grouped: "V73,V81: <reason>" (reason listed once).
+TEST_F(QnnFrameworkOpTraceUnit, MergePerSoc_SameReasonGrouped) {
+  std::vector<qnn::PerSocUnsupportedNodes> per_soc = {
+      {"V73", {{"node7", "Foo", 7, "data type not supported"}}},
+      {"V81", {{"node7", "Foo", 7, "data type not supported"}}},
+  };
+  auto merged = qnn::MergePerSocUnsupportedNodes(per_soc);
+  ASSERT_EQ(merged.size(), 1u) << "same node across SoCs must collapse to one row";
+  EXPECT_EQ(merged[0].node_index, 7u);
+  EXPECT_EQ(merged[0].node_name, "node7");
+  EXPECT_EQ(merged[0].op_type, "Foo");
+  // Identical reason listed once, both SoCs attributed to it.
+  EXPECT_EQ(merged[0].reason, "V73,V81: data type not supported");
+}
+
+// A node rejected for DIFFERENT reasons on different SoCs collapses to one row
+// whose reason concatenates the per-SoC causes in first-seen order.
+TEST_F(QnnFrameworkOpTraceUnit, MergePerSoc_DifferentReasonsConcatenated) {
+  std::vector<qnn::PerSocUnsupportedNodes> per_soc = {
+      {"V73", {{"node7", "Foo", 7, "data type"}}},
+      {"V81", {{"node7", "Foo", 7, "rank too high"}}},
+  };
+  auto merged = qnn::MergePerSocUnsupportedNodes(per_soc);
+  ASSERT_EQ(merged.size(), 1u);
+  EXPECT_EQ(merged[0].node_index, 7u);
+  EXPECT_EQ(merged[0].reason, "V73: data type; V81: rank too high");
+}
+
+// Distinct nodes are emitted in first-seen order; each keeps its own reason(s).
+// soc_model= labels (arch unknown) are used verbatim.
+TEST_F(QnnFrameworkOpTraceUnit, MergePerSoc_MultipleNodesFirstSeenOrder) {
+  std::vector<qnn::PerSocUnsupportedNodes> per_soc = {
+      {"soc_model=60", {{"a", "A", 3, "r1"}, {"b", "B", 9, "r2"}}},
+      {"soc_model=88", {{"b", "B", 9, "r2"}, {"c", "C", 1, "r3"}}},
+  };
+  auto merged = qnn::MergePerSocUnsupportedNodes(per_soc);
+  ASSERT_EQ(merged.size(), 3u);
+  // First-seen order across the flattened stream: 3, 9, 1.
+  EXPECT_EQ(merged[0].node_index, 3u);
+  EXPECT_EQ(merged[0].reason, "soc_model=60: r1");
+  EXPECT_EQ(merged[1].node_index, 9u);
+  EXPECT_EQ(merged[1].reason, "soc_model=60,soc_model=88: r2");
+  EXPECT_EQ(merged[2].node_index, 1u);
+  EXPECT_EQ(merged[2].reason, "soc_model=88: r3");
+}
+
+// Empty input yields an empty result (single-SoC never calls this).
+TEST_F(QnnFrameworkOpTraceUnit, MergePerSoc_Empty) {
+  EXPECT_TRUE(qnn::MergePerSocUnsupportedNodes({}).empty());
+  // SoCs present but no rejections -> still empty.
+  std::vector<qnn::PerSocUnsupportedNodes> per_soc = {{"V73", {}}, {"V81", {}}};
+  EXPECT_TRUE(qnn::MergePerSocUnsupportedNodes(per_soc).empty());
+}
+
+// Two SoCs share the same htp_arch but have different soc_model values (e.g.
+// V73/soc_model=60 and V73/soc_model=61). Their labels must be distinct so that
+// same-reason rejections are NOT conflated - each SoC's attribution is preserved.
+// This tests the "V<arch>/soc_model=<n>" label format that GetMultiSocSupportedNodes
+// emits when both htp_arch and a known soc_model are present.
+TEST_F(QnnFrameworkOpTraceUnit, MergePerSoc_SameArchDifferentModel) {
+  std::vector<qnn::PerSocUnsupportedNodes> per_soc = {
+      {"V73/soc_model=60", {{"node5", "Bar", 5, "rank"}}},
+      {"V73/soc_model=61", {{"node5", "Bar", 5, "rank"}}},
+  };
+  auto merged = qnn::MergePerSocUnsupportedNodes(per_soc);
+  ASSERT_EQ(merged.size(), 1u);
+  EXPECT_EQ(merged[0].node_index, 5u);
+  // Both SoC labels must appear, grouped because the reason is identical.
+  EXPECT_EQ(merged[0].reason, "V73/soc_model=60,V73/soc_model=61: rank");
+}
+
+// Multi-SoC serialization: soc_traces holds N entries and summary.total_socs == N.
+// unsupported_nodes carrying merged multi-SoC reasons round-trip through JSON,
+// and summary.unsupported_nodes is a distinct-node count (one row per node).
+TEST_F(QnnFrameworkOpTraceUnit, SerializeMultiSoc) {
+  qnn::FrameworkOpTrace trace;
+  trace.model_name = "fcb_model.onnx";
+  trace.backend_type = "htp";
+  trace.soc_traces.push_back(qnn::SocTrace{{"V73", 60, 0}});
+  trace.soc_traces.push_back(qnn::SocTrace{{"V81", 88, 0}});
+
+  qnn::OpTraceInfo sg;
+  sg.graph_name = "QnnEP_graph_0";
+  sg.op_mappings.push_back({"Add_0",
+                            "QNN_OP_ELEMENT_WISE_ADD",
+                            {{"/add/Add", qnn::TraceTargetType::kOp}},
+                            "OrtNodeUnit"});
+  trace.subgraph_traces.push_back(std::move(sg));
+  // One merged row for a node rejected differently on the two SoCs.
+  trace.unsupported_nodes.push_back({"node7", "Foo", 7, "V73: data type; V81: rank too high"});
+  qnn::ComputeTraceSummary(trace);
+
+  nlohmann::json j = qnn::SerializeFrameworkOpTrace(trace);
+  EXPECT_EQ(j["schema_version"], 2);
+  EXPECT_FALSE(j.contains("compilation_target"));
+  ASSERT_TRUE(j.contains("soc_traces"));
+  ASSERT_EQ(j["soc_traces"].size(), 2u);
+  EXPECT_EQ(j["soc_traces"][0]["compilation_target"]["htp_arch"], "V73");
+  EXPECT_EQ(j["soc_traces"][1]["compilation_target"]["htp_arch"], "V81");
+  EXPECT_EQ(j["soc_traces"][1]["compilation_target"]["soc_model"], 88);
+  EXPECT_EQ(j["summary"]["total_socs"], 2u);
+  // One distinct unsupported node, merged reason preserved.
+  ASSERT_EQ(j["unsupported_nodes"].size(), 1u);
+  EXPECT_EQ(j["unsupported_nodes"][0]["node_index"], 7u);
+  EXPECT_EQ(j["unsupported_nodes"][0]["reason"], "V73: data type; V81: rank too high");
+  EXPECT_EQ(j["summary"]["unsupported_nodes"], 1u);
 }
 
 // Verify that mixed OP+TENSOR srcInfo is serialized correctly.
@@ -716,20 +863,53 @@ TEST_F(QnnCPUBackendTests, FrameworkOpTrace_CustomOutputDir) {
   EXPECT_FALSE(FindTraceFile(custom_dir).empty());
 }
 
-// Test compilation_target metadata (CPU).
-TEST_F(QnnCPUBackendTests, FrameworkOpTrace_CompilationTargetMetadata) {
+// New schema (FCB readiness): single-SoC sessions populate a length-1
+// soc_traces array, no compilation_target at root, subgraph_traces stays at
+// root, and summary.total_socs reflects soc_traces.size(). Consolidates four
+// previously-separate fixture-rebuild tests into one inference run. Also
+// subsumes the former FrameworkOpTrace_CompilationTargetMetadata (same
+// Add-on-CPU model, strict superset of its assertions).
+TEST_F(QnnCPUBackendTests, FrameworkOpTrace_SingleSoc_NewSchema) {
   ScopedTempDir tmp;
   std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
   auto j = RunModelWithTracing(
       BuildOpTestCase<float>("add_node", "Add",
-                             {TestInputDef<float>({1, 2, 3}, false, data), TestInputDef<float>({1, 2, 3}, false, data)},
+                             {TestInputDef<float>({1, 2, 3}, false, data),
+                              TestInputDef<float>({1, 2, 3}, false, data)},
                              {}, {}, kOnnxDomain),
       tmp.path(), "cpu");
   if (j.empty()) return;
-  ASSERT_TRUE(j.contains("compilation_target"));
-  EXPECT_TRUE(j["compilation_target"].contains("htp_arch"));
-  EXPECT_TRUE(j["compilation_target"].contains("soc_model"));
-  EXPECT_TRUE(j["compilation_target"].contains("device_id"));
+
+  // soc_traces: exactly one entry with a CompilationTarget on a single-SoC run.
+  ASSERT_TRUE(j.contains("soc_traces"));
+  ASSERT_EQ(j["soc_traces"].size(), 1u)
+      << "Single-SoC session must produce exactly one soc_traces entry";
+  const auto& ct = j["soc_traces"][0]["compilation_target"];
+  EXPECT_TRUE(ct.contains("htp_arch"));
+  EXPECT_TRUE(ct.contains("soc_model"));
+  EXPECT_TRUE(ct.contains("device_id"));
+
+  // Breaking schema change: no compilation_target at root.
+  EXPECT_FALSE(j.contains("compilation_target"))
+      << "compilation_target was moved out of root in the FCB-ready schema; "
+         "consumers must read soc_traces[i].compilation_target instead";
+
+  // subgraph_traces stays at root (SoC-agnostic op-builder output) and is
+  // not duplicated under soc_traces[i].
+  ASSERT_TRUE(j.contains("subgraph_traces"))
+      << "subgraph_traces must be at root (SoC-agnostic op mapping)";
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  for (const auto& soc : j["soc_traces"]) {
+    EXPECT_FALSE(soc.contains("subgraph_traces"))
+        << "subgraph_traces must NOT be duplicated under soc_traces[i]";
+  }
+
+  // summary.total_socs mirrors soc_traces.size().
+  ASSERT_TRUE(j.contains("summary"));
+  ASSERT_TRUE(j["summary"].contains("total_socs"));
+  EXPECT_EQ(j["summary"]["total_socs"].get<uint32_t>(), 1u)
+      << "Single-SoC session must report total_socs == 1";
+  EXPECT_EQ(j["soc_traces"].size(), j["summary"]["total_socs"].get<uint32_t>());
 }
 
 // Test explicit output directory (simulates Android non-writable CWD).
@@ -877,7 +1057,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_OneToMany) {
   ValidateTraceStructure(j);
 }
 
-// Test HTP compilation_target metadata.
+// Test HTP compilation_target metadata. New schema: lives under soc_traces[0].
 TEST_F(QnnHTPBackendTests, FrameworkOpTrace_HTP_CompilationTarget) {
   ScopedTempDir tmp;
   std::vector<float> data = GetFloatDataInRange(-10.0f, 10.0f, 6);
@@ -889,8 +1069,12 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_HTP_CompilationTarget) {
   if (j.empty()) return;
 
   EXPECT_EQ(j["backend_type"], "htp");
-  ASSERT_TRUE(j.contains("compilation_target"));
-  EXPECT_TRUE(j["compilation_target"].contains("device_id"));
+  ASSERT_FALSE(j.contains("compilation_target"))
+      << "compilation_target must NOT be at root (moved to soc_traces[0])";
+  ASSERT_TRUE(j.contains("soc_traces"));
+  ASSERT_EQ(j["soc_traces"].size(), 1u);
+  ASSERT_TRUE(j["soc_traces"][0].contains("compilation_target"));
+  EXPECT_TRUE(j["soc_traces"][0]["compilation_target"].contains("device_id"));
 }
 
 // ========================= AOT Path Integration Tests =========================
@@ -2121,6 +2305,202 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_AOT_Phase2_NoSidecar_EmitsEmptyColum
       << "Without a sidecar the annotation column should be present but every cell empty; "
       << "got " << annotated.size() << " non-empty annotations";
 }
+
+// ================= FCB multi-SoC framework op trace (x86-only) =================
+// Multi-SoC FCB EP-context compilation is an x86 offline-preparation feature
+// (the EP rejects it on aarch64), so these E2E tests are x86-only.
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+
+namespace {
+
+// SoC config shared by the FCB framework op trace tests: V73 + V81, two SoCs.
+struct FcbTraceTestConfig {
+  static constexpr size_t kNumSocs = 2;
+  static constexpr const char* kHtpArchStr = "73,81";
+#ifdef _WIN32
+  static constexpr const char* kSocModelStr = "60,88";
+#else
+  static constexpr const char* kSocModelStr = "43,87";
+#endif
+  static const std::vector<std::string>& TargetArches() {
+    static const std::vector<std::string> arches = {"73", "81"};
+    return arches;
+  }
+};
+
+// Build the common multi-SoC + framework-op-trace provider options.
+ProviderOptions MakeFcbTraceProviderOptions(const std::string& trace_dir) {
+  ProviderOptions opts;
+  opts["backend_type"] = "htp";
+  opts["offload_graph_io_quantization"] = "0";
+  opts["htp_arch"] = FcbTraceTestConfig::kHtpArchStr;
+  opts["soc_model"] = FcbTraceTestConfig::kSocModelStr;
+  opts["enable_framework_op_trace"] = "1";
+  opts["framework_op_trace_dir"] = trace_dir;
+  return opts;
+}
+
+// Locate qnn_op_trace.json in dir, parse it, and return the JSON object.
+nlohmann::json FindAndParseTraceFile(const std::filesystem::path& dir) {
+  std::filesystem::path trace_file;
+  for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+    if (entry.path().extension() == ".json" &&
+        entry.path().stem().string().find("_op_trace") != std::string::npos) {
+      trace_file = entry.path();
+      break;
+    }
+  }
+  EXPECT_FALSE(trace_file.empty()) << "No qnn_op_trace.json found in " << dir;
+  if (trace_file.empty()) return {};
+
+  std::ifstream ifs(trace_file);
+  EXPECT_TRUE(ifs.is_open()) << "Failed to open " << trace_file;
+  if (!ifs.is_open()) return {};
+
+  auto j = nlohmann::json::parse(ifs, nullptr, false);
+  EXPECT_FALSE(j.is_discarded()) << "Failed to parse " << trace_file;
+  return j;
+}
+
+// Assert every-trace invariants. Fatal ASSERT_*; wrap call sites in
+// ASSERT_NO_FATAL_FAILURE so a size mismatch aborts before soc_traces[i] indexing.
+void AssertFcbTraceInvariants(const nlohmann::json& j, size_t num_socs) {
+  ASSERT_FALSE(j.empty());
+  ASSERT_TRUE(j.contains("soc_traces"));
+  ASSERT_EQ(j["soc_traces"].size(), num_socs)
+      << "Multi-SoC trace must have one soc_traces entry per htp_arch";
+  ASSERT_TRUE(j.contains("summary"));
+  EXPECT_EQ(j["summary"]["total_socs"].get<uint32_t>(), static_cast<uint32_t>(num_socs));
+  EXPECT_FALSE(j.contains("compilation_target"))
+      << "compilation_target must not be at root (moved to soc_traces[i])";
+}
+
+}  // namespace
+
+// FCB multi-SoC framework op trace E2E test: exercises GetCapabilityImpl ->
+// GetMultiSocSupportedNodes -> CompileMultiSocOnnxModel with tracing enabled.
+TEST_F(QnnHTPBackendTests, EPContextMultiSoc_FrameworkOpTrace) {
+  namespace fs = std::filesystem;
+
+  fs::path trace_dir = fs::temp_directory_path() / "fcb_op_trace_e2e";
+  fs::remove_all(trace_dir);
+  fs::create_directories(trace_dir);
+  fs::path output_model_file = trace_dir / "model_ctx.onnx";
+
+  ProviderOptions provider_options = MakeFcbTraceProviderOptions(trace_dir.string());
+  provider_options["num_graph_prepare_threads"] = "1";
+
+  const ORTCHAR_T* input_model_file = ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.quant.onnx";
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextEmbedMode, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, output_model_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
+  ScopedOrtSession scoped(std::move(registered_ep_device), Ort::Session(*ort_env, input_model_file, so));
+
+  ASSERT_TRUE(fs::exists(output_model_file));
+  fs::remove(output_model_file);
+
+  nlohmann::json j = FindAndParseTraceFile(trace_dir);
+  if (j.empty()) {
+    fs::remove_all(trace_dir);
+    return;
+  }
+  ASSERT_NO_FATAL_FAILURE(AssertFcbTraceInvariants(j, FcbTraceTestConfig::kNumSocs));
+
+  // Each soc_traces[i] carries the expected htp_arch.
+  for (size_t i = 0; i < FcbTraceTestConfig::TargetArches().size(); ++i) {
+    ASSERT_TRUE(j["soc_traces"][i].contains("compilation_target"));
+    EXPECT_EQ(j["soc_traces"][i]["compilation_target"]["htp_arch"],
+              "V" + FcbTraceTestConfig::TargetArches()[i])
+        << "soc_traces[" << i << "] htp_arch mismatch";
+  }
+
+  // At least one op was compiled; subgraph_traces is at root, not per SoC.
+  EXPECT_GT(j["summary"]["total_qnn_ops"].get<size_t>(), 0u);
+  ASSERT_TRUE(j.contains("subgraph_traces"));
+  ASSERT_GE(j["subgraph_traces"].size(), 1u);
+  for (const auto& soc : j["soc_traces"]) {
+    EXPECT_FALSE(soc.contains("subgraph_traces"))
+        << "subgraph_traces must not be duplicated under soc_traces[i]";
+  }
+
+  fs::remove_all(trace_dir);
+}
+
+// Mixed partition (Abs supported, NonZero graph-output rejected): verifies both
+// subgraph_traces and SoC-attributed unsupported_nodes in one trace.
+TEST_F(QnnHTPBackendTests, EPContextMultiSoc_FrameworkOpTrace_Mixed) {
+  namespace fs = std::filesystem;
+
+  fs::path trace_dir = fs::temp_directory_path() / "fcb_op_trace_mixed";
+  fs::remove_all(trace_dir);
+  fs::create_directories(trace_dir);
+  fs::path output_model_file = trace_dir / "model_ctx.onnx";
+
+  ModelTestBuilder helper;
+  auto build_model = [](ModelTestBuilder& builder) {
+    std::vector<float> data = GetFloatDataInRange(-1.0f, 1.0f, 6);
+    builder.MakeInput<float>("input", {1, 2, 3}, data);
+    builder.AddNode("abs_node", "Abs", {"input"}, {"abs_out"});
+    builder.MakeOutput("Y");
+    builder.AddNode("nonzero_node", "NonZero", {"abs_out"}, {"Y"});
+  };
+  build_model(helper);
+  const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+  opset_id_proto->set_domain("");
+  opset_id_proto->set_version(13);
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+  const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
+
+  ProviderOptions provider_options = MakeFcbTraceProviderOptions(trace_dir.string());
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextEmbedMode, "1");
+  so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, output_model_file.string().c_str());
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
+
+  nlohmann::json j = FindAndParseTraceFile(trace_dir);
+  if (j.empty()) {
+    fs::remove_all(trace_dir);
+    return;
+  }
+  ASSERT_NO_FATAL_FAILURE(AssertFcbTraceInvariants(j, FcbTraceTestConfig::kNumSocs));
+
+  // Abs was compiled: subgraph_traces non-empty, total_qnn_ops > 0.
+  ASSERT_TRUE(j.contains("subgraph_traces"));
+  EXPECT_GE(j["subgraph_traces"].size(), 1u);
+  EXPECT_GT(j["summary"]["total_qnn_ops"].get<size_t>(), 0u);
+
+  // NonZero was rejected: unsupported_nodes non-empty with SoC-attributed reason.
+  ASSERT_TRUE(j.contains("unsupported_nodes"));
+  ASSERT_GT(j["unsupported_nodes"].size(), 0u);
+  bool found_nonzero = false;
+  for (const auto& un : j["unsupported_nodes"]) {
+    if (un["op_type"].get<std::string>() == "NonZero") {
+      found_nonzero = true;
+      const std::string reason = un["reason"].get<std::string>();
+      EXPECT_FALSE(reason.empty());
+      EXPECT_TRUE(reason.find("V73") != std::string::npos || reason.find("V81") != std::string::npos)
+          << "Multi-SoC reason must carry SoC label; got: " << reason;
+    }
+  }
+  EXPECT_TRUE(found_nonzero) << "NonZero must appear in unsupported_nodes";
+
+  fs::remove_all(trace_dir);
+}
+
+#endif  // !defined(__aarch64__) && !defined(_M_ARM64)
 
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
## Summary

Extends the framework op trace (PR #345) to support FCB multi-SoC compilation, and wires it through the FCB compile path so tracing is actually emitted for multi-SoC sessions (previously it was force-disabled whenever multi-SoC EP context was requested).

`FrameworkOpTrace.compilation_target` (single) is replaced by `soc_traces: vector<SocTrace>`, with one entry per SoC iteration. `subgraph_traces` stays at root because op-builder output is SoC-agnostic; it is collected once rather than duplicated per SoC. `unsupported_nodes` also stays at root, but is now merged into one row per ONNX node with each rejection reason attributed to the SoC that produced it.

### Schema change

```json
{
  "soc_traces": [{ "compilation_target": { "htp_arch": ..., "soc_model": ... } }, ...],
  "subgraph_traces": [...],
  "unsupported_nodes": [...],
  "summary": { "total_socs": N, ... }
}
```

Single-SoC sessions degenerate to a length-1 soc_traces array — uniform JSON shape for both single- and multi-SoC traces.

### Multi-SoC wiring

- `CompileMultiSocOnnxModel` appends one `SocTrace` per iteration, then finalizes and writes the trace exactly once per session. The single-SoC path appends one `SocTrace` from the current backend target; both converge on the same Finalize / Write stages.
- `subgraph_traces` are collected only on the first SoC iteration (op-builder output is driven by `ModelSettings`, not HTP graph configs, so it is identical across SoCs).
- The empty-partition early-flush path records every configured SoC, so `summary.total_socs` stays correct even when ORT skips `CompileImpl` because no node is supported.

### Unsupported-node attribution

A node rejected on multiple SoCs is emitted as a single row whose reason prefixes each distinct cause with the SoC that produced it, e.g. "V73: <reason>; V81: <reason>". Identical reasons across SoCs are deduplicated. Keeping one row per node keeps `summary.unsupported_nodes` and `total_onnx_nodes` as true distinct-node counts rather than (SoC × node) counts.

### Breaking change

Consumers reading `compilation_target` at root must migrate to `soc_traces[0].compilation_target`. Migration note added to `docs/execution_providers/QNN-ExecutionProvider.md`.