### PR TITLE
Fix invalid use of std::vector::assign in utils

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.cc
@@ -179,7 +179,8 @@ Ort::Status BuildWeightQuantParams(const QnnModelWrapper& qmw,
   if (offsets.empty()) {
     offsets.assign(scales.size(), 0);
   } else if (offsets.size() == 1) {
-    offsets.assign(scales.size(), offsets[0]);
+    const int32_t offset = offsets[0];
+    offsets.assign(scales.size(), offset);
   } else {
     RETURN_IF_NOT(offsets.size() == scales.size(),
                   "B_zp length must equal B_scale length for per-channel");
@@ -209,7 +210,8 @@ Ort::Status PreDequantizePerChannelWeight(const QnnModelWrapper& qmw,
   if (zps_onnx.empty()) {
     zps_onnx.assign(scales.size(), 0);
   } else if (zps_onnx.size() == 1) {
-    zps_onnx.assign(scales.size(), zps_onnx[0]);
+    const int32_t zp = zps_onnx[0];
+    zps_onnx.assign(scales.size(), zp);
   } else {
     RETURN_IF_NOT(zps_onnx.size() == scales.size(), "Per-channel B_zp length mismatch");
   }


### PR DESCRIPTION
### Description
* Using `std::vector::assign` with a reference into the vector itself is undefined behavior (see https://eel.is/c++draft/sequence.reqmts#67).
* The [MSVC implementation](https://github.com/microsoft/STL/blob/926d9b2b1f75c6b0cdc7fe2d65630f9a81825c05/stl/inc/vector#L1349-L1353) triggers an assert in Debug builds if this is attempted.
* To avoid this, copy into a temporary before calling `assign`.

### Motivation and Context
* QnnHTPBackendTests.DQConvIntegerFusion_PerChannelBScale was causing a crash with an MSVC debug build because of the assertion.


