### PR TITLE
Bundle MSVC runtime DLLs into Windows test archive

### DIFF
--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -37,6 +37,36 @@ _AAR_APK_RE = re.compile(r"^java/androidtest/.*\.apk$")
 # Drop __pycache__ and .pytest_cache unconditionally.
 _ALWAYS_REJECT_RE = re.compile(r".*/(__pycache__|\.pytest_cache)/")
 
+# Microsoft Visual C++ runtime DLLs that onnxruntime.dll (from upstream MS prebuilt) imports.
+# Bundled into the Windows test archive so QA machines don't need vc_redist preinstalled.
+# Verified against the v1.26.0 prebuilt PE import tables: x64 onnxruntime.dll imports all four;
+# arm64 imports msvcp140/msvcp140_1/vcruntime140 (no vcruntime140_1). The regex bundles whatever
+# the redist provides; _MSVC_REDIST_REQUIRED is the per-arch completeness floor the loader needs.
+_MSVC_REDIST_FILE_RE = re.compile(r"^(msvcp140|vcruntime140)(_1)?\.dll$", re.IGNORECASE)
+# Per-arch minimum the loader needs to bring up onnxruntime.dll on a clean machine. x64 additionally
+# imports vcruntime140_1.dll; arm64 (and arm64ec/arm64x, which load the native ARM64 CRT) does not.
+# Keys mirror _MSVC_REDIST_ARCH_SUBDIR so the guard's promise ("won't fail to load onnxruntime.dll")
+# holds per arch rather than against a lowest-common-denominator floor that under-covers x64.
+_MSVC_REDIST_REQUIRED = {
+    "windows-x86_64": ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll", "vcruntime140_1.dll"),
+    "windows-arm64": ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"),
+    "windows-arm64ec": ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"),
+    "windows-arm64x": ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"),
+}
+
+# Map per-arch target_platform to the redist subdirectory under VCToolsRedistDir.
+# arm64ec and arm64x both load the native ARM64 CRT (arm64ec/arm64 share the ARM64 runtime;
+# x64 code in the process is emulated), and Microsoft ships no arm64ec redist folder.
+# Keys mirror the argparse --target-platform choices for the windows-* archive targets. The
+# transient "windows-arm64-x-slice" build dir (BuildAsX + Arch=arm64) never runs archive mode
+# — only the arm64ec slice does, as windows-arm64x — so it is intentionally absent here.
+_MSVC_REDIST_ARCH_SUBDIR = {
+    "windows-x86_64": "x64",
+    "windows-arm64": "arm64",
+    "windows-arm64ec": "arm64",
+    "windows-arm64x": "arm64",
+}
+
 
 class PerArchAcceptRules:
     """Accept-list filter for per-arch test archive contents.
@@ -101,6 +131,62 @@ def _iter_qcom_scripts(repo_root: Path):
         yield p
 
 
+def _iter_msvc_redist(vc_redist_dir: Path, target_platform: str):
+    """Yield MSVC redistributable DLLs (msvcp140*.dll, vcruntime140*.dll) for the target arch.
+
+    vc_redist_dir is VCToolsRedistDir, e.g.
+    'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Redist/MSVC/14.40.33807'.
+    Under it, each arch has a 'Microsoft.VC<NNN>.CRT' folder holding the runtime DLLs.
+    """
+    arch_subdir = _MSVC_REDIST_ARCH_SUBDIR.get(target_platform)
+    if arch_subdir is None:
+        logging.warning("No MSVC redist arch mapping for %s; no redist DLLs found.", target_platform)
+        return
+    arch_root = vc_redist_dir / arch_subdir
+    if not arch_root.is_dir():
+        logging.warning("MSVC redist arch dir not found: %s; no redist DLLs found.", arch_root)
+        return
+    crt_dirs = list(arch_root.glob("Microsoft.VC*.CRT"))
+    if not crt_dirs:
+        logging.warning("No Microsoft.VC*.CRT folder under %s; no redist DLLs found.", arch_root)
+        return
+
+    # A side-by-side toolset install can expose multiple CRT version folders. Bundle only the
+    # highest so the archive never carries duplicate-named DLL entries. Sort on the numeric VC
+    # version (e.g. Microsoft.VC143.CRT -> 143), not lexicographically, so VC9 < VC143.
+    def _crt_version(p: Path) -> int:
+        m = re.search(r"Microsoft\.VC(\d+)\.CRT", p.name)
+        return int(m.group(1)) if m else -1
+
+    crt_dir = max(crt_dirs, key=_crt_version)
+    for p in crt_dir.iterdir():
+        if p.is_file() and _MSVC_REDIST_FILE_RE.match(p.name):
+            yield p
+
+
+def _add_msvc_redist(zf: zipfile.ZipFile, vc_redist_dir: Path | None, target_platform: str, arc_root: Path) -> None:
+    """Write the target arch's MSVC redist DLLs into the zip under arc_root. No-op when unset.
+
+    Fails loudly when vc_redist_dir is supplied but the expected runtime DLLs can't be bundled:
+    a silently-incomplete archive fails to load onnxruntime.dll on a clean QA machine, which is
+    exactly what this bundling exists to prevent. This mirrors Get-VcRedistDir, which throws.
+    """
+    if vc_redist_dir is None:
+        return
+    bundled = set()
+    for p in _iter_msvc_redist(vc_redist_dir, target_platform):
+        zf.write(p, str(arc_root / p.name))
+        bundled.add(p.name.lower())
+    required = _MSVC_REDIST_REQUIRED.get(target_platform, ())
+    missing = {n.lower() for n in required} - bundled
+    if missing:
+        raise RuntimeError(
+            f"MSVC redist bundling for {target_platform} is incomplete (missing {sorted(missing)}) "
+            f"under {vc_redist_dir}. The test archive would fail to load onnxruntime.dll on a clean "
+            f"machine. Check the VC redist install and the arch mapping."
+        )
+
+
 def _select_release_entries(release_dir: Path, rules: PerArchAcceptRules, repo_root: Path = REPO_ROOT):
     """Yield (filesystem_path, arcname_relative_to_REPO_ROOT) for accepted Release/ files."""
     for p in _iter_release_files(release_dir):
@@ -131,7 +217,12 @@ def archive_linux(target_platform: str, config: str = "Release", repo_root: Path
             tf.add(p, str(p.relative_to(repo_root)))
 
 
-def archive_windows(target_platform: str, config: str = "Release", repo_root: Path = REPO_ROOT) -> None:
+def archive_windows(
+    target_platform: str,
+    config: str = "Release",
+    repo_root: Path = REPO_ROOT,
+    vc_redist_dir: Path | None = None,
+) -> None:
     build_root = repo_root / "build"
     archive_path = build_root / f"onnxruntime-tests-{target_platform}.zip"
     if config != "Release":
@@ -151,11 +242,16 @@ def archive_windows(target_platform: str, config: str = "Release", repo_root: Pa
                 if src.exists():
                     zf.write(src, str(src.relative_to(repo_root)))
             for fs, arc in _select_release_entries(nested, rules, repo_root):
-                # Drop the inner Release/ doubling so layout matches single-config.
+                # arc is repo-relative (build/<plat>/<config>/<config>/...); rebuild it from
+                # parts[3:] so entries stay rooted at build/<plat>/<config>/, preserving the
+                # doubled <config>/<config>/ dir the VS multi-config generator produces.
                 outer_arc = Path("build") / target_platform / config / Path(*arc.parts[3:])
                 zf.write(fs, str(outer_arc))
             for p in _iter_qcom_scripts(repo_root):
                 zf.write(p, str(p.relative_to(repo_root)))
+            # Binaries (incl. onnxruntime.dll) land under build/<plat>/<config>/<config>/ in this
+            # layout; the redist must co-locate there or the loader won't find it on a clean machine.
+            _add_msvc_redist(zf, vc_redist_dir, target_platform, Path("build") / target_platform / config / config)
         return
 
     archive_path.unlink(missing_ok=True)
@@ -165,6 +261,8 @@ def archive_windows(target_platform: str, config: str = "Release", repo_root: Pa
             zf.write(fs, str(arc))
         for p in _iter_qcom_scripts(repo_root):
             zf.write(p, str(p.relative_to(repo_root)))
+        # Single-config (Ninja): binaries live directly under build/<plat>/<config>/.
+        _add_msvc_redist(zf, vc_redist_dir, target_platform, Path("build") / target_platform / config)
 
 
 def archive_android(target_platform: str, config: str, qairt_sdk_root: Path, repo_root: Path = REPO_ROOT) -> None:
@@ -209,6 +307,15 @@ if __name__ == "__main__":
         ],
     )
     parser.add_argument("--qairt-sdk-root", type=Path, required=True)
+    parser.add_argument(
+        "--vc-redist-dir",
+        type=Path,
+        default=None,
+        help=(
+            "VCToolsRedistDir on Windows. When set, msvcp140*.dll and vcruntime140*.dll for the "
+            "target arch are bundled into the Windows test archive alongside onnxruntime.dll."
+        ),
+    )
     args = parser.parse_args()
 
     if args.target_platform.startswith("android-"):
@@ -216,6 +323,6 @@ if __name__ == "__main__":
     elif args.target_platform.startswith("linux-"):
         archive_linux(args.target_platform, args.config)
     elif args.target_platform.startswith("windows-"):
-        archive_windows(args.target_platform, args.config)
+        archive_windows(args.target_platform, args.config, vc_redist_dir=args.vc_redist_dir)
     else:
         raise ValueError(f"Unknown platform {args.target_platform}.")

--- a/qcom/scripts/all/prepare_test_package.sh
+++ b/qcom/scripts/all/prepare_test_package.sh
@@ -86,12 +86,16 @@ get_arch() {
 
 WINDOWS_FILES=(
     "ep_weight_sharing_ctx_gen.exe"
+    "msvcp140.dll"
+    "msvcp140_1.dll"
     "onnxruntime.dll"
     "onnxruntime_perf_test.exe"
     "onnxruntime_plugin_ep_onnx_test.exe"
     "onnxruntime_provider_test.exe"
     "onnxruntime_providers_qnn.dll"
     "onnxruntime_providers_shared.dll"
+    "vcruntime140.dll"
+    "vcruntime140_1.dll"
 )
 
 LINUX_FILES=(

--- a/qcom/scripts/all/tests/test_archive_tests.py
+++ b/qcom/scripts/all/tests/test_archive_tests.py
@@ -2,13 +2,17 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: MIT
 
+import logging
 import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
 from archive_tests import (
     PerArchAcceptRules,
+    _iter_msvc_redist,
     archive_linux,
+    archive_windows,
 )
 
 
@@ -197,3 +201,189 @@ def test_archive_linux_excludes_testdata(tmp_path):
     assert not any("pytorch-converted" in n for n in names)
     assert not any("backend/test/data/node" in n for n in names)
     assert not any(n.endswith("libfoo.a") for n in names)
+
+
+# --- Windows MSVC redist bundling ---
+
+
+def _make_fake_windows_tree(repo_root: Path, plat: str) -> None:
+    """Minimal single-config build/ tree the archive_windows path can consume."""
+    rel = repo_root / "build" / plat / "Release"
+    _touch(rel / "onnxruntime.dll", "B")
+    _touch(rel / "onnxruntime_providers_qnn.dll", "B")
+    _touch(rel / "onnxruntime_provider_test.exe", "B")
+    _touch(rel / "CTestTestfile.cmake", "ctest")
+    _touch(rel / "run_tests.ps1", "ps")
+    _touch(repo_root / "qcom/scripts/all/foo.py", "B")
+
+
+def _make_fake_windows_tree_nested(repo_root: Path, plat: str) -> None:
+    """Multi-config (VS) build/ tree: binaries nest at build/<plat>/Release/Release/."""
+    outer = repo_root / "build" / plat / "Release"
+    nested = outer / "Release"
+    _touch(nested / "onnxruntime.dll", "B")
+    _touch(nested / "onnxruntime_providers_qnn.dll", "B")
+    _touch(nested / "onnxruntime_provider_test.exe", "B")
+    _touch(outer / "CTestTestfile.cmake", "ctest")
+    _touch(outer / "run_tests.ps1", "ps")
+    _touch(repo_root / "qcom/scripts/all/foo.py", "B")
+
+
+def _make_fake_vc_redist(redist_root: Path, arch_subdir: str) -> None:
+    crt = redist_root / arch_subdir / "Microsoft.VC143.CRT"
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll", "vcruntime140_1.dll"):
+        _touch(crt / name, "REDIST")
+    # Files we should NOT bundle (concrt140, vccorlib140, .props metadata, etc.)
+    _touch(crt / "concrt140.dll", "X")
+    _touch(crt / "Microsoft.VC143.CRT.manifest", "X")
+
+
+@pytest.mark.parametrize(
+    "plat,arch_subdir",
+    [
+        ("windows-x86_64", "x64"),
+        ("windows-arm64", "arm64"),
+        ("windows-arm64ec", "arm64"),  # arm64ec loads the native ARM64 CRT
+        ("windows-arm64x", "arm64"),  # arm64x is a hybrid arm64+arm64ec set; native ARM64 CRT
+    ],
+)
+def test_archive_windows_bundles_msvc_redist(tmp_path, plat, arch_subdir):
+    repo_root = tmp_path / "repo"
+    _make_fake_windows_tree(repo_root, plat)
+    redist_root = tmp_path / "redist"
+    _make_fake_vc_redist(redist_root, arch_subdir)
+
+    archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=redist_root)
+
+    archive = repo_root / "build" / f"onnxruntime-tests-{plat}.zip"
+    assert archive.exists()
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = sorted(zf.namelist())
+
+    redist_prefix = f"build/{plat}/Release/"
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll", "vcruntime140_1.dll"):
+        assert f"{redist_prefix}{name}" in names, f"missing {name} in {names}"
+    # Out-of-scope redist files must not leak in.
+    assert f"{redist_prefix}concrt140.dll" not in names
+    assert not any(n.endswith(".manifest") for n in names)
+
+
+def test_archive_windows_redist_colocates_with_binaries_nested_layout(tmp_path):
+    """Regression: in the VS multi-config layout binaries nest at Release/Release/, so the
+    redist must land there too — otherwise the loader can't find it on a clean machine."""
+    repo_root = tmp_path / "repo"
+    plat = "windows-arm64"
+    _make_fake_windows_tree_nested(repo_root, plat)
+    redist_root = tmp_path / "redist"
+    _make_fake_vc_redist(redist_root, "arm64")
+
+    archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=redist_root)
+
+    archive = repo_root / "build" / f"onnxruntime-tests-{plat}.zip"
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = set(zf.namelist())
+
+    # onnxruntime.dll lands in the doubled Release/Release/ dir; the redist must be in the SAME dir.
+    bin_dir = f"build/{plat}/Release/Release/"
+    assert f"{bin_dir}onnxruntime.dll" in names
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"):
+        assert f"{bin_dir}{name}" in names, f"redist not co-located with onnxruntime.dll: {name}"
+    # And NOT stranded in the outer Release/ directory off the loader's search path.
+    assert f"build/{plat}/Release/msvcp140.dll" not in names
+
+
+def test_archive_windows_omits_redist_when_dir_not_passed(tmp_path):
+    repo_root = tmp_path / "repo"
+    plat = "windows-x86_64"
+    _make_fake_windows_tree(repo_root, plat)
+
+    archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=None)
+
+    archive = repo_root / "build" / f"onnxruntime-tests-{plat}.zip"
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = zf.namelist()
+    assert not any("msvcp140" in n or "vcruntime140" in n for n in names)
+
+
+def test_archive_windows_raises_when_redist_supplied_but_incomplete(tmp_path):
+    """When --vc-redist-dir is given but the runtime can't be bundled, fail loudly rather
+    than ship a silently-broken archive. Here the arch dir doesn't exist under the redist root."""
+    repo_root = tmp_path / "repo"
+    plat = "windows-arm64"  # maps to arm64 subdir
+    _make_fake_windows_tree(repo_root, plat)
+    redist_root = tmp_path / "redist"
+    _make_fake_vc_redist(redist_root, "x64")  # populate a DIFFERENT arch -> arm64 not found
+
+    with pytest.raises(RuntimeError, match="incomplete"):
+        archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=redist_root)
+
+
+def test_iter_msvc_redist_unmapped_platform_yields_nothing(tmp_path, caplog):
+    """An unmapped target_platform warns and yields no DLLs (the warn-then-empty branch)."""
+    redist_root = tmp_path / "redist"
+    _make_fake_vc_redist(redist_root, "x64")
+
+    with caplog.at_level(logging.WARNING):
+        result = list(_iter_msvc_redist(redist_root, "windows-mips"))
+
+    assert result == []
+    assert any("No MSVC redist arch mapping" in r.message for r in caplog.records)
+
+
+def test_archive_windows_x64_floor_requires_vcruntime140_1(tmp_path):
+    """x64 onnxruntime.dll imports vcruntime140_1.dll, so the completeness guard must reject a
+    redist that lacks it — even though arm64 tolerates its absence."""
+    repo_root = tmp_path / "repo"
+    plat = "windows-x86_64"
+    _make_fake_windows_tree(repo_root, plat)
+    redist_root = tmp_path / "redist"
+    crt = redist_root / "x64" / "Microsoft.VC143.CRT"
+    # Everything the x64 floor needs EXCEPT vcruntime140_1.dll.
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"):
+        _touch(crt / name, "REDIST")
+
+    with pytest.raises(RuntimeError, match="vcruntime140_1.dll"):
+        archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=redist_root)
+
+
+def test_archive_windows_arm64_floor_tolerates_missing_vcruntime140_1(tmp_path):
+    """arm64 onnxruntime.dll does NOT import vcruntime140_1.dll; a redist without it must still
+    succeed (the arm64 floor must not over-require the x64-only DLL)."""
+    repo_root = tmp_path / "repo"
+    plat = "windows-arm64"
+    _make_fake_windows_tree(repo_root, plat)
+    redist_root = tmp_path / "redist"
+    crt = redist_root / "arm64" / "Microsoft.VC143.CRT"
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"):
+        _touch(crt / name, "REDIST")
+
+    archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=redist_root)
+
+    archive = repo_root / "build" / f"onnxruntime-tests-{plat}.zip"
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = zf.namelist()
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll"):
+        assert f"build/{plat}/Release/{name}" in names
+
+
+def test_archive_windows_dedupes_multiple_crt_versions(tmp_path):
+    """With side-by-side CRT version folders, the numerically-highest is bundled exactly once
+    (VC9 < VC143 — must not sort lexicographically)."""
+    repo_root = tmp_path / "repo"
+    plat = "windows-x86_64"
+    _make_fake_windows_tree(repo_root, plat)
+    redist_root = tmp_path / "redist"
+    # VC9 would sort AFTER VC143 lexicographically; the numeric sort must still pick VC143.
+    for ver in ("Microsoft.VC9.CRT", "Microsoft.VC142.CRT", "Microsoft.VC143.CRT"):
+        crt = redist_root / "x64" / ver
+        for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll", "vcruntime140_1.dll"):
+            _touch(crt / name, "REDIST")
+
+    archive_windows(target_platform=plat, config="Release", repo_root=repo_root, vc_redist_dir=redist_root)
+
+    archive = repo_root / "build" / f"onnxruntime-tests-{plat}.zip"
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = zf.namelist()
+    # Each redist DLL must appear exactly once despite three CRT folders existing.
+    for name in ("msvcp140.dll", "msvcp140_1.dll", "vcruntime140.dll", "vcruntime140_1.dll"):
+        assert names.count(f"build/{plat}/Release/{name}") == 1, names

