### PR TITLE
[QNN EP] Small robustness fixes: attr type, fusion-walk logging, profiling CSV columns

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
+++ b/onnxruntime/core/providers/qnn/builder/onnx_ctx_model_helper.cc
@@ -389,7 +389,7 @@ Ort::Status CreateEPContextNodes(const OrtNode** fused_nodes,
         }
 
         attr = nullptr;
-        size_t max_size = static_cast<int64_t>(max_spill_fill_buffer_size);
+        int64_t max_size = static_cast<int64_t>(max_spill_fill_buffer_size);
         ORT_CXX_RETURN_ON_API_FAIL(ort_api.CreateOpAttr(MAX_SIZE.c_str(), &max_size, 1, ORT_OP_ATTR_INT, &attr));
         attributes.push_back(attr);
       }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -198,7 +198,15 @@ const OrtNodeUnit* GetChildNodeUnitAllowQdq(
     }
 
     return child_node_unit;
-  } catch (const Ort::Exception&) {
+  } catch (const Ort::Exception& e) {
+    // Treated as "no match" (the fusion matcher bails quietly), but log so a genuine
+    // API error is distinguishable from a normal non-match.
+    if (OrtLoggingManager::HasDefaultLogger()) {
+      ORT_CXX_LOG(OrtLoggingManager::GetDefaultLogger(), ORT_LOGGING_LEVEL_VERBOSE,
+                  (std::string("GetChildNodeUnitAllowQdq: ignoring Ort::Exception during graph walk: ") +
+                   e.what())
+                      .c_str());
+    }
     return nullptr;
   }
 }
@@ -231,7 +239,14 @@ std::optional<std::vector<int64_t>> GetInitializerDataAsInt64(
       return std::nullopt;
     }
     element_count = static_cast<size_t>(shape_tensor_dims[0]);
