### PR TITLE
Allow BatchNorm in float when its output has no Q on HTP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -489,6 +489,30 @@ void OverrideParamTypeForRequantize(Qnn_DataType_t x_dtype,
   }
 }
 
+// Single source of truth for float execution, shared by ProcessInputs (stores params) and
+// ProcessAttributesAndOutputs (emits the op).
+//   - has_float_output: quantized input, no output Q -> float island; BN emits float directly.
+//   - use_float_params: also covers u8/u16 input with per-channel scale, whose fused weight
+//     gamma/sqrt(var+eps) can overflow a single per-tensor requant scale.
+struct BatchNormFloatExecution {
+  bool has_float_output;
+  bool use_float_params;
+};
+
+BatchNormFloatExecution GetBatchNormFloatExecution(const TensorInfo& input_info,
+                                                   const TensorInfo& scale_info,
+                                                   const TensorInfo& output_info) {
+  const bool is_quantized_op = input_info.quant_param.IsQuantized();
+  const bool has_float_output = is_quantized_op && !output_info.quant_param.IsQuantized();
+  const bool use_float_params =
+      has_float_output ||
+      (is_quantized_op &&
+       (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+        input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+       scale_info.quant_param.IsPerChannel());
+  return {has_float_output, use_float_params};
+}
+
 }  // namespace
 
 // BatchNorm is sensitive with data layout, no special validation so far
@@ -587,11 +611,10 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
     const bool is_quantized_op = input_info.quant_param.IsQuantized();
 
-    // Quantized input but a float output: BN runs in float, so params are stored as float and the
-    // input is dequantized in ProcessAttributesAndOutputs.
-    TensorInfo float_output_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], float_output_info));
-    const bool has_float_output = is_quantized_op && !float_output_info.quant_param.IsQuantized();
+    // When BN runs in float, params below are stored as f32 (see GetBatchNormFloatExecution).
+    TensorInfo output_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+    const bool use_float_params = GetBatchNormFloatExecution(input_info, scale_info, output_info).use_float_params;
 
     // Check if bias needs conversion (will be done after preprocessing)
     const bool bias_is_float = !bias_info.quant_param.IsQuantized() &&
@@ -655,16 +678,7 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
       bias_info.quant_param = QnnQuantParamsWrapper(1.0f, 0);  // Placeholder, computed in Postprocess
     }
 
