### PR TITLE
Added support for pad fp16 constval attribute

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/pad_op_builder.cc
@@ -171,6 +171,12 @@ Ort::Status ProcessConstantValue(QnnModelWrapper& qnn_model_wrapper,
         constant_value_qnn_scalar.int64Value = int64_span.data()[0];
         break;
       }
+      case QNN_DATATYPE_FLOAT_16: {
+        const Ort::Float16_t fp16_value = *reinterpret_cast<const Ort::Float16_t*>(unpacked_tensor.data());
+        constant_value_qnn_scalar.dataType = QNN_DATATYPE_FLOAT_32;
+        constant_value_qnn_scalar.floatValue = fp16_value.ToFloat();
+        break;
+      }
       case QNN_DATATYPE_FLOAT_32: {
         auto float_span = ReinterpretAsSpan<const float>(gsl::make_span(unpacked_tensor));
         constant_value_qnn_scalar.floatValue = float_span.data()[0];
@@ -275,20 +281,8 @@ Ort::Status PadOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model
                                         node_helper.GetFloat("value").value(),
                                         QNN_OP_PAD_PARAM_PAD_CONSTANT_VALUE, param_tensor_names));
   } else if ((opset_version >= 11 || domain == kMSDomain) && inputs.size() > 2 && inputs[2].Exists()) {
-    TensorInfo input_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[2], input_info));
-    // Pad doesn't support QNN_DATATYPE_FLOAT_16 pad_constant_value.
-    if (input_info.qnn_data_type != QNN_DATATYPE_FLOAT_16) {
-      // Process optional input constant_value
-      RETURN_IF_ERROR(ProcessConstantValue(qnn_model_wrapper, param_tensor_names, node_unit, inputs[2]));
-    } else {
-      // Qualcomm backends don't support QNN_DATATYPE_FLOAT_16 pad_constant_value. Will use default 0.
-      // Fail validation when a fp16 pad_constant_value is not 0.
-      std::vector<uint8_t> unpacked_pad_constant_tensor;
-      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info.initializer_tensor, unpacked_pad_constant_tensor));
-      Ort::Float16_t fp16_value = *reinterpret_cast<const Ort::Float16_t*>(unpacked_pad_constant_tensor.data());
-      RETURN_IF_NOT(0 == static_cast<float>(fp16_value), "pad_constant_value only support 0 when dtype = QNN_DATATYPE_FLOAT_16.");
-    }
+    // Process optional input constant_value. FP16 values are converted to FP32 inside ProcessConstantValue.
+    RETURN_IF_ERROR(ProcessConstantValue(qnn_model_wrapper, param_tensor_names, node_unit, inputs[2]));
   }
 
   if (!has_negative) {

--- a/onnxruntime/test/providers/qnn/pad_test.cc
+++ b/onnxruntime/test/providers/qnn/pad_test.cc
@@ -366,10 +366,16 @@ TEST_F(QnnHTPBackendTests, PadConstantValue_FP16_0) {
 // is correctly processed by ProcessConstantValue, which converts QNN_DATATYPE_FLOAT_16 to
 // QNN_DATATYPE_FLOAT_32 before passing the scalar to QNN.
 TEST_F(QnnHTPBackendTests, PadHasConstantValueFloat16) {
+#if defined(_WIN32)
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#endif
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
   provider_options["enable_htp_fp16_precision"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
 
   auto data_def = TestInputDef<float>({1, 4, 4, 8}, false, GetFloatDataInRange(-1.0f, 1.0f, 128));
   auto constant_def = TestInputDef<float>({1}, true, {1.0f});

--- a/onnxruntime/test/providers/qnn/pad_test.cc
+++ b/onnxruntime/test/providers/qnn/pad_test.cc
@@ -362,8 +362,29 @@ TEST_F(QnnHTPBackendTests, PadConstantValue_FP16_0) {
                                2e-3f);
 }
 
-// Test MLFlaot 16 Constant = 1
-// Should not be assigned to htp since HTP only support fp16 with constant = 0.
+// Verifies that a Pad node with a float16 constant_value initializer (non-zero value = 1.0)
+// is correctly processed by ProcessConstantValue, which converts QNN_DATATYPE_FLOAT_16 to
+// QNN_DATATYPE_FLOAT_32 before passing the scalar to QNN.
+TEST_F(QnnHTPBackendTests, PadHasConstantValueFloat16) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  auto data_def = TestInputDef<float>({1, 4, 4, 8}, false, GetFloatDataInRange(-1.0f, 1.0f, 128));
+  auto constant_def = TestInputDef<float>({1}, true, {1.0f});
+  auto pads_def = TestInputDef<int64_t>({8}, true, {0, 0, 0, 0, 0, 0, 1, 0});
+  const std::vector<ONNX_NAMESPACE::AttributeProto> attrs = {test::MakeAttribute("mode", "constant")};
+
+  TestFp16ModelAccuracy(
+      BuildPadTestCase<float>(data_def, pads_def, constant_def, attrs),
+      BuildPadTestCase<Ort::Float16_t>(ConvertToFP16InputDef(data_def), pads_def,
+                                       ConvertToFP16InputDef(constant_def), attrs),
+      provider_options, 18, ExpectedEPNodeAssignment::All, 0.004f);
+}
+
+// Test MLFloat16 Constant = 1
+// FP16 constant_value is now converted to FP32 inside ProcessConstantValue, so HTP can execute this.
 TEST_F(QnnHTPBackendTests, PadConstantValue_FP16_1) {
   bool has_constant_value_input = true;
   bool enable_fp16_precision = true;
@@ -376,7 +397,7 @@ TEST_F(QnnHTPBackendTests, PadConstantValue_FP16_1) {
                                TestInputDef<int64_t>({4}, true, {0, 2, 0, 0}),
                                input_fp16_constant,
                                {test::MakeAttribute("mode", "constant")},
-                               ExpectedEPNodeAssignment::None,  // Should not be assigned to htp
+                               ExpectedEPNodeAssignment::All,
                                "htp",
                                has_constant_value_input,
                                18,  // opset


### PR DESCRIPTION
**Description**

Added support for float16 Pad op constant attribute. Since QNN/QAIRT has support for float16 Pad op constant.
This patch prevents CPU fallback for Pad. Which increases the performance drastically. 

**Motivation and Context**

Adding fp16 support for pad constant attribute, this supports HTP execution.
Adding test case to support the code change. 
