### PR TITLE
[QNN EP] Add nightly per-file coverage Excel report to Artifactory QA

### DIFF
--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -19,6 +19,10 @@ on:
         description: "Set to true to upload the per-file coverage Excel to Artifactory"
         type: boolean
         default: false
+      qa_tag:
+        description: "Pre-computed QA tag from the caller; leave blank to auto-generate from today's date + SHA"
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       target_py_vsn:
@@ -29,6 +33,10 @@ on:
         description: "Set to true to upload the per-file coverage Excel to Artifactory"
         type: boolean
         default: false
+      qa_tag:
+        description: "Pre-computed QA tag from the caller; leave blank to auto-generate from today's date + SHA"
+        type: string
+        default: ''
 
 jobs:
   coverage-linux-x86_64:
@@ -116,11 +124,34 @@ jobs:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
 
+      - name: Set QA Build Tag
+        # Use the caller-provided qa_tag if present so coverage shares the exact same
+        # Artifactory directory as the nightly release upload. Falls back to auto-compute
+        # for standalone runs (workflow_dispatch / PR CI). Mirrors qualcomm-internal-release.yml.
+        if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
+        run: |
+          if [ -z "${{ inputs.qa_tag }}" ]; then
+            run_date="$(date --rfc-3339=date)"
+            echo "QA_TAG=nightly-${run_date}-${GITHUB_SHA:0:10}" >> ${GITHUB_ENV}
+            echo "COVERAGE_RUN_DATE=${run_date}" >> ${GITHUB_ENV}
+          else
+            echo "QA_TAG=${{ inputs.qa_tag }}" >> ${GITHUB_ENV}
+            # Extract date portion from the canonical "nightly-YYYY-MM-DD-{sha}" format
+            # so the Excel's date column matches the directory name.
+            echo "COVERAGE_RUN_DATE=$(echo '${{ inputs.qa_tag }}' | sed -n 's/^nightly-\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\)-.*/\1/p')" >> ${GITHUB_ENV}
+          fi
+
       - name: Update per-file coverage Excel
         # !cancelled(): run even when the coverage step failed due to UT failure.
         # coverage.xml is still produced by generate_coverage.sh before it propagates the exit code.
+        # File guard: build-stage failures (cmake, link, submodule) can leave coverage.xml absent — skip cleanly.
+        # update_coverage_excel.py picks up $COVERAGE_RUN_DATE for the Excel's date column.
         if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
         run: |
+          [ -f "${COVERAGE_DIR}/coverage.xml" ] || {
+            echo "::warning::coverage.xml missing — skipping nightly Excel generation"
+            exit 0
+          }
           python3 qcom/build_and_test.py \
             --target-py-version ${{ inputs.target_py_vsn }} \
             --only \
@@ -129,9 +160,13 @@ jobs:
       - name: Upload per-file coverage Excel to Artifactory
         if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
         run: |
+          [ -f "${COVERAGE_DIR}/per_file_coverage.xlsx" ] || {
+            echo "::warning::per_file_coverage.xlsx missing — skipping nightly Artifactory upload"
+            exit 0
+          }
           jf rt upload \
             "${COVERAGE_DIR}/per_file_coverage.xlsx" \
-            "${{ secrets.BUILD_ARTIFACTORY_REPO }}/qa/nightly-$(date -u +%Y-%m-%d)-${GITHUB_SHA:0:10}/" \
+            "${{ secrets.BUILD_ARTIFACTORY_REPO }}/qa/${{ env.QA_TAG }}/" \
             --flat=true
 
       - name: Post Diff Coverage to PR

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -15,12 +15,20 @@ on:
         description: "Python version for the coverage build wheel (does not affect C++ coverage results)"
         type: string
         default: '3.10'
+      nightly_coverage:
+        description: "Set to true on nightly runs to update the per-file coverage Excel in Artifactory"
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       target_py_vsn:
         description: "Python version for the coverage build wheel (does not affect C++ coverage results)"
         type: string
         default: '3.10'
+      nightly_coverage:
+        description: "Set to true to test the nightly Artifactory upload path"
+        type: boolean
+        default: false
 
 jobs:
   coverage-linux-x86_64:
@@ -42,7 +50,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || \
+             [ "${{ inputs.nightly_coverage }}" = "true" ]; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
@@ -79,7 +88,7 @@ jobs:
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v7
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && !cancelled()
         with:
           name: "coverage-linux-x86_64-${{ github.sha }}"
           retention-days: 3
