### PR TITLE
[QNN EP] Add hidden_size supplemental attribute to QNN LSTM and GRU op builders

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gru_op_builder.cc
@@ -205,6 +205,14 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   // Use the actual ONNX direction so QNN sees the correct gate ordering.
   // Time step ordering for reverse is handled by the unrolling loop (iterating t from seq-1 down to 0).
   std::vector<std::string> param_names;
+  // hidden_size
+  // The QAIRT SDK GRU opdef does not declare hidden_size as a formal QNN parameter; the native
+  // converter emits it as a supplemental attribute (assertAttrExists) required by the IR/DLC path.
+  // Only emit it for the IR backend (SERIALIZER).
+  if (IsIrBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_" + direction,
+                                           hidden_size, "hidden_size", param_names));
+  }
   const uint32_t qnn_direction = (direction == "reverse") ? QNN_OP_GRU_DIRECTION_REVERSE : QNN_OP_GRU_DIRECTION_FORWARD;
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_" + direction,
                                          qnn_direction, QNN_OP_GRU_PARAM_DIRECTION, param_names));
@@ -216,7 +224,7 @@ Ort::Status GRUOpBuilder::AddUnidirectionGRU(QnnModelWrapper& qnn_model_wrapper,
   // and post-concat transpose), then let CPU use time_major=true uniformly with layout=0.
   // time_major: on CPU, always use false to work around its batch dimension bug with time_major=true.
   // On other backends (HTP), follow the ONNX layout attribute: layout=0 -> true, layout=1 -> false.
-  const bool is_cpu_backend = qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::CPU;
+  const bool is_cpu_backend = IsCpuBackend(qnn_model_wrapper.GetQnnBackendType());
   const bool time_major = is_cpu_backend ? false : (layout == 0);
   RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), time_major,
                                      QNN_OP_GRU_PARAM_TIME_MAJOR, param_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
@@ -340,6 +340,15 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
   // params
   std::vector<std::string> param_names;
 
+  // hidden_size
+  // The QAIRT SDK LSTM opdef does not declare hidden_size as a formal QNN parameter; the native
+  // converter emits it as a supplemental attribute (assertAttrExists) required by the IR/DLC path.
+  // Only emit it for the IR backend (SERIALIZER).
+  if (IsIrBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           hidden_size, "hidden_size", param_names));
+  }
+
   // direction
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_" + direction,
                                          direction == "forward" ? QNN_OP_LSTM_DIRECTION_FORWARD : QNN_OP_LSTM_DIRECTION_REVERSE,

--- a/onnxruntime/test/providers/qnn/gru_test.cc
+++ b/onnxruntime/test/providers/qnn/gru_test.cc
@@ -217,6 +217,64 @@ static void RunCpuFP32GRUOpTest(const TestInputDef<float>& X_def,
                   tolerance);
 }
 
+// Verify that QNN IR backend successfully generates a DLC for a forward GRU model.
+// All optional inputs are provided as initializers so the IR backend can serialize the graph
+// without null tensor placeholders (the IR serializer does not support null optional tensors).
+TEST_F(QnnIRBackendTests, GRU_HiddenSize_DLC) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "ir";
+  provider_options["dump_qnn_ir_dlc"] = "1";
+  provider_options["dump_qnn_ir_dlc_dir"] = "gru_hidden_size_dlc_output";
+
+  std::filesystem::remove_all("gru_hidden_size_dlc_output");
+
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 2;
+  uint32_t hidden_size = 5;
+  uint32_t input_size = 3;
+  uint32_t seq_len = 4;
+
+  auto B_def = TestInputDef<float>({num_direction, 6 * hidden_size}, false, -0.1f, 0.1f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -0.1f, 0.1f);
+
+  // Build the model in memory and create a QNN IR backend session.
+  // The IR backend is a compile-only serializer: it generates a DLC during session initialization
+  // but does not support inference execution. We intentionally do not run inference here.
+  std::unique_ptr<ModelAndBuilder> model;
+  CreateModelInMemory(model,
+                      BuildGRUTestCase<float>(
+                          TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                          TestInputDef<float>({num_direction, 3 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                          TestInputDef<float>({num_direction, 3 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                          std::ref(B_def),                                                                         // B
+                          std::ref(H_def),                                                                         // initial_h
+                          true,                                                                                    // has_Y
+                          true,                                                                                    // has_Y_h
+                          direction,
+                          hidden_size,
+                          0 /*layout*/,
+                          0 /*linear_before_reset*/),
+                      22 /*opset_version*/);
+
+  Ort::SessionOptions session_opts;
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, provider_options);
+
+  // Session creation triggers QNN graph compile + DLC serialization. No inference is run.
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*GetOrtEnv(), model->model_data.data(),
+                                       model->model_data.size(), session_opts));
+
+  ASSERT_TRUE(std::filesystem::exists("gru_hidden_size_dlc_output"));
+  int dlc_count = 0;
+  for (const auto& entry : std::filesystem::directory_iterator("gru_hidden_size_dlc_output")) {
+    if (entry.path().extension() == ".dlc") ++dlc_count;
+  }
+  EXPECT_GT(dlc_count, 0);
+  std::filesystem::remove_all("gru_hidden_size_dlc_output");
+}
+
 // ============================================================
 // CPU FP32 Tests
 // ============================================================

