### PR TITLE
Add skip_backend_op_validation session option

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -242,6 +242,11 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 |---|---|
 |Backend path (string)|Path to the QNN IR backend library. Defaults to 'libQnnIr.so' or 'QnnIr.dll'. Only effective when `dump_qnn_ir_dlc` is enabled.|
 
+|`"skip_backend_op_validation"`|Description|
+|---|---|
+|'0'|Default. The target backend (e.g. HTP) validates each op config during DLC dump.|
+|'1'|Skip target-backend op validation during DLC dump and fall back to the serializer's generic op checks. Intended for device-less hosts (e.g. cloud x86_64 compilation): there the target backend validates against an arch-agnostic op table and over-rejects arch-specific (v73+) ops such as `ScatterElements(reduction=max)`, even though the op is valid on real hardware. Only effective when `dump_qnn_ir_dlc` is enabled. Op lowering still targets the intended backend; only the validation verdict changes.|
+
 |`"skip_qnn_version_check"`|Description|
 |---|---|
 |'0'|Default. Version check enabled.|

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -380,8 +380,13 @@ Ort::Status QnnBackendManager::LoadQnnSerializerBackend() {
   backend_api_version_ = backend_interface_provider->apiVersion.backendApiVersion;
   SetQnnBackendType(backend_id_);
 
-  // Store the validator interface (e.g., HTP) for use in backendValidateOpConfig calls.
-  qnn_validator_interface_ = backend_interface_provider->QNN_INTERFACE_VER_NAME;
+  // Store the validator interface (e.g., HTP) for use in backendValidateOpConfig calls. Leaving it
+  // null when disabled keeps validator interface/handle both null, so ValidateQnnNode() falls back
+  // to the serializer's generic checks -- correct on a device-less host where the target backend
+  // validates against an arch-agnostic op table and over-rejects arch-specific ops.
+  if (!skip_backend_op_validation_) {
+    qnn_validator_interface_ = backend_interface_provider->QNN_INTERFACE_VER_NAME;
+  }
 
   // Load the serializer backend and set it as the activate backend.
   QnnInterface_t* serializer_interface_provider{nullptr};
@@ -1932,7 +1937,7 @@ Ort::Status QnnBackendManager::SetupBackend(
     }
   }
 