-    // Store fused weight/bias as F32 to avoid per-channel quantization overflow
-    // BN fused_weight = gamma/sqrt(var+eps) can have extreme dynamic range across channels,
-    // which overflows when requantized to a single per-tensor U8/S32 scale
-    // Only needed when scale input is per-channel (per-tensor doesn't have this issue)
-    const bool use_float_params = has_float_output ||
-                                  (is_quantized_op &&
-                                   (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
-                                    input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
-                                   scale_info.quant_param.IsPerChannel());
-
+    // use_float_params stores the fused weight/bias as F32.
     if (!qnn_model_wrapper.IsQnnTensorWrapperExist(scale_name)) {
       std::vector<uint8_t> scale_raw_tensor;
       QnnQuantParamsWrapper scale_quant_param;
@@ -733,14 +747,10 @@ Ort::Status BatchNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
 
-  // Quantized input but a float output: emit BN's float result directly, with no trailing Quantize,
-  // so it flows into the downstream float ops.
-  const bool has_float_output = input_info.quant_param.IsQuantized() && !output_info.quant_param.IsQuantized();
-  const bool use_float_params = has_float_output ||
-                                (input_info.quant_param.IsQuantized() &&
-                                 (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
-                                  input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
-                                 scale_info.quant_param.IsPerChannel());
+  // has_float_output emits BN's float result with no trailing Quantize, feeding downstream float ops.
+  const BatchNormFloatExecution float_exec = GetBatchNormFloatExecution(input_info, scale_info, output_info);
+  const bool has_float_output = float_exec.has_float_output;
+  const bool use_float_params = float_exec.use_float_params;
 
   if (!use_float_params) {
     RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), {},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -587,6 +587,12 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
     const bool is_quantized_op = input_info.quant_param.IsQuantized();
 
+    // Quantized input but a float output: BN runs in float, so params are stored as float and the
+    // input is dequantized in ProcessAttributesAndOutputs.
+    TensorInfo float_output_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], float_output_info));
+    const bool has_float_output = is_quantized_op && !float_output_info.quant_param.IsQuantized();
+
     // Check if bias needs conversion (will be done after preprocessing)
     const bool bias_is_float = !bias_info.quant_param.IsQuantized() &&
                                (bias_info.qnn_data_type == QNN_DATATYPE_FLOAT_32 ||
@@ -653,10 +659,11 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
     // BN fused_weight = gamma/sqrt(var+eps) can have extreme dynamic range across channels,
     // which overflows when requantized to a single per-tensor U8/S32 scale
     // Only needed when scale input is per-channel (per-tensor doesn't have this issue)
-    const bool use_float_params = is_quantized_op &&
-                                  (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
-                                   input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
-                                  scale_info.quant_param.IsPerChannel();
+    const bool use_float_params = has_float_output ||
+                                  (is_quantized_op &&
+                                   (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+                                    input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+                                   scale_info.quant_param.IsPerChannel());
 
     if (!qnn_model_wrapper.IsQnnTensorWrapperExist(scale_name)) {
       std::vector<uint8_t> scale_raw_tensor;
@@ -722,10 +729,18 @@ Ort::Status BatchNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
   TensorInfo scale_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info));
-  const bool use_float_params = input_info.quant_param.IsQuantized() &&
-                                (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
-                                 input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
-                                scale_info.quant_param.IsPerChannel();
+
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
+
+  // Quantized input but a float output: emit BN's float result directly, with no trailing Quantize,
+  // so it flows into the downstream float ops.
+  const bool has_float_output = input_info.quant_param.IsQuantized() && !output_info.quant_param.IsQuantized();
+  const bool use_float_params = has_float_output ||
+                                (input_info.quant_param.IsQuantized() &&
+                                 (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+                                  input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+                                 scale_info.quant_param.IsPerChannel());
 
   if (!use_float_params) {
     RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), {},
@@ -751,11 +766,15 @@ Ort::Status BatchNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   // BN node: all float32
   const auto& outputs = node_unit.Outputs();
   const std::string& orig_output_name = outputs[0].name;
-  const std::string bn_output_name = utils::UniqueNameGenerator().New(orig_output_name, "_bn_f32");
+  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);
 
-  TensorInfo output_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
-  QnnTensorWrapper bn_out_tensor(bn_output_name, QNN_TENSOR_TYPE_NATIVE,
+  // A float output is written directly; otherwise an intermediate feeds the trailing Quantize.
+  const std::string bn_output_name = has_float_output
+                                         ? orig_output_name
+                                         : utils::UniqueNameGenerator().New(orig_output_name, "_bn_f32");
+  Qnn_TensorType_t bn_out_tensor_type = (has_float_output && is_graph_output) ? QNN_TENSOR_TYPE_APP_READ
+                                                                              : QNN_TENSOR_TYPE_NATIVE;
+  QnnTensorWrapper bn_out_tensor(bn_output_name, bn_out_tensor_type,
                                  QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
                                  std::vector<uint32_t>(output_info.shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bn_out_tensor)), "Failed to add tensor");
@@ -767,8 +786,11 @@ Ort::Status BatchNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
                                                 do_op_validation),
                 "Failed to add Batchnorm node");
 
+  if (has_float_output) {
+    return Ort::Status();  // Output is the float result; downstream ops re-quantize as needed.
+  }
+
   // Insert Quantize (Float_32 -> quantized) after BN
-  bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);
   Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
   QnnTensorWrapper final_out_tensor(orig_output_name, out_tensor_type,
                                     output_info.qnn_data_type, std::move(output_info.quant_param),
@@ -818,6 +840,13 @@ Ort::Status BatchNormalizationOpBuilder::CheckHtpDataTypes(const std::vector<Qnn
   Qnn_DataType_t scale_dtype = in_dtypes[1];
   Qnn_DataType_t bias_dtype = in_dtypes[2];
   Qnn_DataType_t y_dtype = out_dtypes[0];
+
+  // Quantized input with a float output: the input is dequantized and BN is run in float.
+  const bool x_is_quantized = (x_dtype == QNN_DATATYPE_UFIXED_POINT_8 || x_dtype == QNN_DATATYPE_SFIXED_POINT_8 ||
+                               x_dtype == QNN_DATATYPE_UFIXED_POINT_16 || x_dtype == QNN_DATATYPE_SFIXED_POINT_16);
+  if (x_is_quantized && (y_dtype == QNN_DATATYPE_FLOAT_32 || y_dtype == QNN_DATATYPE_FLOAT_16)) {
+    return Ort::Status();
+  }
 
   // We likely need to re-quantize scale/bias for HTP compatibility, override dtypes before checking.
   // Note: We conservatively assume scale may have negative values during validation.

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1044,20 +1044,26 @@ bool OrtBatchNormalizationNodeGroupSelector::Check(const OrtGraph* graph, const 
     return false;
   }
 
-  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, num_dq_nodes)) {
+  // No output Q means BN produces a float output and runs in float, so allow the empty-Q group.
+  const bool has_float_output = q_nodes.empty();
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, num_dq_nodes,
+                     /*is_empty_q_nodes_allowed=*/true)) {
     return false;
   }
 
   auto dt_input = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
   auto dt_scale = GetNodeInputDataType(dq_nodes[1], ort_api, 0);