@@ -90,7 +99,7 @@ jobs:
             ${{ env.COVERAGE_DIR }}/diff-coverage.txt
 
       - name: Show Diff Coverage Summary
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && !cancelled()
         run: |
           txt="${COVERAGE_DIR}/diff-coverage.txt"
           if [ -f "${txt}" ]; then
@@ -99,6 +108,31 @@ jobs:
             cat "${txt}" >> "${GITHUB_STEP_SUMMARY}"
             echo '```' >> "${GITHUB_STEP_SUMMARY}"
           fi
+
+      - name: Set up JFrog CLI
+        if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
+        uses: jfrog/setup-jfrog-cli@v5
+        env:
+          JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}
+
+      - name: Update per-file coverage Excel
+        # !cancelled(): run even when the coverage step failed due to UT failure.
+        # coverage.xml is still produced by generate_coverage.sh before it propagates the exit code.
+        if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
+        run: |
+          python3 qcom/build_and_test.py \
+            --target-py-version ${{ inputs.target_py_vsn }} \
+            --only \
+            file_coverage_excel_linux_x86_64
+
+      - name: Upload per-file coverage Excel to Artifactory
+        if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
+        run: |
+          jf rt upload \
+            "${COVERAGE_DIR}/per_file_coverage.xlsx" \
+            "${{ secrets.BUILD_ARTIFACTORY_REPO }}/qa/nightly-$(date -u +%Y-%m-%d)-${GITHUB_SHA:0:10}/" \
+            --flat=true
 
       - name: Post Diff Coverage to PR
         # TODO: re-enable once the coverage pipeline is stable.

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ["self-hosted", "X64", "Linux", "Build"]
     env:
       COVERAGE_DIR: build/linux-x86_64/RelWithDebInfo/coverage
+      # Consumed by upload-qa-artifact's publish_qa.py (reads os.environ["BUILD_ARTIFACTORY_REPO"]).
+      BUILD_ARTIFACTORY_REPO: "${{ secrets.BUILD_ARTIFACTORY_REPO }}"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -126,7 +128,12 @@ jobs:
             echo "QA_TAG=${{ inputs.qa_tag }}" >> ${GITHUB_ENV}
             # Extract date portion from the canonical "nightly-YYYY-MM-DD-{sha}" format
             # so the Excel's date column matches the directory name.
-            echo "COVERAGE_RUN_DATE=$(echo '${{ inputs.qa_tag }}' | sed -n 's/^nightly-\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\)-.*/\1/p')" >> ${GITHUB_ENV}
+            run_date="$(echo '${{ inputs.qa_tag }}' | sed -n 's/^nightly-\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\)-.*/\1/p')"
+            if [ -z "${run_date}" ]; then
+              echo "::warning::qa_tag '${{ inputs.qa_tag }}' is not canonical (nightly-YYYY-MM-DD-*); falling back to today's UTC date for the Excel date column"
+              run_date="$(date --rfc-3339=date)"
+            fi
+            echo "COVERAGE_RUN_DATE=${run_date}" >> ${GITHUB_ENV}
           fi
 
       - name: Update per-file coverage Excel
@@ -138,6 +145,7 @@ jobs:
         run: |
           [ -f "${COVERAGE_DIR}/coverage.xml" ] || {
             echo "::warning::coverage.xml missing — skipping nightly Excel generation"
+            echo "### ⚠️ No coverage Excel produced this nightly (coverage.xml missing)" >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           }
           python3 qcom/build_and_test.py \
@@ -145,17 +153,26 @@ jobs:
             --only \
             file_coverage_excel_linux_x86_64
 
-      - name: Upload per-file coverage Excel to Artifactory
+      - name: Check coverage Excel exists
+        id: check_xlsx
         if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
         run: |
