### PR TITLE
Adopt AddQnnScalar helper across QNN EP op builders and node fusions

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_argmin_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_argmin_op_builder.cc
@@ -58,12 +58,8 @@ Ort::Status ArgMaxMinOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
   RETURN_IF(node_helper.Get("select_last_index", static_cast<int32_t>(0)) != 0,
             "QNN ArgMax/ArgMin only support select_last_index=0.");
   auto onnx_keepdims = node_helper.Get("keepdims", static_cast<int32_t>(1));
-  Qnn_Scalar_t keep_dims_scalar = QNN_SCALAR_INIT;
-  keep_dims_scalar.dataType = QNN_DATATYPE_BOOL_8;
-  keep_dims_scalar.bool8Value = static_cast<uint8_t>(onnx_keepdims == 0 ? 0 : 1);
-  QnnParamWrapper keep_dims_param(node_unit.Index(), node_unit.Name(), QNN_OP_ARGMAX_PARAM_KEEP_DIMS, keep_dims_scalar);
-  param_tensor_names.push_back(keep_dims_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(keep_dims_param));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), onnx_keepdims != 0,
+                                     QNN_OP_ARGMAX_PARAM_KEEP_DIMS, param_tensor_names));
 
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
                                  std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -179,38 +179,23 @@ Ort::Status ClipOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   const auto& inputs = node_unit.Inputs();
   const size_t num_inputs = inputs.size();
 
-  const Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
   std::vector<std::string> param_tensor_names;
 
   // Set the 'min' parameter.
-  Qnn_Scalar_t min_qnn_scalar = QNN_SCALAR_INIT;
-  min_qnn_scalar.dataType = qnn_data_type;
-
+  float min_value = std::numeric_limits<float>::lowest();
   if (num_inputs > 1 && !inputs[1].name.empty()) {
-    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[1], min_qnn_scalar.floatValue));
-  } else {
-    min_qnn_scalar.floatValue = std::numeric_limits<float>::lowest();
+    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[1], min_value));
   }
-
-  QnnParamWrapper min_value_param(node_unit.Index(), node_unit.Name(), QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE,
-                                  min_qnn_scalar);
-  param_tensor_names.push_back(min_value_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(min_value_param));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), min_value,
+                                      QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE, param_tensor_names));
 
   // Set the 'max' parameter.
-  Qnn_Scalar_t max_qnn_scalar = QNN_SCALAR_INIT;
-  max_qnn_scalar.dataType = qnn_data_type;
-
+  float max_value = std::numeric_limits<float>::max();
   if (num_inputs > 2 && !inputs[2].name.empty()) {
-    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[2], max_qnn_scalar.floatValue));
-  } else {
-    max_qnn_scalar.floatValue = std::numeric_limits<float>::max();
+    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[2], max_value));
   }
-
-  QnnParamWrapper max_value_param(node_unit.Index(), node_unit.Name(), QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE,
-                                  max_qnn_scalar);
-  param_tensor_names.push_back(max_value_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(max_value_param));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), max_value,
+                                      QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE, param_tensor_names));
 
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,
                                  std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -1268,12 +1268,8 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                    (group == num_output_channels);
 
   if (!is_depthwise_conv2d) {  // DepthWiseConv2d does not need a group parameter.
-    Qnn_Scalar_t group_qnn_scalar = QNN_SCALAR_INIT;
-    group_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-    group_qnn_scalar.uint32Value = group;
-    QnnParamWrapper group_paramwrapper(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_GROUP, group_qnn_scalar);
-    param_tensor_names.push_back(group_paramwrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(group_paramwrapper));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), group,
+                                           QNN_OP_CONV_2D_PARAM_GROUP, param_tensor_names));
   } else {
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cumsum_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cumsum_op_builder.cc
@@ -106,33 +106,21 @@ Ort::Status CumSumOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   std::vector<std::string> param_tensor_names;
 
   // Add axis param
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
   uint32_t onnx_axis = 0;
   RETURN_IF_ERROR(GetOnnxAxis(qnn_model_wrapper, node_unit, onnx_axis));
-  axis_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-  axis_qnn_scalar.uint32Value = onnx_axis;
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_CUMULATIVE_SUM_PARAM_AXIS, axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), onnx_axis,
+                                         QNN_OP_CUMULATIVE_SUM_PARAM_AXIS, param_tensor_names));
 
   // Add exclusive param
   OrtNodeAttrHelper node_helper(node_unit);
   int64_t exclusive = node_helper.Get("exclusive", static_cast<int64_t>(0));
-  Qnn_Scalar_t exclusive_qnn_scalar = QNN_SCALAR_INIT;
-  exclusive_qnn_scalar.dataType = QNN_DATATYPE_BOOL_8;
-  exclusive_qnn_scalar.bool8Value = static_cast<uint8_t>(exclusive == 0 ? 0 : 1);
-  QnnParamWrapper exclusive_param(node_unit.Index(), node_unit.Name(), QNN_OP_CUMULATIVE_SUM_PARAM_EXCLUSIVE, exclusive_qnn_scalar);
-  param_tensor_names.push_back(exclusive_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(exclusive_param));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), exclusive != 0,
+                                     QNN_OP_CUMULATIVE_SUM_PARAM_EXCLUSIVE, param_tensor_names));
 
   // Add reverse param
   int64_t reverse = node_helper.Get("reverse", static_cast<int64_t>(0));
-  Qnn_Scalar_t reverse_qnn_scalar = QNN_SCALAR_INIT;
-  reverse_qnn_scalar.dataType = QNN_DATATYPE_BOOL_8;
-  reverse_qnn_scalar.bool8Value = static_cast<uint8_t>(reverse == 0 ? 0 : 1);
-  QnnParamWrapper reverse_param(node_unit.Index(), node_unit.Name(), QNN_OP_CUMULATIVE_SUM_PARAM_REVERSE, reverse_qnn_scalar);
-  param_tensor_names.push_back(reverse_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(reverse_param));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), reverse != 0,
+                                     QNN_OP_CUMULATIVE_SUM_PARAM_REVERSE, param_tensor_names));
 
   return ProcessOutputs(qnn_model_wrapper, node_unit,
                         std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
@@ -240,30 +240,24 @@ bool IsEquationReduceSumMulBroadcastX(const Equation& equation) {
  *
  * @param qnn_model_wrapper Pointer to the QnnModelWrapper instance that manages the QNN model.
  * @param node_unit Reference to the OrtNodeUnit representing the ONNX node for which the parameters are being set.
+ * @param param_tensor_names Output vector that the generated parameter tensor names are appended to.
  * @param transpose_in0 Boolean flag indicating whether the 1st input tensor should be transposed (default: false).
  * @param transpose_in1 Boolean flag indicating whether the 2nd input tensor should be transposed (default: false).
- * @return A vector of strings containing the names of the parameter tensors added to the QNN model.
+ * @return Ort::Status indicating success or failure.
  */
-std::vector<std::string> SetMatMulParamTensorNames(
+Ort::Status SetMatMulParamTensorNames(
     onnxruntime::qnn::QnnModelWrapper* qnn_model_wrapper,
     const onnxruntime::OrtNodeUnit& node_unit,
+    std::vector<std::string>& param_tensor_names,
     bool transpose_in0 = false,
     bool transpose_in1 = false) {
-  std::vector<std::string> param_tensor_names;
-  Qnn_Scalar_t scalar_params[2] = {QNN_SCALAR_INIT, QNN_SCALAR_INIT};
-  scalar_params[0].dataType = QNN_DATATYPE_BOOL_8;
-  scalar_params[1].dataType = QNN_DATATYPE_BOOL_8;
-  scalar_params[0].bool8Value = static_cast<uint8_t>(transpose_in0);
-  scalar_params[1].bool8Value = static_cast<uint8_t>(transpose_in1);
-  onnxruntime::qnn::QnnParamWrapper transpose_in0_param(
-      node_unit.Index(), node_unit.Name(), QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, scalar_params[0]);
-  onnxruntime::qnn::QnnParamWrapper transpose_in1_param(
-      node_unit.Index(), node_unit.Name(), QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, scalar_params[1]);
-  param_tensor_names.push_back(transpose_in0_param.GetParamTensorName());
-  param_tensor_names.push_back(transpose_in1_param.GetParamTensorName());
-  qnn_model_wrapper->AddParamWrapper(std::move(transpose_in0_param));
-  qnn_model_wrapper->AddParamWrapper(std::move(transpose_in1_param));
-  return param_tensor_names;
+  RETURN_IF_ERROR(onnxruntime::qnn::AddQnnScalar<bool>(*qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                                       transpose_in0,
+                                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, param_tensor_names));
+  RETURN_IF_ERROR(onnxruntime::qnn::AddQnnScalar<bool>(*qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                                       transpose_in1,
+                                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, param_tensor_names));
+  return Ort::Status();
 }
 
 /**
@@ -322,8 +316,9 @@ Ort::Status CreateMatMulTransposeAll(
       matmul_output_info.quant_param.Copy(), std::vector<uint32_t>(matmul_output_shape));
   RETURN_IF_NOT(qnn_model_wrapper->AddTensorWrapper(std::move(matmul_output_wrapper)),
                 (node_unit.OpType() + " failed to add tensor.").c_str());
-  std::vector<std::string> param_tensor_names = SetMatMulParamTensorNames(
-      qnn_model_wrapper, node_unit, /*transpose_in0=*/false, /*transpose_in1=*/false);
+  std::vector<std::string> param_tensor_names;
+  RETURN_IF_ERROR(SetMatMulParamTensorNames(
+      qnn_model_wrapper, node_unit, param_tensor_names, /*transpose_in0=*/false, /*transpose_in1=*/false));
   RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(/*qnn_node_name=*/onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, QNN_OP_MAT_MUL),
                                                  /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                  /*qnn_node_type=*/QNN_OP_MAT_MUL,
@@ -421,16 +416,8 @@ Ort::Status CreateReduceSumMulBroadcastX(
   RETURN_IF_NOT(qnn_model_wrapper->AddParamWrapper(std::move(param_axes)),
                 "CreateReduceSumMulBroadcastX: failed to add param axes");
 
-  Qnn_Scalar_t keep_dims_scalar = QNN_SCALAR_INIT;
-  keep_dims_scalar.dataType = QNN_DATATYPE_BOOL_8;
-  keep_dims_scalar.bool8Value = SafeInt<uint8_t>(0);
-  onnxruntime::qnn::QnnParamWrapper param_keep_dims(node_unit.Index(),
-                                                    node_unit.Name(),
-                                                    QNN_OP_REDUCE_SUM_PARAM_KEEP_DIMS,
-                                                    keep_dims_scalar);
-  param_tensor_names.push_back(param_keep_dims.GetParamTensorName());
-  RETURN_IF_NOT(qnn_model_wrapper->AddParamWrapper(std::move(param_keep_dims)),
-                "CreateReduceSumMulBroadcastX: failed to add param keep_dims");
+  RETURN_IF_ERROR(onnxruntime::qnn::AddQnnScalar<bool>(*qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
+                                                       QNN_OP_REDUCE_SUM_PARAM_KEEP_DIMS, param_tensor_names));
 
   const std::string out_name = node_unit.Outputs()[0].name;
   Qnn_TensorType_t out_tensor_type = qnn_model_wrapper->IsGraphOutput(out_name) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
@@ -544,8 +531,9 @@ Ort::Status EinsumOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   const std::string equation = node_helper.Get("equation", std::string(""));
   std::optional<Equation> parsed_equation = ParseEquation(equation);
   if (IsEquationMatMul(parsed_equation.value())) {
-    std::vector<std::string> param_tensor_names = SetMatMulParamTensorNames(
-        &qnn_model_wrapper, node_unit, /*transpose_in0=*/false, /*transpose_in1=*/false);
+    std::vector<std::string> param_tensor_names;
+    RETURN_IF_ERROR(SetMatMulParamTensorNames(
+        &qnn_model_wrapper, node_unit, param_tensor_names, /*transpose_in0=*/false, /*transpose_in1=*/false));
     RETURN_IF_ERROR(ProcessOutputs(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                    /*node_unit=*/node_unit,
                                    /*input_names=*/std::move(input_names),
@@ -555,8 +543,9 @@ Ort::Status EinsumOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                    /*qnn_op_type=*/QNN_OP_MAT_MUL));
   } else if (IsEquationMatMulTransposeY(parsed_equation.value()) ||
              IsEquationMatMulBroadcastTransposeY(parsed_equation.value())) {
-    std::vector<std::string> param_tensor_names = SetMatMulParamTensorNames(
-        &qnn_model_wrapper, node_unit, /*transpose_in0=*/false, /*transpose_in1=*/true);
+    std::vector<std::string> param_tensor_names;
+    RETURN_IF_ERROR(SetMatMulParamTensorNames(
+        &qnn_model_wrapper, node_unit, param_tensor_names, /*transpose_in0=*/false, /*transpose_in1=*/true));
     RETURN_IF_ERROR(ProcessOutputs(/*qnn_model_wrapper=*/qnn_model_wrapper,
                                    /*node_unit=*/node_unit,
                                    /*input_names=*/std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/expand_op_builder.cc
@@ -166,14 +166,9 @@ Ort::Status ExpandOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   if (target_op == "And" || target_op == "Expand") {
     uint32_t op_value = (target_op == "And") ? QNN_OP_ELEMENT_WISE_BINARY_OPERATION_AND
                                              : QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    Qnn_Scalar_t op_scalar = QNN_SCALAR_INIT;
-    op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    op_scalar.uint32Value = op_value;
-    QnnParamWrapper op_param(node_unit.Index(), node_unit.Name(),
-                             QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, op_scalar);
-    param_tensor_names.push_back(op_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(op_param)),
-                  "Failed to add operation param");
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           op_value, QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
+                                           param_tensor_names));
   }
 
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), std::move(param_tensor_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/fusedmatmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/fusedmatmul_op_builder.cc
@@ -150,25 +150,15 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
   // Skip using transpose_in0 param when both transA and transBatchA are present
   // Only use transpose_in0 when transA is present and transBatchA is not present
   if (!(transA && transBatchA)) {
-    Qnn_Scalar_t transpose_a_scalar = QNN_SCALAR_INIT;
-    transpose_a_scalar.dataType = QNN_DATATYPE_BOOL_8;
-    transpose_a_scalar.bool8Value = transA ? 1 : 0;
-    QnnParamWrapper transpose_a_param(node_unit.Index(), node_unit.Name(),
-                                      QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, transpose_a_scalar);
-    matmul_param_tensor_names.push_back(transpose_a_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(transpose_a_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), transA,
+                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, matmul_param_tensor_names));
   }
 
   // Skip using transpose_in1 param when both transB and transBatchB are present
   // Only use transpose_in1 when transB is present and transBatchB is not present
   if (!(transB && transBatchB)) {
-    Qnn_Scalar_t transpose_b_scalar = QNN_SCALAR_INIT;
-    transpose_b_scalar.dataType = QNN_DATATYPE_BOOL_8;
-    transpose_b_scalar.bool8Value = transB ? 1 : 0;
-    QnnParamWrapper transpose_b_param(node_unit.Index(), node_unit.Name(),
-                                      QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, transpose_b_scalar);
-    matmul_param_tensor_names.push_back(transpose_b_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(transpose_b_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), transB,
+                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, matmul_param_tensor_names));
   }
 
   // QNN doesn't directly support batch dimension transposition in MatMul

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
@@ -367,20 +367,12 @@ Ort::Status GatherBlockQuantizedOpBuilder::ProcessAttributesAndOutputs(QnnModelW
   std::vector<std::string> param_tensor_names;
   int32_t axis_value = static_cast<int32_t>(axis_attr);
   Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(
-      ProcessAxisAttribute(qnn_model_wrapper,
-                           node_unit,
-                           axis_qnn_scalar,
-                           axis_value));
-
-  QnnParamWrapper axis_param(
-      node_unit.Index(),
-      node_unit.Name(),
-      QNN_OP_GATHER_PARAM_AXIS,
-      axis_qnn_scalar);
-
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
+  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
+                             QNN_OP_GATHER_PARAM_AXIS, axis_qnn_scalar);
   param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(axis_param)),
