### PR TITLE
[QNN EP] Refactor ProcessAxisAttribute to be op-def-driven

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_argmin_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_argmin_op_builder.cc
@@ -48,7 +48,7 @@ Ort::Status ArgMaxMinOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
                                                             bool do_op_validation) const {
   std::vector<std::string> param_tensor_names;
   int32_t axis = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(axis), QNN_OP_ARGMAX_PARAM_AXIS, param_tensor_names));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_argmin_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/argmax_argmin_op_builder.cc
@@ -47,12 +47,10 @@ Ort::Status ArgMaxMinOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
                                                             const Ort::Logger& logger,
                                                             bool do_op_validation) const {
   std::vector<std::string> param_tensor_names;
-  int32_t default_axis_value = 0;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_ARGMAX_PARAM_AXIS, axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  int32_t axis = 0;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(axis), QNN_OP_ARGMAX_PARAM_AXIS, param_tensor_names));
 
   OrtNodeAttrHelper node_helper(node_unit);
   RETURN_IF(node_helper.Get("select_last_index", static_cast<int32_t>(0)) != 0,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -403,30 +403,21 @@ Ort::Status BaseOpBuilder::SetOutputQParamEqualToInputIfNearlyEqual(QnnModelWrap
 
 Ort::Status BaseOpBuilder::ProcessAxisAttribute(const QnnModelWrapper& qnn_model_wrapper,
                                                 const OrtNodeUnit& node_unit,
-                                                Qnn_Scalar_t& axis_qnn_scalar,
-                                                int32_t& default_axis_value) const {
+                                                const std::string& attr_name,
+                                                int32_t default_axis,
+                                                int32_t& axis_out) const {
   const auto& inputs = node_unit.Inputs();
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input_shape), "Cannot get shape");
 
   auto rank = static_cast<int32_t>(input_shape.size());
   OrtNodeAttrHelper node_helper(node_unit);
-  int32_t onnx_axis = node_helper.Get("axis", default_axis_value);
-  if (onnx_axis < 0) {
-    onnx_axis += rank;
+  int32_t axis = node_helper.Get(attr_name, default_axis);
+  if (axis < 0) {
+    axis += rank;
   }
-  RETURN_IF_NOT((onnx_axis >= 0 && onnx_axis < rank), "QNN requires axis range [0, rank-1].");
-  default_axis_value = onnx_axis;
-
-  bool is_gather_op = (node_unit.OpType() == "Gather" || node_unit.OpType() == "GatherBlockQuantized");
-  if (is_gather_op) {
-    axis_qnn_scalar.dataType = QNN_DATATYPE_INT_32;
-    axis_qnn_scalar.int32Value = onnx_axis;
-  } else {
-    axis_qnn_scalar.dataType = QNN_DATATYPE_UINT_32;
-    axis_qnn_scalar.uint32Value = static_cast<uint32_t>(onnx_axis);
-  }
-
+  RETURN_IF_NOT((axis >= 0 && axis < rank), "QNN requires axis range [0, rank-1].");
+  axis_out = axis;
   return Ort::Status();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -401,11 +401,11 @@ Ort::Status BaseOpBuilder::SetOutputQParamEqualToInputIfNearlyEqual(QnnModelWrap
   return Ort::Status();
 }
 
-Ort::Status BaseOpBuilder::ProcessAxisAttribute(const QnnModelWrapper& qnn_model_wrapper,
-                                                const OrtNodeUnit& node_unit,
-                                                const std::string& attr_name,
-                                                int32_t default_axis,
-                                                int32_t& axis_out) const {
+Ort::Status BaseOpBuilder::GetCanonicalizedAxisAttribute(const QnnModelWrapper& qnn_model_wrapper,
+                                                         const OrtNodeUnit& node_unit,
+                                                         const std::string& attr_name,
+                                                         int32_t default_axis,
+                                                         int32_t& axis_out) const {
   const auto& inputs = node_unit.Inputs();
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input_shape), "Cannot get shape");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -243,10 +243,14 @@ class BaseOpBuilder : public IOpBuilder {
     }
   }
 
+  // Reads the named axis attribute, normalizes negative values against the input rank,
+  // and range-checks. Call this before AddQnnScalar<T> — T and the QNN param name are
+  // the caller's responsibility since they depend on the QNN op definition.
   Ort::Status ProcessAxisAttribute(const QnnModelWrapper& qnn_model_wrapper,
                                    const OrtNodeUnit& node_unit,
-                                   Qnn_Scalar_t& axis_qnn_scalar,
-                                   int32_t& default_axis_value) const;
+                                   const std::string& attr_name,
+                                   int32_t default_axis,
+                                   int32_t& axis_out) const;
 
   size_t GetInputCountQnnRequired(const OrtNodeUnit& node_unit) const {
     auto input_output_cout = GetInputOutputCountQnnRequired(node_unit.OpType());

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -246,11 +246,11 @@ class BaseOpBuilder : public IOpBuilder {
   // Reads the named axis attribute, normalizes negative values against the input rank,
   // and range-checks. Call this before AddQnnScalar<T> — T and the QNN param name are
   // the caller's responsibility since they depend on the QNN op definition.
-  Ort::Status ProcessAxisAttribute(const QnnModelWrapper& qnn_model_wrapper,
-                                   const OrtNodeUnit& node_unit,
-                                   const std::string& attr_name,
-                                   int32_t default_axis,
-                                   int32_t& axis_out) const;
+  Ort::Status GetCanonicalizedAxisAttribute(const QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit,
+                                            const std::string& attr_name,
+                                            int32_t default_axis,
+                                            int32_t& axis_out) const;
 
   size_t GetInputCountQnnRequired(const OrtNodeUnit& node_unit) const {
     auto input_output_cout = GetInputOutputCountQnnRequired(node_unit.OpType());

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -191,14 +191,9 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   std::vector<std::string> param_tensor_names;
   const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
   if (is_fp_to_bool_cast) {
-    Qnn_Scalar_t op_scalar = QNN_SCALAR_INIT;
-    op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_NOT_EQUAL;
-    QnnParamWrapper op_param(node_unit.Index(), cast_node_name,
-                             QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, op_scalar);
-    param_tensor_names.push_back(op_param.GetParamTensorName());
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(op_param)),
-                  "Failed to add NotEqual operation param for FP-to-bool Cast.");
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), cast_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_NOT_EQUAL),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, param_tensor_names));
   }
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/concat_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/concat_op_builder.cc
@@ -92,7 +92,7 @@ Ort::Status ConcatOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   // Process axis attribute
   int32_t axis = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(axis), QNN_OP_CONCAT_PARAM_AXIS, param_tensor_names));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/concat_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/concat_op_builder.cc