-          [ -f "${COVERAGE_DIR}/per_file_coverage.xlsx" ] || {
+          if [ -f "${COVERAGE_DIR}/per_file_coverage.xlsx" ]; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
             echo "::warning::per_file_coverage.xlsx missing — skipping nightly Artifactory upload"
-            exit 0
-          }
-          jf rt upload \
-            "${COVERAGE_DIR}/per_file_coverage.xlsx" \
-            "${{ secrets.BUILD_ARTIFACTORY_REPO }}/qa/${{ env.QA_TAG }}/" \
-            --flat=true
+            echo "### ⚠️ No coverage Excel produced this nightly (per_file_coverage.xlsx missing)" >> "${GITHUB_STEP_SUMMARY}"
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Upload per-file coverage Excel to Artifactory
+        # Reuse the shared QA upload action so the qa/{tag} path convention lives in one place
+        # (publish_qa.py -> QaArtifactory.artifact_root) instead of being re-derived here.
+        if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled() && steps.check_xlsx.outputs.exists == 'true'
+        uses: ./.github/actions/upload-qa-artifact
+        with:
+          src_pattern: "linux-x86_64/RelWithDebInfo/coverage/per_file_coverage.xlsx"
+          qa_tag: ${{ env.QA_TAG }}
 
       - name: Post Diff Coverage to PR
         # TODO: re-enable once the coverage pipeline is stable.

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -16,7 +16,7 @@ on:
         type: string
         default: '3.10'
       nightly_coverage:
-        description: "Set to true on nightly runs to update the per-file coverage Excel in Artifactory"
+        description: "Set to true to upload the per-file coverage Excel to Artifactory"
         type: boolean
         default: false
   workflow_dispatch:
@@ -26,7 +26,7 @@ on:
         type: string
         default: '3.10'
       nightly_coverage:
-        description: "Set to true to test the nightly Artifactory upload path"
+        description: "Set to true to upload the per-file coverage Excel to Artifactory"
         type: boolean
         default: false
 

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   workflow_call:
-    inputs:
+    inputs: &common_inputs
       target_py_vsn:
         description: "Python version for the coverage build wheel (does not affect C++ coverage results)"
         type: string
@@ -24,19 +24,7 @@ on:
         type: string
         default: ''
   workflow_dispatch:
-    inputs:
-      target_py_vsn:
-        description: "Python version for the coverage build wheel (does not affect C++ coverage results)"
-        type: string
-        default: '3.10'
-      nightly_coverage:
-        description: "Set to true to upload the per-file coverage Excel to Artifactory"
-        type: boolean
-        default: false
-      qa_tag:
-        description: "Pre-computed QA tag from the caller; leave blank to auto-generate from today's date + SHA"
-        type: string
-        default: ''
+    inputs: *common_inputs
 
 jobs:
   coverage-linux-x86_64:

--- a/.github/workflows/qualcomm-internal-release-nightly.yml
+++ b/.github/workflows/qualcomm-internal-release-nightly.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   setup:
     name: Compute Shared QA Tag
-    runs-on: ubuntu-latest
+    runs-on: [Linux, self-hosted]
     outputs:
       qa_tag: ${{ steps.t.outputs.qa_tag }}
     steps:

--- a/.github/workflows/qualcomm-internal-release-nightly.yml
+++ b/.github/workflows/qualcomm-internal-release-nightly.yml
@@ -13,8 +13,21 @@ on:
     - cron: "0 9 * * *"  # Every day at 2am in San Diego/PDT (9am UTC)
 
 jobs:
+  setup:
+    name: Compute Shared QA Tag
+    runs-on: ubuntu-latest
+    outputs:
+      qa_tag: ${{ steps.t.outputs.qa_tag }}
+    steps:
+      - id: t
+        # Compute the QA tag once so all downstream jobs (publish-artifacts + coverage)
+        # upload to the exact same Artifactory directory. Same format as
+        # qualcomm-internal-release.yml's auto-compute fallback.
+        run: echo "qa_tag=nightly-$(date --rfc-3339=date)-${GITHUB_SHA:0:10}" >> "$GITHUB_OUTPUT"
+
   publish-artifacts:
     name: Publish Artifacts
+    needs: setup
     uses: ./.github/workflows/qualcomm-internal-release.yml
     secrets: inherit
     with:
@@ -23,11 +36,14 @@ jobs:
       skip_publish_wheel: false
       build_windows_arm64_debug: true
       build_windows_arm64_relwithdebinfo: true
+      qa_tag: ${{ needs.setup.outputs.qa_tag }}
 
   coverage:
     name: Per-File Coverage Tracking
+    needs: setup
     uses: ./.github/workflows/qualcomm-internal-coverage.yml
     secrets: inherit
     continue-on-error: true
     with:
       nightly_coverage: true
+      qa_tag: ${{ needs.setup.outputs.qa_tag }}