+                "Failed to add axis param.");
 
   // Creating Qnn node
   RETURN_IF_NOT(

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gathernd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gathernd_op_builder.cc
@@ -126,14 +126,10 @@ Ort::Status GatherNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
   OrtNodeAttrHelper node_helper(node_unit);
   const int64_t batch_dims = node_helper.Get("batch_dims", static_cast<int64_t>(0));
 
-  Qnn_Scalar_t batch_dims_scalar = QNN_SCALAR_INIT;
-  batch_dims_scalar.dataType = QNN_DATATYPE_UINT_32;
-  batch_dims_scalar.uint32Value = static_cast<uint32_t>(batch_dims);
-
-  QnnParamWrapper batch_dims_param(node_unit.Index(), node_unit.Name(),
-                                   QNN_OP_GATHER_ND_PARAM_BATCH_DIMS, batch_dims_scalar);
-  std::vector<std::string> param_tensor_names = {batch_dims_param.GetParamTensorName()};
-  qnn_model_wrapper.AddParamWrapper(std::move(batch_dims_param));
+  std::vector<std::string> param_tensor_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(batch_dims),
+                                         QNN_OP_GATHER_ND_PARAM_BATCH_DIMS, param_tensor_names));
 
   // Get tensor wrappers for shape calculation
   const auto& data_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -588,19 +588,16 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     std::string bias_name = input_names[2];
 
     std::string add_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-    Qnn_Scalar_t op_scalar = QNN_SCALAR_INIT;
-    op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD;
-    QnnParamWrapper op_param(node_unit.Index(), add_node_name,
-                             QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, op_scalar);
-    std::string param_name = op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(op_param)), "Failed to add operation param.");
+    std::vector<std::string> add_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), add_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(add_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {fc_output_name, bias_name},
                                                   {org_output_name},
-                                                  {param_name},
+                                                  std::move(add_param_names),
                                                   do_op_validation),
                   "Failed to add ElementWiseAdd node.");
   } else {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/groupnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/groupnormalization_op_builder.cc
@@ -121,26 +121,13 @@ Ort::Status GroupNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   std::vector<std::string> param_tensor_names;
 
   const float epsilon = node_helper.Get("epsilon", 1e-05f);
-  Qnn_Scalar_t epsilon_param = QNN_SCALAR_INIT;
-  epsilon_param.dataType = QNN_DATATYPE_FLOAT_32;
-  epsilon_param.floatValue = epsilon;
-  QnnParamWrapper epsilon_param_wrapper(node_unit.Index(),
-                                        node_unit.Name(),
-                                        QNN_OP_GROUP_NORM_PARAM_EPSILON,
-                                        epsilon_param);
-  param_tensor_names.push_back(epsilon_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(epsilon_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), epsilon,
+                                      QNN_OP_GROUP_NORM_PARAM_EPSILON, param_tensor_names));
 
   const int64_t num_groups = node_helper.Get("num_groups", static_cast<int64_t>(1));
-  Qnn_Scalar_t num_groups_param = QNN_SCALAR_INIT;
-  num_groups_param.dataType = QNN_DATATYPE_UINT_32;
-  num_groups_param.uint32Value = static_cast<uint32_t>(num_groups);
-  QnnParamWrapper num_groups_param_wrapper(node_unit.Index(),
-                                           node_unit.Name(),
-                                           QNN_OP_GROUP_NORM_PARAM_GROUP,
-                                           num_groups_param);
-  param_tensor_names.push_back(num_groups_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(num_groups_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(num_groups),
+                                         QNN_OP_GROUP_NORM_PARAM_GROUP, param_tensor_names));
 
   return ProcessOutputs(qnn_model_wrapper, node_unit,
                         std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instancenormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instancenormalization_op_builder.cc
@@ -195,15 +195,8 @@ Ort::Status InstanceNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModel
   std::vector<std::string> param_tensor_names;
 
   const float epsilon = node_helper.Get("epsilon", 1e-05f);  // Default is 1e-05 according to ONNX spec.
-  Qnn_Scalar_t epsilon_param = QNN_SCALAR_INIT;
-  epsilon_param.dataType = QNN_DATATYPE_FLOAT_32;
-  epsilon_param.floatValue = epsilon;
-  QnnParamWrapper epsilon_param_wrapper(node_unit.Index(),
-                                        node_unit.Name(),
-                                        QNN_OP_INSTANCE_NORM_PARAM_EPSILON,
-                                        epsilon_param);
-  param_tensor_names.push_back(epsilon_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(epsilon_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), epsilon,
+                                      QNN_OP_INSTANCE_NORM_PARAM_EPSILON, param_tensor_names));
 
   const auto& outputs = node_unit.Outputs();
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/inverse_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/inverse_op_builder.cc
@@ -178,19 +178,16 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(det_mul_0_output)),
                 "Failed to add Inverse - Det - Mul(a, d) output tensor.");
 
-  Qnn_Scalar_t mul_0_scalar = QNN_SCALAR_INIT;
-  mul_0_scalar.dataType = QNN_DATATYPE_UINT_32;
-  mul_0_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  QnnParamWrapper mul_0_param(node_unit.Index(), det_mul_0_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_0_scalar);
-  std::string mul_0_param_name = mul_0_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_0_param)), "Failed to add operation param.");
+  std::vector<std::string> mul_0_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), det_mul_0_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_0_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(det_mul_0_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {sliced_output_names[0], sliced_output_names[3]},
                                                 {det_mul_0_output_name},
-                                                {mul_0_param_name},
+                                                std::move(mul_0_param_names),
                                                 do_op_validation),
                 "Failed to add Inverse - Det - Mul(a, d) node.");
 
@@ -204,19 +201,16 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(det_mul_1_output)),
                 "Failed to add Inverse - Det - Mul(b, c) output tensor.");
 
-  Qnn_Scalar_t mul_1_scalar = QNN_SCALAR_INIT;
-  mul_1_scalar.dataType = QNN_DATATYPE_UINT_32;
-  mul_1_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  QnnParamWrapper mul_1_param(node_unit.Index(), det_mul_1_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_1_scalar);
-  std::string mul_1_param_name = mul_1_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_1_param)), "Failed to add operation param.");
+  std::vector<std::string> mul_1_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), det_mul_1_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_1_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(det_mul_1_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {sliced_output_names[1], sliced_output_names[2]},
                                                 {det_mul_1_output_name},
-                                                {mul_1_param_name},
+                                                std::move(mul_1_param_names),
                                                 do_op_validation),
                 "Failed to add Inverse - Det - Mul(b, c) node.");
 
@@ -230,19 +224,16 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(det_sub_output)),
                 "Failed to add Inverse - Det - Sub(ad, bc) output tensor.");
 
-  Qnn_Scalar_t sub_scalar = QNN_SCALAR_INIT;
-  sub_scalar.dataType = QNN_DATATYPE_UINT_32;
-  sub_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT;
-  QnnParamWrapper sub_param(node_unit.Index(), det_sub_name,
-                            QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, sub_scalar);
-  std::string sub_param_name = sub_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(sub_param)), "Failed to add operation param.");
+  std::vector<std::string> sub_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), det_sub_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, sub_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(det_sub_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {det_mul_0_output_name, det_mul_1_output_name},
                                                 {det_sub_output_name},
-                                                {sub_param_name},
+                                                std::move(sub_param_names),
                                                 do_op_validation),
                 "Failed to add Inverse - Det - Sub(ad, bc) node.");
 
@@ -301,19 +292,16 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(adj_mul_output)),
                 "Failed to add Inverse - Adj - Mul([d, b, a, c], [1, -1, -1, 1]) output tensor.");
 
-  Qnn_Scalar_t adj_mul_scalar = QNN_SCALAR_INIT;
-  adj_mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-  adj_mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  QnnParamWrapper adj_mul_param(node_unit.Index(), adj_mul_name,
-                                QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, adj_mul_scalar);
-  std::string adj_mul_param_name = adj_mul_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(adj_mul_param)), "Failed to add operation param.");
+  std::vector<std::string> adj_mul_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), adj_mul_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, adj_mul_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(adj_mul_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {adj_cat_output_name, adj_mul_tensor_name},
                                                 {adj_mul_output_name},
-                                                {adj_mul_param_name},
+                                                std::move(adj_mul_param_names),
                                                 do_op_validation),
                 "Failed to add Inverse - Adj - Mul([d, b, a, c], [1, -1, -1, 1]) node.");
 
@@ -329,19 +317,16 @@ Ort::Status InverseOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                 "Failed to add Inverse - Adj / Det output tensor.");
 
   // Expect QNN element-wise ops to broadcast unit dimensions.
-  Qnn_Scalar_t div_scalar = QNN_SCALAR_INIT;
-  div_scalar.dataType = QNN_DATATYPE_UINT_32;
-  div_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE;
-  QnnParamWrapper div_param(node_unit.Index(), inverse_div_name,
-                            QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_scalar);
-  std::string div_param_name = div_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(div_param)), "Failed to add operation param.");
+  std::vector<std::string> div_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), inverse_div_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(inverse_div_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {adj_mul_output_name, det_sub_output_name},
                                                 {inverse_div_output_name},
-                                                {div_param_name},
+                                                std::move(div_param_names),
                                                 do_op_validation),
                 "Failed to add Inverse - Adj / Det node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -250,15 +250,8 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   std::vector<std::string> param_tensor_names;
 
   const float epsilon = node_helper.Get("epsilon", 1e-05f);  // Default is 1e-05 according to ONNX spec.