-  auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
 
-  if (!dt_input.has_value() || !dt_scale.has_value() || !dt_output.has_value()) {
+  if (!dt_input.has_value() || !dt_scale.has_value()) {
     return false;
   }
 
-  if (dt_input.value() != dt_output.value()) {
-    return false;
+  // The input/output dtype match only applies when the output is quantized.
+  if (!has_float_output) {
+    auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
+    if (!dt_output.has_value() || dt_input.value() != dt_output.value()) {
+      return false;
+    }
   }
 
   // INT8 is 3 in ONNX_NAMESPACE::TensorProto_DataType

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -786,6 +786,133 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U8) {
                        qdq_model_fn, provider_options, 21, ExpectedEPNodeAssignment::All);
 }
 
+// Builds the float (reference) form of the NASNet reduction-cell pattern:
+//   X -> BatchNormalization -> Relu -> Conv -> Y
+template <typename FLOAT_TYPE>
+static GetTestModelFn BuildBatchNormFloatOutputTestCase(const TestInputDef<FLOAT_TYPE>& input_def,
+                                                        const std::vector<FLOAT_TYPE>& scale_data,
+                                                        const std::vector<FLOAT_TYPE>& bias_data,
+                                                        const std::vector<FLOAT_TYPE>& conv_w_data) {
+  QNN_ASSERT(input_def.IsRawData());
+  return [input_def, scale_data, bias_data, conv_w_data](ModelTestBuilder& builder) {
+    const auto& input_shape = input_def.GetShape();
+    const auto& input_data = input_def.GetRawData();
+    const int64_t num_channels = input_shape[1];
+
+    std::vector<FLOAT_TYPE> mean_vals(num_channels);
+    std::vector<FLOAT_TYPE> var_vals(num_channels);
+    ComputeChannelMeanAndVar<FLOAT_TYPE>(input_data, input_shape, mean_vals, var_vals);
+
+    MakeTestInput<FLOAT_TYPE>(builder, "X", input_def);
+    builder.MakeInitializer<FLOAT_TYPE>("scale", {num_channels}, scale_data);
+    builder.MakeInitializer<FLOAT_TYPE>("bias", {num_channels}, bias_data);
+    builder.MakeInitializer<FLOAT_TYPE>("mean", {num_channels}, mean_vals);
+    builder.MakeInitializer<FLOAT_TYPE>("var", {num_channels}, var_vals);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> bn_attrs;
+    bn_attrs.push_back(builder.MakeScalarAttribute("epsilon", 1e-5f));
+    builder.AddNode("bn", "BatchNormalization", {"X", "scale", "bias", "mean", "var"}, {"bn_out"}, "", bn_attrs);
+    builder.AddNode("relu", "Relu", {"bn_out"}, {"relu_out"});
+
+    builder.MakeInitializer<FLOAT_TYPE>("conv_w", {num_channels, num_channels, 1, 1}, conv_w_data);
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", std::string("NOTSET")));
+    builder.AddNode("conv", "Conv", {"relu_out", "conv_w"}, {"Y"}, "", conv_attrs);
+    builder.MakeOutput("Y");
+  };
+}
+
+// Builds the QDQ form where BN has DQ on its inputs but no Q on its output, so its result flows in
+// float through the Relu and Conv before the Conv's output Q re-quantizes it.
+//
+//   DQ(x) + DQ(scale) -> BN(float bias/mean/var) -> Relu -> Conv -> Q(graph output)
+template <typename InputQType, typename ScaleQType>
+static GetTestQDQModelFn<InputQType> BuildBatchNormFloatOutputQDQTestCase(
+    const TestInputDef<float>& input_def,
+    const std::vector<float>& scale_data,
+    const std::vector<float>& bias_data,
+    const std::vector<float>& conv_w_data) {
+  QNN_ASSERT(input_def.IsRawData());
+  return [input_def, scale_data, bias_data, conv_w_data](ModelTestBuilder& builder,
+                                                         std::vector<QuantParams<InputQType>>& output_qparams) {
+    const auto& input_shape = input_def.GetShape();
+    const auto& input_data = input_def.GetRawData();
+    const int64_t num_channels = input_shape[1];
+
+    // Input: float -> Q -> DQ.
+    bool symmetric = sizeof(InputQType) == sizeof(uint16_t);
+    MakeTestInput<float>(builder, "input", input_def);
+    QuantParams<InputQType> input_qparams = GetTestInputQuantParams<InputQType>(input_def, symmetric);
+    std::string input_dq = AddQDQNodePair<InputQType>(builder, "input_qdq", "input",
+                                                      input_qparams.scale, input_qparams.zero_point);
+
+    // Scale: float_init -> Q -> DQ (per-tensor). Makes scale a DQ output, not a raw initializer,
+    // which is what made the old selector treat it as "dynamic".
+    float scale_abs_max = 0.0f;
+    for (float v : scale_data) scale_abs_max = std::max(scale_abs_max, std::abs(v));
+    if (scale_abs_max == 0.0f) scale_abs_max = 1.0f;
+    float scale_qscale = scale_abs_max / static_cast<float>(std::numeric_limits<ScaleQType>::max());
+    builder.MakeInitializer<float>("scale_init", {num_channels}, scale_data);
+    std::string scale_dq = AddQDQNodePair<ScaleQType>(builder, "scale_qdq", "scale_init",
+                                                      scale_qscale, static_cast<ScaleQType>(0));
+
+    // Float bias/mean/var initializers.
+    builder.MakeInitializer<float>("bias", {num_channels}, bias_data);
+    std::vector<float> mean_vals(num_channels);
+    std::vector<float> var_vals(num_channels);
+    ComputeChannelMeanAndVar(input_data, input_shape, mean_vals, var_vals);
+    builder.MakeInitializer<float>("mean", {num_channels}, mean_vals);
+    builder.MakeInitializer<float>("var", {num_channels}, var_vals);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> bn_attrs;
+    bn_attrs.push_back(builder.MakeScalarAttribute("epsilon", 1e-5f));
+    // BN output "bn_out" has NO Q after it, so it stays float.
+    builder.AddNode("bn", "BatchNormalization",
+                    {input_dq, scale_dq, "bias", "mean", "var"}, {"bn_out"}, "", bn_attrs);
+
+    // Relu and Conv run in float; the graph re-enters quantized space only at the Conv's output Q.
+    builder.AddNode("relu", "Relu", {"bn_out"}, {"relu_out"});
+    builder.MakeInitializer<float>("conv_w", {num_channels, num_channels, 1, 1}, conv_w_data);
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", std::string("NOTSET")));
+    builder.AddNode("conv", "Conv", {"relu_out", "conv_w"}, {"conv_out"}, "", conv_attrs);
+
+    AddQDQNodePairWithOutputAsGraphOutput<InputQType>(builder, "output_qdq", "conv_out",
+                                                      output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+}
+
+// A BatchNormalization with no Q on its output must be captured by QNN (entire graph), not fall back
+// to CPU. Accuracy is compared against the float reference.
+TEST_F(QnnHTPBackendTests, BatchNorm_NoOutputQ) {
+  constexpr int64_t batch = 1;
+  constexpr int64_t channels = 2;
+  constexpr int64_t H = 4;
+  constexpr int64_t W = 4;
+  constexpr int64_t num_elems = batch * channels * H * W;
+
+  std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, num_elems);
+  std::vector<float> scale_data = {1.0f, 2.0f};
+  std::vector<float> bias_data = {1.1f, 2.1f};
+  // 1x1 conv weights keep spatial dims unchanged: shape [out_ch, in_ch, 1, 1].
+  // Use positive weights to avoid fp16 catastrophic cancellation: the float region executes in fp16
+  // on HTP, so a near-zero cancelled output would be precision-dominated.
+  std::vector<float> conv_w_data = {0.5f, 0.25f, 0.25f, 0.5f};
+
+  TestInputDef<float> input_def({batch, channels, H, W}, false, input_data);
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildBatchNormFloatOutputTestCase<float>(input_def, scale_data, bias_data, conv_w_data),
+                       BuildBatchNormFloatOutputQDQTestCase<uint8_t, int8_t>(input_def, scale_data, bias_data,
+                                                                             conv_w_data),
+                       provider_options,
+                       21,
+                       ExpectedEPNodeAssignment::All);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test


### PR DESCRIPTION
AIMET emits QDQ graphs where BatchNormalization is intentionally left with no Quantize on its output, signaling the result flows in float into a downstream island (e.g. BN -> Relu -> Conv in NASNet's reduction cell) before being re-quantized. The QNN EP's BN QDQ selector required a Q on the output, so these BNs dropped to a SingleNode unit where the DQ-fed scale looked dynamic, and the BN plus its neighbors fell back to CPU. That fragments the graph; AI Hub then reports "cannot capture the entire model".

Treat a quantized-input / no-output-Q BN as a float island and execute it in FP:
- Selector (qnn_ep_utils.cc): allow the empty-Q group and skip the input/output dtype-match check when the output is not quantized.
- Op builder (batchnormalization_op_builder.cc): reuse the existing float-param path (dequantize input, run BN in f32) but emit the BN's float result directly with no trailing Quantize; the island re-quantizes downstream at the next Q edge.
- CheckHtpDataTypes: accept quantized input with float output.

Adds QnnHTPBackendTests.BatchNorm_FloatIsland_NoOutputQ reproducing DQ -> BN -> Relu -> Conv -> Q and asserting whole-graph QNN assignment.