### PR TITLE
[OpBuilder] Add Shape op builder for QNN EP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -108,6 +108,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateScatterElementsOpBuilder("ScatterElements", *this);
   CreateScatterNDOpBuilder("ScatterND", *this);
   CreateSeluOpBuilder("Selu", *this);
+  CreateShapeOpBuilder("Shape", *this);
   CreateSimpleOpBuilder("Sigmoid", *this);
   CreateSimpleOpBuilder("Sign", *this);
   CreateSimpleOpBuilder("Sin", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -104,6 +104,7 @@ void CreateRotaryEmbeddingOpBuilder(const std::string& op_type, OpBuilderRegistr
 void CreateScatterElementsOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateScatterNDOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateShapeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSimpleOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSliceOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateSoftmaxOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -204,6 +204,7 @@ class BaseOpBuilder : public IOpBuilder {
         {"Round", QNN_OP_ELEMENT_WISE_UNARY},
         {"ScatterElements", QNN_OP_SCATTER_ELEMENTS},
         {"ScatterND", QNN_OP_SCATTER_ND},
+        {"Shape", QNN_OP_SHAPE},
         {"Sigmoid", QNN_OP_SIGMOID},
         {"Sign", QNN_OP_ELEMENT_WISE_UNARY},
         {"SimplifiedLayerNormalization", QNN_OP_RMS_NORM},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -13,7 +13,7 @@ namespace qnn {
 
 // Shape op builder.
 // Maps ONNX Shape -> QNN Shape. ONNX Shape produces an int64 1-D tensor; QNN requires the
-// output to be uint32/int32, so the int64 output is downcast to int32 (BaseOpBuilder::ProcessOutputs
+// output to be int32, so the int64 output is downcast to int32 (BaseOpBuilder::ProcessOutputs
 // inserts a Cast back to int64 when the output is a graph output). For intermediate outputs,
 // the QNN tensor type remains INT_32 and downstream ops consume it directly.
 // The ONNX `start`/`end` attributes are mapped to the QNN `start`/`end` scalar params (uint32).
@@ -34,14 +34,12 @@ class ShapeOpBuilder : public BaseOpBuilder {
 };
 
 Qnn_DataType_t ShapeOpBuilder::GetSupportedOutputDataType(size_t index, Qnn_DataType_t qnn_data_type) const {
-  // ONNX Shape has an int64 output, but QNN requires uint32 or int32.
-  // If this node produces a graph output, BaseOpBuilder::ProcessOutputs() adds a Cast node after the Shape op.
-  // Otherwise, it just sets the output type to uint32 or int32.
+  // ONNX Shape always produces an int64 output (no unsigned variant per the ONNX spec), but QNN
+  // requires int32. If this node produces a graph output, BaseOpBuilder::ProcessOutputs() adds a
+  // Cast node after the Shape op. Otherwise, it just sets the output type to int32.
   ORT_UNUSED_PARAMETER(index);
   if (qnn_data_type == QNN_DATATYPE_INT_64) {
     return QNN_DATATYPE_INT_32;
-  } else if (qnn_data_type == QNN_DATATYPE_UINT_64) {
-    return QNN_DATATYPE_UINT_32;
   }
 
   return qnn_data_type;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -58,8 +58,9 @@ Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   const int64_t rank = static_cast<int64_t>(input_shape.size());
   RETURN_IF(rank < 1, "QNN Shape requires an input of rank >= 1.");
 
-  // ONNX `start`/`end` attributes (opset >= 15). Negative values index from the end and are
-  // clamped to [0, rank], matching the ONNX Shape spec.
+  // Step 1: Resolve `start`/`end` per the ONNX Shape spec (opset >= 15). The reference op is
+  // `data.shape[start:end]`: negative values count from the end (add rank), then both are clamped
+  // to [0, rank]. The resolved output length is max(0, end - start) (start >= end => empty shape).
   OrtNodeAttrHelper node_helper(node_unit);
   int64_t start = node_helper.Get("start", static_cast<int64_t>(0));
   int64_t end = node_helper.Get("end", rank);
@@ -72,13 +73,19 @@ Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   }
   start = std::min<int64_t>(std::max<int64_t>(start, 0), rank);
   end = std::min<int64_t>(std::max<int64_t>(end, 0), rank);
+  const int64_t output_length = std::max<int64_t>(0, end - start);
 
-  // QNN constraints: start must be in [0, rank] and end must be in [start+1, rank]
-  // (start == rank is valid for an empty slice at the tail end).
-  RETURN_IF_NOT(start >= 0 && start <= rank,
-                "QNN Shape requires the resolved `start` axis to be in range [0, rank].");
-  RETURN_IF_NOT(end >= start + 1 && end <= rank,
-                "QNN Shape requires the resolved `end` axis to be in range [start+1, rank].");
+  // Step 2: Postprocess to match the QNN op definition. Per QnnOpDef (MasterOpDef "Shape"), the
+  // output is a 1-D tensor of shape [M] with M = end - start, and QNN constrains `end` to
+  // [start + 1, N] -- i.e. M >= 1. QNN cannot represent a zero-length output, so the ONNX-valid
+  // empty-slice case (output_length == 0) has no QNN equivalent. Clamping `end` up to `start + 1`
+  // would silently produce a length-1 output and corrupt results, so instead we reject the op here.
+  // Returning an error from IsOpSupported() leaves the node unassigned, and it falls back to CPU EP.
+  RETURN_IF(output_length < 1,
+            "QNN Shape produces a 1-D output of length (end - start) and requires end >= start + 1; "
+            "the ONNX empty-slice case (start >= end) is not supported by QNN and falls back to CPU.");
+  // With output_length >= 1 we have end >= start + 1 and end <= rank, which also implies
+  // start in [0, rank - 1] (QNN's `start` constraint), so no separate start-range check is needed.
 
   std::vector<std::string> param_tensor_names;
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -1,0 +1,112 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Shape op builder.
+// Maps ONNX Shape -> QNN Shape. ONNX Shape produces an int64 1-D tensor; QNN requires the
+// output to be uint32/int32, so the int64 output is downcast to int32 (BaseOpBuilder::ProcessOutputs
+// inserts a Cast back to int64 when the output is a graph output).
+// The ONNX `start`/`end` attributes are mapped to the QNN `start`/`end` scalar params (uint32).
+class ShapeOpBuilder : public BaseOpBuilder {
+ public:
+  ShapeOpBuilder() : BaseOpBuilder("ShapeOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ShapeOpBuilder);
+
+ protected:
+  Qnn_DataType_t GetSupportedOutputDataType(size_t index,
+                                            Qnn_DataType_t qnn_data_type) const override ORT_MUST_USE_RESULT;
+
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+};
+
+Qnn_DataType_t ShapeOpBuilder::GetSupportedOutputDataType(size_t index, Qnn_DataType_t qnn_data_type) const {
+  // ONNX Shape has an int64 output, but QNN requires uint32 or int32.
+  // If this node produces a graph output, BaseOpBuilder::ProcessOutputs() adds a Cast node after the Shape op.
+  // Otherwise, it just sets the output type to uint32 or int32.
+  ORT_UNUSED_PARAMETER(index);
+  if (qnn_data_type == QNN_DATATYPE_INT_64) {
+    return QNN_DATATYPE_INT_32;
+  } else if (qnn_data_type == QNN_DATATYPE_UINT_64) {
+    return QNN_DATATYPE_UINT_32;
+  }
+
+  return qnn_data_type;
+}
+
+Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                        const OrtNodeUnit& node_unit,
+                                                        std::vector<std::string>&& input_names,
+                                                        const Ort::Logger& logger,
+                                                        bool do_op_validation) const {
+  const auto& inputs = node_unit.Inputs();
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input_shape),
+                "QNN EP: Cannot get input shape for Shape op.");
+  const int64_t rank = static_cast<int64_t>(input_shape.size());
+  RETURN_IF(rank < 1, "QNN Shape requires an input of rank >= 1.");
+
+  // ONNX `start`/`end` attributes (opset >= 15). Negative values index from the end and are
+  // clamped to [0, rank], matching the ONNX Shape spec.
+  OrtNodeAttrHelper node_helper(node_unit);
+  int64_t start = node_helper.Get("start", static_cast<int64_t>(0));
+  int64_t end = node_helper.Get("end", rank);
+
+  if (start < 0) {
+    start += rank;
+  }
+  if (end < 0) {
+    end += rank;
+  }
+  start = std::min<int64_t>(std::max<int64_t>(start, 0), rank);
+  end = std::min<int64_t>(std::max<int64_t>(end, 0), rank);
+
+  // QNN constraints: start must be in [0, rank] and end must be in [start+1, rank]
+  // (start == rank is valid for an empty slice at the tail end).
+  RETURN_IF_NOT(start >= 0 && start <= rank,
+                "QNN Shape requires the resolved `start` axis to be in range [0, rank].");
+  RETURN_IF_NOT(end >= start + 1 && end <= rank,
+                "QNN Shape requires the resolved `end` axis to be in range [start+1, rank].");
+
+  std::vector<std::string> param_tensor_names;
+
+  Qnn_Scalar_t start_qnn_scalar = QNN_SCALAR_INIT;
+  start_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
+  start_qnn_scalar.uint32Value = static_cast<uint32_t>(start);
+  QnnParamWrapper start_param(node_unit.Index(), node_unit.Name(), QNN_OP_SHAPE_PARAM_START, start_qnn_scalar);
+  param_tensor_names.push_back(start_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(start_param));
+
+  Qnn_Scalar_t end_qnn_scalar = QNN_SCALAR_INIT;
+  end_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
+  end_qnn_scalar.uint32Value = static_cast<uint32_t>(end);
+  QnnParamWrapper end_param(node_unit.Index(), node_unit.Name(), QNN_OP_SHAPE_PARAM_END, end_qnn_scalar);
+  param_tensor_names.push_back(end_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(end_param));
+
+  RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
+                                 std::move(input_names),
+                                 std::move(param_tensor_names),
+                                 logger, do_op_validation, QNN_OP_SHAPE));
+
+  return Ort::Status();
+}
+
+void CreateShapeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<ShapeOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/shape_op_builder.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -45,6 +46,12 @@ Qnn_DataType_t ShapeOpBuilder::GetSupportedOutputDataType(size_t index, Qnn_Data
   return qnn_data_type;
 }
 