-  Qnn_Scalar_t epsilon_param = QNN_SCALAR_INIT;
-  epsilon_param.dataType = QNN_DATATYPE_FLOAT_32;
-  epsilon_param.floatValue = epsilon;
-  QnnParamWrapper epsilon_param_wrapper(node_unit.Index(),
-                                        node_unit.Name(),
-                                        QNN_OP_LAYER_NORM_PARAM_EPSILON,
-                                        epsilon_param);
-  param_tensor_names.push_back(epsilon_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(epsilon_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), epsilon,
+                                      QNN_OP_LAYER_NORM_PARAM_EPSILON, param_tensor_names));
 
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of input 0");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -597,19 +597,16 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
                     "Failed to add decomposed Mul output tensor.");
     }
     std::string mul_node_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_mul");
-    Qnn_Scalar_t mul_scalar = QNN_SCALAR_INIT;
-    mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_param(node_unit.Index(), mul_node_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_scalar);
-    std::string mul_param_name = mul_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_param)), "Failed to add mul operation param.");
+    std::vector<std::string> mul_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), mul_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(mul_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {current, mul_scale_name},
                                                   {mul_out_name},
-                                                  {mul_param_name},
+                                                  std::move(mul_param_names),
                                                   do_op_validation),
                   "Failed to add decomposed Mul node.");
     current = mul_out_name;
@@ -692,19 +689,16 @@ Ort::Status LayerNormalizationOpBuilder::BuildDecomposedLayerNorm(QnnModelWrappe
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_out_tensor)),
                   "Failed to add decomposed Add output tensor.");
     std::string add_node_name = utils::UniqueNameGenerator().New(node_unit, "_ln_decomposed_add");
-    Qnn_Scalar_t add_scalar = QNN_SCALAR_INIT;
-    add_scalar.dataType = QNN_DATATYPE_UINT_32;
-    add_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD;
-    QnnParamWrapper add_param(node_unit.Index(), add_node_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_scalar);
-    std::string add_param_name = add_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(add_param)), "Failed to add operation param.");
+    std::vector<std::string> add_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), add_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(add_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {current, bias_name},
                                                   {final_output_name},
-                                                  {add_param_name},
+                                                  std::move(add_param_names),
                                                   do_op_validation),
                   "Failed to add decomposed Add node.");
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lp_pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lp_pool_op_builder.cc
@@ -319,13 +319,8 @@ Ort::Status LpPoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // honors rounding_mode correctly. rounding_mode was populated by ResolvePoolAttributes from the
   // ONNX ceil_mode attribute.
   if (rounding_mode != 0) {
-    Qnn_Scalar_t scalar = QNN_SCALAR_INIT;
-    scalar.dataType = QNN_DATATYPE_UINT_32;
-    scalar.int32Value = rounding_mode;
-    QnnParamWrapper rounding_mode_param(node_unit.Index(), node_unit.Name(), p_round, scalar);
-    pool_param_names.push_back(rounding_mode_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(rounding_mode_param)),
-                  "Failed to add param rounding_mode.");
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(rounding_mode), p_round, pool_param_names));
   }
   // count_pad_for_edges intentionally left at the QNN default (false). The denominator becomes
   // count_real per window; the per-position scale tensor below compensates.

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lrn_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lrn_op_builder.cc
@@ -103,58 +103,39 @@ Ort::Status LRNOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
 
   // Parameter 'radius'
   {
-    Qnn_Scalar_t qnn_radius = QNN_SCALAR_INIT;
-    qnn_radius.dataType = QNN_DATATYPE_INT_32;
-    qnn_radius.int32Value = SafeInt<int32_t>((onnx_size - 1) / 2);  // Convert ONNX size into QNN radius.
-
-    QnnParamWrapper qnn_param(node_unit.Index(), node_unit.Name(), QNN_OP_LRN_PARAM_RADIUS, qnn_radius);
-    param_tensor_names.push_back(qnn_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
+    const int32_t qnn_radius = SafeInt<int32_t>((onnx_size - 1) / 2);  // Convert ONNX size into QNN radius.
+    RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), qnn_radius,
+                                          QNN_OP_LRN_PARAM_RADIUS, param_tensor_names));
   }
 
   // Parameter 'alpha'
   {
     float onnx_alpha = GetOnnxAttr(node_helper, onnx_alpha_attr);
-    Qnn_Scalar_t qnn_alpha = QNN_SCALAR_INIT;
-    qnn_alpha.dataType = QNN_DATATYPE_FLOAT_32;
-    qnn_alpha.floatValue = onnx_alpha / static_cast<float>(onnx_size);  // QNN doesn't scale alpha by size.
-
-    QnnParamWrapper qnn_param(node_unit.Index(), node_unit.Name(), QNN_OP_LRN_PARAM_ALPHA, qnn_alpha);
-    param_tensor_names.push_back(qnn_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
+    const float qnn_alpha = onnx_alpha / static_cast<float>(onnx_size);  // QNN doesn't scale alpha by size.
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), qnn_alpha,
+                                        QNN_OP_LRN_PARAM_ALPHA, param_tensor_names));
   }
 
   // Parameter 'beta'
   {
-    Qnn_Scalar_t qnn_beta = QNN_SCALAR_INIT;
-    qnn_beta.dataType = QNN_DATATYPE_FLOAT_32;
-    qnn_beta.floatValue = GetOnnxAttr(node_helper, onnx_beta_attr);
-
-    QnnParamWrapper qnn_param(node_unit.Index(), node_unit.Name(), QNN_OP_LRN_PARAM_BETA, qnn_beta);
-    param_tensor_names.push_back(qnn_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
+    const float qnn_beta = GetOnnxAttr(node_helper, onnx_beta_attr);
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), qnn_beta,
+                                        QNN_OP_LRN_PARAM_BETA, param_tensor_names));
   }
 
   // Parameter 'bias'
   {
-    Qnn_Scalar_t qnn_bias = QNN_SCALAR_INIT;
-    qnn_bias.dataType = QNN_DATATYPE_FLOAT_32;
-    qnn_bias.floatValue = GetOnnxAttr(node_helper, onnx_bias_attr);
-
-    QnnParamWrapper qnn_param(node_unit.Index(), node_unit.Name(), QNN_OP_LRN_PARAM_BIAS, qnn_bias);
-    param_tensor_names.push_back(qnn_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
+    const float qnn_bias = GetOnnxAttr(node_helper, onnx_bias_attr);
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), qnn_bias,
+                                        QNN_OP_LRN_PARAM_BIAS, param_tensor_names));
   }
 
   // Parameter 'region'
   {
-    Qnn_Scalar_t qnn_region = QNN_SCALAR_INIT;
-    qnn_region.dataType = QNN_DATATYPE_UINT_32;
-    qnn_region.uint32Value = QNN_OP_LRN_REGION_ACROSS_CHANNEL;  // ONNX's LRN only supports "across channel".
-
-    QnnParamWrapper qnn_param(node_unit.Index(), node_unit.Name(), QNN_OP_LRN_PARAM_REGION, qnn_region);
-    param_tensor_names.push_back(qnn_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_param));
+    // ONNX's LRN only supports "across channel".
+    const uint32_t qnn_region = QNN_OP_LRN_REGION_ACROSS_CHANNEL;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), qnn_region,
+                                           QNN_OP_LRN_PARAM_REGION, param_tensor_names));
   }
 
   return ProcessOutputs(qnn_model_wrapper, node_unit, std::move(input_names), std::move(param_tensor_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
@@ -532,19 +532,16 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
         RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_output_tensorwrapper)),
                       "QNN EP: Failed to add output tensor for inserted ElementWiseAdd node.");
         std::string add_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-        Qnn_Scalar_t add_scalar = QNN_SCALAR_INIT;
-        add_scalar.dataType = QNN_DATATYPE_UINT_32;
-        add_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD;
-        QnnParamWrapper add_param(node_unit.Index(), add_node_name,
-                                  QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_scalar);
-        std::string add_param_name = add_param.GetParamTensorName();
-        RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(add_param)), "Failed to add operation param.");
+        std::vector<std::string> add_param_names;
+        RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), add_node_name,
+                                               static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD),
+                                               QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_param_names));
         RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(add_node_name,
                                                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                       QNN_OP_ELEMENT_WISE_BINARY,
                                                       std::move(add_input_names),
                                                       {qnn_lstm_bias_name[i]},
-                                                      {add_param_name},
+                                                      std::move(add_param_names),
                                                       do_op_validation),
                       "Failed to create manually inserted ElementWiseAdd node.");
         qnn_lstm_input_names[qnn_input_indices[i]] = qnn_lstm_bias_name[i];

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -698,18 +698,10 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // optional, but older versions of QNN SDK failed validation if not explicitly provided.
   std::vector<std::string> param_tensor_names;
   if (!use_fully_connected) {
-    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-    scalar_param.dataType = QNN_DATATYPE_BOOL_8;
-    scalar_param.bool8Value = 0;
-    QnnParamWrapper transpose_in0_param(node_unit.Index(), node_unit.Name(), QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0,
-                                        scalar_param);
-    param_tensor_names.push_back(transpose_in0_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(transpose_in0_param));
-
-    QnnParamWrapper transpose_in1_param(node_unit.Index(), node_unit.Name(), QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1,
-                                        scalar_param);
-    param_tensor_names.push_back(transpose_in1_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(transpose_in1_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
+                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, param_tensor_names));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
+                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, param_tensor_names));
   }
 
   const std::string& org_output_name = node_unit.Outputs()[0].name;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mean_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mean_op_builder.cc
@@ -55,19 +55,16 @@ Ort::Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                 QnnQuantParamsWrapper(), std::move(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(add_tensor)), "Failed to add Add tensor wrapper.");
     std::string add_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-    Qnn_Scalar_t add_scalar = QNN_SCALAR_INIT;
-    add_scalar.dataType = QNN_DATATYPE_UINT_32;
-    add_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD;
-    QnnParamWrapper add_param(node_unit.Index(), add_node_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_scalar);
-    std::string add_param_name = add_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(add_param)), "Failed to add operation param.");
+    std::vector<std::string> add_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), add_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(add_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {sum_output, input_names[i]},
                                                   {add_output},
-                                                  {add_param_name},
+                                                  std::move(add_param_names),
                                                   do_op_validation),
                   "Create Qnn Node for Add Op Failed");
 
@@ -100,19 +97,16 @@ Ort::Status MeanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor)), "Failed to add output tensor wrapper.");
   std::vector<std::string> div_inputs = {sum_output, divisor_name};
   std::string div_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-  Qnn_Scalar_t div_scalar = QNN_SCALAR_INIT;
-  div_scalar.dataType = QNN_DATATYPE_UINT_32;
-  div_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE;
-  QnnParamWrapper div_param(node_unit.Index(), div_node_name,
-                            QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_scalar);
-  std::string div_param_name = div_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(div_param)), "Failed to add operation param.");
+  std::vector<std::string> div_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), div_node_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(div_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {sum_output, divisor_name},
                                                 {output_name},
-                                                {div_param_name},
+                                                std::move(div_param_names),
                                                 do_op_validation),
                 "Failed to create Mean_Div node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
@@ -146,19 +146,16 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                                 std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(div_output)),
                   "Failed to add Mod - ElementWiseDiv output tensor.");
-    Qnn_Scalar_t div_scalar = QNN_SCALAR_INIT;
-    div_scalar.dataType = QNN_DATATYPE_UINT_32;
-    div_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE;
-    QnnParamWrapper div_param(node_unit.Index(), div_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_scalar);
-    std::string div_param_name = div_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(div_param)), "Failed to add operation param.");
+    std::vector<std::string> div_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), div_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(div_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   std::move(div_input),
                                                   {div_output_name},
-                                                  {div_param_name},
+                                                  std::move(div_param_names),
                                                   do_op_validation),
                   "Failed to add Mod - ElementWiseDiv node.");
 
@@ -194,19 +191,16 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                                 std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mul_output)),
                   "Failed to add Mod - ElementWiseMul output tensor.");
-    Qnn_Scalar_t mul_scalar = QNN_SCALAR_INIT;
-    mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_param(node_unit.Index(), mul_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_scalar);
-    std::string mul_param_name = mul_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_param)), "Failed to add operation param.");
+    std::vector<std::string> mul_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), mul_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(mul_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   std::move(mul_input),
                                                   {mul_output_name},
-                                                  {mul_param_name},
+                                                  std::move(mul_param_names),
                                                   do_op_validation),
                   "Failed to add Mod - ElementWiseMul node.");
 
@@ -223,19 +217,16 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                                 std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(mod_output)),
                   "Failed to add Mod output tensor.");