--- a/.github/workflows/qualcomm-internal-release-nightly.yml
+++ b/.github/workflows/qualcomm-internal-release-nightly.yml
@@ -23,3 +23,11 @@ jobs:
       skip_publish_wheel: false
       build_windows_arm64_debug: true
       build_windows_arm64_relwithdebinfo: true
+
+  coverage:
+    name: Per-File Coverage Tracking
+    uses: ./.github/workflows/qualcomm-internal-coverage.yml
+    secrets: inherit
+    continue-on-error: true
+    with:
+      nightly_coverage: true

--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -39,6 +39,7 @@ from ep_build.tasks.build import (
     BuildEpWindowsTask,
     GenerateCoverageTask,
     GenerateDiffCoverageTask,
+    GenerateFileCoverageExcelTask,
     QdcTestsTask,
     RunAsanTask,
 )
@@ -54,6 +55,7 @@ from ep_build.typing import BuildConfigT, TargetPyVersionT
 from ep_build.util import (
     DEFAULT_PYTHON,
     REPO_ROOT,
+    git_head_sha,
     is_host_arm64,
     is_host_linux,
     is_host_mac,
@@ -979,6 +981,23 @@ class TaskLibrary:
                 ],
             )
         )
+
+    if is_host_linux() and is_host_x86_64():
+
+        @public_task("Generate per-file coverage Excel from coverage.xml (Linux x86_64)")
+        @depends(["coverage_linux_x86_64"])
+        def file_coverage_excel_linux_x86_64(self, plan: Plan) -> str:
+            build_dir = REPO_ROOT / "build" / "linux-x86_64"
+            excel_file = build_dir / "RelWithDebInfo" / "coverage" / "per_file_coverage.xlsx"
+            return plan.add_step(
+                GenerateFileCoverageExcelTask(
+                    "Generating per-file coverage Excel",
+                    self.__venv_path,
+                    build_dir,
+                    excel_file,
+                    git_head_sha(),
+                )
+            )
 
     if is_host_windows():
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -256,6 +256,40 @@ class GenerateDiffCoverageTask(CompositeTask):
         )
 
 