@@ -91,12 +91,10 @@ Ort::Status ConcatOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   std::vector<std::string> param_tensor_names;
 
   // Process axis attribute
-  int32_t default_axis = 0;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONCAT_PARAM_AXIS, axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  int32_t axis = 0;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(axis), QNN_OP_CONCAT_PARAM_AXIS, param_tensor_names));
 
   // Process outputs
   return ProcessOutputs(qnn_model_wrapper, node_unit,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/einsum_op_builder.cc
@@ -392,21 +392,18 @@ Ort::Status CreateReduceSumMulBroadcastX(
                 "CreateReduceSumMulBroadcastX: failed to AddTensorWrapper");
   const std::string mul_node_name =
       onnxruntime::qnn::utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-  Qnn_Scalar_t mul_op_scalar = QNN_SCALAR_INIT;
-  mul_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  mul_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  onnxruntime::qnn::QnnParamWrapper mul_op_param(node_unit.Index(), mul_node_name,
-                                                 QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_op_scalar);
-  const std::string mul_op_param_name = mul_op_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper->AddParamWrapper(std::move(mul_op_param)),
-                "CreateReduceSumMulBroadcastX: failed to add Mul operation param");
+  std::vector<std::string> mul_param_names;
+  RETURN_IF_ERROR(onnxruntime::qnn::AddQnnScalar<uint32_t>(
+      *qnn_model_wrapper, node_unit.Index(), mul_node_name,
+      static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_param_names));
   RETURN_IF_NOT(qnn_model_wrapper->CreateQnnNode(
                     /*qnn_node_name=*/mul_node_name,
                     /*package_name=*/QNN_OP_PACKAGE_NAME_QTI_AISW,
                     /*qnn_node_type=*/QNN_OP_ELEMENT_WISE_BINARY,
                     /*input_names=*/{reshape_out_name, input_names[1]},
                     /*output_names=*/{mul_out_name},
-                    /*param_tensor_names=*/{mul_op_param_name},
+                    /*param_tensor_names=*/std::move(mul_param_names),
                     /*do_op_validation=*/do_op_validation),
                 "CreateReduceSumMulBroadcastX: failed to create Mul node");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/fusedmatmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/fusedmatmul_op_builder.cc
@@ -258,20 +258,16 @@ Ort::Status FusedMatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(alpha_tensor_wrapper)), "Failed to add alpha tensor.");
 
     std::string alpha_scale_node_name = utils::UniqueNameGenerator().New(node_unit.Name() + "_alpha_scale");