--- a/qcom/scripts/windows/build.ps1
+++ b/qcom/scripts/windows/build.ps1
@@ -260,10 +260,12 @@ Push-Location $RepoRoot
 
 $failed = $false
 if ($MakeTestArchive) {
+    $VcRedistDir = (Get-VcRedistDir)
     python.exe "$RepoRoot\qcom\scripts\all\archive_tests.py" `
         "--config=$Config" `
         "--qairt-sdk-root=$QairtSdkRoot" `
-        "--target-platform=windows-$BuildDirArch"
+        "--target-platform=windows-$BuildDirArch" `
+        "--vc-redist-dir=$VcRedistDir"
     if (-not $?) {
         $failed = $true
     }

--- a/qcom/scripts/windows/utils.ps1
+++ b/qcom/scripts/windows/utils.ps1
@@ -78,21 +78,63 @@ function Exit-PyVenv() {
     $env:Path = $PathNoVenv
 }
 
-function Get-InstalledVsGenerator() {
+# Enumerate installed Visual Studio roots, newest first. Single source of truth for the
+# supported VS versions and editions consumed by Get-InstalledVsGenerator and Get-VcRedistDir.
+# Each result carries the install Dir token, the CMake Generator name, and the install Root path.
+function Get-VsInstallRoots() {
     $VsInstalls = @(
         @{ Dir = "18"; Generator = "Visual Studio 18 2026" },
         @{ Dir = "2022"; Generator = "Visual Studio 17 2022" }
     )
-    $Editions = @("Enterprise", "Professional", "Community", "Preview")
+    $Editions = @("Enterprise", "Professional", "Community", "Preview", "BuildTools")
+    $Roots = @()
     foreach ($vs in $VsInstalls) {
         foreach ($edition in $Editions) {
-            $DevShell = "$env:ProgramW6432\Microsoft Visual Studio\$($vs.Dir)\$edition\Common7\Tools\Launch-VsDevShell.ps1"
-            if (Test-Path $DevShell) {
-                return [PSCustomObject]@{ Generator = $vs.Generator; DevShell = $DevShell }
+            $Root = "$env:ProgramW6432\Microsoft Visual Studio\$($vs.Dir)\$edition"
+            if (Test-Path $Root) {
+                $Roots += [PSCustomObject]@{ Dir = $vs.Dir; Generator = $vs.Generator; Root = $Root }
             }
         }
     }
+    return $Roots
+}
+
+function Get-InstalledVsGenerator() {
+    foreach ($vs in (Get-VsInstallRoots)) {
+        $DevShell = "$($vs.Root)\Common7\Tools\Launch-VsDevShell.ps1"
+        if (Test-Path $DevShell) {
+            return [PSCustomObject]@{ Generator = $vs.Generator; DevShell = $DevShell }
+        }
+    }
     throw "No supported Visual Studio installation found (2026 or 2022)."
+}
+
+# Locate the MSVC redistributable directory (VCToolsRedistDir). archive_tests.py uses this
+# to bundle msvcp140*.dll and vcruntime140*.dll into the Windows test archive so QA machines
+# don't need vc_redist preinstalled to run tests that load onnxruntime.dll.
+function Get-VcRedistDir() {
+    # Trailing backslashes must be stripped: Launch-VsDevShell.ps1 sets $env:VCToolsRedistDir
+    # with a trailing '\'. When the value is then passed through to python.exe as a quoted
+    # argument, Windows' CRT argv parser interprets the final '\"' as an escaped quote (per
+    # CommandLineToArgvW rules), embedding a stray '"' into the value. The downstream Path
+    # join then yields ...\14.42.34433"\x64 and the arch dir lookup fails.
+    if ($env:VCToolsRedistDir -and (Test-Path $env:VCToolsRedistDir)) {
+        return (Resolve-Path $env:VCToolsRedistDir).Path.TrimEnd('\')
+    }
+
+    # Fall back to the VS install's pinned redist version for cross-compile builds (VS
+    # generator) that never ran Launch-VsDevShell.ps1 in this session.
+    foreach ($vs in (Get-VsInstallRoots)) {
+        $VersionFile = "$($vs.Root)\VC\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt"
+        if (Test-Path $VersionFile) {
+            $Version = (Get-Content $VersionFile -Raw).Trim()
+            $RedistDir = "$($vs.Root)\VC\Redist\MSVC\$Version"
+            if (Test-Path $RedistDir) {
+                return (Resolve-Path $RedistDir).Path.TrimEnd('\')
+            }
+        }
+    }
+    throw "Could not locate VC redist directory (VCToolsRedistDir unset and no VS install found)."
 }
 
 function Get-DefaultCMakeGenerator() {


### PR DESCRIPTION
### Description
Bundle the MSVC C++ runtime DLLs (`msvcp140*.dll`, `vcruntime140*.dll`) into the per-arch Windows test archive (`onnxruntime-tests-windows-*.zip`), sourced from the build runner's VC redist directory.

List the dependencies of `onnxruntime.dll` for each arch below:
| Arch| msvcp140.dll | msvcp140_1.dll | vcruntime140.dll | vcruntime140_1.dll |
|--------|--------|--------|--------|--------|
| windows-x86_64 | Y | Y | Y | Y |
| windows-arm64 | Y | Y | Y | N |
| windows-arm64ec | Y | Y | Y | N |
| windows-arm64x | Y | Y | Y | N |

Since we copy all the MSVC DLLs from `vc_redist_dir`, we can also include `vcruntime140_1.dll` for all arm64-related Archs. That whould prevent the `WINDOWS_FILES` check in `qcom/scripts/all/prepare_test_package.sh` from failing.


### Motivation and Context
Although `onnxruntime_providers_qnn.dll` is statically linked and does not require the MSVC runtime, `onnxruntime.dll` does — and those dependencies are not included in the upstream Microsoft release package we consume. As a result, QA machines running end-to-end nightly tests fail to load `onnxruntime.dll` unless vc_redist is preinstalled out-of-band. This PR bundles those dependencies into the nightly test archive so QA tests run on a clean machine without manual setup.