-    Qnn_Scalar_t sub_scalar = QNN_SCALAR_INIT;
-    sub_scalar.dataType = QNN_DATATYPE_UINT_32;
-    sub_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT;
-    QnnParamWrapper sub_param(node_unit.Index(), sub_name,
-                              QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, sub_scalar);
-    std::string sub_param_name = sub_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(sub_param)), "Failed to add operation param.");
+    std::vector<std::string> sub_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), sub_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, sub_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(sub_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   std::move(sub_input),
                                                   {sub_output_name},
-                                                  {sub_param_name},
+                                                  std::move(sub_param_names),
                                                   do_op_validation),
                   "Failed to add Mod - ElementWiseSub node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/one_hot_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/one_hot_op_builder.cc
@@ -324,13 +324,8 @@ Ort::Status OneHotOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
         return MAKE_EP_FAIL("OneHot: unsupported data type for depth input.");
     }
 
-    Qnn_Scalar_t depth_scalar = QNN_SCALAR_INIT;
-    depth_scalar.dataType = QNN_DATATYPE_UINT_32;
-    depth_scalar.uint32Value = depth_val;
-    QnnParamWrapper depth_param(node_unit.Index(), node_unit.Name(),
-                                QNN_OP_ONE_HOT_PARAM_DEPTH, depth_scalar);
-    param_tensor_names.push_back(depth_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(depth_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), depth_val,
+                                           QNN_OP_ONE_HOT_PARAM_DEPTH, param_tensor_names));
   }
 
   // -----------------------------------------------------------------------
@@ -382,13 +377,9 @@ Ort::Status OneHotOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF(onnx_axis < 0 || onnx_axis > rank,
               "OneHot: axis out of valid range [-(rank+1), rank].");
 
-    Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-    axis_scalar.dataType = QNN_DATATYPE_UINT_32;
-    axis_scalar.uint32Value = static_cast<uint32_t>(onnx_axis);
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
-                               QNN_OP_ONE_HOT_PARAM_AXIS, axis_scalar);
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(onnx_axis),
+                                           QNN_OP_ONE_HOT_PARAM_AXIS, param_tensor_names));
   }
 
   RETURN_IF_ERROR(ProcessOutputs(qnn_model_wrapper, node_unit,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -262,9 +262,8 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
   }
 
   std::vector<uint32_t> pad_amount_dim{static_cast<uint32_t>(pad_amount.size() / 2), static_cast<uint32_t>(2)};
-  QnnParamWrapper mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_PAD_PARAM_SCHEME, mode_qnn_scalar);
-  param_tensor_names.push_back(mode_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(mode_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         mode_qnn_scalar.uint32Value, QNN_OP_PAD_PARAM_SCHEME, param_tensor_names));
 
   QnnParamWrapper pad_amount_param(node_unit.Index(), node_unit.Name(), QNN_OP_PAD_PARAM_PAD_AMOUNT,
                                    std::move(pad_amount_dim), std::vector<uint32_t>(pad_amount));
@@ -273,15 +272,9 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
 
   if (opset_version < 11 && domain != kMSDomain && node_helper.HasAttr("value")) {
     // Process optional attribute value
-    Qnn_Scalar_t constant_value_qnn_scalar = QNN_SCALAR_INIT;
-    constant_value_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
-    constant_value_qnn_scalar.floatValue = node_helper.GetFloat("value").value();
-    QnnParamWrapper constant_value_param(node_unit.Index(),
-                                         node_unit.Name(),
-                                         QNN_OP_PAD_PARAM_PAD_CONSTANT_VALUE,
-                                         constant_value_qnn_scalar);
-    param_tensor_names.push_back(constant_value_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(constant_value_param));
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                        node_helper.GetFloat("value").value(),
+                                        QNN_OP_PAD_PARAM_PAD_CONSTANT_VALUE, param_tensor_names));
   } else if ((opset_version >= 11 || domain == kMSDomain) && inputs.size() > 2 && inputs[2].Exists()) {
     TensorInfo input_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], input_info));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -245,25 +245,24 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
 
   RETURN_IF("reflect" == mode && has_negative, "reflect mode doesn't support negative padding value.");
 
-  Qnn_Scalar_t mode_qnn_scalar = QNN_SCALAR_INIT;
-  mode_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
+  uint32_t mode_value = QNN_OP_PAD_SCHEME_CONSTANT;
   if ("constant" == mode) {
-    mode_qnn_scalar.uint32Value = QNN_OP_PAD_SCHEME_CONSTANT;
+    mode_value = QNN_OP_PAD_SCHEME_CONSTANT;
   } else if ("reflect" == mode) {
     for (size_t i = 0; i < input_shape.size(); i++) {
       RETURN_IF(pad_amount[i * 2] > input_shape[i] - 1 || pad_amount[(i * 2) + 1] > input_shape[i] - 1,
                 "Pad amount should not be greater than shape(input[0])[i] - 1");
     }
-    mode_qnn_scalar.uint32Value = QNN_OP_PAD_SCHEME_MIRROR_REFLECT;
+    mode_value = QNN_OP_PAD_SCHEME_MIRROR_REFLECT;
   } else if ("edge" == mode) {
-    mode_qnn_scalar.uint32Value = QNN_OP_PAD_SCHEME_EDGE;
+    mode_value = QNN_OP_PAD_SCHEME_EDGE;
   } else {
     return MAKE_EP_FAIL("Pad mode only support constant.");
   }
 
   std::vector<uint32_t> pad_amount_dim{static_cast<uint32_t>(pad_amount.size() / 2), static_cast<uint32_t>(2)};
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
-                                         mode_qnn_scalar.uint32Value, QNN_OP_PAD_PARAM_SCHEME, param_tensor_names));
+                                         mode_value, QNN_OP_PAD_PARAM_SCHEME, param_tensor_names));
 
   QnnParamWrapper pad_amount_param(node_unit.Index(), node_unit.Name(), QNN_OP_PAD_PARAM_PAD_AMOUNT,
                                    std::move(pad_amount_dim), std::vector<uint32_t>(pad_amount));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pool_op_builder.cc
@@ -197,29 +197,15 @@ Ort::Status PoolOpBuilder::AddQnnPoolParamWrappers(const OrtNodeUnit& node_unit,
   }
 
   if (qnn_pool_params.rounding_mode != 0) {
-    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-    scalar_param.dataType = QNN_DATATYPE_UINT_32;
-    scalar_param.int32Value = qnn_pool_params.rounding_mode;
-    QnnParamWrapper rounding_mode_param(node_unit.Index(),
-                                        node_unit.Name(),
-                                        qnn_pool_config.param_rounding_mode,
-                                        scalar_param);
-    param_tensor_names.push_back(rounding_mode_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(rounding_mode_param)),
-                  "Failed to add param rounding_mode.");
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(qnn_pool_params.rounding_mode),
+                                           qnn_pool_config.param_rounding_mode, param_tensor_names));
   }
 
   if (qnn_pool_config.param_count_pad_for_edges != nullptr) {
-    Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-    scalar_param.dataType = QNN_DATATYPE_BOOL_8;
-    scalar_param.bool8Value = static_cast<uint8_t>(qnn_pool_params.count_pad_for_edges);
-    QnnParamWrapper count_pad_param(node_unit.Index(),
-                                    node_unit.Name(),
-                                    qnn_pool_config.param_count_pad_for_edges,
-                                    scalar_param);
-    param_tensor_names.push_back(count_pad_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(count_pad_param)),
-                  "Failed to add param count_pad_for_edges.");
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                       qnn_pool_params.count_pad_for_edges,
+                                       qnn_pool_config.param_count_pad_for_edges, param_tensor_names));
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/quickgelu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/quickgelu_op_builder.cc
@@ -85,19 +85,16 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
 
     // Step 1: Create Mul node for alpha * x
     std::string alpha_mul_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha_mul");
-    Qnn_Scalar_t alpha_mul_scalar = QNN_SCALAR_INIT;
-    alpha_mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-    alpha_mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper alpha_mul_param(node_unit.Index(), alpha_mul_name,
-                                    QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, alpha_mul_scalar);
-    std::string alpha_mul_param_name = alpha_mul_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(alpha_mul_param)), "Failed to add operation param.");
+    std::vector<std::string> alpha_mul_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), alpha_mul_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, alpha_mul_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(alpha_mul_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {alpha_tensor_name, input_name},
                                                   {alpha_mul_output_name},
-                                                  {alpha_mul_param_name},
+                                                  std::move(alpha_mul_param_names),
                                                   do_op_validation),
                   "Failed to create alpha_mul node.");
   }
@@ -131,19 +128,16 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
 
   // Step 3: Create Mul node for x * sigmoid(alpha * x) or x * sigmoid(x)
   std::string final_mul_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_final_mul");
-  Qnn_Scalar_t final_mul_scalar = QNN_SCALAR_INIT;
-  final_mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-  final_mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  QnnParamWrapper final_mul_param(node_unit.Index(), final_mul_name,
-                                  QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, final_mul_scalar);
-  std::string final_mul_param_name = final_mul_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(final_mul_param)), "Failed to add operation param.");
+  std::vector<std::string> final_mul_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), final_mul_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, final_mul_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(final_mul_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {input_name, sigmoid_output_name},
                                                 {output_name},
-                                                {final_mul_param_name},
+                                                std::move(final_mul_param_names),
                                                 do_op_validation),
                 "Failed to create final_mul node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/randomnormallike_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/randomnormallike_op_builder.cc
@@ -119,29 +119,13 @@ Ort::Status RandomNormalLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapp
 
   // Extract 'mean' attribute
   float mean = node_helper.Get("mean", 0.0f);
-  Qnn_Scalar_t mean_param = QNN_SCALAR_INIT;
-  mean_param.dataType = QNN_DATATYPE_FLOAT_32;
-  mean_param.floatValue = mean;
-  QnnParamWrapper mean_param_wrapper(node_unit.Index(),
-                                     node_unit.Name(),
-                                     QNN_OP_RANDOM_NORMAL_LIKE_PARAM_MEAN,
-                                     mean_param);
-
-  param_names.push_back(mean_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(mean_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), mean,
+                                      QNN_OP_RANDOM_NORMAL_LIKE_PARAM_MEAN, param_names));
 
   // Extract 'scale' attribute
   float scale = node_helper.Get("scale", 1.0f);
-  Qnn_Scalar_t scale_param = QNN_SCALAR_INIT;
-  scale_param.dataType = QNN_DATATYPE_FLOAT_32;
-  scale_param.floatValue = scale;
-  QnnParamWrapper scale_param_wrapper(node_unit.Index(),
-                                      node_unit.Name(),
-                                      QNN_OP_RANDOM_NORMAL_LIKE_PARAM_SCALE,
-                                      scale_param);
-
-  param_names.push_back(scale_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(scale_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), scale,
+                                      QNN_OP_RANDOM_NORMAL_LIKE_PARAM_SCALE, param_names));
 
   const auto& outputs = node_unit.Outputs();
   const std::string& output_name = outputs[0].name;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/randomuniformlike_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/randomuniformlike_op_builder.cc
@@ -116,29 +116,13 @@ Ort::Status RandomUniformLikeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrap
 
   // Extract 'low' attribute
   float low = node_helper.Get("low", 0.0f);
-  Qnn_Scalar_t low_param = QNN_SCALAR_INIT;
-  low_param.dataType = QNN_DATATYPE_FLOAT_32;
-  low_param.floatValue = low;
-  QnnParamWrapper low_param_wrapper(node_unit.Index(),
-                                    node_unit.Name(),
-                                    QNN_OP_RANDOM_UNIFORM_LIKE_PARAM_LOW,
-                                    low_param);
-
-  param_names.push_back(low_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(low_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), low,
+                                      QNN_OP_RANDOM_UNIFORM_LIKE_PARAM_LOW, param_names));
 
   // Extract 'high' attribute
   float high = node_helper.Get("high", 1.0f);
-  Qnn_Scalar_t high_param = QNN_SCALAR_INIT;
-  high_param.dataType = QNN_DATATYPE_FLOAT_32;
-  high_param.floatValue = high;
-  QnnParamWrapper high_param_wrapper(node_unit.Index(),
-                                     node_unit.Name(),
-                                     QNN_OP_RANDOM_UNIFORM_LIKE_PARAM_HIGH,
-                                     high_param);
-
-  param_names.push_back(high_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(high_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), high,
+                                      QNN_OP_RANDOM_UNIFORM_LIKE_PARAM_HIGH, param_names));
 
   const auto& outputs = node_unit.Outputs();
   const std::string& output_name = outputs[0].name;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -94,19 +94,16 @@ Ort::Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qn
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add output tensor.");
 
   std::string div_node_name = utils::UniqueNameGenerator().New(node_unit);
-  Qnn_Scalar_t div_scalar = QNN_SCALAR_INIT;
-  div_scalar.dataType = QNN_DATATYPE_UINT_32;
-  div_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE;
-  QnnParamWrapper div_param(node_unit.Index(), div_node_name,
-                            QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_scalar);
-  std::string div_param_name = div_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(div_param)), "Failed to add operation param.");
+  std::vector<std::string> div_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), div_node_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(div_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {divisor_name, input_names[0]},
                                                 {output_name},
-                                                {div_param_name},
+                                                std::move(div_param_names),
                                                 do_op_validation),
                 "Failed to create Div node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -220,12 +220,8 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // Handle keepdims param.
   //
   auto onnx_keepdims = node_attr_helper.Get("keepdims", (int32_t)1);