-    Qnn_Scalar_t alpha_mul_scalar = QNN_SCALAR_INIT;
-    alpha_mul_scalar.dataType = QNN_DATATYPE_UINT_32;
-    alpha_mul_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper alpha_mul_param(node_unit.Index(), alpha_scale_node_name,
-                                    QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, alpha_mul_scalar);
-    std::string alpha_mul_param_name = alpha_mul_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(alpha_mul_param)),
-                  "Failed to add alpha scaling operation param.");
+    std::vector<std::string> alpha_mul_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), alpha_scale_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, alpha_mul_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(alpha_scale_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_BINARY,
                                                   {matmul_output_name, alpha_tensor_name},
                                                   {output_name},
-                                                  {alpha_mul_param_name},
+                                                  std::move(alpha_mul_param_names),
                                                   do_op_validation),
                   "Failed to create alpha scaling node for FusedMatMul.");
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -263,7 +263,7 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // axis_value is kept in scope as uint32_t for the GatherElements output shape computation below.
   std::vector<std::string> param_tensor_names;
   int32_t axis_normalized = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis_normalized));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis_normalized));
   const uint32_t axis_value = static_cast<uint32_t>(axis_normalized);
   if (is_gather_elems) {
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gather_op_builder.cc
@@ -259,16 +259,19 @@ Ort::Status GatherOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   const bool needs_bool_cast = (qnn_model_wrapper.GetQnnBackendType() == QnnBackendType::HTP &&
                                 node_unit.Inputs()[0].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL);
 
-  // Create QNN 'axis' parameter.
+  // Create QNN 'axis' parameter. dtype differs by op: Gather->INT_32, GatherElements->UINT_32.
+  // axis_value is kept in scope as uint32_t for the GatherElements output shape computation below.
   std::vector<std::string> param_tensor_names;
-  int32_t axis_value = 0;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
-                             (is_gather_elems ? QNN_OP_GATHER_ELEMENTS_PARAM_AXIS : QNN_OP_GATHER_PARAM_AXIS),
-                             axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  int32_t axis_normalized = 0;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis_normalized));
+  const uint32_t axis_value = static_cast<uint32_t>(axis_normalized);
+  if (is_gather_elems) {
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           axis_value, QNN_OP_GATHER_ELEMENTS_PARAM_AXIS, param_tensor_names));
+  } else {
+    RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                          axis_normalized, QNN_OP_GATHER_PARAM_AXIS, param_tensor_names));
+  }
 
   if (is_gather_elems) {
     if (!needs_bool_cast) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
@@ -345,9 +345,6 @@ Ort::Status GatherBlockQuantizedOpBuilder::ProcessAttributesAndOutputs(QnnModelW
                                                                        std::vector<std::string>&& input_names,
                                                                        const Ort::Logger& logger,
                                                                        bool do_op_validation) const {
-  OrtNodeAttrHelper helper(node_unit);
-  const int64_t axis_attr = helper.Get("gather_axis", 0);
-
   // Output info
   const OrtNodeUnitIODef& output_tensor = node_unit.Outputs()[0];
   TensorInfo output_info{};
@@ -366,8 +363,7 @@ Ort::Status GatherBlockQuantizedOpBuilder::ProcessAttributesAndOutputs(QnnModelW
   // Creating axis param wrapper — GatherBlockQuantized uses "gather_axis", dtype INT_32.
   std::vector<std::string> param_tensor_names;
   int32_t axis = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "gather_axis",
-                                       static_cast<int32_t>(axis_attr), axis));
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "gather_axis", 0, axis));
   RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                         axis, QNN_OP_GATHER_PARAM_AXIS, param_tensor_names));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
@@ -363,7 +363,7 @@ Ort::Status GatherBlockQuantizedOpBuilder::ProcessAttributesAndOutputs(QnnModelW
   // Creating axis param wrapper — GatherBlockQuantized uses "gather_axis", dtype INT_32.
   std::vector<std::string> param_tensor_names;
   int32_t axis = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "gather_axis", 0, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "gather_axis", 0, axis));
   RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                         axis, QNN_OP_GATHER_PARAM_AXIS, param_tensor_names));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gatherblockquantized_op_builder.cc
@@ -363,16 +363,13 @@ Ort::Status GatherBlockQuantizedOpBuilder::ProcessAttributesAndOutputs(QnnModelW
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)), "Failed to add output");
   }
 
-  // Creating axis param wrapper
+  // Creating axis param wrapper — GatherBlockQuantized uses "gather_axis", dtype INT_32.
   std::vector<std::string> param_tensor_names;