+// Resolves the ONNX Shape `start`/`end` attributes against the input rank per the ONNX spec
+// (opset >= 15). Mirrors `data.shape[start:end]`: negative values count from the end (add rank),
+// then both are clamped to [0, rank]. Returns the resolved (start, end, output_length) where
+// output_length = max(0, end - start).
+// Defined inline in shape_op_builder.h for unit-test visibility.
+
 Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                         const OrtNodeUnit& node_unit,
                                                         std::vector<std::string>&& input_names,
@@ -57,22 +64,14 @@ Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   const int64_t rank = static_cast<int64_t>(input_shape.size());
   RETURN_IF(rank < 1, "QNN Shape requires an input of rank >= 1.");
 
-  // Step 1: Resolve `start`/`end` per the ONNX Shape spec (opset >= 15). The reference op is
-  // `data.shape[start:end]`: negative values count from the end (add rank), then both are clamped
-  // to [0, rank]. The resolved output length is max(0, end - start) (start >= end => empty shape).
+  // Step 1: Resolve `start`/`end` per the ONNX Shape spec (opset >= 15).
   OrtNodeAttrHelper node_helper(node_unit);
-  int64_t start = node_helper.Get("start", static_cast<int64_t>(0));
-  int64_t end = node_helper.Get("end", rank);
-
-  if (start < 0) {
-    start += rank;
-  }
-  if (end < 0) {
-    end += rank;
-  }
-  start = std::min<int64_t>(std::max<int64_t>(start, 0), rank);
-  end = std::min<int64_t>(std::max<int64_t>(end, 0), rank);
-  const int64_t output_length = std::max<int64_t>(0, end - start);
+  const int64_t start_attr = node_helper.Get("start", static_cast<int64_t>(0));
+  const int64_t end_attr = node_helper.Get("end", rank);
+  int64_t start = 0;
+  int64_t end = 0;
+  int64_t output_length = 0;
+  ResolveShapeBounds(rank, start_attr, end_attr, start, end, output_length);
 
   // Step 2: Postprocess to match the QNN op definition. Per QnnOpDef (MasterOpDef "Shape"), the
   // output is a 1-D tensor of shape [M] with M = end - start, and QNN constrains `end` to

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -90,19 +90,13 @@ Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
 
   std::vector<std::string> param_tensor_names;
 