-  Qnn_Scalar_t scalar_param = QNN_SCALAR_INIT;
-  scalar_param.dataType = QNN_DATATYPE_BOOL_8;
-  scalar_param.bool8Value = static_cast<uint8_t>(onnx_keepdims == 0 ? 0 : 1);
-  QnnParamWrapper keep_dims_param(node_unit.Index(), node_unit.Name(), QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, scalar_param);
-  param_tensor_names.push_back(keep_dims_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(keep_dims_param));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), onnx_keepdims != 0,
+                                     QNN_OP_REDUCE_MAX_PARAM_KEEP_DIMS, param_tensor_names));
 
   if (node_unit.OpType() == "ReduceL2") {
     // If ReduceL2, QNN doesn't have a single Op for it, we need to add a

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -245,19 +245,16 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                         std::move(input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pow2_tensorwrapper)), "AddTensorWrapper failed");
     std::string pow2_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-    Qnn_Scalar_t pow2_scalar = QNN_SCALAR_INIT;
-    pow2_scalar.dataType = QNN_DATATYPE_UINT_32;
-    pow2_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper pow2_param(node_unit.Index(), pow2_node_name,
-                               QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, pow2_scalar);
-    std::string pow2_param_name = pow2_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(pow2_param)), "Failed to add operation param.");
+    std::vector<std::string> pow2_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), pow2_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, pow2_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(pow2_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {input_name, input_name},
                                                   {pow2_output_name},
-                                                  {pow2_param_name},
+                                                  std::move(pow2_param_names),
                                                   do_op_validation),
                   "CreateQnnNode failed");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -363,22 +363,14 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     qnn_op_type = "ResizeNearestNeighbor";
 
     // 'align_corners'
-    Qnn_Scalar_t qnn_align_corners = QNN_SCALAR_INIT;
-    qnn_align_corners.dataType = QNN_DATATYPE_BOOL_8;
-    qnn_align_corners.bool8Value = static_cast<uint8_t>(transformation_mode == "align_corners");
-    QnnParamWrapper qnn_align_corners_param(node_unit.Index(), node_unit.Name(),
-                                            QNN_OP_RESIZE_NEAREST_NEIGHBOR_PARAM_ALIGN_CORNERS, qnn_align_corners);
-    param_tensor_names.push_back(qnn_align_corners_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_align_corners_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                       transformation_mode == "align_corners",
+                                       QNN_OP_RESIZE_NEAREST_NEIGHBOR_PARAM_ALIGN_CORNERS, param_tensor_names));
 
     // 'half_pixel_centers'
-    Qnn_Scalar_t qnn_half_pixel = QNN_SCALAR_INIT;
-    qnn_half_pixel.dataType = QNN_DATATYPE_BOOL_8;
-    qnn_half_pixel.bool8Value = static_cast<uint8_t>(transformation_mode == "half_pixel");
-    QnnParamWrapper qnn_half_pixel_param(node_unit.Index(), node_unit.Name(),
-                                         QNN_OP_RESIZE_NEAREST_NEIGHBOR_PARAM_HALF_PIXEL_CENTERS, qnn_half_pixel);
-    param_tensor_names.push_back(qnn_half_pixel_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_half_pixel_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                       transformation_mode == "half_pixel",
+                                       QNN_OP_RESIZE_NEAREST_NEIGHBOR_PARAM_HALF_PIXEL_CENTERS, param_tensor_names));
   } else if (is_npu_backend && input_rank == 4 && interp_mode == "linear" &&
              (transformation_mode != "pytorch_half_pixel" ||
               IsPyTorchHalfPixelEquivalentToHalfPixel(node_unit))) {
@@ -393,82 +385,56 @@ Ort::Status ResizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     qnn_op_type = "ResizeBilinear";
 
     // 'align_corners'
-    Qnn_Scalar_t qnn_align_corners = QNN_SCALAR_INIT;
-    qnn_align_corners.dataType = QNN_DATATYPE_BOOL_8;
-    qnn_align_corners.bool8Value = static_cast<uint8_t>(transformation_mode == "align_corners");
-
-    QnnParamWrapper qnn_align_corners_param(node_unit.Index(), node_unit.Name(),
-                                            QNN_OP_RESIZE_BILINEAR_PARAM_ALIGN_CORNERS, qnn_align_corners);
-
-    param_tensor_names.push_back(qnn_align_corners_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_align_corners_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                       transformation_mode == "align_corners",
+                                       QNN_OP_RESIZE_BILINEAR_PARAM_ALIGN_CORNERS, param_tensor_names));
 
     // 'half_pixel_centers'
-    Qnn_Scalar_t qnn_half_pixel = QNN_SCALAR_INIT;
-    qnn_half_pixel.dataType = QNN_DATATYPE_BOOL_8;
-    qnn_half_pixel.bool8Value = static_cast<uint8_t>(transformation_mode == "half_pixel" ||
-                                                     transformation_mode == "pytorch_half_pixel");
-
-    QnnParamWrapper qnn_half_pixel_param(node_unit.Index(), node_unit.Name(),
-                                         QNN_OP_RESIZE_BILINEAR_PARAM_HALF_PIXEL_CENTERS, qnn_half_pixel);
-
-    param_tensor_names.push_back(qnn_half_pixel_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_half_pixel_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                       transformation_mode == "half_pixel" ||
+                                           transformation_mode == "pytorch_half_pixel",
+                                       QNN_OP_RESIZE_BILINEAR_PARAM_HALF_PIXEL_CENTERS, param_tensor_names));
   } else {
     // Fallback to QNN's Resize operator, which seems to align better with ONNX's Resize attributes and supports
     // input ranks other than 4, but may not perform as optimally (at the moment).
 
     // Parameter 'transformation_mode'
-    Qnn_Scalar_t qnn_transformation_mode = QNN_SCALAR_INIT;
-    qnn_transformation_mode.dataType = QNN_DATATYPE_UINT_32;
+    uint32_t qnn_transformation_mode_value = 0;
     RETURN_IF_ERROR(GetQnnModeValFromOnnxString(supported_coord_transf_modes, transformation_mode,
                                                 "coordinate_transformation_mode",
-                                                qnn_transformation_mode.uint32Value));
-
-    QnnParamWrapper qnn_transformation_mode_param(node_unit.Index(), node_unit.Name(),
-                                                  QNN_OP_RESIZE_PARAM_TRANSFORMATION_MODE, qnn_transformation_mode);
-    param_tensor_names.push_back(qnn_transformation_mode_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_transformation_mode_param));
+                                                qnn_transformation_mode_value));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           qnn_transformation_mode_value,
+                                           QNN_OP_RESIZE_PARAM_TRANSFORMATION_MODE, param_tensor_names));
 
     // Parameter 'exclude_outside'
-    Qnn_Scalar_t qnn_exclude_outside = QNN_SCALAR_INIT;
-    qnn_exclude_outside.dataType = QNN_DATATYPE_BOOL_8;
-    qnn_exclude_outside.bool8Value = static_cast<uint8_t>(GetOnnxAttr(node_helper, onnx_exclude_outside_attr) != 0);
-
-    QnnParamWrapper qnn_exclude_outside_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_EXCLUDE_OUTSIDE,
-                                              qnn_exclude_outside);
-    param_tensor_names.push_back(qnn_exclude_outside_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_exclude_outside_param));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                       GetOnnxAttr(node_helper, onnx_exclude_outside_attr) != 0,
+                                       QNN_OP_RESIZE_PARAM_EXCLUDE_OUTSIDE, param_tensor_names));
 
     // Parameter 'interpolation_mode'
-    Qnn_Scalar_t qnn_interp_mode = QNN_SCALAR_INIT;
-    qnn_interp_mode.dataType = QNN_DATATYPE_UINT_32;
-    RETURN_IF_ERROR(GetQnnModeValFromOnnxString(supported_modes, interp_mode, "mode", qnn_interp_mode.uint32Value));
+    uint32_t qnn_interp_mode_value = 0;
+    RETURN_IF_ERROR(GetQnnModeValFromOnnxString(supported_modes, interp_mode, "mode", qnn_interp_mode_value));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           qnn_interp_mode_value,
+                                           QNN_OP_RESIZE_PARAM_INTERPOLATION_MODE, param_tensor_names));
 
-    QnnParamWrapper qnn_interp_mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_INTERPOLATION_MODE,
-                                          qnn_interp_mode);
-    param_tensor_names.push_back(qnn_interp_mode_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(qnn_interp_mode_param));
-
-    if (is_npu_backend && qnn_interp_mode.uint32Value == QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC) {
+    if (is_npu_backend && qnn_interp_mode_value == QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC) {
       const ONNXTensorElementDataType input_dtype = node_unit.Inputs()[0].type;
       RETURN_IF(input_dtype == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16, kNpuBF16InterpolationLimitations);
     }
 
     // Parameter 'nearest_mode'. Processed only when 'interpolation_mode' is NEAREST(0).
-    if (qnn_interp_mode.uint32Value == 0) {
-      Qnn_Scalar_t qnn_nearest_mode = QNN_SCALAR_INIT;
-      qnn_nearest_mode.dataType = QNN_DATATYPE_UINT_32;
+    if (qnn_interp_mode_value == 0) {
+      uint32_t qnn_nearest_mode_value = 0;
       RETURN_IF_ERROR(GetQnnModeValFromOnnxString(supported_nearest_modes, nearest_mode, "nearest_mode",
-                                                  qnn_nearest_mode.uint32Value));
-
-      QnnParamWrapper qnn_nearest_mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_RESIZE_PARAM_NEAREST_MODE,
-                                             qnn_nearest_mode);
-      param_tensor_names.push_back(qnn_nearest_mode_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(qnn_nearest_mode_param));
+                                                  qnn_nearest_mode_value));
+      RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                             qnn_nearest_mode_value,
+                                             QNN_OP_RESIZE_PARAM_NEAREST_MODE, param_tensor_names));
     }
 
-    if (qnn_interp_mode.uint32Value == QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC) {
+    if (qnn_interp_mode_value == QNN_OP_RESIZE_INTERPOLATION_MODE_CUBIC) {
       const float cubic_coeff = GetOnnxAttr(node_helper, onnx_cubic_coeff_a_attr);
       RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper,
                                           node_unit.Index(),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -139,15 +139,8 @@ Ort::Status RMSNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapp
 
   // Process epsilon attribute
   const float epsilon = node_helper.Get("epsilon", 1e-05f);
-  Qnn_Scalar_t epsilon_param = QNN_SCALAR_INIT;
-  epsilon_param.dataType = QNN_DATATYPE_FLOAT_32;
-  epsilon_param.floatValue = epsilon;
-  QnnParamWrapper epsilon_param_wrapper(node_unit.Index(),
-                                        node_unit.Name(),
-                                        QNN_OP_RMS_NORM_PARAM_EPSILON,
-                                        epsilon_param);
-  param_tensor_names.push_back(epsilon_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(epsilon_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), epsilon,
+                                      QNN_OP_RMS_NORM_PARAM_EPSILON, param_tensor_names));
 
   // Process axis attribute and create axes parameter
   std::vector<uint32_t> input_shape;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rotary_embedding_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rotary_embedding_op_builder.cc
@@ -480,13 +480,8 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
     std::vector<std::string> split_param_names;
 
     // axis = 3 (last dimension)
-    Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-    axis_scalar.dataType = QNN_DATATYPE_INT_32;
-    axis_scalar.int32Value = 3;
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name() + "_split_axis",
-                               QNN_OP_SPLIT_PARAM_AXIS, axis_scalar);
-    split_param_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_split_axis",
+                                          static_cast<int32_t>(3), QNN_OP_SPLIT_PARAM_AXIS, split_param_names));
 
     // split_index = [rotary_half_dim] (implicit 0 at start)
     std::vector<uint32_t> split_index_data = {rotary_half_dim};
@@ -538,13 +533,8 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
       std::vector<std::string> gather_param_names;
 
       // axis = 0 (gather along sequence dimension)
-      Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-      axis_scalar.dataType = QNN_DATATYPE_INT_32;
-      axis_scalar.int32Value = 0;
-      QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name() + "_cos_gather_axis",
-                                 QNN_OP_GATHER_PARAM_AXIS, axis_scalar);
-      gather_param_names.push_back(axis_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+      RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_cos_gather_axis",
+                                            static_cast<int32_t>(0), QNN_OP_GATHER_PARAM_AXIS, gather_param_names));
 
       // Output shape: [B, S, rotary_half_dim]
       std::vector<uint32_t> cos_gathered_shape = {batch_size, seq_len, rotary_half_dim};