-  } catch (const Ort::Exception&) {
+  } catch (const Ort::Exception& e) {
+    // Treated as "no match", but log so a genuine API error is not silently swallowed.
+    if (OrtLoggingManager::HasDefaultLogger()) {
+      ORT_CXX_LOG(OrtLoggingManager::GetDefaultLogger(), ORT_LOGGING_LEVEL_VERBOSE,
+                  (std::string("GetInitializerDataAsInt64: ignoring Ort::Exception while reading shape: ") +
+                   e.what())
+                      .c_str());
+    }
     return std::nullopt;
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.cc
@@ -158,7 +158,7 @@ Ort::Status Serializer::ProcessEvent(const QnnProfile_EventId_t event_id, const 
              << ","
              << event_level << ","
              << (event_data.identifier ? event_data.identifier : "NULL");
-    if (profiling_info_.op_trace_lookup) {
+    if (emit_onnx_sources_column_) {
       outfile_ << "," << LookupOnnxSources(event_data.identifier);
     }
     outfile_ << "\n";
@@ -250,6 +250,21 @@ Ort::Status Serializer::InitCsvFile() {
   // Write to CSV in append mode
   std::ifstream infile(output_filepath.c_str());
   bool exists = infile.good();
+
+  // Decide whether rows carry the trailing "ONNX Source Ops" column. By default this follows
+  // whether a trace lookup is attached this session. But when appending to an existing file we
+  // must match that file's header, otherwise rows written now would desync from a header written
+  // by a previous session that had a different trace-enable setting.
+  const bool want_onnx_sources = profiling_info_.op_trace_lookup != nullptr;
+  emit_onnx_sources_column_ = want_onnx_sources;
+  if (exists) {
+    std::string existing_header;
+    if (std::getline(infile, existing_header)) {
+      const bool header_has_onnx_sources =
+          existing_header.find("ONNX Source Ops") != std::string::npos;
+      emit_onnx_sources_column_ = header_has_onnx_sources;
+    }
+  }
   if (infile.is_open()) {
     infile.close();
   }
@@ -260,7 +275,7 @@ Ort::Status Serializer::InitCsvFile() {
   // `ONNX Source Ops` column when a trace lookup is attached, matching the
   // per-event row layout written by ProcessEvent.
   if (!exists) {
-    if (profiling_info_.op_trace_lookup) {
+    if (emit_onnx_sources_column_) {
       outfile_ << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier,ONNX Source Ops\n";
     } else {
       outfile_ << "Msg Timestamp,Message,Time,Unit of Measurement,Timing Source,Event Level,Event Identifier\n";

--- a/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.cc
@@ -210,7 +210,7 @@ Ort::Status Serializer::ProcessExtendedEvent(const QnnProfile_EventId_t event_id
                << ","
                << event_level << ","
                << (event_data.v1.identifier ? event_data.v1.identifier : "NULL");
-      if (profiling_info_.op_trace_lookup) {
+      if (emit_onnx_sources_column_) {
         outfile_ << "," << LookupOnnxSources(event_data.v1.identifier);
       }
       outfile_ << "\n";
@@ -263,6 +263,13 @@ Ort::Status Serializer::InitCsvFile() {
       const bool header_has_onnx_sources =
           existing_header.find("ONNX Source Ops") != std::string::npos;
       emit_onnx_sources_column_ = header_has_onnx_sources;
+      if (header_has_onnx_sources != want_onnx_sources && OrtLoggingManager::HasDefaultLogger()) {
+        ORT_CXX_LOG(OrtLoggingManager::GetDefaultLogger(), ORT_LOGGING_LEVEL_VERBOSE,
+                    (std::string("InitCsvFile: appending to existing profiling CSV '") + output_filepath +
+                     "' whose header " + (header_has_onnx_sources ? "has" : "lacks") +
+                     " the 'ONNX Source Ops' column, overriding this session's trace-enable setting to match")
+                        .c_str());
+      }
     }
   }
   if (infile.is_open()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_profile_serializer.h
@@ -170,6 +170,10 @@ class Serializer {
   QNN_SYSTEM_INTERFACE_VER_TYPE qnn_system_interface_;
   bool tracelogging_provider_ep_enabled_ = false;
   std::ofstream outfile_;
+  // Whether the CSV rows include the trailing "ONNX Source Ops" column. Normally driven by
+  // profiling_info_.op_trace_lookup, but when appending to an existing CSV it is reconciled to
+  // that file's existing header so rows never desync from the header across sessions.
+  bool emit_onnx_sources_column_ = false;
 };
 
 }  // namespace profile


### PR DESCRIPTION
## Summary

Three independent, low-risk robustness/diagnostics fixes in the QNN EP. No success-path behavior changes; each was verified against the surrounding code.

## Changes

### 1. `onnx_ctx_model_helper.cc` — contradictory `MAX_SIZE` attribute type
In `CreateEPContextNodes`, the local was declared:
```cpp
size_t max_size = static_cast<int64_t>(max_spill_fill_buffer_size);
```
which casts to `int64_t` and then stores into a `size_t` — a self-contradictory type. `CreateOpAttr` with `ORT_OP_ATTR_INT` reads the pointed-to data as `int64_t` (the sibling `MAIN_CONTEXT` / `EMBED_MODE` calls in the same function correctly use an `int64_t` local). Declared `max_size` as `int64_t` to match. No behavioral change on LP64/LLP64 targets — removes the type mismatch.

### 2. `qnn_node_group/utils.cc` — silently swallowed `Ort::Exception`
`GetChildNodeUnitAllowQdq` and `GetInitializerDataAsInt64` both caught `Ort::Exception` and returned `nullptr` / `nullopt` with no trace. Bailing quietly is intentional (fusion matchers must not propagate exceptions), but a genuine API error was indistinguishable from a normal non-match. Added a `VERBOSE` log inside each `catch`, guarded by `OrtLoggingManager::HasDefaultLogger()`. Control flow is unchanged.

### 3. `qnn_profile_serializer` — CSV header/row column desync across sessions
The profiling CSV header is only written when the file is newly created, and both the header and the per-row layout grew an `ONNX Source Ops` column depending on `op_trace_lookup`. When appending to a file created by a previous session that had a *different* trace-enable setting, the newly appended rows desynced from the existing header (e.g. 7-column header, 8-column rows).

Fix: when appending to an existing file, read its header and reconcile the row layout to it (new member `emit_onnx_sources_column_`), so rows always match the header that's actually in the file. When creating a new file, behavior is unchanged.

## Scope / risk

- All three are isolated and additive. (1) is a type correction with no runtime effect on supported targets; (2) only adds logging; (3) only changes the append-to-existing-file path of the (debug-only) profiling CSV.

## Testing

- `lintrunner` — clean.
- These are diagnostics/robustness changes on paths not exercised by the standard unit suite (profiling CSV is debug-only; the fusion-walk catches fire on malformed graphs). Verified by code review against sibling usage. Recommend a build in a normal environment before merge.
