### PR TITLE
[QNN EP] Rename test package version

### DIFF
--- a/.github/workflows/qualcomm-internal-release.yml
+++ b/.github/workflows/qualcomm-internal-release.yml
@@ -533,10 +533,11 @@ jobs:
 
       - name: Prepare Test Package Archive
         run: |
+          TEST_PACKAGE_VERSION=$(cat "${{ github.workspace }}/VERSION_NUMBER")
           ./qcom/scripts/all/prepare_test_package.sh \
             "${{ github.workspace }}/test_archives" \
             "${{ github.workspace }}/build" \
-            "${{ env.QA_TAG }}"
+            "$TEST_PACKAGE_VERSION"
 
       - name: Upload Artifacts to QA Artifactory
         if: ${{ !inputs.skip_publish_qa }}

--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -518,15 +518,17 @@ jobs:
 
       - name: Prepare Test Package Archive
         run: |
+          TEST_PACKAGE_VERSION=$(cat "${{ github.workspace }}/VERSION_NUMBER")
           if [ -z "${{ inputs.version_suffix }}" ]; then
             VERSION=$(cat "${{ github.workspace }}/VERSION_NUMBER")
           else
             VERSION="${{ inputs.version_suffix }}"
+            TEST_PACKAGE_VERSION = $TEST_PACKAGE_VERSION-$VERSION"
           fi
           ./qcom/scripts/all/prepare_test_package.sh \
             "${{ github.workspace }}/test_archives" \
             "${{ github.workspace }}/build" \
-            "$VERSION"
+            "$TEST_PACKAGE_VERSION"
 
       - name: Publish Zip
         if: ${{ !inputs.skip_publish }}


### PR DESCRIPTION
This PR renames the test package version to have only the version number in the `test_package.zip` created every nightly and RC


