### PR TITLE
[QNN EP] Fix and complete provider option docs in QNN-ExecutionProvider.md

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -175,6 +175,7 @@ Alternatively to setting profiling_level at compile time, profiling can be enabl
 |'69'|HTP v69.|
 |'73'|HTP v73.|
 |'75'|HTP v75.|
+|'81'|HTP v81.|
 
 Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10/topic/enum_QnnHtpDevice_8h_1a0ed976142af98a86143459dfd326f717.html) for the full list of valid values.
 
@@ -186,6 +187,11 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 |---|---|
 |'0'|Disabled. Inference with fp32 precision if it's fp32 model.|
 |'1'|Default. Enable the float32 model to be inferenced with fp16 precision.|
+
+|`"disable_htp_monolithic_lstm"`|Description|
+|---|---|
+|'0'|Default. HTP uses the monolithic LSTM graph configuration.|
+|'1'|Disable the monolithic LSTM graph configuration on HTP.|
 
 |`"enable_htp_spill_fill_buffer"`|Description|
 |---|---|
@@ -254,7 +260,7 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 
 |`"num_graph_prepare_threads"`|Description|
 |---|---|
-|Number (string)|The number of threads to use during model compilation. Must be greater than 1 and no more than the maximum supported concurrency threads as [reported by the hardware](https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency.html).<br><br>An invalid value will result in a warning and default behavior.<br><br>Defaults to 8 or the maximum supported threads, whichever is lower.<br><br><b>Will only take effect if the model is partitioned into 5+ subgraphs</b><br><br><b>Currently only supported on Windows ARM64 devices</b>|
+|Number (string)|The number of threads to use during model compilation. Must be at least 1 (a value of 1 disables the feature) and no more than the maximum supported concurrency threads as [reported by the hardware](https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency.html).<br><br>An invalid value will result in a warning and default behavior.<br><br>Defaults to 8 or the maximum supported threads, whichever is lower.<br><br><b>Will only take effect if the model is partitioned into 5+ subgraphs</b><br><br><b>Currently only supported on Windows ARM64 devices</b>|
 
 For more information, see the [Parallel Graph Preparation](#parallel-graph-preparation) section below.
 


### PR DESCRIPTION
## Summary

Three documentation inaccuracies in the QNN EP provider options reference (`docs/execution_providers/QNN-ExecutionProvider.md`). Documentation only — no code changes. Each correction was verified against the current parser code.

## Changes

### 1. `htp_arch` — missing `'81'`
The value table listed `0/68/69/73/75`, but `ParseHtpArchitecture` (`qnn_execution_provider.cc`) also accepts `'81'` → `QNN_HTP_DEVICE_ARCH_V81`. Added the missing row so the documented set matches the parser.

### 2. `num_graph_prepare_threads` — "must be greater than 1" was wrong
The table stated the value *"Must be greater than 1"*. This contradicts:
- the code: the allowable range is `[1, max_supported]`, and `is_valid_number` only rejects `0` / leading-zero values; and
- the **"Feature Disabled if `num_graph_prepare_threads` is 1"** subsection later in the *same* document, which treats `1` as a valid (feature-disabling) value.

Corrected to *"Must be at least 1 (a value of 1 disables the feature)"*.

### 3. `disable_htp_monolithic_lstm` — undocumented
This session config key is read and applied by the EP (it controls whether the HTP `QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM` graph config is set), but had no entry in the options reference. Added a table documenting its `0`/`1` values and default.

## Testing

- `lintrunner` — clean.
- Markdown table formatting reviewed for consistency with surrounding option tables.
