### PR TITLE
[QNN EP] Include QNN error string in QNN API failure messages

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -201,9 +201,8 @@ Ort::Status QnnBackendManager::ParseLoraConfig(std::string lora_config_path) {
           auto context_apply_binary_section_rt = qnn_interface_.contextApplyBinarySection(
               contexts_[cIdx], graph, QNN_CONTEXT_SECTION_UPDATABLE, &contextBuffer, profile_backend_handle_, nullptr);
           RETURN_IF(QNN_SUCCESS != context_apply_binary_section_rt,
-                    ("Failed to apply binary section. Error: " +
-                     QnnErrorHandleToString(context_apply_binary_section_rt) +
-                     ", Code: " + std::to_string(context_apply_binary_section_rt))
+                    ("Failed to apply binary section. " +
+                     utils::FormatQnnError(qnn_interface_, context_apply_binary_section_rt))
                         .c_str());
           break;
         }

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -200,7 +200,11 @@ Ort::Status QnnBackendManager::ParseLoraConfig(std::string lora_config_path) {
 
           auto context_apply_binary_section_rt = qnn_interface_.contextApplyBinarySection(
               contexts_[cIdx], graph, QNN_CONTEXT_SECTION_UPDATABLE, &contextBuffer, profile_backend_handle_, nullptr);
-          RETURN_IF(QNN_SUCCESS != context_apply_binary_section_rt, "Failed to apply binary section.");
+          RETURN_IF(QNN_SUCCESS != context_apply_binary_section_rt,
+                    ("Failed to apply binary section. Error: " +
+                     QnnErrorHandleToString(context_apply_binary_section_rt) +
+                     ", Code: " + std::to_string(context_apply_binary_section_rt))
+                        .c_str());
           break;
         }
         RETURN_IF_NOT(graph_retrieve_success,

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -359,9 +359,8 @@ Ort::Status QnnModel::FinalizeGraphs(const Ort::Logger& logger) {
 #endif
 
   if (QNN_GRAPH_NO_ERROR != status) {
-    const std::string qnn_err = utils::GetQnnErrorMessage(qnn_backend_manager_->GetQnnInterface(), status);
-    return MAKE_EP_FAIL(("Failed to finalize QNN graph. Error: " + qnn_err +
-                         ", Code: " + std::to_string(status))
+    return MAKE_EP_FAIL(("Failed to finalize QNN graph. " +
+                         utils::FormatQnnError(qnn_backend_manager_->GetQnnInterface(), status))
                             .c_str());
   }
 
@@ -601,9 +600,8 @@ Ort::Status QnnModel::ExecuteGraph(OrtKernelContext* context,
   }
 
   if (QNN_GRAPH_NO_ERROR != execute_status) {
-    const std::string qnn_err = utils::GetQnnErrorMessage(qnn_backend_manager_->GetQnnInterface(), execute_status);
-    return MAKE_EP_FAIL(("QNN graph execute error. Error: " + qnn_err +
-                         ", Code: " + std::to_string(execute_status))
+    return MAKE_EP_FAIL(("QNN graph execute error. " +
+                         utils::FormatQnnError(qnn_backend_manager_->GetQnnInterface(), execute_status))
                             .c_str());
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -359,10 +359,10 @@ Ort::Status QnnModel::FinalizeGraphs(const Ort::Logger& logger) {
 #endif
 
   if (QNN_GRAPH_NO_ERROR != status) {
-    std::ostringstream oss;
-    oss << "Failed to finalize QNN graph. Error code: " << status;
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_ERROR, oss.str().c_str());
-    return MAKE_EP_FAIL("Failed to finalize QNN graph.");
+    const std::string qnn_err = utils::GetQnnErrorMessage(qnn_backend_manager_->GetQnnInterface(), status);
+    return MAKE_EP_FAIL(("Failed to finalize QNN graph. Error: " + qnn_err +
+                         ", Code: " + std::to_string(status))
+                            .c_str());
   }
 
   // NOTE: This function returns immediately when profiling is disabled.
@@ -601,7 +601,10 @@ Ort::Status QnnModel::ExecuteGraph(OrtKernelContext* context,
   }
 
   if (QNN_GRAPH_NO_ERROR != execute_status) {
-    return MAKE_EP_FAIL(("QNN graph execute error. Error code: " + std::to_string(execute_status)).c_str());
+    const std::string qnn_err = utils::GetQnnErrorMessage(qnn_backend_manager_->GetQnnInterface(), execute_status);
+    return MAKE_EP_FAIL(("QNN graph execute error. Error: " + qnn_err +
+                         ", Code: " + std::to_string(execute_status))
+                            .c_str());
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -39,7 +39,11 @@ bool QnnModelWrapper::CreateQnnGraph(const Qnn_ContextHandle_t& context,
   if (rt != QNN_GRAPH_NO_ERROR || graph_ == nullptr) {
     rt = qnn_interface_.graphRetrieve(context, graph_name.c_str(), &graph_);
     if (rt != QNN_GRAPH_NO_ERROR || graph_ == nullptr) {
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, ("Failed to create Qnn graph: " + graph_name).c_str());
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR,
+                  ("Failed to create Qnn graph: " + graph_name +
+                   ". Error: " + utils::GetQnnErrorMessage(qnn_interface_, rt) +
+                   ", Code: " + std::to_string(rt))
+                      .c_str());
       return false;
     }
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -40,9 +40,8 @@ bool QnnModelWrapper::CreateQnnGraph(const Qnn_ContextHandle_t& context,
     rt = qnn_interface_.graphRetrieve(context, graph_name.c_str(), &graph_);
     if (rt != QNN_GRAPH_NO_ERROR || graph_ == nullptr) {
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR,
-                  ("Failed to create Qnn graph: " + graph_name +
-                   ". Error: " + utils::GetQnnErrorMessage(qnn_interface_, rt) +
-                   ", Code: " + std::to_string(rt))
+                  ("Failed to create Qnn graph: " + graph_name + ". " +
+                   utils::FormatQnnError(qnn_interface_, rt))
                       .c_str());
       return false;
     }

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1274,6 +1274,10 @@ std::string GetQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface, Qnn_
   return "Unknown error. QNN error handle: " + std::to_string(qnn_error_handle);
 }
 
+std::string FormatQnnError(const QNN_INTERFACE_VER_TYPE& qnn_interface, Qnn_ErrorHandle_t error) {
+  return "Error: " + GetQnnErrorMessage(qnn_interface, error) + ", Code: " + std::to_string(error);
+}
+
 std::string GetVerboseQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                                       Qnn_ErrorHandle_t qnn_error_handle) {
   const char* error_msg = nullptr;

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -468,9 +468,12 @@ Ort::Status PermuteShape(gsl::span<const T> input_shape, gsl::span<const P> perm
 std::string GetQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                                Qnn_ErrorHandle_t qnn_error_handle);
 
-// // Gets verbose error message associated with QNN error handle value.
+// Gets verbose error message associated with QNN error handle value.
 std::string GetVerboseQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                                       Qnn_ErrorHandle_t qnn_error_handle);
+
+// Returns "Error: <qnn_message>, Code: <code>" suffix for error messages.
+std::string FormatQnnError(const QNN_INTERFACE_VER_TYPE& qnn_interface, Qnn_ErrorHandle_t error);
 
 // NCHW shape to channel last
 template <typename T>


### PR DESCRIPTION
## Summary

Several QNN API call sites in the QNN EP returned an error (either an `OrtStatus` propagated to the caller, or an error log line) that **dropped the QNN error handle**, surfacing only a hardcoded English message or a bare integer code. When one of these calls fails at runtime, the user is left with a message like `"Failed to finalize QNN graph."` or `"QNN graph execute error. Error code: 6005"` — with no symbolic indication of *why* it failed (out-of-memory vs. an unsupported op vs. a driver/SSR fault all look the same).

This PR aligns four such call sites with the convention **already used throughout `qnn_backend_manager.cc`** (e.g. `backendCreate`, `profileCreate`, `contextCreate`, `contextCreateFromBinaryListAsync`), which append the QNN symbolic message via the existing helpers `utils::GetQnnErrorMessage(...)` / `QnnBackendManager::QnnErrorHandleToString(...)`.

## Why this is needed

The QNN SDK exposes `errorGetMessage` / `errorGetVerboseMessage`, and the EP already wraps it in `utils::GetQnnErrorMessage` (`qnn_utils.cc`). Most QNN API call sites already use it, but these four were inconsistent and discarded the handle. The result is that field failures on these specific paths (graph finalize, graph execute, graph create, and LoRA-adapter binary-section apply) produce error text that cannot be triaged without attaching a debugger or correlating raw integer codes against the SDK headers by hand. Enriching these messages brings them in line with the rest of the file and makes failures self-describing.

## Changes

| Call site | File | Before | After |
|-----------|------|--------|-------|
| `graphFinalize` | `qnn_model.cc` | logged the code, then returned a generic `"Failed to finalize QNN graph."` that discarded it | returns `utils::GetQnnErrorMessage(...)` + code in the `OrtStatus` |
| `graphExecute` | `qnn_model.cc` | returned `"... Error code: <int>"` (bare integer) | includes the symbolic QNN message + code; the existing `QNN_COMMON_ERROR_SYSTEM_COMMUNICATION` (SSR / NPU-crash) special case is **left unchanged** |
| `graphCreate` | `qnn_model_wrapper.cc` | error log carried only the graph name | log now includes the QNN message + code from the failing call (function still returns `bool`; control flow unchanged) |
| `contextApplyBinarySection` | `qnn_backend_manager.cc` | hardcoded `"Failed to apply binary section."` | appended with `QnnErrorHandleToString(...)` + code |

Message format follows the existing convention in the same files: `"<context>. Error: <message>, Code: <int>"`.

## Scope / risk

- **Error-path only.** No success-path behavior, control flow, or public API changes. Each hunk only enriches the text emitted when a QNN call has *already* failed.
- The `graphExecute` SSR/NPU-crash branch is intentionally preserved as-is.
- `graphCreate` returns `bool`; only its log is enriched, the early-return is untouched.

## Testing

These are error-path message enrichments that only trigger on real QNN API failures, which are not exercised by the standard unit suite. Verified by:
- `lintrunner` (clang-format) — clean, no formatting changes required.
- Type/linkage review: `utils::GetQnnErrorMessage(const QNN_INTERFACE_VER_TYPE&, Qnn_ErrorHandle_t)` matches the `GetQnnInterface()` return type; the helper is already included and used elsewhere in these translation units' sibling files.