-  int32_t axis_value = static_cast<int32_t>(axis_attr);
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
-                             QNN_OP_GATHER_PARAM_AXIS, axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(axis_param)),
-                "Failed to add axis param.");
+  int32_t axis = 0;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "gather_axis",
+                                       static_cast<int32_t>(axis_attr), axis));
+  RETURN_IF_ERROR(AddQnnScalar<int32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                        axis, QNN_OP_GATHER_PARAM_AXIS, param_tensor_names));
 
   // Creating Qnn node
   RETURN_IF_NOT(

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -204,7 +204,7 @@ Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_mode
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
     int32_t ln_axis = -1;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
+    RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
     RETURN_IF(static_cast<size_t>(ln_axis) != input_rank - 1,
               "QNN LayerNorm on HTP only supports normalization along the last axis.");
   }
@@ -256,8 +256,8 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of input 0");
   const size_t input_rank = input_shape.size();
   int32_t ln_axis = -1;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
-  // ProcessAxisAttribute normalizes ln_axis into [0, input_rank); range-check before
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
+  // GetCanonicalizedAxisAttribute normalizes ln_axis into [0, input_rank); range-check before
   // the subtract so a malformed axis fails loudly instead of underflowing axes_rank to ~SIZE_MAX.
   RETURN_IF(ln_axis < 0 || static_cast<size_t>(ln_axis) >= input_rank,
             "QNN LayerNorm: axis out of range after normalization.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -203,9 +203,8 @@ Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_mode
   // Explicit check and provide clear message here
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    int32_t ln_axis = -1;
-    Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, ln_axis));
+    int32_t ln_axis = 0;
+    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
     RETURN_IF(static_cast<size_t>(ln_axis) != input_rank - 1,
               "QNN LayerNorm on HTP only supports normalization along the last axis.");
   }
@@ -257,9 +256,8 @@ Ort::Status LayerNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of input 0");
   const size_t input_rank = input_shape.size();
   int32_t ln_axis = -1;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, ln_axis));
-  // ProcessAxisAttribute is supposed to normalize ln_axis into [0, input_rank); range-check before
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
+  // ProcessAxisAttribute normalizes ln_axis into [0, input_rank); range-check before
   // the subtract so a malformed axis fails loudly instead of underflowing axes_rank to ~SIZE_MAX.
   RETURN_IF(ln_axis < 0 || static_cast<size_t>(ln_axis) >= input_rank,
             "QNN LayerNorm: axis out of range after normalization.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/layernormalization_op_builder.cc
@@ -203,7 +203,7 @@ Ort::Status LayerNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_mode
   // Explicit check and provide clear message here
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    int32_t ln_axis = 0;
+    int32_t ln_axis = -1;
     RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, ln_axis));
     RETURN_IF(static_cast<size_t>(ln_axis) != input_rank - 1,
               "QNN LayerNorm on HTP only supports normalization along the last axis.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lp_pool_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lp_pool_op_builder.cc
@@ -259,39 +259,32 @@ Ort::Status LpPoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   if (p_value == 2) {
     std::string square_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-    Qnn_Scalar_t square_op_scalar = QNN_SCALAR_INIT;
-    square_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    square_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper square_op_param(node_unit.Index(), square_node_name,
-                                    QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, square_op_scalar);
-    std::string square_op_param_name = square_op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(square_op_param)),
-                  "Failed to add square (Multiply) operation param.");
+    std::vector<std::string> square_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), square_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, square_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       square_node_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_BINARY,
                       {input_names[0], input_names[0]},
                       {preprocess_out_name},
-                      {square_op_param_name},
+                      std::move(square_param_names),
                       do_op_validation),
                   "Failed to create square (Multiply) node.");
   } else {
     std::string abs_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_UNARY);
-    Qnn_Scalar_t abs_op_scalar = QNN_SCALAR_INIT;
-    abs_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    abs_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_UNARY_OPERATION_ABS;
-    QnnParamWrapper abs_op_param(node_unit.Index(), abs_node_name,
-                                 QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, abs_op_scalar);
-    std::string abs_op_param_name = abs_op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(abs_op_param)), "Failed to add Abs operation param.");
+    std::vector<std::string> abs_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), abs_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_OPERATION_ABS),
+                                           QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, abs_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       abs_node_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_UNARY,
                       {input_names[0]},
                       {preprocess_out_name},
-                      {abs_op_param_name},
+                      std::move(abs_param_names),
                       do_op_validation),
                   "Failed to create Abs node.");
   }
@@ -372,19 +365,15 @@ Ort::Status LpPoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sqrt_out_tensor)),
                   "Failed to add sqrt output tensor.");
     std::string sqrt_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_UNARY);
