### PR TITLE
[QNN EP] Error out when prepare_only is set without ep.context_enable

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -464,6 +464,12 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     ORT_CXX_LOG(logger_,
                 ORT_LOGGING_LEVEL_VERBOSE,
                 ("User specified option - enable_htp_prepare_only: " + prepare_only_str).c_str());
+
+    if (prepare_only_ && !context_cache_enabled_) {
+      throw std::runtime_error(
+          "enable_htp_prepare_only=1 requires ep.context_enable=1. "
+          "prepare_only mode only generates the context model for ahead-of-time compilation.");
+    }
   }
 
   std::string backend_path = kDefaultHtpBackendPath;
@@ -1545,13 +1551,6 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
                                                  const OrtGraph* graph,
                                                  OrtEpGraphSupportInfo* graph_support_info) noexcept {
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
-
-  if (ep->prepare_only_ && !ep->context_cache_enabled_) {
-    ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_WARNING,
-                "enable_htp_prepare_only=1 requires ep.context_enable=1. "
-                "Disabling enable_htp_prepare_only since context cache is not enabled.");
-    ep->prepare_only_ = false;
-  }
 
   const OrtNode* parent_node = nullptr;
   RETURN_IF_NOT_NULL(ep->ort_api.Graph_GetParentNode(graph, &parent_node));

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3177,8 +3177,8 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_CtxFileWritten) {
   CleanUpCtxFile(ctx_path);
 }
 
-// Test 2: prepare_only without explicit ep.context_enable gets disabled with a warning — session still creates.
-TEST_F(QnnHTPBackendTests, PrepareOnly_DisabledWhenContextCacheNotSet) {
+// Test 2: prepare_only without explicit ep.context_enable errors out at session creation
+TEST_F(QnnHTPBackendTests, PrepareOnly_ErrorsWhenContextCacheNotSet) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -3204,18 +3204,19 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_DisabledWhenContextCacheNotSet) {
   std::remove(ctx_path.c_str());
 
   Ort::SessionOptions so;
-  // Intentionally omit kOrtSessionOptionEpContextEnable — prepare_only_ should be disabled with warning.
+  // Intentionally omit kOrtSessionOptionEpContextEnable — session creation should fail.
   SetPrepareOnlyOptions(so, ctx_path, /*explicit_context_enable=*/false);
 
   RegisteredEpDeviceUniquePtr registered_ep_device;
   RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
 
-  // since ep.context_enable was not set. Session falls back to normal (non-prepare_only) mode.
+  // ep.context_enable was not set, so prepare_only is invalid: GetCapability returns EP_FAIL
+  // instead of silently downgrading to a normal JIT session.
   try {
     Ort::Session session(*ort_env, model_data_span.data(), model_data_span.size(), so);
-    SUCCEED();
+    FAIL() << "Expected session creation to fail when prepare_only is set without ep.context_enable";
   } catch (const std::exception& e) {
-    FAIL() << "Session creation should not throw: " << e.what();
+    ASSERT_THAT(e.what(), testing::HasSubstr("enable_htp_prepare_only=1 requires ep.context_enable=1"));
   }
 }
 


### PR DESCRIPTION


### Description
- Follow-up to PR #347
- Now: throw std::runtime_error in QnnEp ctor; CreateEpImpl converts to ORT_FAIL and aborts session creation.


### Motivation and Context
- Previously: warned and silently flipped prepare_only_=false → session ran as full JIT. Opposite of intent.

