### PR TITLE
Migrate the Artifactory to QDC

### DIFF
--- a/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory-from-github.yml
@@ -223,7 +223,7 @@ jobs:
           NETRC_FILE=$(mktemp -p /tmp)
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" <<EOF
-          machine artifactory-las.qualcomm.com
+          machine artifactory-qdc-global.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
@@ -290,7 +290,7 @@ jobs:
         run: |
           $netrcFile = New-TemporaryFile
           @"
-          machine artifactory-las.qualcomm.com
+          machine artifactory-qdc-global.qualcomm.com
           login $env:ARTIFACTORY_USERNAME
           password $env:ARTIFACTORY_PASSWORD
           "@ | Set-Content -Path $netrcFile
@@ -462,7 +462,7 @@ jobs:
           NETRC_FILE=$(mktemp -p /tmp)
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" <<EOF
-          machine artifactory-las.qualcomm.com
+          machine artifactory-qdc-global.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
@@ -539,7 +539,7 @@ jobs:
                        mktemp -p "${{ github.workspace }}")
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" << EOF
-          machine artifactory-las.qualcomm.com
+          machine artifactory-qdc-global.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF

--- a/.github/workflows/qualcomm-internal-upload-artifactory.yml
+++ b/.github/workflows/qualcomm-internal-upload-artifactory.yml
@@ -201,7 +201,7 @@ jobs:
                        mktemp -p "${{ github.workspace }}")
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" << EOF
-          machine artifactory-las.qualcomm.com
+          machine artifactory-qdc-global.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF
@@ -252,7 +252,7 @@ jobs:
                        mktemp -p "${{ github.workspace }}")
           chmod 600 "$NETRC_FILE"
           cat > "$NETRC_FILE" << EOF
-          machine artifactory-las.qualcomm.com
+          machine artifactory-qdc-global.qualcomm.com
           login ${{ secrets.ARTIFACTORY_USERNAME }}
           password ${{ secrets.ARTIFACTORY_UPLOADER_PASSWORD }}
           EOF

--- a/qcom/scripts/signing/upload_unsigned_to_artifactory.ps1
+++ b/qcom/scripts/signing/upload_unsigned_to_artifactory.ps1
@@ -31,7 +31,7 @@ $repoRoot = git rev-parse --show-toplevel
 Write-Host "Uploading $Filename"
 
 $caCertPath = Join-Path $repoRoot "qcom/scripts/upleveling/certs/artifactory-ca.pem"
-$uploadUrl = "https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/$Version/unsigned_libs/$Filename"
+$uploadUrl = "https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/$Version/unsigned_libs/$Filename"
 
 curl.exe -T "$ZipFile" --fail `
     --cacert "$caCertPath" `

--- a/qcom/scripts/signing/upload_unsigned_to_artifactory.sh
+++ b/qcom/scripts/signing/upload_unsigned_to_artifactory.sh
@@ -35,6 +35,6 @@ echo "Uploading $FILENAME"
 curl --fail -s -T "$ZIP_FILE" \
     --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
     --netrc-file "$NETRC_FILE" \
-    https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/"${VERSION}"/unsigned_libs/"$FILENAME" > /dev/null
+    https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/"${VERSION}"/unsigned_libs/"$FILENAME" > /dev/null
 
 echo "Successfully uploaded $FILENAME"

--- a/qcom/scripts/upleveling/.pypirc
+++ b/qcom/scripts/upleveling/.pypirc
@@ -10,23 +10,23 @@ index-servers =
 
 
 [artifactory-pypi-test-users]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-test-users-pypi-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/pypi/aisw-test-users-pypi-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-pypi-test-project]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-test-project-pypi-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/pypi/aisw-test-project-pypi-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-pypi-test-public]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-test-public-pypi-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/pypi/aisw-test-public-pypi-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-pypi-project]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-project-pypi-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/pypi/aisw-project-pypi-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-pypi-public]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/pypi/aisw-public-pypi-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/pypi/aisw-public-pypi-virtual
 cert: certs/artifactory-ca.pem
 
 [pypi]

--- a/qcom/scripts/upleveling/config.ini
+++ b/qcom/scripts/upleveling/config.ini
@@ -12,35 +12,35 @@ index-servers =
   artifactory-zip-public
 
 [artifactory-nuget-test-users]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-test-users-nuget-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/nuget/aisw-test-users-nuget-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-nuget-test-project]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-test-project-nuget-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/nuget/aisw-test-project-nuget-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-nuget-project]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-project-nuget-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/nuget/aisw-project-nuget-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-nuget-public]
-repository: https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-public-nuget-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/api/nuget/aisw-public-nuget-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-zip-test-users]
-repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testuser-generic-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testuser-generic-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-zip-test-project]
-repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-zip-project]
-repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-project-generic-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-project-generic-virtual
 cert: certs/artifactory-ca.pem
 
 [artifactory-zip-public]
-repository: https://artifactory-las.qualcomm.com/artifactory/aisw-zip-public-generic-virtual
+repository: https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-public-generic-virtual
 cert: certs/artifactory-ca.pem
 
 [nuget]

--- a/qcom/scripts/upleveling/maven/README.md
+++ b/qcom/scripts/upleveling/maven/README.md
@@ -121,7 +121,7 @@ Central Portal account settings.
 The self-hosted build runners must satisfy:
 
 1. **Qualcomm Root CA in the Java truststore** — `artifactory-qdc-global.qualcomm.com`
-   uses the Qualcomm Root CA G2 (same CA as `artifactory-las.qualcomm.com`).
+   uses the Qualcomm Root CA G2.
    If `mvn deploy:deploy-file` fails with an SSL handshake error, import the CA
    cert (`qcom/scripts/upleveling/certs/artifactory-ca.pem`) into the JDK's
    `cacerts` keystore once on the runner:

--- a/qcom/scripts/upleveling/upload_nupkg_to_artifactory.ps1
+++ b/qcom/scripts/upleveling/upload_nupkg_to_artifactory.ps1
@@ -25,7 +25,7 @@ foreach ($file in $nugetFiles) {
     Write-Host "${fileBasename}: $version"
 
     $sourceName = "artifactory-nuget-test-project-$version"
-    $sourceUrl = "https://artifactory-las.qualcomm.com/artifactory/api/nuget/aisw-test-project-nuget-virtual/onnxruntime-qnn/$version"
+    $sourceUrl = "https://artifactory-qdc-global.qualcomm.com/artifactory/api/nuget/aisw-test-project-nuget-virtual/onnxruntime-qnn/$version"
 
     # Use PackageSourceCredentials environment variables for secure authentication
     # NuGet automatically reads credentials from environment variables in the format:

--- a/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
+++ b/qcom/scripts/upleveling/upload_zip_to_artifactory.sh
@@ -48,7 +48,7 @@ find "$INPUT_DIR" \( -name "*.zip" -o -name "*.tgz" \) -type f -print0 | while I
     curl --fail -s -T "$file" \
         --cacert "$REPO_ROOT/qcom/scripts/upleveling/certs/artifactory-ca.pem" \
         --netrc-file "$NETRC_FILE" \
-        https://artifactory-las.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename" > /dev/null
+        https://artifactory-qdc-global.qualcomm.com/artifactory/aisw-zip-testproj-generic-virtual/onnxruntime-qnn/"${version}${TARGET_SUFFIX}"/"$file_basename" > /dev/null
 
     echo "Successfully uploaded $file_basename"
 done


### PR DESCRIPTION
### Description
Migrate the Artifactory server to artifactory-qdc-global.



### Motivation and Context
Update the artifactory server to that recommended by the artifactory team.


