### PR TITLE
[QNN EP] 2.3.0 Release Doc Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is maintained by Qualcomm. For the general ONNX Runtime project,
 
 ONNX Runtime supports hardware acceleration through **Execution Providers (EPs)**. The QNN EP is a *plugin* EP — a separately distributed shared library that plugs into a standard ONNX Runtime installation at runtime, without requiring a custom ORT build.
 
-> **QNN EP 2.2.0 is the Plugin QNN EP.** Starting with version 2.0.0, the QNN EP ships as a standalone plugin package (`onnxruntime-qnn>=2.0.0`) that works with any standard ORT installation — no custom build required. [Learn more about Plugin EPs →](https://onnxruntime.ai/docs/execution-providers/plugin-ep-libraries/)
+> **QNN EP 2.3.0 is the Plugin QNN EP.** Starting with version 2.0.0, the QNN EP ships as a standalone plugin package (`onnxruntime-qnn>=2.0.0`) that works with any standard ORT installation — no custom build required. [Learn more about Plugin EPs →](https://onnxruntime.ai/docs/execution-providers/plugin-ep-libraries/)
 
 <br/>
 <p align="center"><img width="80%" src="docs/images/PluginEP-final.png" /></p>
@@ -21,6 +21,18 @@ ONNX Runtime supports hardware acceleration through **Execution Providers (EPs)*
 | Distribution | Bundled with ORT | Separate package |
 | ORT build required | Yes | No |
 | Install | `pip install onnxruntime-qnn==1.x.x` | `pip install onnxruntime-qnn==`**`2.x.x`** |
+
+---
+
+## Platform Support
+
+| Package | Windows ARM64 | Windows x64 | Linux ARM64 | Linux x86_64 | Android ARM64 |
+|---|---|---|---|---|---|
+| Python Wheel | Inference | AOT compilation | Inference | AOT compilation | — |
+| NuGet | Inference | — | — | — | — |
+| ZIP | Inference | — | — | — | — |
+| tgz | — | — | Inference | — | — |
+| Maven | — | — | — | — | Inference |
 
 ---
 
@@ -39,6 +51,9 @@ The Plugin QNN EP workflow is different from the classic built-in EP. Follow the
 ```python
 import onnxruntime as ort
 import onnxruntime_qnn as qnn_ep
+
+# ORT QNN EP Version
+print(qnn_ep.__version__)
 
 # Register QNN EP library
 ep_lib_path = qnn_ep.get_library_path()
@@ -74,19 +89,20 @@ ort.unregister_execution_provider_library(lib_registration_name)
 ## Install
 
 ```bash
-pip install onnxruntime
-pip install onnxruntime-qnn
+pip install onnxruntime==1.24.4
+pip install onnxruntime-qnn==2.3.0
 ```
 
 **Requirements:**
 - Windows ARM64 (for on-device inference with Qualcomm NPU)
 - Windows X64 (for model quantization and AOT compilation)
 
-For NuGet: [`Qualcomm.ML.OnnxRuntime.QNN`](https://www.nuget.org/packages/Qualcomm.ML.OnnxRuntime.QNN) (Windows ARM64 only)
+For NuGet: [`Qualcomm.ML.OnnxRuntime.QNN`](https://www.nuget.org/packages/Qualcomm.ML.OnnxRuntime.QNN) (Windows ARM64 (ARM64X))
 
 ### Linux Wheels and .tar.gz Files
 
-- **2.2.0+**: Linux ARM64 Wheels and .tar.gz files available
+- **2.3.0+**: Linux x86_64 Wheels available (Preview)
+- **2.1.1+**: Linux ARM64 Wheels and .tgz files available
 - **2.1.0**: Linux ARM64 preview wheels available
 - **2.0.0**: No Linux ARM64 Wheels or .tar.gz files
 

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -38,16 +38,15 @@ download the Qualcomm AI Runtime SDK (QAIRT SDK) from [https://qpm.qualcomm.com/
 ONNX Runtime QNN EP has been built and tested with the following SDK version combinations on Windows:
 | QNN EP Version | QAIRT SDK Version | ONNX Runtime Version |
 |----------------|-------------------|----------------------|
-| v2.3.0         | v2.45.40           | v1.24.4              |
+| v2.3.0         | v2.47.0           | v1.24.4              |
 
-> **Note**: ONNX Runtime QNN EP is built and tested by using the arm64 ONNX Runtime SDK (ex: onnxruntime-win-arm64-1.24.0.zip).
+> **Note**: ONNX Runtime QNN EP 2.3.0 was built and tested with ORT 1.24.4 but it is compatible with ORT >= 1.24.1
 
 ## Build (Windows)
 For build instructions, please see the [BUILD page](./build.md).
 
 ## Pre-built Packages
 - [NuGet package](https://www.nuget.org/packages/Qualcomm.ML.OnnxRuntime.QNN)
-  - **Note**: The NuGet package only supports Windows ARM64 platform
 - [Python package](https://pypi.org/project/onnxruntime-qnn/)
   - Requirements:
     - Windows ARM64 (for inferencing on local device with Qualcomm NPU)
@@ -166,7 +165,13 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 
 |`"htp_arch"`|Description|
 |---|---|
-|Hardware architecture (string)|HTP Architecture number. Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10/topic/enum_QnnHtpDevice_8h_1a0ed976142af98a86143459dfd326f717.html) for valid values. Defaults to "0" (none).|
+|'0'|Default. No architecture specified.|
+|'68'|HTP v68.|
+|'69'|HTP v69.|
+|'73'|HTP v73.|
+|'75'|HTP v75.|
+
+Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10/topic/enum_QnnHtpDevice_8h_1a0ed976142af98a86143459dfd326f717.html) for the full list of valid values.
 
 |`"device_id"`|Description|
 |---|---|
@@ -191,6 +196,11 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 |---|---|
 |'0'|Default. Disabled.|
 |'1'|Enable the QNN HTP shared memory allocator. Requires libcdsprpc.so/dll to be available. [Code example](https://github.com/microsoft/onnxruntime/blob/544bdd60730270f49f6a5baafdff54065f626776/onnxruntime/test/shared_lib/test_inference.cc#L2262-L2354)|
+
+|`"extended_udma"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Enable HTP extended UDMA mode for better performance on supported hardware.|
 
 |`"op_packages"`|Description|
 |---|---|
@@ -229,6 +239,26 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 
 For more information, see the [Parallel Graph Preparation](#parallel-graph-preparation) section below.
 
+|`"htp_share_resource_optimization"`|Description|
+|---|---|
+|'1'|Enable HTP VTCM backup buffer sharing across sessions. Only `'1'` is a valid value. Supersedes `enable_vtcm_backup_buffer_sharing`. Requires QNN API version >= 2.26.|
+
+**Note:** `htp_share_resource_optimization` and `enable_vtcm_backup_buffer_sharing` both enable the same underlying feature. Prefer `htp_share_resource_optimization`.
+
+|`"disable_file_mapped_weights"`|Description|
+|---|---|
+|'0'|Default. File-mapped weights enabled (when supported).|
+|'1'|Disable file-mapped weight loading. File-mapped weights are only available on Windows ARM64 with QNN API >= 2.32; this option is ignored on other platforms.|
+
+|`"htp_bf16_enable"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Enable BFloat16 precision on the HTP backend. Requires `soc_model` to be set to a value >= 88 (e.g., SM8750). An error is raised at session creation if `soc_model` is unset or below 88.|
+
+|`"enable_htp_prepare_only"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Compile the model and save the QNN context binary, but skip inference. `OnRunStart`, `OnRunEnd`, `CreateState`, and `SetDynamicOptions` are all no-ops. Useful for a compile-once/run-later workflow. Requires `ep.context_enable=1`; silently disabled with a warning if context cache is not enabled.|
 
 ### Run Options
 
@@ -245,6 +275,9 @@ Run options can be set dynamically at runtime using the ORT Run API. These optio
 ```python
 import onnxruntime as ort
 import onnxruntime_qnn as qnn_ep
+
+# ORT QNN EP Version
+print(qnn_ep.__version__)
 
 # Register QNN EP library
 ep_lib_path = qnn_ep.get_library_path()
@@ -291,11 +324,13 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:Clip|fp16 supported since 1.18.0|
 |ai.onnx:Concat||
 |ai.onnx:Conv|3d supported since 1.18.0|
+|ai.onnx:ConvInteger|Supported exclusively via DynamicQuantizeLinear → ConvInteger fusion pattern|
 |ai.onnx:ConvTranspose|3d supported since 1.18.0|
 |ai.onnx:Cos||
 |ai.onnx:CumSum||
 |ai.onnx:DepthToSpace||
 |ai.onnx:DequantizeLinear||
+|ai.onnx:DynamicQuantizeLinear|Supported exclusively via ConvInteger and MatMulInteger fusion patterns|
 |ai.onnx:Div||
 |ai.onnx:Einsum||
 |ai.onnx:Elu||
@@ -314,10 +349,13 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:Greater||
 |ai.onnx:GreaterOrEqual||
 |ai.onnx:GridSample||
+|ai.onnx:GroupNormalization||
 |ai.onnx:HardSigmoid||
 |ai.onnx:HardSwish||
+|ai.onnx:Identity||
 |ai.onnx:InstanceNormalization||
 |ai.onnx:Inverse||
+|ai.onnx:IsNaN||
 |ai.onnx:LRN||
 |ai.onnx:LSTM||
 |ai.onnx:LayerNormalization||
@@ -328,6 +366,7 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:LogSoftmax||
 |ai.onnx:LpNormalization|p == 2|
 |ai.onnx:MatMul|Supported input data types on HTP backend: (uint8, uint8), (uint8, uint16), (uint16, uint8)|
+|ai.onnx:MatMulInteger|Supported exclusively via DynamicQuantizeLinear → MatMulInteger fusion pattern|
 |ai.onnx:Max||
 |ai.onnx:MaxPool||
 |ai.onnx:Mean||
@@ -335,12 +374,14 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:Mod||
 |ai.onnx:Mul||
 |ai.onnx:Neg||
+|ai.onnx:NonZero||
 |ai.onnx:Not||
 |ai.onnx:Or||
 |ai.onnx:PRelu|fp16, int32 supported since 1.18.0|
 |ai.onnx:Pad||
 |ai.onnx:Pow||
 |ai.onnx:QuantizeLinear||
+|ai.onnx:RandomNormalLike||
 |ai.onnx:RandomUniformLike||
 |ai.onnx:Reciprocal||
 |ai.onnx:ReduceL2||
@@ -350,8 +391,12 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:ReduceProd||
 |ai.onnx:ReduceSum||
 |ai.onnx:Relu||
+|ai.onnx:RMSNormalization||
+|ai.onnx:Reshape||
 |ai.onnx:Resize||
+|ai.onnx:RoiAlign||
 |ai.onnx:Round||
+|ai.onnx:RotaryEmbedding|HTP backend only|
 |ai.onnx:STFT||
 |ai.onnx:ScatterElements||
 |ai.onnx:ScatterND||
@@ -360,12 +405,14 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:Sin||
 |ai.onnx:Slice||
 |ai.onnx:Softmax||
+|ai.onnx:Softplus||
 |ai.onnx:SpaceToDepth||
 |ai.onnx:Split||
 |ai.onnx:Sqrt||
 |ai.onnx:Squeeze||
 |ai.onnx:Sub||
 |ai.onnx:Sum||
+|ai.onnx:Tan||
 |ai.onnx:Tanh||
 |ai.onnx:ThresholdedRelu||
 |ai.onnx:Tile||
@@ -375,11 +422,60 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:Upsample||
 |ai.onnx:Where||
 |com.microsoft:DequantizeLinear|Provides 16-bit integer dequantization support|
+|com.microsoft:FusedMatMul||
 |com.microsoft:Gelu||
+|com.microsoft.MatMulNBits||
 |com.microsoft:QuantizeLinear|Provides 16-bit integer quantization support|
-|com.microsoft.MatMulNBits|Supported bits == 4 on GPU backend|
+|com.microsoft:QuickGelu||
+|com.microsoft:RotaryEmbedding|HTP backend only|
+|com.microsoft:SimplifiedLayerNormalization||
 
 Supported data types vary by operator and QNN backend. Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10/topic/operations.html) for more information.
+
+## Supported operator fusions
+
+QNN EP recognizes the following multi-op patterns and fuses them into a single QNN operation or a more efficient subgraph. Fusions are attempted before individual op builders run.
+
+### DQ/Q and quantization fusions
+
+| Pattern | Fused QNN op | Notes |
+|---|---|---|
+| `DequantizeLinear → QuantizeLinear` | `QNN_OP_CONVERT` | Eliminates redundant re-quantization between compatible quantization schemes. Scalar scale/zero-point required. |
+| `(non-DQ node) → Cast(→float) → QuantizeLinear` | `QNN_OP_CONVERT` | Fuses a cast-to-float followed by quantization when there is no preceding DQ node. |
+| `DynamicQuantizeLinear → ConvInteger → Cast → Mul → [Add]` | `QNN_OP_CONV_2D` / `QNN_OP_DEPTH_WISE_CONV_2D` | ConvInteger is supported exclusively via this fusion. Dynamic quantization + integer convolution pattern. Constant int8/uint8 weights required. |
+| `DynamicQuantizeLinear → MatMulInteger → Cast → Mul → [Add]` | `QNN_OP_MAT_MUL` | MatMulInteger is supported exclusively via this fusion. Dynamic quantization + integer matmul pattern. Constant rank-2 int8/uint8 weights required. |
+
+### Low-Power Block Quantization (LPBQ) fusions
+
+| Pattern | Fused QNN op | Notes |
+|---|---|---|
+| `Scale_DQL → [W_QL →] W_DQL → Act_DQL → Gemm → QL` | `QNN_OP_FULLY_CONNECTED` | Per-block integer scales with per-channel float scales. HTP/NPU backend only. |
+| `Scale_DQL → [W_QL →] W_DQL → MatMul` | `QNN_OP_MAT_MUL` | Per-block integer scales with per-channel float scales. int4/int8 weights. HTP/NPU backend only. |
+
+### Operator decomposition fusions
+
+| Pattern | Fused QNN op | Notes |
+|---|---|---|
+| `[Div/Mul(√2)] → Erf → [Mul(0.5) →] Add(1) → Mul → [Mul(0.5)]` | `QNN_OP_GELU` | Matches two common Gelu decomposition variants (ErfAdd and ErfMul). Surrounding DQ nodes are also handled. |
+| `HardSigmoid(α=1/6, β=0.5) → Mul` (shared input) | `QNN_OP_ELEMENT_WISE_NEURON` (HardSwish) | Both inputs to Mul must originate from the same source tensor. |
+| `ReduceMean → Sub → Pow(2) → ReduceMean → Add(ε) → Sqrt → Div → Mul(γ) → Add(β)` | `QNN_OP_LAYER_NORM` | Matches the manual LayerNorm decomposition. Gamma and beta must be constants. |
+| `Mul(scalar constant) → Softmax` | `QNN_OP_SOFTMAX` | The scalar multiplier is folded into the beta parameter of QNN's Softmax. |
+
+### Layout and reshape fusions
+
+| Pattern | Fused QNN op | Notes |
+|---|---|---|
+| `Transpose → Reshape → Transpose → Reshape → Transpose` | `QNN_OP_CHANNEL_SHUFFLE` | 5-node pattern. Head and tail transposes must cancel; middle transpose permutes only the channel dimension. |
+| `[Transpose →] Reshape(4D→6D) → Transpose(DCR/CRD) → Reshape(6D→4D) [→ Transpose]` | `QNN_OP_SPACE_TO_DEPTH` | Matches both NCHW and NHWC layout variants and both DCR and CRD modes. Static dimensions required. |
+| `Reshape(4D→6D) → Einsum(transpose-equivalent) → Reshape(6D→4D)` | `QNN_OP_DEPTH_TO_SPACE + QNN_OP_TRANSPOSE` | Matches Einsum used as a rank-6 permutation with perm `[0,5,1,3,2,4]` (DCR DepthToSpace). |
+| `Reshape(5D→6D) → Transpose → Reshape(6D→5D)` (unit dim) | `QNN_OP_RESHAPE + QNN_OP_TRANSPOSE` | Unit dimension must appear at the same index in the rank-6 intermediate. Does not apply to SpaceToDepth decompositions. |
+| `Gather(rank-5, axis=4) → Transpose → Reshape` | Multi-node QNN subgraph | Constant rank-2 indices (row-major or column-major). |
+
+### Miscellaneous fusions
+
+| Pattern | Fused QNN op | Notes |
+|---|---|---|
+| `[DQ inputs →] Custom UDO op [→ Q outputs]` | Custom QNN UDO | Strips surrounding DQ/Q nodes and passes quantization parameters directly into the user-defined operator. |
 
 ## Running a model with QNN EP's HTP backend (Python)
 <p align="center"><img width="100%" src="../images/qnn_ep_quant_workflow.png" alt="Offline workflow for quantizing an ONNX model for use on QNN EP"/></p>

--- a/docs/execution_providers/build.md
+++ b/docs/execution_providers/build.md
@@ -123,10 +123,22 @@ python qcom/build_and_test.py build_ort_windows_x86_64
 python qcom/build_and_test.py build
 ```
 
-#### Build for x86-64 Linux
+#### Build for x86-64 Linux on Docker
+
+```bash
+python qcom/build_and_test.py build_ort_linux_x86_64_ubuntu_22_04
+```
+
+#### Build for x86-64 Linux outside Docker
 
 ```bash
 python qcom/build_and_test.py build_ort_linux_x86_64
+```
+
+#### Build for ARM64 Linux
+
+```bash
+python qcom/build_and_test.py test_ort_linux_aarch64_manylinux_2_34
 ```
 
 #### Build for AArch64 Linux (OpenEmbedded GCC 11.2)
@@ -180,8 +192,14 @@ python qcom/build_and_test.py test_ort_windows_arm64ec
 # Test on host
 python qcom/build_and_test.py test
 
-# Test x86-64 build
+# Test x86-64 build inside docker
+python qcom/build_and_test.py test_ort_linux_x86_64_ubuntu_22_04
+
+# Test x86-64 build outside docker
 python qcom/build_and_test.py test_ort_linux_x86_64
+
+# Test ARM64 build
+python qcom/build_and_test.py test_ort_linux_aarch64_manylinux_2_34
 ```
 
 ### Device Testing
@@ -247,7 +265,8 @@ Located in `build/Release/Release/dist/` (Windows) or `build/Release/dist/` (Lin
 
 * Windows ARM64: `onnxruntime_qnn-[version]-cp[py_version]-cp[py_version]-win_arm64.whl`
 * Windows x86-64: `onnxruntime_qnn-[version]-cp[py_version]-cp[py_version]-win_amd64.whl`
-* Linux x86-64: `onnxruntime_qnn-[version]-cp[py_version]-cp[py_version]-linux_x86_64.whl`
+* Linux x86-64 (Preview): `onnxruntime_qnn-[version]-cp[py_version]-cp[py_version]-manylinux_2_35_x86_64.whl`
+* Linux x86-64 (built outside the docker container): `onnxruntime_qnn-[version]-cp[py_version]-cp[py_version]-linux_x86_64.whl`
 * Linux AArch64: `onnxruntime_qnn-[version]-cp[py_version]-cp[py_version]-manylinux_2_34_aarch64.whl`
 
 #### NuGet Packages
@@ -341,7 +360,8 @@ python qcom/build_and_test.py lint_and_fix
 * Visual Studio 2022 with C++ development tools is required
 
 **Linux**:
-* Docker is required for manylinux builds
+* Docker is required for manylinux builds and Ubuntu 22.04 builds
+* The Dockerfile for Ubuntu 22.04 builds uses a Jammy 22.04 base image hosted in an internal Qualcomm mirror. External users must replace the base image with the equivalent image from `docker.io` for the build to succeed. Use the [`ubuntu:jammy`](https://hub.docker.com/_/ubuntu) image (digest: `sha256:4f838adc`).
 * For Android builds, set `ANDROID_HOME` and `ANDROID_NDK_HOME`
 
 ### Getting Help

--- a/docs/execution_providers/development.md
+++ b/docs/execution_providers/development.md
@@ -5,6 +5,7 @@
 This guide provides instructions for developing features for the ONNX Runtime (ORT) QNN Execution Provider using the plugin EP library. The ABI compatibility ensures stable interfaces and streamlined session creation.
 
 - **Note**: QNN EP version < 2.0 is **NOT** included in this page.
+- **Note**: QNN EP version < 2.0 will be deprecated and no longer maintained.
 
 ## Contents
 

--- a/docs/python/README.rst
+++ b/docs/python/README.rst
@@ -9,6 +9,21 @@ This repository is maintained by Qualcomm. For the general ONNX Runtime project,
 Changes
 -------
 
+2.3.0
+^^^^^^
+
+Release Notes : https://github.com/onnxruntime/onnxruntime-qnn/releases/tag/v2.3.0
+
+2.2.0
+^^^^^^
+
+Release Notes : https://github.com/onnxruntime/onnxruntime-qnn/releases/tag/v2.2.0
+
+2.1.1
+^^^^^^
+
+Release Notes : https://github.com/onnxruntime/onnxruntime-qnn/releases/tag/v2.1.1
+
 2.1.0
 ^^^^^^
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,182 @@
+# ONNX Runtime QNN Execution Provider v2.3.0
+
+**ONNX Runtime Compatibility:** >= 1.24.1 (compiled with v1.24.4)<br>
+**QAIRT SDK Compatibility:** 2.47.0
+
+```
+pip install onnxruntime==1.24.4
+pip install onnxruntime-qnn==2.3.0
+```
+
+## Packaging
+
+### New in 2.3.0
+
+- **NuGet** — ARM64 (ARM64X) package support added. Previously ARM64-only.
+- **Linux x86_64 Python wheels** — New **preview** wheels for Ubuntu 22.04 (`manylinux_2_35_x86_64`), Python 3.11–3.14. Requires GLIBC >= 2.35 due to QAIRT library dependencies.
+- **Maven (Android)** — New Android ARM64 package. Group ID / Artifact ID: `com.qualcomm.qti:onnxruntime-android-qnn`.
+
+For instructions on building wheels across different architectures, see the [Build Guide](execution_providers/build.md).
+
+### Platform Support
+
+| Package | Windows ARM64 | Windows x64 | Linux ARM64 | Linux x86_64 | Android ARM64 |
+|---|---|---|---|---|---|
+| Python Wheel | Inference | AOT compilation | Inference | AOT compilation | — |
+| NuGet | Inference | — | — | — | — |
+| ZIP | Inference | — | — | — | — |
+| tgz | — | — | Inference | — | — |
+| Maven | — | — | — | — | Inference |
+
+## New Operators and Fusions
+
+- NonZero ([#217](https://github.com/onnxruntime/onnxruntime-qnn/pull/217))
+- RandomNormalLike ([#266](https://github.com/onnxruntime/onnxruntime-qnn/pull/266))
+- Identity ([#268](https://github.com/onnxruntime/onnxruntime-qnn/pull/268))
+- **Gelu Pattern 3** — New `Erf*0.5 + 0.5` decomposition variant; fixes models previously not fused. ([#236](https://github.com/onnxruntime/onnxruntime-qnn/pull/236))
+- **DynamicQuantizeLinear + MatMulInteger** — Fuses `DQL → MatMulInteger → Cast → Mul → [Add]` into a float QNN MatMul. ([#367](https://github.com/onnxruntime/onnxruntime-qnn/pull/367))
+- **DynamicQuantizeLinear + ConvInteger** — Fuses `DQL → ConvInteger → Cast → Mul → [Add]` into a float QNN Conv2d. ([#364](https://github.com/onnxruntime/onnxruntime-qnn/pull/364))
+
+For the full list of supported operators, see [Supported ONNX Operators](execution_providers/QNN-ExecutionProvider.md#supported-onnx-operators) and for supported fusions, see [Supported Operator Fusions](execution_providers/QNN-ExecutionProvider.md#supported-operator-fusions).
+
+## Improvements
+
+- Added `htp_share_resource_optimization` and `ep.enable_htp_prepare_only` provider options. See [Configuration Options](execution_providers/QNN-ExecutionProvider.md#configuration-options). ([#107](https://github.com/onnxruntime/onnxruntime-qnn/pull/107), [#347](https://github.com/onnxruntime/onnxruntime-qnn/pull/347))
+- Added int32 input support for ScatterElements (QAIRT 2.45+). ([#247](https://github.com/onnxruntime/onnxruntime-qnn/pull/247))
+- GatherND now uses shared index-normalization primitives for consistency with ScatterND/ScatterElements. ([#336](https://github.com/onnxruntime/onnxruntime-qnn/pull/336))
+- Gemm with `beta=0.0` now maps to QNN FullyConnected without bias instead of falling back to CPU. ([#375](https://github.com/onnxruntime/onnxruntime-qnn/pull/375))
+- RoiAlign now accepts `coordinate_transformation_mode=half_pixel` and `sampling_ratio=0`. ([#389](https://github.com/onnxruntime/onnxruntime-qnn/pull/389))
+- MatMulNBits extended to HTP with 2-bit and 4-bit support (block sizes 32/64).([#288](https://github.com/onnxruntime/onnxruntime-qnn/pull/288))
+- Graph verification in tests migrated to the public `GetEpGraphAssignmentInfo` API. ([#346](https://github.com/onnxruntime/onnxruntime-qnn/pull/346))
+- Conv now supports block-quantized weights on HTP via the `BW_FLOAT_BLOCK` kernel, including int2 support. ([#429](https://github.com/onnxruntime/onnxruntime-qnn/pull/429))
+- Static MSVC runtime linkage enabled for Windows x86_64 builds. ([#432](https://github.com/onnxruntime/onnxruntime-qnn/pull/432))
+
+## Bug Fixes
+
+- BatchNormalization: incorrect QNN offset handling for `QNN_DATATYPE_UFIXED_POINT_16` scale inputs. ([#135](https://github.com/onnxruntime/onnxruntime-qnn/pull/135))
+- ThresholdedRelu: stale `add → relu → sign → mul` pattern replaced with QAIRT-aligned `Greater → Select`. ([#221](https://github.com/onnxruntime/onnxruntime-qnn/pull/221))
+- Graph composition failure when `offload_graph_io_quantization=1` and a graph input fans out to multiple QDQ pairs. ([#295](https://github.com/onnxruntime/onnxruntime-qnn/pull/295))
+- Softmax `axis ≠ rank-1` falling back to CPU due to missing upstream tensor wrappers at validation time. ([#304](https://github.com/onnxruntime/onnxruntime-qnn/pull/304))
+- ScatterND/ScatterElements silent CPU fallback for negative or INT_64 indices. ([#311](https://github.com/onnxruntime/onnxruntime-qnn/pull/311), [#317](https://github.com/onnxruntime/onnxruntime-qnn/pull/317))
+- Build failure on Ubuntu 24.04 / GCC 13 due to false-positive `-Wmaybe-uninitialized`. ([#387](https://github.com/onnxruntime/onnxruntime-qnn/pull/387))
+- QNN EP failure on devices where DXCore cannot discover the NPU. ([#12](https://github.com/onnxruntime/onnxruntime-qnn/pull/12))
+- ORT Core version floor raised to `>= 1.24.2`, preventing accidental downgrade. ([#448](https://github.com/onnxruntime/onnxruntime-qnn/pull/448))
+
+**Full Changelog:** [rel/ort-qnn-ep/2.2.0...rel-2.3.0](https://github.com/onnxruntime/onnxruntime-qnn/compare/rel/ort-qnn-ep/2.2.0...rel-2.3.0)
+
+## Known Issues
+
+- **WoS AMD64 — Python 3.11 installer issue** — `ep.get_library_path()` returns the `amd64` path instead of `arm64ec`; manually construct the path to the `arm64ec` library as a workaround. Ongoing.
+
+## Contributors
+
+This release includes contributions from:
+
+[Ashwath Shankarnarayan](https://github.com/qti-ashwshan), [Badri Narayanan](https://github.com/qti-mbadnara), [Chun-Chih Teng](https://github.com/qti-chuteng), [Hua-Yu Chou](https://github.com/huaychou), [Hung-Jui Wang](https://github.com/qti-hungjuiw), [Jaykumar Luhar](https://github.com/qti-luharj), [Kuan-Yu Lin](https://github.com/kuanyul-qti), [Min Fong Hong](https://github.com/minfhong-qti), [Mu-Chien Hsu](https://github.com/quic-muchhsu), [Shubham Patel](https://github.com/qti-shubham), [Tirupathi Reddy T](https://github.com/tirupath-qti), [Xia Han](https://github.com/xiha0704), [Yathindra Kota](https://github.com/quic-ykota), [Yu-Hung Chuang](https://github.com/yuhuchua-qti), [Yuduo Wu](https://github.com/qti-yuduo)
+
+---
+
+---
+
+# ONNX Runtime QNN Execution Provider v2.2.0
+This release delivers operator coverage improvements, multi-NPU device selection, and build fixes.
+
+**ONNX Runtime Compatibility:** >= 1.24.1 (compiled with v1.24.4)<br>
+**QAIRT SDK Compatibility:** 2.46.0
+
+```
+pip install onnxruntime==1.24.4
+pip install onnxruntime-qnn==2.2.0
+```
+
+## Bug Fixes
+
+- QNN EP: Fixed `GlobalMaxPool`/`GlobalAveragePool` falsely claiming rank-3 support; unified the 3D→4D reshape path with windowed pool ops. ([#201](https://github.com/onnxruntime/onnxruntime-qnn/pull/201))
+- QNN EP: Restored Genie builds against QAIRT SDKs older than 2.45.0 by keying conditional compilation off the Genie API version (`GenieDlc.h` breaking change). ([#225](https://github.com/onnxruntime/onnxruntime-qnn/pull/225))
+- QNN EP: Fixed GCC 13 build failures: corrected `memory_order_acq_rel` on `std::atomic::store()` to `memory_order_release`, and suppressed a false-positive `-Wmaybe-uninitialized` in `TestInputDef`. ([#228](https://github.com/onnxruntime/onnxruntime-qnn/pull/228))
+- QNN EP: Fixed HNRD Model Compatibility checks incorrectly running on x86 platforms where they don't apply. ([#319](https://github.com/onnxruntime/onnxruntime-qnn/pull/319))
+
+## Improvements
+
+- QNN EP: Relaxed QDQ BatchNormalization selector to accept BN nodes with 2 dequantized inputs (instead of requiring 3), matching the common pattern where `bias`/`mean`/`variance` stay as float initializers. Reduces CPU fallback and graph fragmentation. ([#209](https://github.com/onnxruntime/onnxruntime-qnn/pull/209))
+- QNN EP: NPU device selection now supports HTP cores with non-zero device IDs. ([#215](https://github.com/onnxruntime/onnxruntime-qnn/pull/215))
+
+## Known Issues
+
+- **WoS AMD64 — Python 3.11 installer issue causes inference failure** — On Windows on Snapdragon, `ep.get_library_path()` returns the `amd64` folder path instead of `arm64ec`, causing inference to fail in the AMD64 Python 3.11 environment, due to a known issue with the installer. As a workaround, manually construct the path to the `arm64ec` library. This issue affects Python 3.11 only.
+
+### Platform Support
+
+| Package | Windows ARM64 | Windows x64 | Linux ARM64 |
+|---|---|---|---|
+| Python Wheel | Inference | AOT compilation + Inference | Inference |
+| NuGet | Inference | — | — |
+| ZIP | Inference | — | — |
+| tgz | — | — | Inference |
+
+**Full Changelog:** [rel-2.1.0...rel/ort-qnn-ep/2.2.0](https://github.com/onnxruntime/onnxruntime-qnn/compare/rel-2.1.0...rel/ort-qnn-ep/2.2.0)
+
+## Contributors
+
+This release includes contributions from:
+
+[Arnav Deshpande](https://github.com/qti-arnadesh), [Ashwath Shankarnarayan](https://github.com/qti-ashwshan), [Badri Narayanan](https://github.com/qti-mbadnara), [Calvin Nguyen](https://github.com/quic-calvnguy), [Cheng-Hsin Weng](https://github.com/qti-chenweng), [Chun-Chih Teng](https://github.com/qti-chuteng), [Hua-Yu Chou](https://github.com/huaychou), [Hung-Jui Wang](https://github.com/qti-hungjuiw), [Jeff Kilpatrick](https:/github.com/qti-jkilpatrick), [Kuan-Yu Lin](https://github.com/kuanyul-qti), [Kyle Romero](https://github.com/qti-kromero), [Matthew Sinclair](https://github.com/qti-mattsinc), [Mike Hsu](https://github.com/quic-muchhsu), [Min Fong Hong](https://github.com/minfhong-qti), [Shubham Patel](https://github.com/qti-shubham), [Tirupathi Reddy T](https://github.com/tirupath-qti), [Yathindra Kota](https://github.com/quic-ykota), [Yuduo Wu](https://github.com/qti-yuduo), [Yu-Hung Chuang](https://github.com/yuhuchua-qti)
+
+---
+
+---
+
+
+
+# ONNX Runtime QNN Execution Provider v2.1.1
+This is a patch release of the QNN Execution Provider, containing bug fixes and packaging updates.
+
+**ONNX Runtime Compatibility:** >= 1.24.1 (compiled with v1.24.4)<br>
+**QAIRT SDK Compatibility:** 2.45.41
+
+```
+pip install onnxruntime==1.24.4
+pip install onnxruntime-qnn==2.1.1
+```
+
+## Bug Fixes
+
+- QNN EP: Fixed a per-tensor, per-inference memory leak in `OrtTensorTypeAndShapeInfo` during `ExecuteGraph` on the ABI path. ([#326](https://github.com/onnxruntime/onnxruntime-qnn/pull/326))
+- QNN EP: Fixed `TryGetMaxSpillFillSize` reading all EP contexts instead of only main contexts, which caused `QNN_CONTEXT_ERROR_INVALID_CONFIG` on multi-split weight-shared models. ([#328](https://github.com/onnxruntime/onnxruntime-qnn/pull/328))
+
+## Improvements
+
+- QNN EP: Switched `onnxruntime_providers_qnn.dll` to static MSVC runtime linkage, eliminating the runtime dependency on `MSVCP140.dll` and `VCRUNTIME140.dll`. ([#241](https://github.com/onnxruntime/onnxruntime-qnn/pull/241))
+- QNN EP: Reduced peak memory in model compatibility validation from ~200 MB to ~50 MB by removing the context blob version from compatibility checks, avoiding the fake context binary creation and preparation library load. ([#366](https://github.com/onnxruntime/onnxruntime-qnn/pull/366))
+
+## Packaging
+
+- Linux ARM64 Python wheels — promoted from preview (v2.1.0) to officially supported. As with Windows, wheels are published for Python 3.11 through Python 3.14.
+- Linux ARM64 `.tgz` archive — new distribution shipping the QNN EP shared library and headers for use outside of Python.
+
+### Platform Support
+
+| Package | Windows ARM64 | Windows x64 | Linux ARM64 |
+|---|---|---|---|
+| Python Wheel | Inference | AOT compilation + Inference | Inference |
+| NuGet | Inference | — | — |
+| ZIP | Inference | — | — |
+| tgz | — | — | Inference |
+
+**Full Changelog:** [rel-2.1.0...rel-2.1.1](https://github.com/onnxruntime/onnxruntime-qnn/compare/rel-2.1.0...rel-2.1.1)
+
+## Contributors
+
+This release includes contributions from:
+
+[Arnav Deshpande](https://github.com/qti-arnadesh), [Ashwath Shankarnarayan](https://github.com/qti-ashwshan), [Badri Narayanan](https://github.com/qti-mbadnara), [Calvin Nguyen](https://github.com/quic-calvnguy), [Cheng-Hsin Weng](https://github.com/qti-chenweng), [Chun-Chih Teng](https://github.com/qti-chuteng), [Hua-Yu Chou](https://github.com/huaychou), [Hung-Jui Wang](https://github.com/qti-hungjuiw), [Jeff Kilpatrick](https:/github.com/qti-jkilpatrick), [Kuan-Yu Lin](https://github.com/kuanyul-qti), [Kyle Romero](https://github.com/qti-kromero), [Matthew Sinclair](https://github.com/qti-mattsinc), [Mike Hsu](https://github.com/quic-muchhsu), [Min Fong Hong](https://github.com/minfhong-qti), [Samrat Dutta](https://github.com/samrdutt-design), [Shubham Patel](https://github.com/qti-shubham), [Tirupathi Reddy T](https://github.com/tirupath-qti), [Yathindra Kota](https://github.com/quic-ykota), [Yuduo Wu](https://github.com/qti-yuduo), [Yu-Hung Chuang](https://github.com/yuhuchua-qti)
+
+---
+
+---
+
+
+
 # ONNX Runtime QNN Execution Provider v2.1.0
 
 **ONNX Runtime Compatibility:** >= 1.24.1 (compiled with v1.24.4)


### PR DESCRIPTION
This PR cherry-picks #484 from the `mainline` onto the `rel-2.3.0`