-  if (status.IsOK() && qnn_serializer_config_) {
+  if (status.IsOK() && qnn_serializer_config_ && !skip_backend_op_validation_) {
     status = InitializeQnnValidatorLog();
     if (status.IsOK()) {
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "InitializeQnnValidatorLog succeed.");
@@ -1949,6 +1954,10 @@ Ort::Status QnnBackendManager::SetupBackend(
     if (status.IsOK()) {
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "CreateValidatorDevice succeed.");
     }
+  } else if (qnn_serializer_config_ && skip_backend_op_validation_) {
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO,
+                    "skip_backend_op_validation=1: skipping target-backend op validation; "
+                    "DLC dump will use the serializer's generic op validation.");
   }
 
   if (status.IsOK()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -128,6 +128,7 @@ struct QnnBackendManagerConfig {
   // profiling settings so it is set once at backend-manager construction and
   // remains constant for the manager's lifetime.
   bool enable_framework_op_trace = false;
+  bool skip_backend_op_validation = false;
 };
 
 class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager> {
@@ -160,6 +161,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
         soc_model_(config.soc_model),
         op_packages_(config.op_packages),
         skip_qnn_version_check_(config.skip_qnn_version_check),
+        skip_backend_op_validation_(config.skip_backend_op_validation),
         htp_power_config_manager_(power::HtpPowerConfigManager()),
         api_ptrs_(api_ptrs),
         logger_ptr_(&logger) {
@@ -715,6 +717,9 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   uint32_t soc_model_ = QNN_SOC_MODEL_UNKNOWN;
   const std::vector<OpPackage> op_packages_;
   bool skip_qnn_version_check_ = false;
+  // When true, skip wiring up the target-backend validator during DLC dump so that
+  // op validation falls back to the serializer's generic checks (see SetupBackend).
+  bool skip_backend_op_validation_ = false;
 
   power::HtpPowerConfigManager htp_power_config_manager_;
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1043,6 +1043,16 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                 false,
                                                 logger_);
 
+  // When dumping to DLC on a device-less host, the target backend validates op configs against an
+  // arch-agnostic op table and over-rejects arch-specific (v73+) ops. This option skips that
+  // validation, falling back to the serializer's generic checks. Default false keeps validation on.
+  static const std::string SKIP_BACKEND_OP_VALIDATION = "skip_backend_op_validation";
+  auto skip_backend_op_validation = ParseBoolOption(ort_api,
+                                                    session_options,
+                                                    FormatEPConfigKey(SKIP_BACKEND_OP_VALIDATION),
+                                                    false,
+                                                    logger_);
+
   // For context binary generation with weight sharing enabled, use the QnnBackendManager from the shared context if it exits
   // So that all graphs from later sessions will be compiled into the same QNN context
   if (
@@ -1069,7 +1079,8 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                      soc_model,
                                      op_packages,
                                      skip_qnn_version_check,
-                                     enable_framework_op_trace_},
+                                     enable_framework_op_trace_,
+                                     skip_backend_op_validation},
         ApiPtrs{ort_api, ep_api, model_editor_api}, logger_);
     if (htp_share_resource_optimization_ == 1) {
       SharedContext::GetInstance().SetSharedQnnBackendManager(qnn_backend_manager_);

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1086,6 +1086,86 @@ TEST_F(QnnHTPBackendTests, QnnIr_HtpValidator_OutputFiles) {
   EXPECT_EQ(file_count, 1);
 }
 
+#if defined(__linux__) && !defined(__aarch64__)
+// Dumps a single ScatterElements(reduction=max) model -- a v73+ op the device-less HTP validator
+// rejects -- to DLC. Rejection is silent (the op drops to CPU, no throw), so the .dlc count is the
+// only signal: 0 = rejected, 1 = accepted onto QNN.
+static int CountScatterElementsMaxDlcFiles(const std::filesystem::path& qnn_dlc_dir,
+                                           bool skip_backend_op_validation) {
+  std::filesystem::remove_all(qnn_dlc_dir);
+
+  ModelTestBuilder helper;
+  // `data` must be a runtime input, else ORT constant-folds ScatterElements away before the EP sees it.
+  std::vector<float> data(8, 0.0f);
+  helper.MakeInput<float>("data", {8}, data);
+  helper.MakeInitializer<int64_t>("indices", {1}, {0});
+  helper.MakeInitializer<float>("updates", {1}, {1.0f});
+  helper.AddNode("scatter", "ScatterElements", {"data", "indices", "updates"}, {"Y"}, kOnnxDomain,
+                 {test::MakeAttribute("reduction", std::string("max"))});
+  helper.MakeOutput("Y");
+
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 18}, {kMSDomain, 1}};
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  ProviderOptions options;
+  options["backend_path"] = "libQnnHtp.so";
+  options["offload_graph_io_quantization"] = "0";
+  options["dump_qnn_ir_dlc"] = "1";
+  options["dump_qnn_ir_dlc_dir"] = qnn_dlc_dir.string();
+  options["qnn_ir_backend_path"] = "libQnnIr.so";
+  if (skip_backend_op_validation) {
+    options["skip_backend_op_validation"] = "1";
+  }
+
+  Ort::SessionOptions so;
+  so.SetGraphOptimizationLevel(ORT_ENABLE_ALL);
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
+  ScopedOrtSession scoped(std::move(registered_ep_device),
+                          Ort::Session(*ort_env, model_data.data(), model_data.size(), so));
+
+  if (!std::filesystem::exists(qnn_dlc_dir)) {
+    return 0;
+  }
+  int file_count = 0;
+  for (const auto& entry : std::filesystem::directory_iterator(qnn_dlc_dir)) {
+    if (entry.is_regular_file() && entry.path().extension() == ".dlc") {
+      ++file_count;
+    }
+  }
+  return file_count;
+}
+
+// Real A/B regression test for skip_backend_op_validation, valid ONLY on a device-less x86_64 Linux
+// host. There the HTP backend validates op configs against a static, arch-agnostic op table (no NPU
+// bound) and over-rejects v73+ ops such as ScatterElements(reduction=max) -- the #438 regression.
+// On real HTP hardware the validator is device-bound and accepts the op, so flag-off and flag-on
+// would behave identically; hence the x86_64-only guard.
+TEST_F(QnnHTPBackendTests, QnnIr_ScatterElementsMax_SkipBackendOpValidation_AB) {
+  BackendSupport ir_backend_support = IsIRBackendSupported();
+  if (ir_backend_support == BackendSupport::UNSUPPORTED) {
+    GTEST_SKIP() << "QNN IR backend is not available! Skipping test.";
+  }
+  ASSERT_NE(ir_backend_support, BackendSupport::SUPPORT_ERROR) << "Failed to check if QNN IR backend is available.";
+
+  const std::filesystem::path qnn_dlc_dir = kDlcOutputDir;
+
+  // Flag off (#438 regression): backend validator rejects the op -> no QNN partition -> no DLC.
+  EXPECT_EQ(CountScatterElementsMaxDlcFiles(qnn_dlc_dir, /*skip_backend_op_validation*/ false), 0);
+
+  // Flag on (the fix): generic validation accepts the op -> it stays on QNN -> one DLC.
+  EXPECT_EQ(CountScatterElementsMaxDlcFiles(qnn_dlc_dir, /*skip_backend_op_validation*/ true), 1);
+}
+#endif  // defined(__linux__) && !defined(__aarch64__)
+
 // Test that QNN Saver generates the expected files for a model meant to run on the QNN HTP backend.
 TEST_F(QnnHTPBackendTests, DISABLED_QnnSaver_OutputFiles) {
   const std::filesystem::path qnn_saver_output_dir = "saver_output";


### PR DESCRIPTION
On device-less x86_64 hosts (cloud compilation), PR #438 routes DLC-dump op validation through the target backend, which runs against an arch-agnostic static op table and over-rejects v73+ kernels (error 3110). htp_arch/soc_model cannot fix this because QnnBackend_validateOpConfig takes only a backend handle -- the device-level arch never reaches the validation verdict without real hardware bridging device->backend via a context.

This adds a boolean EP session option `skip_backend_op_validation` that, when set, skips the target-backend validator initialization so that ValidateQnnNode falls through to the generic QnnIr serializer validation (pre-#438 behavior). The DLC serialization path is unaffected -- op lowering still uses the intended backend (e.g. HTP) and the IR serializer writes the DLC as before.