@@ -573,13 +563,8 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
       std::vector<std::string> gather_input_names = {sin_cache_name, position_ids_name};
       std::vector<std::string> gather_param_names;
 
-      Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-      axis_scalar.dataType = QNN_DATATYPE_INT_32;
-      axis_scalar.int32Value = 0;
-      QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name() + "_sin_gather_axis",
-                                 QNN_OP_GATHER_PARAM_AXIS, axis_scalar);
-      gather_param_names.push_back(axis_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+      RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_sin_gather_axis",
+                                            static_cast<int32_t>(0), QNN_OP_GATHER_PARAM_AXIS, gather_param_names));
 
       std::vector<uint32_t> sin_gathered_shape = {batch_size, seq_len, rotary_half_dim};
       QnnTensorWrapper sin_gathered_tensor(sin_gathered, QNN_TENSOR_TYPE_NATIVE,
@@ -851,13 +836,9 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
       std::vector<std::string> concat_input_names = {real_reshaped, imag_reshaped};
       std::vector<std::string> concat_param_names;
 
-      Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-      axis_scalar.dataType = QNN_DATATYPE_INT_32;
-      axis_scalar.int32Value = 4;  // last dimension
-      QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name() + "_stack_axis",
-                                 QNN_OP_CONCAT_PARAM_AXIS, axis_scalar);
-      concat_param_names.push_back(axis_param.GetParamTensorName());
-      qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+      RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_stack_axis",
+                                            static_cast<int32_t>(4),  // last dimension
+                                            QNN_OP_CONCAT_PARAM_AXIS, concat_param_names));
 
       QnnTensorWrapper stacked_tensor(stacked, QNN_TENSOR_TYPE_NATIVE,
                                       qnn_data_type, input_info.quant_param.Copy(),
@@ -888,13 +869,9 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
     std::vector<std::string> concat_input_names = {real, imag};
     std::vector<std::string> concat_param_names;
 
-    Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-    axis_scalar.dataType = QNN_DATATYPE_INT_32;
-    axis_scalar.int32Value = 3;  // last dimension
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name() + "_concat_axis",
-                               QNN_OP_CONCAT_PARAM_AXIS, axis_scalar);
-    concat_param_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_concat_axis",
+                                          static_cast<int32_t>(3),  // last dimension
+                                          QNN_OP_CONCAT_PARAM_AXIS, concat_param_names));
 
     QnnTensorWrapper x_rotated_tensor(x_rotated, QNN_TENSOR_TYPE_NATIVE,
                                       qnn_data_type, input_info.quant_param.Copy(),
@@ -920,13 +897,9 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
     std::vector<std::string> concat_input_names = {x_rotated, x_tail_name};
     std::vector<std::string> concat_param_names;
 
-    Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-    axis_scalar.dataType = QNN_DATATYPE_INT_32;
-    axis_scalar.int32Value = 3;  // last dimension
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name() + "_concat_tail_axis",
-                               QNN_OP_CONCAT_PARAM_AXIS, axis_scalar);
-    concat_param_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_concat_tail_axis",
+                                          static_cast<int32_t>(3),  // last dimension
+                                          QNN_OP_CONCAT_PARAM_AXIS, concat_param_names));
 
     QnnTensorWrapper output_normalized_tensor(output_normalized, QNN_TENSOR_TYPE_NATIVE,
                                               qnn_data_type, input_info.quant_param.Copy(),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rotary_embedding_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rotary_embedding_op_builder.cc
@@ -640,20 +640,17 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
                   "Failed to add cos_x1 tensor");
 
     std::string mul_cos_x1_name = utils::UniqueNameGenerator().New(node_unit, "_mul_cos_x1");
-    Qnn_Scalar_t mul_cos_x1_scalar = QNN_SCALAR_INIT;
-    mul_cos_x1_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_cos_x1_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_cos_x1_param(node_unit.Index(), mul_cos_x1_name,
-                                     QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_cos_x1_scalar);
-    std::string mul_cos_x1_param_name = mul_cos_x1_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_cos_x1_param)), "Failed to add operation param.");
+    std::vector<std::string> mul_cos_x1_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), mul_cos_x1_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_cos_x1_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       mul_cos_x1_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       std::move(mul_input_names),
                       {cos_x1},
-                      {mul_cos_x1_param_name},
+                      std::move(mul_cos_x1_param_names),
                       do_op_validation),
                   "Failed to create Multiply node for cos*x1");
   }
@@ -669,20 +666,17 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
                   "Failed to add sin_x2 tensor");
 
     std::string mul_sin_x2_name = utils::UniqueNameGenerator().New(node_unit, "_mul_sin_x2");
-    Qnn_Scalar_t mul_sin_x2_scalar = QNN_SCALAR_INIT;
-    mul_sin_x2_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_sin_x2_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_sin_x2_param(node_unit.Index(), mul_sin_x2_name,
-                                     QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_sin_x2_scalar);
-    std::string mul_sin_x2_param_name = mul_sin_x2_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_sin_x2_param)), "Failed to add operation param.");
+    std::vector<std::string> mul_sin_x2_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), mul_sin_x2_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_sin_x2_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       mul_sin_x2_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       std::move(mul_input_names),
                       {sin_x2},
-                      {mul_sin_x2_param_name},
+                      std::move(mul_sin_x2_param_names),
                       do_op_validation),
                   "Failed to create Multiply node for sin*x2");
   }
@@ -698,20 +692,17 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
                   "Failed to add real tensor");
 
     std::string sub_real_name = utils::UniqueNameGenerator().New(node_unit, "_sub_real");
-    Qnn_Scalar_t sub_real_scalar = QNN_SCALAR_INIT;
-    sub_real_scalar.dataType = QNN_DATATYPE_UINT_32;
-    sub_real_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT;
-    QnnParamWrapper sub_real_param(node_unit.Index(), sub_real_name,
-                                   QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, sub_real_scalar);
-    std::string sub_real_param_name = sub_real_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(sub_real_param)), "Failed to add operation param.");
+    std::vector<std::string> sub_real_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), sub_real_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, sub_real_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       sub_real_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       std::move(sub_input_names),
                       {real},
-                      {sub_real_param_name},
+                      std::move(sub_real_param_names),
                       do_op_validation),
                   "Failed to create Subtract node for real");
   }
@@ -727,20 +718,17 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
                   "Failed to add sin_x1 tensor");
 
     std::string mul_sin_x1_name = utils::UniqueNameGenerator().New(node_unit, "_mul_sin_x1");
-    Qnn_Scalar_t mul_sin_x1_scalar = QNN_SCALAR_INIT;
-    mul_sin_x1_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_sin_x1_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_sin_x1_param(node_unit.Index(), mul_sin_x1_name,
-                                     QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_sin_x1_scalar);
-    std::string mul_sin_x1_param_name = mul_sin_x1_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_sin_x1_param)), "Failed to add operation param.");
+    std::vector<std::string> mul_sin_x1_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), mul_sin_x1_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_sin_x1_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       mul_sin_x1_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       std::move(mul_input_names),
                       {sin_x1},
-                      {mul_sin_x1_param_name},
+                      std::move(mul_sin_x1_param_names),
                       do_op_validation),
                   "Failed to create Multiply node for sin*x1");
   }
@@ -756,20 +744,17 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
                   "Failed to add cos_x2 tensor");
 
     std::string mul_cos_x2_name = utils::UniqueNameGenerator().New(node_unit, "_mul_cos_x2");
-    Qnn_Scalar_t mul_cos_x2_scalar = QNN_SCALAR_INIT;
-    mul_cos_x2_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_cos_x2_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_cos_x2_param(node_unit.Index(), mul_cos_x2_name,
-                                     QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_cos_x2_scalar);
-    std::string mul_cos_x2_param_name = mul_cos_x2_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_cos_x2_param)), "Failed to add operation param.");
+    std::vector<std::string> mul_cos_x2_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), mul_cos_x2_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_cos_x2_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       mul_cos_x2_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       std::move(mul_input_names),
                       {cos_x2},
-                      {mul_cos_x2_param_name},
+                      std::move(mul_cos_x2_param_names),
                       do_op_validation),
                   "Failed to create Multiply node for cos*x2");
   }
@@ -785,20 +770,17 @@ Ort::Status RotaryEmbeddingOpBuilder::DecomposeRotaryEmbedding(QnnModelWrapper& 
                   "Failed to add imag tensor");
 
     std::string add_imag_name = utils::UniqueNameGenerator().New(node_unit, "_add_imag");
-    Qnn_Scalar_t add_imag_scalar = QNN_SCALAR_INIT;
-    add_imag_scalar.dataType = QNN_DATATYPE_UINT_32;
-    add_imag_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD;
-    QnnParamWrapper add_imag_param(node_unit.Index(), add_imag_name,
-                                   QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_imag_scalar);
-    std::string add_imag_param_name = add_imag_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(add_imag_param)), "Failed to add operation param.");
+    std::vector<std::string> add_imag_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), add_imag_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, add_imag_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       add_imag_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       std::move(add_input_names),
                       {imag},
-                      {add_imag_param_name},
+                      std::move(add_imag_param_names),
                       do_op_validation),
                   "Failed to create Add node for imag");
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
@@ -152,24 +152,21 @@ Ort::Status ScatterElementsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
   param_tensor_names.push_back(axis_param.GetParamTensorName());
   qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-  Qnn_Scalar_t reduction_scalar = QNN_SCALAR_INIT;
-  reduction_scalar.dataType = QNN_DATATYPE_UINT_32;
+  uint32_t reduction_value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_NONE;
   if (reduction == "none") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_NONE;
+    reduction_value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_NONE;
   } else if (reduction == "add") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_ADD;
+    reduction_value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_ADD;
   } else if (reduction == "mul") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MUL;
+    reduction_value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MUL;
   } else if (reduction == "max") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MAX;
+    reduction_value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_MAX;
   } else {
     return MAKE_EP_FAIL(("Unexpected ScatterElements reduction: " + reduction).c_str());
   }
 
-  QnnParamWrapper reduction_param(node_unit.Index(), node_unit.Name(),
-                                  QNN_OP_SCATTER_ELEMENTS_PARAM_REDUCTION, reduction_scalar);
-  param_tensor_names.push_back(reduction_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), reduction_value,
+                                         QNN_OP_SCATTER_ELEMENTS_PARAM_REDUCTION, param_tensor_names));
 
   return ProcessOutputs(qnn_model_wrapper, node_unit,
                         std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
@@ -125,22 +125,20 @@ Ort::Status ScatterNDOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
   RETURN_IF_NOT(utils::ArrayHasString(kSupportedReductions, reduction),
                 ("ScatterND does not support reduction " + reduction).c_str());
 
-  Qnn_Scalar_t reduction_scalar = QNN_SCALAR_INIT;
-  reduction_scalar.dataType = QNN_DATATYPE_UINT_32;
+  uint32_t reduction_value = QNN_OP_SCATTER_ND_REDUCTION_NONE;
   if (reduction == "none") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_NONE;
+    reduction_value = QNN_OP_SCATTER_ND_REDUCTION_NONE;
   } else if (reduction == "add") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_ADD;
+    reduction_value = QNN_OP_SCATTER_ND_REDUCTION_ADD;
   } else if (reduction == "mul") {
-    reduction_scalar.uint32Value = QNN_OP_SCATTER_ND_REDUCTION_MUL;
+    reduction_value = QNN_OP_SCATTER_ND_REDUCTION_MUL;
   } else {
     return MAKE_EP_FAIL(("Unexpected ScatterND reduction: " + reduction).c_str());
   }
 
-  QnnParamWrapper reduction_param(node_unit.Index(), node_unit.Name(),
-                                  QNN_OP_SCATTER_ND_PARAM_REDUCTION, reduction_scalar);
-  std::vector<std::string> param_tensor_names = {reduction_param.GetParamTensorName()};
-  qnn_model_wrapper.AddParamWrapper(std::move(reduction_param));
+  std::vector<std::string> param_tensor_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), reduction_value,
+                                         QNN_OP_SCATTER_ND_PARAM_REDUCTION, param_tensor_names));
 
   return ProcessOutputs(qnn_model_wrapper, node_unit,
                         std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/selu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/selu_op_builder.cc
@@ -56,25 +56,16 @@ Ort::Status SeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(elu_output_wrapper)),
                 "Selu: failed to add intermediate ELU output tensor.");
 
+  std::vector<std::string> elu_param_names;
+
   // operation param: ELU
-  Qnn_Scalar_t elu_op_scalar = QNN_SCALAR_INIT;
-  elu_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  elu_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_ELU;
-  QnnParamWrapper elu_op_param(node_unit.Index(), node_unit.Name(),
-                               QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, elu_op_scalar);
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_NEURON_OPERATION_ELU),
+                                         QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, elu_param_names));
 
   // alpha param