+class GenerateFileCoverageExcelTask(RunExecutablesWithVenvTask):
+    """Generate a per-day per-file coverage Excel snapshot from a Cobertura XML report.
+
+    Calls update_coverage_excel.py with the coverage.xml produced by
+    GenerateCoverageTask and writes a fresh Excel file containing today's
+    line% and branch% for every QNN EP source file.  Each nightly run
+    produces an independent snapshot; historical aggregation across days is
+    handled by merge_coverage_excel.py and the aggregate CI workflow
+    (future work, tracked in PR 2).
+
+    Prerequisite: coverage.xml must already exist under
+    <build_dir>/<config>/coverage/ (enforced via @depends in build_and_test.py).
+    """
+
+    def __init__(
+        self,
+        group_name: str | None,
+        venv: Path | None,
+        build_dir: Path,
+        excel_file: Path,
+        commit_sha: str,
+        config: str = "RelWithDebInfo",
+    ) -> None:
+        coverage_xml = build_dir / config / "coverage" / "coverage.xml"
+        cmd = [
+            "python3",
+            str(REPO_ROOT / "qcom" / "scripts" / "linux" / "update_coverage_excel.py"),
+            f"--coverage-xml={coverage_xml}",
+            f"--excel={excel_file}",
+            f"--commit-sha={commit_sha}",
+        ]
+        super().__init__(group_name, venv, [cmd])
+
+
 class AdbTestsTask(RunInTempDirectoryTask):
     def __init__(
         self,

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -261,10 +261,10 @@ class GenerateFileCoverageExcelTask(RunExecutablesWithVenvTask):
 
     Calls update_coverage_excel.py with the coverage.xml produced by
     GenerateCoverageTask and writes a fresh Excel file containing today's
-    line% and branch% for every QNN EP source file.  Each nightly run
-    produces an independent snapshot; historical aggregation across days is
-    handled by merge_coverage_excel.py and the aggregate CI workflow
-    (future work, tracked in PR 2).
+    line% and branch% for every QNN EP source file.
+
+    # TODO: enable the aggregate CI workflow to merge daily snapshots into
+    # a 30-day history report.
 
     Prerequisite: coverage.xml must already exist under
     <build_dir>/<config>/coverage/ (enforced via @depends in build_and_test.py).

--- a/qcom/requirements.txt
+++ b/qcom/requirements.txt
@@ -7,6 +7,7 @@ certifi >= 2025.4.26
 diff-cover >= 9.2.0, == 9.*
 lcov_cobertura >= 2.0.2, == 2.*
 json-with-comments >= 1.2.10, == 1.2.*
+openpyxl >= 3.1.0, == 3.*
 prettytable >= 3.16.0, == 3.*
 pyyaml >= 6.0.2, == 6.*
 requests >= 2.32.3, == 2.*

--- a/qcom/scripts/linux/update_coverage_excel.py
+++ b/qcom/scripts/linux/update_coverage_excel.py
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: MIT
 #
 # Generate a per-day coverage snapshot Excel from a Cobertura XML report.
-# Each nightly run creates an independent file; historical aggregation across
-# days is handled by merge_coverage_excel.py and the aggregate CI workflow
-# (future work, tracked in PR 2).
+# Each nightly run creates an independent file.
+# TODO: enable the aggregate CI workflow to merge daily snapshots into a 30-day history report.
 #
 # Usage:
 #   python3 update_coverage_excel.py \

--- a/qcom/scripts/linux/update_coverage_excel.py
+++ b/qcom/scripts/linux/update_coverage_excel.py
@@ -14,6 +14,7 @@
 #       [--date        YYYY-MM-DD]         # default: today (UTC)
 
 import argparse
+import os
 import sys
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -37,7 +38,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--coverage-xml", required=True, type=Path, help="Path to Cobertura XML (coverage.xml)")
     p.add_argument("--excel", required=True, type=Path, help="Output Excel path (overwritten if exists)")
     p.add_argument("--commit-sha", required=True, help="Current commit SHA (full 40-char)")
-    p.add_argument("--date", default=None, help="Override date as YYYY-MM-DD (default: today UTC)")
+    p.add_argument(
+        "--date",
+        default=None,
+        help="Override date as YYYY-MM-DD (default: $COVERAGE_RUN_DATE if set, else today UTC)",
+    )
     return p.parse_args()
 
 
@@ -91,7 +96,10 @@ def create_workbook(run_date: str, commit_sha: str, file_rows: list[dict]) -> Wo
 def main() -> None:
     args = parse_args()
 
-    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # Date source-of-truth order: CLI --date > $COVERAGE_RUN_DATE env > today UTC.
+    # The env var lets CI pass a date computed once upstream so multiple consumers
+    # (this script + downstream upload path) agree even across UTC midnight.
+    run_date = args.date or os.environ.get("COVERAGE_RUN_DATE") or datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     print(f"Coverage XML : {args.coverage_xml}")
     print(f"Excel        : {args.excel}")

--- a/qcom/scripts/linux/update_coverage_excel.py
+++ b/qcom/scripts/linux/update_coverage_excel.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Generate a per-day coverage snapshot Excel from a Cobertura XML report.
+# Each nightly run creates an independent file; historical aggregation across
+# days is handled by merge_coverage_excel.py and the aggregate CI workflow
+# (future work, tracked in PR 2).
+#
+# Usage:
+#   python3 update_coverage_excel.py \
+#       --coverage-xml <path/to/coverage.xml> \
+#       --excel        <path/to/per_file_coverage.xlsx> \
+#       --commit-sha   <40-char SHA> \
+#       [--date        YYYY-MM-DD]         # default: today (UTC)
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from openpyxl import Workbook
+    from openpyxl.styles import Font, PatternFill
+except ImportError:
+    print("ERROR: openpyxl is not installed. Activate the project venv or: pip install openpyxl", file=sys.stderr)
+    sys.exit(1)
+
+SHEET_NAME = "History"
+HEADER = ["date", "commit_sha", "file", "line_pct", "branch_pct"]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Generate a per-day per-file coverage snapshot Excel from a Cobertura XML report."
+    )
+    p.add_argument("--coverage-xml", required=True, type=Path, help="Path to Cobertura XML (coverage.xml)")
+    p.add_argument("--excel", required=True, type=Path, help="Output Excel path (overwritten if exists)")
+    p.add_argument("--commit-sha", required=True, help="Current commit SHA (full 40-char)")
+    p.add_argument("--date", default=None, help="Override date as YYYY-MM-DD (default: today UTC)")
+    return p.parse_args()
+
+
+def parse_coverage_xml(xml_path: Path) -> list[dict]:
+    if not xml_path.is_file():
+        print(f"ERROR: coverage XML not found: {xml_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        tree = ET.parse(xml_path)
+    except ET.ParseError as e:
+        print(f"ERROR: failed to parse coverage XML {xml_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    root = tree.getroot()
+
+    rows: list[dict] = []
+    for cls in root.iter("class"):
+        filename = cls.get("filename", "").strip()
+        if not filename:
+            continue
+        rows.append(
+            {
+                "file": filename,
+                "line_pct": round(float(cls.get("line-rate", "0")) * 100, 1),
+                "branch_pct": round(float(cls.get("branch-rate", "0")) * 100, 1),
+            }
+        )
+
+    rows.sort(key=lambda r: r["file"])
+    return rows
+
+
+def create_workbook(run_date: str, commit_sha: str, file_rows: list[dict]) -> Workbook:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = SHEET_NAME
+
+    ws.append(HEADER)
+    header_font = Font(bold=True)
+    header_fill = PatternFill(fill_type="solid", fgColor="D9E1F2")
+    for cell in ws[1]:
+        cell.font = header_font
+        cell.fill = header_fill
+
+    for r in file_rows:
+        ws.append([run_date, commit_sha, r["file"], r["line_pct"], r["branch_pct"]])
+
+    return wb
+
+
+def main() -> None:
+    args = parse_args()
+
+    run_date = args.date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    print(f"Coverage XML : {args.coverage_xml}")
+    print(f"Excel        : {args.excel}")
+    print(f"Commit SHA   : {args.commit_sha}")
+    print(f"Date         : {run_date}")
+
+    file_rows = parse_coverage_xml(args.coverage_xml)
+    print(f"Files parsed : {len(file_rows)}")
+
+    args.excel.parent.mkdir(parents=True, exist_ok=True)
+    wb = create_workbook(run_date, args.commit_sha, file_rows)
+    wb.save(args.excel)
+    print(f"Saved        : {args.excel}")
+
+
+if __name__ == "__main__":
+    main()

--- a/qcom/scripts/linux/update_coverage_excel.py
+++ b/qcom/scripts/linux/update_coverage_excel.py
@@ -107,6 +107,8 @@ def main() -> None:
     print(f"Date         : {run_date}")
 
     file_rows = parse_coverage_xml(args.coverage_xml)
+    if not file_rows:
+        print("WARNING: coverage XML contains zero <class> elements — Excel will be empty", file=sys.stderr)
     print(f"Files parsed : {len(file_rows)}")
 
     args.excel.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
  ## Summary

  - Add `update_coverage_excel.py`: parses `coverage.xml` (Cobertura format) and produces a per-file line%/branch% Excel for the current day
  - Add `GenerateFileCoverageExcelTask` + `file_coverage_excel_linux_x86_64` build task (depends on `coverage_linux_x86_64`) 
  - Add `openpyxl` to `qcom/requirements.txt`
  - Update `qualcomm-internal-coverage.yml`:
    - Add `nightly_coverage` input to both `workflow_call` and `workflow_dispatch`
    - After coverage build: generate Excel → upload to Artifactory
    - Add `!cancelled()` to post-build steps so UT failures don't suppress uploads
  - Update `qualcomm-internal-release-nightly.yml`: add `coverage` job with `continue-on-error: true`

  ## How it works
  
  Each nightly run uploads an independent file to:
  {REPO}/qa/nightly-YYYY-MM-DD-{commit[:10]}/per_file_coverage.xlsx
  This follows the existing QA artifact naming convention. 30-day retention is handled by the existing `qualcomm-internal-clean-artifacts.yml` policy.

  | Scenario | Behavior |
  |---|---|
  | UT failure during coverage build | `coverage.xml` still generated; Excel and Artifactory upload still run (`!cancelled()`) |
  | Coverage job failure | `publish-artifacts` job unaffected (no `needs:` dependency; `continue-on-error: true` prevents nightly workflow from showing ❌) |

  ## How to validate
  
  Manually dispatch `qualcomm-internal-coverage.yml` from GitHub UI or via `gh` CLI with `nightly_coverage: true`, then verify `{REPO}/qa/nightly-YYYY-MM-DD-{commit[:10]}/per_file_coverage.xlsx` appears in Artifactory.
  
  ## Note
  
  Historical aggregation of daily snapshots into a 30-day report is tracked as a follow-up.