--- a/onnxruntime/test/providers/qnn/lstm_test.cc
+++ b/onnxruntime/test/providers/qnn/lstm_test.cc
@@ -227,6 +227,70 @@ static GetTestQDQModelFn<InputQType> BuildQDQLSTMTestCase(const TestInputDef<flo
   };
 }
 
+// Verify that QNN IR backend successfully generates a DLC for a forward LSTM model.
+// This exercises the hidden_size supplemental attribute emission path in the QNN EP
+// ONNX Converter; DLC generation would fail with a hidden_size mismatch error without it.
+// All optional inputs are provided as initializers so the IR backend can serialize the graph
+// without null tensor placeholders (the IR serializer does not support null optional tensors).
+TEST_F(QnnIRBackendTests, LSTM_HiddenSize_DLC) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "ir";
+  provider_options["dump_qnn_ir_dlc"] = "1";
+  provider_options["dump_qnn_ir_dlc_dir"] = "lstm_hidden_size_dlc_output";
+
+  std::filesystem::remove_all("lstm_hidden_size_dlc_output");
+
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 2;
+  uint32_t hidden_size = 6;
+  uint32_t input_size = 3;
+  uint32_t seq_len = 4;
+
+  auto B_def = TestInputDef<float>({num_direction, 8 * hidden_size}, false, -0.1f, 0.1f);
+  auto H_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -0.1f, 0.1f);
+  auto C_def = TestInputDef<float>({num_direction, batch_size, hidden_size}, false, -0.1f, 0.1f);
+
+  // Build the model in memory and create a QNN IR backend session.
+  // The IR backend is a compile-only serializer: it generates a DLC during session initialization
+  // but does not support inference execution. We intentionally do not run inference here.
+  std::unique_ptr<ModelAndBuilder> model;
+  CreateModelInMemory(model,
+                      BuildLSTMTestCase<float>(
+                          TestInputDef<float>({seq_len, batch_size, input_size}, false, -1.0f, 1.0f),              // X
+                          TestInputDef<float>({num_direction, 4 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                          TestInputDef<float>({num_direction, 4 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                          std::ref(B_def),                                                                         // B
+                          std::ref(H_def),                                                                         // initial_h
+                          std::ref(C_def),                                                                         // initial_c
+                          std::nullopt,                                                                            // P (peephole — not supported by QNN LSTM)
+                          true,                                                                                    // has_Y
+                          true,                                                                                    // has_Y_h
+                          true,                                                                                    // has_Y_c
+                          direction,
+                          hidden_size,
+                          0 /*layout*/),
+                      22 /*opset_version*/);
+
+  Ort::SessionOptions session_opts;
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, session_opts, kQnnExecutionProvider, provider_options);
+
+  // Session creation triggers QNN graph compile + DLC serialization. No inference is run.
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*GetOrtEnv(), model->model_data.data(),
+                                       model->model_data.size(), session_opts));
+
+  // Verify at least one DLC was produced.
+  ASSERT_TRUE(std::filesystem::exists("lstm_hidden_size_dlc_output"));
+  int dlc_count = 0;
+  for (const auto& entry : std::filesystem::directory_iterator("lstm_hidden_size_dlc_output")) {
+    if (entry.path().extension() == ".dlc") ++dlc_count;
+  }
+  EXPECT_GT(dlc_count, 0);
+  std::filesystem::remove_all("lstm_hidden_size_dlc_output");
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64)
 
 // Runs an LSTM model on the QNN HTP backend. Checks the graph node assignment, and that inference


### PR DESCRIPTION
The QAIRT SDK LSTM and GRU opdef do not declare hidden_size as a formal QNN parameter. The native QAIRT converter emits it as a supplemental attribute (assertAttrExists, defined in IrOpDefs/LstmOp.cpp) required by the IR/DLC backend. The QNN EP path was missing this attribute, causing DLC generation to fail with a hidden_size mismatch error.

Emit hidden_size as a supplemental uint32 scalar param, gated on IsIrBackend() (QnnBackendType::SERIALIZER only). The QNN CPU and HTP backends do not expect supplemental params and must not receive it.

Tests added:
- QnnIRBackendTests.LSTM_HiddenSize_DLC (verifies DLC generation succeeds)
- QnnIRBackendTests.GRU_HiddenSize_DLC

Kill-test confirmed: removing the IsIrBackend() guard causes both DLC tests to fail with a hidden_size mismatch error.