-    Qnn_Scalar_t sqrt_op_scalar = QNN_SCALAR_INIT;
-    sqrt_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    sqrt_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SQRT;
-    QnnParamWrapper sqrt_op_param(node_unit.Index(), sqrt_node_name,
-                                  QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, sqrt_op_scalar);
-    std::string sqrt_op_param_name = sqrt_op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(sqrt_op_param)),
-                  "Failed to add SquareRoot operation param.");
+    std::vector<std::string> sqrt_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), sqrt_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SQRT),
+                                           QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, sqrt_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                       sqrt_node_name,
                       QNN_OP_PACKAGE_NAME_QTI_AISW,
                       QNN_OP_ELEMENT_WISE_UNARY,
-                      {pool_out_name}, {sqrt_out_name}, {sqrt_op_param_name}, do_op_validation),
+                      {pool_out_name}, {sqrt_out_name}, std::move(sqrt_param_names), do_op_validation),
                   "Failed to create SquareRoot node.");
     sqrt_or_pool_out_name = sqrt_out_name;
   }
@@ -459,16 +448,12 @@ Ort::Status LpPoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   if (!requires_rank3_reshape) {
     // Final Multiply produces the ONNX output tensor directly (handled by ProcessOutputs).
-    Qnn_Scalar_t mul_op_scalar = QNN_SCALAR_INIT;
-    mul_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    mul_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-    QnnParamWrapper mul_op_param(node_unit.Index(), node_unit.Name(),
-                                 QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_op_scalar);
-    std::string mul_op_param_name = mul_op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(mul_op_param)),
-                  "Failed to add final scale (Multiply) operation param.");
+    std::vector<std::string> mul_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, mul_param_names));
     return ProcessOutputs(qnn_model_wrapper, node_unit,
-                          {sqrt_or_pool_out_name, scale_name}, {mul_op_param_name},
+                          {sqrt_or_pool_out_name, scale_name}, std::move(mul_param_names),
                           logger, do_op_validation, QNN_OP_ELEMENT_WISE_BINARY);
   }
 
@@ -484,21 +469,17 @@ Ort::Status LpPoolOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                   "Failed to add scaled intermediate tensor.");
   }
   std::string scale_mul_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-  Qnn_Scalar_t scale_mul_op_scalar = QNN_SCALAR_INIT;
-  scale_mul_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  scale_mul_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY;
-  QnnParamWrapper scale_mul_op_param(node_unit.Index(), scale_mul_node_name,
-                                     QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, scale_mul_op_scalar);
-  std::string scale_mul_op_param_name = scale_mul_op_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(scale_mul_op_param)),
-                "Failed to add final scale (Multiply) operation param.");
+  std::vector<std::string> scale_mul_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), scale_mul_node_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, scale_mul_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
                     scale_mul_node_name,
                     QNN_OP_PACKAGE_NAME_QTI_AISW,
                     QNN_OP_ELEMENT_WISE_BINARY,
                     {sqrt_or_pool_out_name, scale_name},
                     {scaled_out_name},
-                    {scale_mul_op_param_name},
+                    std::move(scale_mul_param_names),
                     do_op_validation),
                 "Failed to create final scale (Multiply) node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/mod_op_builder.cc
@@ -169,20 +169,16 @@ Ort::Status ModOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                                   std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(floor_output)),
                   "Failed to add Mod - ElementWiseFloor output tensor.");
-    Qnn_Scalar_t floor_op_scalar = QNN_SCALAR_INIT;
-    floor_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    floor_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_UNARY_OPERATION_FLOOR;
-    QnnParamWrapper floor_op_param(node_unit.Index(), floor_name,
-                                   QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, floor_op_scalar);
-    std::string floor_op_param_name = floor_op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(floor_op_param)),
-                  "Failed to add Mod - ElementWiseFloor operation param.");
+    std::vector<std::string> floor_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), floor_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_OPERATION_FLOOR),
+                                           QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, floor_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(floor_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_UNARY,
                                                   {div_output_name},
                                                   {floor_output_name},
-                                                  {floor_op_param_name},
+                                                  std::move(floor_param_names),
                                                   do_op_validation),
                   "Failed to add Mod - ElementWiseFloor node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -279,19 +279,16 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                         QnnQuantParamsWrapper(), std::move(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sqrt_tensorwrapper)), "AddTensorWrapper failed");
     std::string sqrt_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_UNARY);