-  Qnn_Scalar_t start_qnn_scalar = QNN_SCALAR_INIT;
-  start_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-  start_qnn_scalar.uint32Value = static_cast<uint32_t>(start);
-  QnnParamWrapper start_param(node_unit.Index(), node_unit.Name(), QNN_OP_SHAPE_PARAM_START, start_qnn_scalar);
-  param_tensor_names.push_back(start_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(start_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(start), QNN_OP_SHAPE_PARAM_START,
+                                         param_tensor_names));
 
-  Qnn_Scalar_t end_qnn_scalar = QNN_SCALAR_INIT;
-  end_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-  end_qnn_scalar.uint32Value = static_cast<uint32_t>(end);
-  QnnParamWrapper end_param(node_unit.Index(), node_unit.Name(), QNN_OP_SHAPE_PARAM_END, end_qnn_scalar);
-  param_tensor_names.push_back(end_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(end_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(end), QNN_OP_SHAPE_PARAM_END,
+                                         param_tensor_names));
 
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
                                  std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -13,10 +13,9 @@ namespace onnxruntime {
 namespace qnn {
 
 // Shape op builder.
-// Maps ONNX Shape -> QNN Shape. ONNX Shape produces an int64 1-D tensor; QNN requires the
-// output to be int32, so the int64 output is downcast to int32 (BaseOpBuilder::ProcessOutputs
-// inserts a Cast back to int64 when the output is a graph output). For intermediate outputs,
-// the QNN tensor type remains INT_32 and downstream ops consume it directly.
+// Maps ONNX Shape -> QNN Shape. ONNX Shape produces an int64 1-D tensor; QNN generates output
+// in int32. If the output is not an intermediate tensor in the graph, then a Cast op is
+// inserted to convert to int64.
 // The ONNX `start`/`end` attributes are mapped to the QNN `start`/`end` scalar params (uint32).
 class ShapeOpBuilder : public BaseOpBuilder {
  public:
@@ -46,12 +45,6 @@ Qnn_DataType_t ShapeOpBuilder::GetSupportedOutputDataType(size_t index, Qnn_Data
   return qnn_data_type;
 }
 
-// Resolves the ONNX Shape `start`/`end` attributes against the input rank per the ONNX spec
-// (opset >= 15). Mirrors `data.shape[start:end]`: negative values count from the end (add rank),
-// then both are clamped to [0, rank]. Returns the resolved (start, end, output_length) where
-// output_length = max(0, end - start).
-// Defined inline in shape_op_builder.h for unit-test visibility.
-
 Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                         const OrtNodeUnit& node_unit,
                                                         std::vector<std::string>&& input_names,
@@ -68,10 +61,8 @@ Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   OrtNodeAttrHelper node_helper(node_unit);
   const int64_t start_attr = node_helper.Get("start", static_cast<int64_t>(0));
   const int64_t end_attr = node_helper.Get("end", rank);
-  int64_t start = 0;
-  int64_t end = 0;
-  int64_t output_length = 0;
-  ResolveShapeBounds(rank, start_attr, end_attr, start, end, output_length);
+  const auto [start, end] = ResolveShapeBounds(rank, start_attr, end_attr);
+  const int64_t output_length = std::max<int64_t>(0, end - start);
 
   // Step 2: Postprocess to match the QNN op definition. Per QnnOpDef (MasterOpDef "Shape"), the
   // output is a 1-D tensor of shape [M] with M = end - start, and QNN constrains `end` to
@@ -98,7 +89,7 @@ Ort::Status ShapeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
                                  std::move(input_names),
                                  std::move(param_tensor_names),
-                                 logger, do_op_validation, QNN_OP_SHAPE));
+                                 logger, do_op_validation, GetQnnOpType(node_unit.OpType())));
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.cc
@@ -14,7 +14,8 @@ namespace qnn {
 // Shape op builder.
 // Maps ONNX Shape -> QNN Shape. ONNX Shape produces an int64 1-D tensor; QNN requires the
 // output to be uint32/int32, so the int64 output is downcast to int32 (BaseOpBuilder::ProcessOutputs
-// inserts a Cast back to int64 when the output is a graph output).
+// inserts a Cast back to int64 when the output is a graph output). For intermediate outputs,
+// the QNN tensor type remains INT_32 and downstream ops consume it directly.
 // The ONNX `start`/`end` attributes are mapped to the QNN `start`/`end` scalar params (uint32).
 class ShapeOpBuilder : public BaseOpBuilder {
  public:

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.h
@@ -5,21 +5,17 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <utility>
 
 namespace onnxruntime {
 namespace qnn {
 
 // Resolves the ONNX Shape `start`/`end` attributes against the input rank per the ONNX spec
 // (opset >= 15). Mirrors `data.shape[start:end]`: negative values count from the end (add rank),
-// then both are clamped to [0, rank]. Returns the resolved (start, end, output_length) where
-// output_length = max(0, end - start).
-//
-// Defined inline in this header so it can be unit-tested directly from the test binary; the
-// op-builder also includes this header to ensure a single source of truth.
-inline void ResolveShapeBounds(int64_t rank, int64_t start_attr, int64_t end_attr,
-                               int64_t& start, int64_t& end, int64_t& output_length) {
-  start = start_attr;
-  end = end_attr;
+// then both are clamped to [0, rank]. Returns the resolved (start, end) pair.
+inline std::pair<int64_t, int64_t> ResolveShapeBounds(int64_t rank, int64_t start_attr, int64_t end_attr) {
+  int64_t start = start_attr;
+  int64_t end = end_attr;
   if (start < 0) {
     start += rank;
   }
@@ -28,7 +24,7 @@ inline void ResolveShapeBounds(int64_t rank, int64_t start_attr, int64_t end_att
   }
   start = std::min<int64_t>(std::max<int64_t>(start, 0), rank);
   end = std::min<int64_t>(std::max<int64_t>(end, 0), rank);
-  output_length = std::max<int64_t>(0, end - start);
+  return {start, end};
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/shape_op_builder.h
@@ -1,0 +1,35 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace onnxruntime {
+namespace qnn {
+
+// Resolves the ONNX Shape `start`/`end` attributes against the input rank per the ONNX spec
+// (opset >= 15). Mirrors `data.shape[start:end]`: negative values count from the end (add rank),
+// then both are clamped to [0, rank]. Returns the resolved (start, end, output_length) where
+// output_length = max(0, end - start).
+//
+// Defined inline in this header so it can be unit-tested directly from the test binary; the
+// op-builder also includes this header to ensure a single source of truth.
+inline void ResolveShapeBounds(int64_t rank, int64_t start_attr, int64_t end_attr,
+                               int64_t& start, int64_t& end, int64_t& output_length) {
+  start = start_attr;
+  end = end_attr;
+  if (start < 0) {
+    start += rank;
+  }
+  if (end < 0) {
+    end += rank;
+  }
+  start = std::min<int64_t>(std::max<int64_t>(start, 0), rank);
+  end = std::min<int64_t>(std::max<int64_t>(end, 0), rank);
+  output_length = std::max<int64_t>(0, end - start);
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/shape_op_test.cc
+++ b/onnxruntime/test/providers/qnn/shape_op_test.cc
@@ -1,0 +1,115 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+// Runs a Shape model on the specified QNN backend. Checks the graph node assignment and that inference
+// outputs for QNN EP and CPU EP match.
+static void RunShapeOpTest(TestInputDef<float> input_def,
+                           const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                           ExpectedEPNodeAssignment expected_ep_assignment,
+                           const std::string& backend_name = "cpu",
+                           int opset = 15) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend_name;
+
+  RunQnnModelTest(BuildOpTestCase<float>("shape_node", "Shape", {input_def}, {}, attrs),
+                  provider_options,
+                  opset,
+                  expected_ep_assignment);
+}
+
+//
+// CPU tests:
+//
+
+// Test that Shape with default attributes (no start/end) works on QNN CPU backend.
+// Input: float32 [3, 4, 5]. Expected output: int64 [3, 4, 5] (QNN EP downcasts to int32 internally,
+// then BaseOpBuilder::ProcessOutputs casts back to int64 for the graph output).
+TEST_F(QnnCPUBackendTests, Shape_Default_Float) {
+  RunShapeOpTest(TestInputDef<float>({3, 4, 5}, false, -10.0f, 10.0f),
+                 {},  // Default attributes: start=0, end=rank.
+                 ExpectedEPNodeAssignment::All, "cpu", 15);
+}
+
+// Test that Shape with explicit start=1 and end=3 works on QNN CPU backend.
+// Input: float32 [2, 3, 4, 5]. Expected output: int64 [3, 4].
+TEST_F(QnnCPUBackendTests, Shape_StartEnd_Float) {
+  RunShapeOpTest(TestInputDef<float>({2, 3, 4, 5}, false, -10.0f, 10.0f),
+                 {test::MakeAttribute("start", static_cast<int64_t>(1)),
+                  test::MakeAttribute("end", static_cast<int64_t>(3))},
+                 ExpectedEPNodeAssignment::All, "cpu", 15);
+}
+
+// Test that Shape with a negative start index is normalized correctly on QNN CPU backend.
+// Input: float32 [2, 3, 4]. start=-2 normalizes to rank+(-2) = 3-2 = 1, end=3.
+// Expected output: int64 [3, 4].
+TEST_F(QnnCPUBackendTests, Shape_NegativeStart_Float) {
+  RunShapeOpTest(TestInputDef<float>({2, 3, 4}, false, -10.0f, 10.0f),
+                 {test::MakeAttribute("start", static_cast<int64_t>(-2)),
+                  test::MakeAttribute("end", static_cast<int64_t>(3))},
+                 ExpectedEPNodeAssignment::All, "cpu", 15);
+}
+
+// Test that Shape on a 1-D input works on QNN CPU backend.
+// Input: float32 [7]. Expected output: int64 [7].
+TEST_F(QnnCPUBackendTests, Shape_1D_Float) {
+  RunShapeOpTest(TestInputDef<float>({7}, false, -10.0f, 10.0f),
+                 {},  // Default attributes: start=0, end=rank=1.
+                 ExpectedEPNodeAssignment::All, "cpu", 15);
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+//
+// HTP tests:
+//
+
+// Test that Shape with default attributes works on QNN HTP backend.
+// Shape is a data-independent op (output depends only on input shape, not values),
+// so HTP support may vary by SDK version. The test verifies that when the op is
+// assigned to QNN EP the outputs match the CPU EP baseline.
+TEST_F(QnnHTPBackendTests, Shape_Default_Float_HTP) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildOpTestCase<float>("shape_node", "Shape",
+                                         {TestInputDef<float>({3, 4, 5}, false, -10.0f, 10.0f)},
+                                         {}, {}),
+                  provider_options,
+                  15,
+                  ExpectedEPNodeAssignment::All);
+}
+
+// Test that Shape with start=1 and end=3 works on QNN HTP backend.
+// Input: float32 [2, 3, 4, 5]. Expected output: int64 [3, 4].
+TEST_F(QnnHTPBackendTests, Shape_StartEnd_Float_HTP) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildOpTestCase<float>("shape_node", "Shape",
+                                         {TestInputDef<float>({2, 3, 4, 5}, false, -10.0f, 10.0f)},
+                                         {},
+                                         {test::MakeAttribute("start", static_cast<int64_t>(1)),
+                                          test::MakeAttribute("end", static_cast<int64_t>(3))}),
+                  provider_options,
+                  15,
+                  ExpectedEPNodeAssignment::All);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/shape_op_test.cc
+++ b/onnxruntime/test/providers/qnn/shape_op_test.cc
@@ -69,6 +69,19 @@ TEST_F(QnnCPUBackendTests, Shape_1D_Float) {
                  ExpectedEPNodeAssignment::All, "cpu", 15);
 }
 
+// Test that an empty shape slice (start == end) is NOT assigned to QNN EP.
+// ONNX defines output_length = max(0, end - start), so start == end is a valid empty slice
+// (length 0). However, QNN's Shape op (QnnOpDef MasterOpDef) requires end in [start + 1, N] and
+// cannot represent a zero-length output, so the op builder rejects it during IsOpSupported() and
+// the node falls back to the CPU EP.
+// Input: float32 [2, 3, 4, 5]. start=2, end=2 -> empty slice.
+TEST_F(QnnCPUBackendTests, Shape_EmptySlice_Float) {
+  RunShapeOpTest(TestInputDef<float>({2, 3, 4, 5}, false, -10.0f, 10.0f),
+                 {test::MakeAttribute("start", static_cast<int64_t>(2)),
+                  test::MakeAttribute("end", static_cast<int64_t>(2))},
+                 ExpectedEPNodeAssignment::None, "cpu", 15);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:

--- a/onnxruntime/test/providers/qnn/shape_test.cc
+++ b/onnxruntime/test/providers/qnn/shape_test.cc
@@ -6,12 +6,197 @@
 #include <string>
 #include <vector>
 
+#include "core/providers/qnn/builder/opbuilder/shape_op_builder.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 
 #include "gtest/gtest.h"
 
 namespace onnxruntime {
 namespace test {
+
+//
+// ResolveShapeBounds unit tests (pure function — no QNN runtime required).
+// Scenarios mirror the ONNX Shape spec (opset >= 15) and the 20-case checklist from PR review.
+//
+namespace {
+
+struct ResolvedBounds {
+  int64_t start;
+  int64_t end;
+  int64_t output_length;
+};
+
+ResolvedBounds Resolve(int64_t rank, int64_t start_attr, int64_t end_attr) {
+  ResolvedBounds r{};
+  qnn::ResolveShapeBounds(rank, start_attr, end_attr, r.start, r.end, r.output_length);
+  return r;
+}
+
+}  // namespace
+
+// (1) Defaults: start=0, end=rank -> full shape.
+TEST(QnnResolveShapeBoundsTest, DefaultsCoverFullRank) {
+  auto r = Resolve(/*rank=*/4, /*start_attr=*/0, /*end_attr=*/4);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 4);
+}
+
+// (2) start default (0), explicit end < rank.
+TEST(QnnResolveShapeBoundsTest, DefaultStartExplicitEnd) {
+  auto r = Resolve(4, 0, 2);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 2);
+  EXPECT_EQ(r.output_length, 2);
+}
+
+// (3) Explicit start, end default (=rank).
+TEST(QnnResolveShapeBoundsTest, ExplicitStartDefaultEnd) {
+  auto r = Resolve(4, 1, 4);
+  EXPECT_EQ(r.start, 1);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 3);
+}
+
+// (4) Basic positive: start=1, end=3.
+TEST(QnnResolveShapeBoundsTest, BasicPositiveRange) {
+  auto r = Resolve(4, 1, 3);
+  EXPECT_EQ(r.start, 1);
+  EXPECT_EQ(r.end, 3);
+  EXPECT_EQ(r.output_length, 2);
+}
+
+// (5) Full span: start=0, end=rank.
+TEST(QnnResolveShapeBoundsTest, FullSpanZeroToRank) {
+  auto r = Resolve(5, 0, 5);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 5);
+  EXPECT_EQ(r.output_length, 5);
+}
+
+// (6) Negative start: start=-1 normalizes to rank-1.
+TEST(QnnResolveShapeBoundsTest, NegativeStart) {
+  auto r = Resolve(4, -1, 4);
+  EXPECT_EQ(r.start, 3);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 1);
+}
+
+// (7) Negative end: end=-1 normalizes to rank-1.
+TEST(QnnResolveShapeBoundsTest, NegativeEnd) {
+  auto r = Resolve(4, 0, -1);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 3);
+  EXPECT_EQ(r.output_length, 3);
+}
+
+// (8) Negative start exactly at -rank: start=-r normalizes to 0.
+TEST(QnnResolveShapeBoundsTest, NegativeStartEqualMinusRank) {
+  auto r = Resolve(4, -4, 4);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 4);
+}
+
+// (9) Both negative: start=-2, end=-1 -> (r-2, r-1).
+TEST(QnnResolveShapeBoundsTest, BothNegative) {
+  auto r = Resolve(4, -2, -1);
+  EXPECT_EQ(r.start, 2);
+  EXPECT_EQ(r.end, 3);
+  EXPECT_EQ(r.output_length, 1);
+}
+
+// (10) Clamp high: end > rank -> end clamped to rank.
+TEST(QnnResolveShapeBoundsTest, ClampEndAboveRank) {
+  auto r = Resolve(4, 0, 100);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 4);
+}
+
+// (11) Clamp high: start > rank -> start clamped to rank (empty result).
+TEST(QnnResolveShapeBoundsTest, ClampStartAboveRank) {
+  auto r = Resolve(4, 100, 4);
+  EXPECT_EQ(r.start, 4);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (12) Clamp low: start < -rank -> 0.
+TEST(QnnResolveShapeBoundsTest, ClampStartBelowMinusRank) {
+  auto r = Resolve(4, -100, 4);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 4);
+}
+
+// (13) Clamp low: end < -rank -> 0.
+TEST(QnnResolveShapeBoundsTest, ClampEndBelowMinusRank) {
+  auto r = Resolve(4, 0, -100);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 0);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (14) start > end -> empty result, output_length clamped to 0.
+TEST(QnnResolveShapeBoundsTest, StartGreaterThanEndIsEmpty) {
+  auto r = Resolve(4, 3, 1);
+  EXPECT_EQ(r.start, 3);
+  EXPECT_EQ(r.end, 1);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (15) start == end (mid-range) -> empty result.
+TEST(QnnResolveShapeBoundsTest, StartEqualsEndIsEmpty) {
+  auto r = Resolve(4, 2, 2);
+  EXPECT_EQ(r.start, 2);
+  EXPECT_EQ(r.end, 2);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (16) Scalar input (rank=0): defaults yield (0, 0).
+TEST(QnnResolveShapeBoundsTest, ScalarRankYieldsEmpty) {
+  auto r = Resolve(0, 0, 0);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 0);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (17) Rank 1: start=0, end=1 -> full shape (single dim).
+TEST(QnnResolveShapeBoundsTest, Rank1FullSpan) {
+  auto r = Resolve(1, 0, 1);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 1);
+  EXPECT_EQ(r.output_length, 1);
+}
+
+// (18) Boundary: start=rank, end=rank -> empty.
+TEST(QnnResolveShapeBoundsTest, BothAtRankIsEmpty) {
+  auto r = Resolve(4, 4, 4);
+  EXPECT_EQ(r.start, 4);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (19) Boundary: start=0, end=0 -> empty.
+TEST(QnnResolveShapeBoundsTest, BothAtZeroIsEmpty) {
+  auto r = Resolve(4, 0, 0);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 0);
+  EXPECT_EQ(r.output_length, 0);
+}
+
+// (20) Negative one past the lower edge: start=-(rank+1) -> clamped to 0.
+TEST(QnnResolveShapeBoundsTest, NegativeOnePastLowerEdge) {
+  auto r = Resolve(4, -5, 4);
+  EXPECT_EQ(r.start, 0);
+  EXPECT_EQ(r.end, 4);
+  EXPECT_EQ(r.output_length, 4);
+}
+
+//
+// Integration tests (QNN runtime required).
+//
 
 // Runs a Shape model on the specified QNN backend. Checks the graph node assignment and that inference
 // outputs for QNN EP and CPU EP match.
@@ -198,6 +383,84 @@ TEST_F(QnnHTPBackendTests, Shape_RankGreaterThan4_Unsupported) {
                   provider_options,
                   15,
                   ExpectedEPNodeAssignment::None);
+}
+
+// Builds a model from `build_model`, runs it on the CPU EP and the QNN HTP EP, and compares each
+// graph output element-by-element. Used by the Shape -> Gather composition tests below.
+static void RunShapeCompositionTest(const GetTestModelFn& build_model, int opset_version,
+                                    ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All) {
+  ModelTestBuilder helper;
+  build_model(helper);
+  const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+  opset_id_proto->set_domain(kOnnxDomain);
+  opset_id_proto->set_version(opset_version);
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::vector<Ort::Value> expected;
+  InferenceModelCPU(model_data, "Shape_Composition_CPU", helper.feeds_, expected);
+  std::vector<Ort::Value> actual;
+  InferenceModel(model_data, "Shape_Composition_QNN", provider_options, expected_ep_assignment,
+                 helper.feeds_, actual);
+
+  ASSERT_EQ(expected.size(), actual.size());
+  for (size_t out_idx = 0; out_idx < expected.size(); ++out_idx) {
+    auto exp_shape = expected[out_idx].GetTensorTypeAndShapeInfo().GetShape();
+    auto act_shape = actual[out_idx].GetTensorTypeAndShapeInfo().GetShape();
+    ASSERT_EQ(exp_shape, act_shape) << "Shape mismatch for output " << out_idx;
+    const size_t element_count = expected[out_idx].GetTensorTypeAndShapeInfo().GetElementCount();
+    const int64_t* exp_data = expected[out_idx].GetTensorData<int64_t>();
+    const int64_t* act_data = actual[out_idx].GetTensorData<int64_t>();
+    for (size_t i = 0; i < element_count; ++i) {
+      EXPECT_EQ(exp_data[i], act_data[i]) << "Mismatch at output " << out_idx << " index " << i;
+    }
+  }
+}
+
+// Shape output is consumed by Gather (intermediate-output path). The Shape tensor is INT_32 on the
+// QNN side via ShapeOpBuilder::GetSupportedOutputDataType; Gather then consumes it without an
+// INT_64 -> INT_32 cast (ProcessInt64Tensors is a no-op because the tensor is already INT_32).
+TEST_F(QnnHTPBackendTests, Shape_To_Gather_HTP) {
+  RunShapeCompositionTest([](ModelTestBuilder& builder) {
+    TestInputDef<float> input_def({2, 3, 4}, false, -10.0f, 10.0f);
+    MakeTestInput<float>(builder, "X", input_def);
+
+    // Shape(X) -> shape_out [3] (int64, intermediate).
+    builder.AddNode("shape_node", "Shape", {"X"}, {"shape_out"}, kOnnxDomain);
+
+    // Gather(shape_out, idx=1, axis=0) -> Y = shape_out[1] = 3.
+    builder.MakeInitializer<int64_t>("idx", {1}, {1});
+    builder.AddNode("gather_node", "Gather", {"shape_out", "idx"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))});
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{1});
+  },
+                          15);
+}
+
+// Shape output is BOTH a graph output AND consumed by a downstream node. This exercises the
+// dual-use path: BaseOpBuilder::ProcessOutputs inserts a Cast (INT_32 -> INT_64) for the graph
+// output, while the QNN Gather node consumes the native INT_64 graph-output tensor (which the
+// downstream op's ProcessInt64Tensors then casts back to INT_32).
+TEST_F(QnnHTPBackendTests, Shape_DualUse_HTP) {
+  RunShapeCompositionTest([](ModelTestBuilder& builder) {
+    TestInputDef<float> input_def({2, 3, 4}, false, -10.0f, 10.0f);
+    MakeTestInput<float>(builder, "X", input_def);
+
+    // Shape(X) -> shape_out is BOTH a graph output and a Gather input.
+    builder.AddNode("shape_node", "Shape", {"X"}, {"shape_out"}, kOnnxDomain);
+    builder.MakeOutput<int64_t>("shape_out", std::vector<int64_t>{3});
+
+    builder.MakeInitializer<int64_t>("idx", {1}, {1});
+    builder.AddNode("gather_node", "Gather", {"shape_out", "idx"}, {"Y"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))});
+    builder.MakeOutput<int64_t>("Y", std::vector<int64_t>{1});
+  },
+                          15);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/shape_test.cc
+++ b/onnxruntime/test/providers/qnn/shape_test.cc
@@ -185,6 +185,21 @@ TEST_F(QnnHTPBackendTests, Shape_Default_QDQ_U16_HTP) {
                               true);  // Use com.microsoft Q/DQ ops (uint16 zero-point not in ONNX opset 15)
 }
 