-  Qnn_Scalar_t alpha_scalar = QNN_SCALAR_INIT;
-  alpha_scalar.dataType = QNN_DATATYPE_FLOAT_32;
-  alpha_scalar.floatValue = alpha;
-  QnnParamWrapper alpha_param(node_unit.Index(), node_unit.Name(),
-                              QNN_OP_ELEMENT_WISE_NEURON_PARAM_ALPHA, alpha_scalar);
-
-  std::vector<std::string> elu_param_names;
-  elu_param_names.push_back(elu_op_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(elu_op_param));
-  elu_param_names.push_back(alpha_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(alpha_param));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), alpha,
+                                      QNN_OP_ELEMENT_WISE_NEURON_PARAM_ALPHA, elu_param_names));
 
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit.Name() + "_elu"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/selu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/selu_op_builder.cc
@@ -119,19 +119,16 @@ Ort::Status SeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                 "Selu: failed to add output tensor.");
 
   std::string gamma_mul_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_gamma_mul");
-  Qnn_Scalar_t gamma_mul_scalar = QNN_SCALAR_INIT;
-  gamma_mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-  gamma_mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  QnnParamWrapper gamma_mul_param(node_unit.Index(), gamma_mul_name,
-                                  QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, gamma_mul_scalar);
-  std::string gamma_mul_param_name = gamma_mul_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(gamma_mul_param)), "Failed to add operation param.");
+  std::vector<std::string> gamma_mul_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), gamma_mul_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, gamma_mul_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(gamma_mul_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {gamma_tensor_name, elu_output_name},
                                                 {output_name},
-                                                {gamma_mul_param_name},
+                                                std::move(gamma_mul_param_names),
                                                 do_op_validation),
                 "Selu: failed to create Multiply node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -152,13 +152,8 @@ Ort::Status ProcessNodeAttribute(QnnModelWrapper& qnn_model_wrapper,
                                  const float default_value = 1.0f) {
   OrtNodeAttrHelper node_helper(node_unit);
   float attr_value = node_helper.Get(onnx_attr_key, default_value);
-  Qnn_Scalar_t attr_qnn_scalar = QNN_SCALAR_INIT;
-  attr_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
-  attr_qnn_scalar.floatValue = attr_value;
-
-  QnnParamWrapper alpha_param(node_unit.Index(), node_unit.Name(), qnn_param_key, attr_qnn_scalar);
-  param_tensor_names.push_back(alpha_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(alpha_param));
+  RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), attr_value,
+                                      qnn_param_key, param_tensor_names));
 
   return Ort::Status();
 }
@@ -183,19 +178,17 @@ Ort::Status ProcessModeAttribute(QnnModelWrapper& qnn_model_wrapper,
                                  std::vector<std::string>& param_tensor_names) {
   OrtNodeAttrHelper node_helper(node_unit);
   std::string mode = node_helper.Get("mode", "DCR");
-  Qnn_Scalar_t mode_qnn_scalar = QNN_SCALAR_INIT;
-  mode_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
+  uint32_t mode_value = QNN_OP_DEPTH_TO_SPACE_MODE_DCR;
   if ("DCR" == mode) {
-    mode_qnn_scalar.uint32Value = QNN_OP_DEPTH_TO_SPACE_MODE_DCR;
+    mode_value = QNN_OP_DEPTH_TO_SPACE_MODE_DCR;
   } else if ("CRD" == mode) {
-    mode_qnn_scalar.uint32Value = QNN_OP_DEPTH_TO_SPACE_MODE_CRD;  // CRD mode
+    mode_value = QNN_OP_DEPTH_TO_SPACE_MODE_CRD;  // CRD mode
   } else {
     return MAKE_EP_FAIL("DepthToSpace mode only support DCR & CRD.");
   }
 
-  QnnParamWrapper mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_DEPTH_TO_SPACE_PARAM_MODE, mode_qnn_scalar);
-  param_tensor_names.push_back(mode_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(mode_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), mode_value,
+                                         QNN_OP_DEPTH_TO_SPACE_PARAM_MODE, param_tensor_names));
 
   return Ort::Status();
 }
@@ -253,42 +246,34 @@ Ort::Status ProcessGridSampleAttributes(QnnModelWrapper& qnn_model_wrapper,
                                         std::vector<std::string>& param_tensor_names) {
   OrtNodeAttrHelper node_helper(node_unit);
   int64_t align_corners = node_helper.Get("align_corners", static_cast<int64_t>(0));
-  Qnn_Scalar_t align_corners_qnn_scalar = QNN_SCALAR_INIT;
-  align_corners_qnn_scalar.dataType = QNN_DATATYPE_BOOL_8;
-  align_corners_qnn_scalar.bool8Value = static_cast<uint8_t>(align_corners == 0 ? 0 : 1);
-  QnnParamWrapper align_corners_param(node_unit.Index(), node_unit.Name(), QNN_OP_GRID_SAMPLE_PARAM_ALIGN_CORNERS, align_corners_qnn_scalar);
-  param_tensor_names.push_back(align_corners_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(align_corners_param));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), align_corners != 0,
+                                     QNN_OP_GRID_SAMPLE_PARAM_ALIGN_CORNERS, param_tensor_names));
 
   std::string mode = node_helper.Get("mode", "linear");
-  Qnn_Scalar_t mode_qnn_scalar = QNN_SCALAR_INIT;
-  mode_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
+  uint32_t mode_value = QNN_OP_GRID_SAMPLE_MODE_BILINEAR;
   if ("linear" == mode || "bilinear" == mode) {
-    mode_qnn_scalar.uint32Value = QNN_OP_GRID_SAMPLE_MODE_BILINEAR;
+    mode_value = QNN_OP_GRID_SAMPLE_MODE_BILINEAR;
   } else if ("nearest" == mode) {
-    mode_qnn_scalar.uint32Value = QNN_OP_GRID_SAMPLE_MODE_NEAREST;
+    mode_value = QNN_OP_GRID_SAMPLE_MODE_NEAREST;
   } else {
     return MAKE_EP_FAIL("GridSample mode only support [linear, bilinear, nearest].");
   }
-  QnnParamWrapper mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_GRID_SAMPLE_PARAM_MODE, mode_qnn_scalar);
-  param_tensor_names.push_back(mode_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(mode_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), mode_value,
+                                         QNN_OP_GRID_SAMPLE_PARAM_MODE, param_tensor_names));
 
   std::string padding_mode = node_helper.Get("padding_mode", "zeros");
-  Qnn_Scalar_t padding_mode_qnn_scalar = QNN_SCALAR_INIT;
-  padding_mode_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
+  uint32_t padding_mode_value = QNN_OP_GRID_SAMPLE_PADDING_MODE_ZEROS;
   if ("zeros" == padding_mode) {
-    padding_mode_qnn_scalar.uint32Value = QNN_OP_GRID_SAMPLE_PADDING_MODE_ZEROS;
+    padding_mode_value = QNN_OP_GRID_SAMPLE_PADDING_MODE_ZEROS;
   } else if ("border" == padding_mode) {
-    padding_mode_qnn_scalar.uint32Value = QNN_OP_GRID_SAMPLE_PADDING_MODE_BORDER;
+    padding_mode_value = QNN_OP_GRID_SAMPLE_PADDING_MODE_BORDER;
   } else if ("reflection" == padding_mode) {
-    padding_mode_qnn_scalar.uint32Value = QNN_OP_GRID_SAMPLE_PADDING_MODE_REFLECTION;
+    padding_mode_value = QNN_OP_GRID_SAMPLE_PADDING_MODE_REFLECTION;
   } else {
     return MAKE_EP_FAIL("GridSample padding_mode only support [zeros, border, reflection].");
   }
-  QnnParamWrapper padding_mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_GRID_SAMPLE_PARAM_PADDING_MODE, padding_mode_qnn_scalar);
-  param_tensor_names.push_back(padding_mode_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(padding_mode_param));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), padding_mode_value,
+                                         QNN_OP_GRID_SAMPLE_PARAM_PADDING_MODE, param_tensor_names));
 
   return Ort::Status();
 }
@@ -367,29 +352,13 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   if (op_type == "Softplus") {
     // ONNX Softplus has no attributes; set QNN defaults (beta=1, threshold=20).
-    Qnn_Scalar_t beta_scalar = QNN_SCALAR_INIT;
-    beta_scalar.dataType = QNN_DATATYPE_FLOAT_32;
-    beta_scalar.floatValue = 1.0f;
-    QnnParamWrapper beta_param(node_unit.Index(), node_unit.Name(),
-                               QNN_OP_ELEMENT_WISE_NEURON_PARAM_BETA, beta_scalar);
-    param_tensor_names.push_back(beta_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(beta_param));
-
-    Qnn_Scalar_t threshold_scalar = QNN_SCALAR_INIT;
-    threshold_scalar.dataType = QNN_DATATYPE_FLOAT_32;
-    threshold_scalar.floatValue = 20.0f;
-    QnnParamWrapper threshold_param(node_unit.Index(), node_unit.Name(),
-                                    QNN_OP_ELEMENT_WISE_NEURON_PARAM_THRESHOLD, threshold_scalar);
-    param_tensor_names.push_back(threshold_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(threshold_param));
-
-    Qnn_Scalar_t neuron_operation = QNN_SCALAR_INIT;
-    neuron_operation.dataType = QNN_DATATYPE_UINT_32;
-    neuron_operation.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_SOFTPLUS;
-    QnnParamWrapper operation_param(node_unit.Index(), node_unit.Name(),
-                                    QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, neuron_operation);
-    param_tensor_names.push_back(operation_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(operation_param));
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), 1.0f,
+                                        QNN_OP_ELEMENT_WISE_NEURON_PARAM_BETA, param_tensor_names));
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), 20.0f,
+                                        QNN_OP_ELEMENT_WISE_NEURON_PARAM_THRESHOLD, param_tensor_names));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_NEURON_OPERATION_SOFTPLUS),
+                                           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, param_tensor_names));
   }
 
   if (op_type == "HardSwish") {
@@ -403,15 +372,9 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_ERROR(ProcessNodeAttribute(qnn_model_wrapper, node_unit, "beta",
                                          QNN_OP_ELEMENT_WISE_NEURON_PARAM_BETA,
                                          param_tensor_names, 0.5f));
-    Qnn_Scalar_t neuron_operation = QNN_SCALAR_INIT;
-    neuron_operation.dataType = QNN_DATATYPE_UINT_32;
-    neuron_operation.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_HARD_SIGMOID;
-
-    QnnParamWrapper operation_param(node_unit.Index(), node_unit.Name(),
-                                    QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
-                                    neuron_operation);
-    param_tensor_names.push_back(operation_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(operation_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_NEURON_OPERATION_HARD_SIGMOID),
+                                           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, param_tensor_names));
   }
 
   if (op_type == "DepthToSpace") {
@@ -421,14 +384,9 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   if (op_type == "SpaceToDepth") {
     RETURN_IF_ERROR(ProcessBlockSizeAttribute(qnn_model_wrapper, node_unit, param_tensor_names));
-
-    Qnn_Scalar_t mode_qnn_scalar = QNN_SCALAR_INIT;
-    mode_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mode_qnn_scalar.uint32Value = QNN_OP_SPACE_TO_DEPTH_MODE_DCR;
-
-    QnnParamWrapper mode_param(node_unit.Index(), node_unit.Name(), QNN_OP_SPACE_TO_DEPTH_PARAM_MODE, mode_qnn_scalar);
-    param_tensor_names.push_back(mode_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(mode_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(QNN_OP_SPACE_TO_DEPTH_MODE_DCR),
+                                           QNN_OP_SPACE_TO_DEPTH_PARAM_MODE, param_tensor_names));
   }
 
   if (op_type == "GridSample") {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/stft_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/stft_op_builder.cc
@@ -97,18 +97,10 @@ Ort::Status STFTOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                   "Failed to add expanded signal tensor.");
 
     // Create axis parameter for ExpandDims (add dimension at the end)
-    Qnn_Scalar_t axis_param = QNN_SCALAR_INIT;
-    axis_param.dataType = QNN_DATATYPE_UINT_32;
-    axis_param.uint32Value = static_cast<uint32_t>(2);  // Add at the end
-
-    QnnParamWrapper axis_param_wrapper(node_unit.Index(),
-                                       node_unit.Name(),
-                                       "axis",
-                                       axis_param);
-
     std::vector<std::string> expand_dims_params;
-    expand_dims_params.push_back(axis_param_wrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param_wrapper));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(2),  // Add at the end
+                                           "axis", expand_dims_params));
 
     // Create the ExpandDims node
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
@@ -236,15 +228,8 @@ Ort::Status STFTOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     std::vector<uint8_t> frame_step_data;
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(frame_step.initializer_tensor, frame_step_data));
     frame_step_info = *reinterpret_cast<uint32_t*>(frame_step_data.data());