-    Qnn_Scalar_t sqrt_op_scalar = QNN_SCALAR_INIT;
-    sqrt_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    sqrt_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SQRT;
-    QnnParamWrapper sqrt_op_param(node_unit.Index(), sqrt_node_name,
-                                  QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, sqrt_op_scalar);
-    std::string sqrt_op_param_name = sqrt_op_param.GetParamTensorName();
-    RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(sqrt_op_param)), "AddParamWrapper failed");
+    std::vector<std::string> sqrt_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), sqrt_node_name,
+                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SQRT),
+                                           QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, sqrt_param_names));
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(sqrt_node_name,
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_UNARY,
                                                   {reduce_output_name},
                                                   {output.name},
-                                                  {sqrt_op_param_name},
+                                                  std::move(sqrt_param_names),
                                                   do_op_validation),
                   "CreateQnnNode failed");
   } else {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -64,9 +64,8 @@ Ort::Status RMSNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_
   // Additional constraints for NPU backend
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    int32_t axis = -1;
-    Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
+    int32_t axis = 0;
+    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
     RETURN_IF(static_cast<size_t>(axis) != input_rank - 1,
               "QNN RMSNorm for NPU backend only supports axis with last input dimension");
   }
@@ -147,8 +146,7 @@ Ort::Status RMSNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapp
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of Input 0");
   const size_t input_rank = input_shape.size();
   int32_t axis = -1;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
   size_t axes_rank = input_rank - static_cast<size_t>(axis);
   std::vector<uint32_t> axes(axes_rank, 0);
   std::vector<uint32_t> axes_shape{SafeInt<uint32_t>(axes_rank)};

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -65,7 +65,7 @@ Ort::Status RMSNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
     int32_t axis = 0;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+    RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
     RETURN_IF(static_cast<size_t>(axis) != input_rank - 1,
               "QNN RMSNorm for NPU backend only supports axis with last input dimension");
   }
@@ -146,7 +146,7 @@ Ort::Status RMSNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapp
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of Input 0");
   const size_t input_rank = input_shape.size();
   int32_t axis = -1;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
   size_t axes_rank = input_rank - static_cast<size_t>(axis);
   std::vector<uint32_t> axes(axes_rank, 0);
   std::vector<uint32_t> axes_shape{SafeInt<uint32_t>(axes_rank)};

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
@@ -143,14 +143,11 @@ Ort::Status ScatterElementsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
                 ("ScatterElements does not support reduction " + reduction).c_str());
 
   std::vector<std::string> param_tensor_names;
-
-  int32_t axis_value = 0;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(),
-                             QNN_OP_SCATTER_ELEMENTS_PARAM_AXIS, axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  int32_t axis = 0;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         static_cast<uint32_t>(axis),
+                                         QNN_OP_SCATTER_ELEMENTS_PARAM_AXIS, param_tensor_names));
 
   uint32_t reduction_value = QNN_OP_SCATTER_ELEMENTS_REDUCTION_NONE;
   if (reduction == "none") {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatterelements_op_builder.cc
@@ -144,7 +144,7 @@ Ort::Status ScatterElementsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
 
   std::vector<std::string> param_tensor_names;
   int32_t axis = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis));
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          static_cast<uint32_t>(axis),
                                          QNN_OP_SCATTER_ELEMENTS_PARAM_AXIS, param_tensor_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -328,7 +328,7 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // Add attribute
   if (op_type == "LpNormalization") {
     int32_t axis = 0;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+    RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                            static_cast<uint32_t>(axis), QNN_OP_L2_NORM_PARAM_AXIS, param_tensor_names));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -327,12 +327,10 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   std::vector<std::string> param_tensor_names;
   // Add attribute
   if (op_type == "LpNormalization") {
-    int32_t default_axis = -1;
-    Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, default_axis));
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_L2_NORM_PARAM_AXIS, axis_qnn_scalar);
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    int32_t axis = 0;
+    RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(axis), QNN_OP_L2_NORM_PARAM_AXIS, param_tensor_names));
 
     OrtNodeAttrHelper node_helper(node_unit);
     int64_t norm_p_order = node_helper.Get("p", static_cast<int64_t>(2));
@@ -415,13 +413,9 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   };
   auto binary_it = binary_op_to_operation.find(op_type);
   if (binary_it != binary_op_to_operation.end()) {
-    Qnn_Scalar_t op_scalar = QNN_SCALAR_INIT;
-    op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    op_scalar.uint32Value = binary_it->second;
-    QnnParamWrapper op_param(node_unit.Index(), node_unit.Name(),
-                             QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, op_scalar);
-    param_tensor_names.push_back(op_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(op_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(binary_it->second),
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, param_tensor_names));
   }
 
   static const std::unordered_map<std::string, uint32_t> unary_op_to_operation = {
@@ -442,13 +436,9 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   };
   auto unary_it = unary_op_to_operation.find(op_type);
   if (unary_it != unary_op_to_operation.end()) {
-    Qnn_Scalar_t op_scalar = QNN_SCALAR_INIT;
-    op_scalar.dataType = QNN_DATATYPE_UINT_32;
-    op_scalar.uint32Value = unary_it->second;
-    QnnParamWrapper op_param(node_unit.Index(), node_unit.Name(),
-                             QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, op_scalar);
-    param_tensor_names.push_back(op_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(op_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(unary_it->second),
+                                           QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, param_tensor_names));
   }
 
   return ProcessOutputs(qnn_model_wrapper, node_unit,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -68,8 +68,7 @@ Ort::Status SoftmaxOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
   const int opset_version = node_unit.SinceVersion();
   int32_t axis = GetDefaultAxisAttribute(opset_version);
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", axis, axis));
 
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
@@ -161,8 +160,7 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
 
   const int opset_version = node_unit.SinceVersion();
   int32_t axis = GetDefaultAxisAttribute(opset_version);
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis));
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", axis, axis));
 
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));
@@ -172,15 +170,12 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     std::string reshape_input_name = utils::UniqueNameGenerator().New(orig_output_name, "_reshape");
 
     std::vector<uint32_t> reshape_input_shape = FlattenShapeFromAxis(output_info.shape, axis);