+// HtpOpDefSupplement caps Shape's input rank at 4 on HTP. A rank-5 input must fall back to CPU EP
+// (ExpectedEPNodeAssignment::None), mirroring ArgMaxMinU8_RankGreaterThan4_Unsupported.
+TEST_F(QnnHTPBackendTests, Shape_RankGreaterThan4_Unsupported) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildOpTestCase<float>("shape_node", "Shape",
+                                         {TestInputDef<float>({2, 3, 4, 5, 6}, false, -10.0f, 10.0f)},
+                                         {}, {}),
+                  provider_options,
+                  15,
+                  ExpectedEPNodeAssignment::None);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/shape_test.cc
+++ b/onnxruntime/test/providers/qnn/shape_test.cc
@@ -29,6 +29,44 @@ static void RunShapeOpTest(TestInputDef<float> input_def,
                   expected_ep_assignment);
 }
 
+// Builds a QDQ model wrapping ONNX Shape. Shape's output is int64 (data-independent), so only
+// the input is quantized -- there is no output Q/DQ node.
+template <typename QType = uint8_t>
+static GetTestQDQModelFn<QType> BuildQDQShapeTestCase(TestInputDef<float> input_def,
+                                                      const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                                      bool use_contrib_qdq = false) {
+  return [input_def, attrs, use_contrib_qdq](ModelTestBuilder& builder,
+                                             std::vector<QuantParams<QType>>& output_qparams) {
+    QNN_TEST_UNUSED_PARAMETER(output_qparams);
+    MakeTestInput(builder, "X", input_def);
+    QuantParams<QType> input_qparams = GetTestInputQuantParams<QType>(input_def);
+    std::string x_dq_name = AddQDQNodePair<QType>(builder, "qdq1", "X", input_qparams.scale,
+                                                  input_qparams.zero_point, use_contrib_qdq);
+
+    // DQ -> Shape
+    builder.AddNode("shape_node", "Shape", {x_dq_name.c_str()}, {"Y"}, "", attrs);
+    builder.MakeOutput("Y");
+  };
+}
+
+// Runs a QDQ Shape model on the QNN HTP backend and checks output accuracy vs the CPU EP baseline.
+template <typename QType = uint8_t>
+static void RunQDQShapeOpTest(TestInputDef<float> input_def,
+                              const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                              ExpectedEPNodeAssignment expected_ep_assignment,
+                              int opset = 15,
+                              bool use_contrib_qdq = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildOpTestCase<float>("shape_node", "Shape", {input_def}, {}, attrs),
+                       BuildQDQShapeTestCase<QType>(input_def, attrs, use_contrib_qdq),
+                       provider_options,
+                       opset,
+                       expected_ep_assignment);
+}
+
 //
 // CPU tests:
 //