-    Qnn_Scalar_t frame_step_param = QNN_SCALAR_INIT;
-    frame_step_param.dataType = QNN_DATATYPE_UINT_32;
-    frame_step_param.uint32Value = frame_step_info;
-    QnnParamWrapper frame_step_param_wrapper(node_unit.Index(),
-                                             node_unit.Name(),
-                                             QNN_OP_STFT_PARAM_FRAME_STEP,
-                                             frame_step_param);
-    param_tensor_names.push_back(frame_step_param_wrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(frame_step_param_wrapper));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), frame_step_info,
+                                           QNN_OP_STFT_PARAM_FRAME_STEP, param_tensor_names));
   }
 
   // Process frame_length if it exists
@@ -257,15 +242,8 @@ Ort::Status STFTOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     frame_length_info = *reinterpret_cast<uint32_t*>(frame_length_data.data());
 
     // Create frame_length parameter
-    Qnn_Scalar_t frame_length_param = QNN_SCALAR_INIT;
-    frame_length_param.dataType = QNN_DATATYPE_UINT_32;
-    frame_length_param.uint32Value = frame_length_info;
-    QnnParamWrapper frame_length_param_wrapper(node_unit.Index(),
-                                               node_unit.Name(),
-                                               QNN_OP_STFT_PARAM_FRAME_LENGTH,
-                                               frame_length_param);
-    param_tensor_names.push_back(frame_length_param_wrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(frame_length_param_wrapper));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), frame_length_info,
+                                           QNN_OP_STFT_PARAM_FRAME_LENGTH, param_tensor_names));
   }
 
   const auto& outputs = node_unit.Outputs();
@@ -281,17 +259,9 @@ Ort::Status STFTOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                         output_info.quant_param.Copy(), std::move(output_info.shape));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add output tensor.");
 
-  Qnn_Scalar_t onesided_param = QNN_SCALAR_INIT;
-  onesided_param.dataType = QNN_DATATYPE_BOOL_8;
-  onesided_param.bool8Value = static_cast<bool>(onesided);
-
-  QnnParamWrapper onesided_param_wrapper(node_unit.Index(),
-                                         node_unit.Name(),
-                                         QNN_OP_STFT_PARAM_ONESIDED,
-                                         onesided_param);
-
-  param_tensor_names.push_back(onesided_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(onesided_param_wrapper));
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                     static_cast<bool>(onesided),
+                                     QNN_OP_STFT_PARAM_ONESIDED, param_tensor_names));
 
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                     utils::UniqueNameGenerator().New(node_unit),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
@@ -129,23 +129,14 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   } else {
     return MAKE_EP_FAIL("QNN TopK operator requires constant input parameter k.");
   }
-  Qnn_Scalar_t qnn_scalar_k = QNN_SCALAR_INIT;
-  qnn_scalar_k.dataType = QNN_DATATYPE_UINT_32;
-  qnn_scalar_k.uint32Value = k;
-  QnnParamWrapper k_param(node_unit.Index(), node_unit.Name(), QNN_OP_TOP_K_PARAM_K, qnn_scalar_k);
-  std::string k_param_name = k_param.GetParamTensorName();
-  qnn_model_wrapper.AddParamWrapper(std::move(k_param));
-  std::vector<std::string> param_tensor_names{k_param_name};
+  std::vector<std::string> param_tensor_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), k,
+                                         QNN_OP_TOP_K_PARAM_K, param_tensor_names));
 
   // Add largest to TopK attr
   uint8_t largest = static_cast<uint8_t>(OrtNodeAttrHelper(node_unit).Get("largest", 1));
-  Qnn_Scalar_t qnn_largest_k = QNN_SCALAR_INIT;
-  qnn_largest_k.dataType = QNN_DATATYPE_BOOL_8;
-  qnn_largest_k.bool8Value = largest;
-  QnnParamWrapper k_largest(node_unit.Index(), node_unit.Name(), QNN_OP_TOP_K_PARAM_LARGEST, qnn_largest_k);
-  std::string k_largest_name = k_largest.GetParamTensorName();
-  qnn_model_wrapper.AddParamWrapper(std::move(k_largest));
-  param_tensor_names.push_back(k_largest_name);
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), largest != 0,
+                                     QNN_OP_TOP_K_PARAM_LARGEST, param_tensor_names));
 
   // HTP only supports TopK at the last axis, and thus check whether extra Transpose is required.
   TensorInfo input_info = {};

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -559,8 +559,10 @@ inline Ort::Status AddQnnScalar(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF(true, "QNN EP: Unsupported scalar dtype");
   }
   QnnParamWrapper qnn_param_wrapper(node_index, node_name, qnn_scalar_param_name, qnn_scalar);
-  param_names.push_back(qnn_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(qnn_param_wrapper));
+  std::string param_tensor_name = qnn_param_wrapper.GetParamTensorName();
+  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(qnn_param_wrapper)),
+                ("QNN EP: Failed to add scalar param " + qnn_scalar_param_name).c_str());
+  param_names.push_back(std::move(param_tensor_name));
   return Ort::Status();
 }
 
@@ -574,8 +576,10 @@ inline Ort::Status AddQnnScalar(QnnModelWrapper& qnn_model_wrapper,
   qnn_scalar.dataType = QNN_DATATYPE_STRING;
   qnn_scalar.stringValue = scalar.c_str();
   QnnParamWrapper qnn_param_wrapper(node_index, node_name, qnn_scalar_param_name, qnn_scalar);
-  param_names.push_back(qnn_param_wrapper.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(qnn_param_wrapper));
+  std::string param_tensor_name = qnn_param_wrapper.GetParamTensorName();
+  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(qnn_param_wrapper)),
+                ("QNN EP: Failed to add scalar param " + qnn_scalar_param_name).c_str());
+  param_names.push_back(std::move(param_tensor_name));
   return Ort::Status();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/channel_shuffle_fusion.cc
@@ -164,15 +164,9 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
 
     // Set channel axis parameter
     const uint32_t channel_axis = static_cast<uint32_t>(transpose_head_input_dims_count - 1);
-    Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-    axis_scalar.dataType = QNN_DATATYPE_UINT_32;
-    axis_scalar.uint32Value = channel_axis;
-    QnnParamWrapper param_wrapper(transpose_tail->Index(),
-                                  transpose_tail->Name(),
-                                  QNN_OP_CHANNEL_SHUFFLE_PARAM_AXIS,
-                                  axis_scalar);
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(param_wrapper)), "Failed to add axis param");
-    param_tensor_names.push_back(param_wrapper.GetParamTensorName());
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, transpose_tail->Index(),
+                                           transpose_tail->Name(), channel_axis,
+                                           QNN_OP_CHANNEL_SHUFFLE_PARAM_AXIS, param_tensor_names));
   }
 
   // Extract number of groups from reshape1 output shape
@@ -201,15 +195,10 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                                      reshape1_output_dims_count));
 
     // Set number of groups parameter
-    Qnn_Scalar_t num_groups_scalar = QNN_SCALAR_INIT;
-    num_groups_scalar.dataType = QNN_DATATYPE_UINT_32;
-    num_groups_scalar.uint32Value = static_cast<uint32_t>(reshape1_output_dims[1]);
-    QnnParamWrapper param_wrapper(transpose_tail->Index(),
-                                  transpose_tail->Name(),
-                                  QNN_OP_CHANNEL_SHUFFLE_PARAM_NUM_GROUPS,
-                                  num_groups_scalar);
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(param_wrapper)), "Failed to add num_groups param");
-    param_tensor_names.push_back(param_wrapper.GetParamTensorName());
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, transpose_tail->Index(),
+                                           transpose_tail->Name(),
+                                           static_cast<uint32_t>(reshape1_output_dims[1]),
+                                           QNN_OP_CHANNEL_SHUFFLE_PARAM_NUM_GROUPS, param_tensor_names));
   }
 
   // Create tensor wrappers for input and output

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
@@ -139,8 +139,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          einsum_node_unit.Name(),
                                          static_cast<uint32_t>(QNN_OP_DEPTH_TO_SPACE_MODE_DCR),
                                          QNN_OP_DEPTH_TO_SPACE_PARAM_MODE, mode_param_names));
-  RETURN_IF_NOT(mode_param_names.size() == 1, "Failed to add DepthToSpace mode param.");
-  const std::string mode_param_name = mode_param_names[0];
+  const std::string mode_param_name = std::move(mode_param_names.back());
 
   const OrtNodeUnitIODef& einsum_output = einsum_node_unit.Outputs()[0];
   TensorInfo einsum_output_info = {};

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
@@ -139,6 +139,7 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                          einsum_node_unit.Name(),
                                          static_cast<uint32_t>(QNN_OP_DEPTH_TO_SPACE_MODE_DCR),
                                          QNN_OP_DEPTH_TO_SPACE_PARAM_MODE, mode_param_names));
+  RETURN_IF_NOT(mode_param_names.size() == 1, "Failed to add DepthToSpace mode param.");
   const std::string mode_param_name = mode_param_names[0];
 
   const OrtNodeUnitIODef& einsum_output = einsum_node_unit.Outputs()[0];

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
@@ -134,16 +134,12 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(block_size_param)), "Failed to add param.");
 
   // Add attribute mode fixed to DCR which is guaranteed previously.
-  Qnn_Scalar_t mode_qnn_scalar = QNN_SCALAR_INIT;
-  mode_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-  mode_qnn_scalar.uint32Value = QNN_OP_DEPTH_TO_SPACE_MODE_DCR;
-
-  QnnParamWrapper mode_param(einsum_node_unit.Index(),
-                             einsum_node_unit.Name(),
-                             QNN_OP_DEPTH_TO_SPACE_PARAM_MODE,
-                             mode_qnn_scalar);
-  const std::string mode_param_name = mode_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mode_param)), "Failed to add param.");
+  std::vector<std::string> mode_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, einsum_node_unit.Index(),
+                                         einsum_node_unit.Name(),
+                                         static_cast<uint32_t>(QNN_OP_DEPTH_TO_SPACE_MODE_DCR),
+                                         QNN_OP_DEPTH_TO_SPACE_PARAM_MODE, mode_param_names));
+  const std::string mode_param_name = mode_param_names[0];
 
   const OrtNodeUnitIODef& einsum_output = einsum_node_unit.Outputs()[0];
   TensorInfo einsum_output_info = {};

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.cc
@@ -204,30 +204,18 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
   {  // axis
     std::optional<uint32_t> axis = GetPositiveSoftmaxAxis(mul_node_unit, softmax_node_unit, ort_api);
     if (axis.has_value()) {
-      Qnn_Scalar_t axis_scalar = QNN_SCALAR_INIT;
-      axis_scalar.dataType = QNN_DATATYPE_UINT_32;
-      axis_scalar.uint32Value = axis.value();
-      QnnParamWrapper param_wrapper(softmax_node_unit.Index(),
-                                    softmax_node_unit.Name(),
-                                    QNN_OP_SOFTMAX_PARAM_AXIS,
-                                    axis_scalar);
-      param_tensor_names.push_back(param_wrapper.GetParamTensorName());
-      RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(param_wrapper)), "Failed to add axis param");
+      RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, softmax_node_unit.Index(),
+                                             softmax_node_unit.Name(), axis.value(),
+                                             QNN_OP_SOFTMAX_PARAM_AXIS, param_tensor_names));
     }
   }
   {  // beta
     OrtNodeAttrHelper softmax_attr_helper(softmax_node_unit);
     float beta = softmax_attr_helper.Get("beta", 1.0f);
     float scale = ExtractScalarValueFromMul(qnn_model_wrapper, mul_node_unit, ort_api).value_or(1.0f);
-    Qnn_Scalar_t beta_scalar = QNN_SCALAR_INIT;
-    beta_scalar.dataType = QNN_DATATYPE_FLOAT_32;
-    beta_scalar.floatValue = scale * beta;
-    QnnParamWrapper param_wrapper(softmax_node_unit.Index(),
-                                  softmax_node_unit.Name(),
-                                  QNN_OP_SOFTMAX_PARAM_BETA,
-                                  beta_scalar);
-    param_tensor_names.push_back(param_wrapper.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(param_wrapper)), "Failed to add beta param");
+    RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, softmax_node_unit.Index(),
+                                        softmax_node_unit.Name(), scale * beta,
+                                        QNN_OP_SOFTMAX_PARAM_BETA, param_tensor_names));
   }
 
   QnnTensorWrapper fused_softmax_input;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Replace the verbose manual scalar-parameter construction (declare Qnn_Scalar_t, set dataType + value-union field, build QnnParamWrapper, push name, AddParamWrapper) with the AddQnnScalar<T> helper across all applicable op builders and node fusions.
- Fix two dtype/value-field mismatches
- Fix a use-after-move bug in channel_shuffle_fusion.cc

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Found that most of the scalar-parameters are constructed manully