-    if (axis == 0) {
-      // Override axis due to the inserted batch=1 to the first dimension
-      axis_qnn_scalar.uint32Value = 1;
-    }
+    // Override axis due to the inserted batch=1 to the first dimension
+    uint32_t qnn_axis = (axis == 0) ? 1u : static_cast<uint32_t>(axis);
 
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           qnn_axis, QNN_OP_SOFTMAX_PARAM_AXIS, param_tensor_names));
 
     QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
@@ -211,12 +206,11 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     transpose_input_shape[axis] = output_info.shape[output_rank - 1];
 
     // Override axis due to the actual shape after the inserted transpose node
-    axis_qnn_scalar.uint32Value = static_cast<uint32_t>(output_rank) - 1;
+    const uint32_t qnn_axis = static_cast<uint32_t>(output_rank) - 1;
 
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           qnn_axis, QNN_OP_SOFTMAX_PARAM_AXIS, param_tensor_names));
 
     QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
                                           output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
@@ -247,10 +241,10 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
                                                        false,
                                                        is_graph_output));
   } else {
-    QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SOFTMAX_PARAM_AXIS, axis_qnn_scalar);
     std::vector<std::string> param_tensor_names;
-    param_tensor_names.push_back(axis_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                           static_cast<uint32_t>(axis),
+                                           QNN_OP_SOFTMAX_PARAM_AXIS, param_tensor_names));
 
     return ProcessOutputs(qnn_model_wrapper, node_unit,
                           std::move(input_names),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -68,7 +68,7 @@ Ort::Status SoftmaxOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
   const int opset_version = node_unit.SinceVersion();
   int32_t axis = GetDefaultAxisAttribute(opset_version);
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", axis, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", axis, axis));
 
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
@@ -160,7 +160,7 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
 
   const int opset_version = node_unit.SinceVersion();
   int32_t axis = GetDefaultAxisAttribute(opset_version);
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", axis, axis));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", axis, axis));
 
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[0], output_info));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
@@ -69,12 +69,11 @@ Ort::Status SplitOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
                                                         const Ort::Logger& logger,
                                                         bool do_op_validation) const {
   std::vector<std::string> param_tensor_names;
-  int32_t axis_value = 0;
-  Qnn_Scalar_t axis_qnn_scalar = QNN_SCALAR_INIT;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, axis_qnn_scalar, axis_value));
-  QnnParamWrapper axis_param(node_unit.Index(), node_unit.Name(), QNN_OP_SPLIT_PARAM_AXIS, axis_qnn_scalar);
-  param_tensor_names.push_back(axis_param.GetParamTensorName());
-  qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
+  int32_t axis_normalized = 0;
+  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis_normalized));
+  uint32_t axis_value = static_cast<uint32_t>(axis_normalized);
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
+                                         axis_value, QNN_OP_SPLIT_PARAM_AXIS, param_tensor_names));
 
   std::vector<uint32_t> split_index;
   if (node_unit.Inputs().size() > 1) {
@@ -112,7 +111,7 @@ Ort::Status SplitOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
     // Get the length according to axis and split it equally
     std::vector<uint32_t> input_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape");
-    RETURN_IF_NOT(static_cast<int32_t>(input_shape.size()) > axis_value, "axis not valid!");
+    RETURN_IF_NOT(axis_value < static_cast<uint32_t>(input_shape.size()), "axis not valid!");
     RETURN_IF_NOT(input_shape.at(axis_value) > 0, "Shape value not valid!");
 
     // ONNX spec states that if not evenly divisible by `num_outputs`, the last chunk is smaller.

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/split_op_builder.cc
@@ -70,7 +70,7 @@ Ort::Status SplitOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
                                                         bool do_op_validation) const {
   std::vector<std::string> param_tensor_names;
   int32_t axis_normalized = 0;
-  RETURN_IF_ERROR(ProcessAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis_normalized));
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", 0, axis_normalized));
   uint32_t axis_value = static_cast<uint32_t>(axis_normalized);
   RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(),
                                          axis_value, QNN_OP_SPLIT_PARAM_AXIS, param_tensor_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/tan_op_builder.cc
