### PR TITLE
[QNN EP] Fix cmake deps mirror on Windows: resilience + ort_core propagation

### DIFF
--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -106,6 +106,11 @@ else()
         endif()
     endif()
 
+    if(onnxruntime_CMAKE_DEPS_MIRROR_DIR)
+        list(APPEND ORT_BUILD_COMMAND --cmake_deps_mirror_dir)
+        list(APPEND ORT_BUILD_COMMAND "${onnxruntime_CMAKE_DEPS_MIRROR_DIR}")
+    endif()
+
     list(APPEND ORT_BUILD_COMMAND --targets)
     list(APPEND ORT_BUILD_COMMAND onnxruntime_perf_test)
     list(APPEND ORT_BUILD_COMMAND onnxruntime_plugin_ep_onnx_test)

--- a/qcom/scripts/all/fetch_cmake_deps.py
+++ b/qcom/scripts/all/fetch_cmake_deps.py
@@ -25,9 +25,17 @@ def main(deps_dir: Path, mirror_dir: Path) -> None:
 
     logging.info(f"Downloading dependencies into {deps_dir}")
     cached_paths: list[tuple[str, Path]] = []
+    failed: list[str] = []
     for name, url, sha1 in deps:
-        cached_paths.append((url, cache.fetch(name, url, expected_sha1=sha1)))
-        logging.debug(f"{name} --> {cached_paths[-1]}")
+        try:
+            cached_paths.append((url, cache.fetch(name, url, expected_sha1=sha1)))
+            logging.debug(f"{name} --> {cached_paths[-1]}")
+        except Exception as e:
+            logging.warning(f"Failed to fetch {name} ({url}): {e}")
+            failed.append(name)
+
+    if failed:
+        logging.error(f"Could not fetch {len(failed)} dep(s): {', '.join(failed)}. CMake will attempt to download them directly.")
 
     logging.info(f"Making dependencies available in {mirror_dir}")
     if mirror_dir.exists():

--- a/qcom/scripts/all/fetch_cmake_deps.py
+++ b/qcom/scripts/all/fetch_cmake_deps.py
@@ -35,7 +35,9 @@ def main(deps_dir: Path, mirror_dir: Path) -> None:
             failed.append(name)
 
     if failed:
-        logging.error(f"Could not fetch {len(failed)} dep(s): {', '.join(failed)}. CMake will attempt to download them directly.")
+        logging.error(
+            f"Could not fetch {len(failed)} dep(s): {', '.join(failed)}. CMake will attempt to download them directly."
+        )
 
     logging.info(f"Making dependencies available in {mirror_dir}")
     if mirror_dir.exists():

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -286,7 +286,9 @@ else {
 
     if ($GenerateBuild -or $DoBuild) {
         try {
-            python.exe "$RepoRoot\qcom\scripts\all\fetch_cmake_deps.py"
+            Assert-Success -ErrorMessage "Failed to fetch CMake dependencies" {
+                python.exe "$RepoRoot\qcom\scripts\all\fetch_cmake_deps.py"
+            }
             $BuildBatPath = (Join-Path $RepoRoot "build.bat")
 
             if ($GenerateBuild) {

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -333,7 +333,10 @@ else {
         finally {
             # Whatever happens, blow away mirror to avoid it showing up in git; it's okay, it's
             # very cheap to regenerate.
-            Remove-Item -Recurse -Force (Join-Path $RepoRoot "mirror")
+            $mirrorDir = Join-Path $RepoRoot "mirror"
+            if (Test-Path $mirrorDir) {
+                Remove-Item -Recurse -Force $mirrorDir
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Two fixes to make the cmake dependency mirror work reliably on Windows machines where libcurl (used by CMake's FetchContent) cannot follow HTTPS redirects due to certificate revocation check failures (`CRYPT_E_NO_REVOCATION_CHECK`), but `urllib`/WinINet can.

**1. `fetch_cmake_deps.py`: resilient per-dep download**

Previously, a single failed `cache.fetch()` call would abort the entire script, leaving the mirror directory unpopulated — even for deps that were already in the local cache (`~/.ort-package-cache`). Wrapped each fetch in a try/except so cached deps still get mirrored when others fail to download. Logs a warning per failure and an error summary at the end.

**2. `build.ps1`: surface `fetch_cmake_deps.py` failures**

The script was called without `Assert-Success`, so failures were silently ignored and the build continued with an empty mirror. Wrapped with `Assert-Success` so failures are visible in CI logs.

**3. `onnxruntime_prebuilt.cmake`: forward mirror dir to ort_core build**

The ARM64X build invokes ort_core as a separate cmake process via ORT's `build.py`. That process computes its own default `onnxruntime_CMAKE_DEPS_MIRROR_DIR` relative to its own source tree (pointing at a non-existent `_deps/mirror`), so it bypasses the mirror and attempts live downloads. Passes `--cmake_deps_mirror_dir` explicitly so the ort_core cmake uses the same pre-populated mirror as the parent build.

### Motivation and Context

On certain Windows CI runners, CMake's bundled libcurl fails to follow GitHub release asset redirects (`github.com` → `release-assets.githubusercontent.com`) due to corporate certificate revocation policy. `Invoke-WebRequest` and Python's `urllib` (via `fetch_cmake_deps.py`) work because they use the WinINet stack which respects system trust settings. This change ensures the mirror populated by `fetch_cmake_deps.py` is used end-to-end for all cmake FetchContent downloads.