@@ -87,7 +125,7 @@ TEST_F(QnnCPUBackendTests, Shape_EmptySlice_Float) {
 // HTP tests:
 //
 
-// Test that Shape with default attributes works on QNN HTP backend.
+// Test that Shape with default attributes works on QNN HTP backend (FP32 input).
 // Shape is a data-independent op (output depends only on input shape, not values),
 // so HTP support may vary by SDK version. The test verifies that when the op is
 // assigned to QNN EP the outputs match the CPU EP baseline.
@@ -104,7 +142,7 @@ TEST_F(QnnHTPBackendTests, Shape_Default_Float_HTP) {
                   ExpectedEPNodeAssignment::All);
 }
 
-// Test that Shape with start=1 and end=3 works on QNN HTP backend.
+// Test that Shape with start=1 and end=3 works on QNN HTP backend (FP32 input).
 // Input: float32 [2, 3, 4, 5]. Expected output: int64 [3, 4].
 TEST_F(QnnHTPBackendTests, Shape_StartEnd_Float_HTP) {
   ProviderOptions provider_options;
@@ -119,6 +157,32 @@ TEST_F(QnnHTPBackendTests, Shape_StartEnd_Float_HTP) {
                   provider_options,
                   15,
                   ExpectedEPNodeAssignment::All);
+}
+
+// QDQ (uint8) Shape with default attributes on HTP. Shape is data-independent so only the
+// input is quantized; output is int64 and passes through unquantized.
+TEST_F(QnnHTPBackendTests, Shape_Default_QDQ_U8_HTP) {
+  RunQDQShapeOpTest<uint8_t>(TestInputDef<float>({3, 4, 5}, false, -10.0f, 10.0f),
+                             {},
+                             ExpectedEPNodeAssignment::All);
+}
+
+// QDQ (uint8) Shape with start=1, end=3 on HTP.
+// Input: uint8-quantized [2, 3, 4, 5]. Expected output: int64 [3, 4].
+TEST_F(QnnHTPBackendTests, Shape_StartEnd_QDQ_U8_HTP) {
+  RunQDQShapeOpTest<uint8_t>(TestInputDef<float>({2, 3, 4, 5}, false, -10.0f, 10.0f),
+                             {test::MakeAttribute("start", static_cast<int64_t>(1)),
+                              test::MakeAttribute("end", static_cast<int64_t>(3))},
+                             ExpectedEPNodeAssignment::All);
+}
+
+// QDQ (uint16) Shape with default attributes on HTP.
+TEST_F(QnnHTPBackendTests, Shape_Default_QDQ_U16_HTP) {
+  RunQDQShapeOpTest<uint16_t>(TestInputDef<float>({3, 4, 5}, false, -10.0f, 10.0f),
+                              {},
+                              ExpectedEPNodeAssignment::All,
+                              15,     // opset
+                              true);  // Use com.microsoft Q/DQ ops (uint16 zero-point not in ONNX opset 15)
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/shape_test.cc
+++ b/onnxruntime/test/providers/qnn/shape_test.cc
@@ -3,6 +3,7 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -28,7 +29,10 @@ struct ResolvedBounds {
 
 ResolvedBounds Resolve(int64_t rank, int64_t start_attr, int64_t end_attr) {
   ResolvedBounds r{};
-  qnn::ResolveShapeBounds(rank, start_attr, end_attr, r.start, r.end, r.output_length);
+  const auto [start, end] = qnn::ResolveShapeBounds(rank, start_attr, end_attr);
+  r.start = start;
+  r.end = end;
+  r.output_length = std::max<int64_t>(0, end - start);
   return r;
 }
 
@@ -410,10 +414,14 @@ static void RunShapeCompositionTest(const GetTestModelFn& build_model, int opset
 
   ASSERT_EQ(expected.size(), actual.size());
   for (size_t out_idx = 0; out_idx < expected.size(); ++out_idx) {
-    auto exp_shape = expected[out_idx].GetTensorTypeAndShapeInfo().GetShape();
-    auto act_shape = actual[out_idx].GetTensorTypeAndShapeInfo().GetShape();
+    auto exp_info = expected[out_idx].GetTensorTypeAndShapeInfo();
+    auto act_info = actual[out_idx].GetTensorTypeAndShapeInfo();
+    ASSERT_EQ(exp_info.GetElementType(), act_info.GetElementType())
+        << "Element type mismatch for output " << out_idx;
+    auto exp_shape = exp_info.GetShape();
+    auto act_shape = act_info.GetShape();
     ASSERT_EQ(exp_shape, act_shape) << "Shape mismatch for output " << out_idx;
-    const size_t element_count = expected[out_idx].GetTensorTypeAndShapeInfo().GetElementCount();
+    const size_t element_count = exp_info.GetElementCount();
     const int64_t* exp_data = expected[out_idx].GetTensorData<int64_t>();
     const int64_t* act_data = actual[out_idx].GetTensorData<int64_t>();
     for (size_t i = 0; i < element_count; ++i) {


### PR DESCRIPTION
Add Shape op builder for QNN EP.
Downcasts the int64 output to int32 (same mechanism as ArgMax/ArgMin) and forwards the start/end attributes to the QNN start/end scalar params