@@ -80,36 +80,30 @@ Ort::Status TanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                 "Failed to add Cos output tensor.");
 
   // Create Sin node: input -> sin_out
-  Qnn_Scalar_t sin_op_scalar = QNN_SCALAR_INIT;
-  sin_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  sin_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SIN;
-  QnnParamWrapper sin_op_param(node_unit.Index(), node_unit.Name() + "_Sin",
-                               QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, sin_op_scalar);
-  std::string sin_op_param_name = sin_op_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(sin_op_param)), "Failed to add Sin operation param.");
+  std::vector<std::string> sin_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_Sin",
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SIN),
+                                         QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, sin_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_Sin"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_UNARY,
                                                 {input_names[0]},
                                                 {sin_output_name},
-                                                {sin_op_param_name},
+                                                std::move(sin_param_names),
                                                 do_op_validation),
                 "Failed to create Sin node.");
 
   // Create Cos node: input -> cos_out
-  Qnn_Scalar_t cos_op_scalar = QNN_SCALAR_INIT;
-  cos_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  cos_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_UNARY_OPERATION_COS;
-  QnnParamWrapper cos_op_param(node_unit.Index(), node_unit.Name() + "_Cos",
-                               QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, cos_op_scalar);
-  std::string cos_op_param_name = cos_op_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(cos_op_param)), "Failed to add Cos operation param.");
+  std::vector<std::string> cos_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name() + "_Cos",
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_OPERATION_COS),
+                                         QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION, cos_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_Cos"),
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_UNARY,
                                                 {input_names[0]},
                                                 {cos_output_name},
-                                                {cos_op_param_name},
+                                                std::move(cos_param_names),
                                                 do_op_validation),
                 "Failed to create Cos node.");
 
@@ -123,19 +117,16 @@ Ort::Status TanOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
 
   // Create Div node: sin_out / cos_out -> output
   std::string div_node_name = utils::UniqueNameGenerator().New(node_unit, "_Div");
-  Qnn_Scalar_t div_op_scalar = QNN_SCALAR_INIT;
-  div_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  div_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE;
-  QnnParamWrapper div_op_param(node_unit.Index(), div_node_name,
-                               QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_op_scalar);
-  std::string div_op_param_name = div_op_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(div_op_param)), "Failed to add Div operation param.");
+  std::vector<std::string> div_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), div_node_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, div_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(div_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {sin_output_name, cos_output_name},
                                                 {output_name},
-                                                {div_op_param_name},
+                                                std::move(div_param_names),
                                                 do_op_validation),
                 "Failed to create Div node.");
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/thresholdedrelu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/thresholdedrelu_op_builder.cc
@@ -174,20 +174,16 @@ Ort::Status ThresholdedReluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrappe
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(greater_output)),
                 "Failed to add ThresholdRelu - Greater output tensor.");
 
-  Qnn_Scalar_t greater_op_scalar = QNN_SCALAR_INIT;
-  greater_op_scalar.dataType = QNN_DATATYPE_UINT_32;
-  greater_op_scalar.uint32Value = QNN_OP_ELEMENT_WISE_BINARY_OPERATION_GREATER;
-  QnnParamWrapper greater_op_param(node_unit.Index(), greater_name,
-                                   QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, greater_op_scalar);
-  std::string greater_op_param_name = greater_op_param.GetParamTensorName();
-  RETURN_IF_NOT(qnn_model_wrapper.AddParamWrapper(std::move(greater_op_param)),
-                "Failed to add ThresholdRelu - Greater operation param.");
+  std::vector<std::string> greater_param_names;
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), greater_name,
+                                         static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_GREATER),
+                                         QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, greater_param_names));
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(greater_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 QNN_OP_ELEMENT_WISE_BINARY,
                                                 {input_name, alpha_tensor_name},
                                                 {greater_output_name},
-                                                {greater_op_param_name},
+                                                std::move(greater_param_names),
                                                 do_op_validation),
                 "Failed to add ThresholdRelu - Greater node.");
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Replace ad-hoc ProcessAxisAttribute overloads with a general design
- Replace qnn_axis_scalar with AddQnnScalar


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The follow up of https://github.com/onnxruntime/onnxruntime-qnn/pull/525
- Update ProcessAxisAttribute behavior to Replace qnn_axis_scalar with AddQnnScalar
