### PR TITLE
[CI] Clean Linux coverage build directory before build job

### DIFF
--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -34,6 +34,9 @@ jobs:
           fetch-depth: 0
           # submodules omitted here; initialized below only when coverage is needed.
 
+      - name: Clean previous build directory
+        run: rm -rf "${{ github.workspace }}/build/linux-x86_64/RelWithDebInfo"
+
       - name: Check if coverage is needed
         id: gate
         run: |


### PR DESCRIPTION
## Summary

- Add a `rm -rf build/linux-x86_64/RelWithDebInfo` step in `qualcomm-internal-coverage.yml`, executed before the path gate check on every run
- Targets coverage build only (the only job that produces `.gcda`/`.gcno` files that accumulate across successive runs)
- Uses `rm -rf` so it is a no-op when the directory does not yet exist

## Motivation

Linux CI coverage runners accumulate build artifacts across successive PR runs. Incremental builds leave stale `.o`, `.gcda`, and `_deps/` files that are never removed, eventually filling up `/local/mnt/workspace` and causing failures like:

Error: No space left on device: '/local/mnt/workspace/actions-runner/_diag/Worker_xxx.log'

## Test plan

- [x] Verify "Clean previous build directory" step appears in coverage job log on next run