### PR TITLE
[QNN EP] NPU detection on Linux

### DIFF
--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -146,7 +146,9 @@ jobs:
       target_py_vsn: ${{ inputs.target_py_vsn }}
       upload_test_archive: true
       upload_wheel: true
-      test_wheel: false  # Fails because the HTP is not discovered
+      # HTP NPU is discovered by qnn_provider_factory's fastRPC probe (/dev/fastrpc-cdsp);
+      # ORT Core's Linux discovery doesn't see Qualcomm NPUs.
+      test_wheel: true
       run_tests: true
       build_test_same_runner: false
       test_runner_arch: arm64

--- a/.github/workflows/qualcomm-internal-build-and-test.yml
+++ b/.github/workflows/qualcomm-internal-build-and-test.yml
@@ -146,9 +146,7 @@ jobs:
       target_py_vsn: ${{ inputs.target_py_vsn }}
       upload_test_archive: true
       upload_wheel: true
-      # HTP NPU is discovered by qnn_provider_factory's fastRPC probe (/dev/fastrpc-cdsp);
-      # ORT Core's Linux discovery doesn't see Qualcomm NPUs.
-      test_wheel: true
+      test_wheel: false
       run_tests: true
       build_test_same_runner: false
       test_runner_arch: arm64

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -11,6 +11,10 @@
 #include <iostream>
 #include <optional>
 
+#if !defined(_WIN32)
+#include <glob.h>
+#endif
+
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_ep_device_ep_metadata_keys.h"
 #include "QnnCommon.h"
@@ -185,11 +189,21 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this
   }
 
   if (!has_npu_hw_device && num_ep_devices < max_ep_devices) {
-    if (qnn::soc::GetSocId() != 0) {
-      // If ORT Core does not detect NPU hardware but we recognize the device as WoS (through qnn::soc::GetSocId),
-      // exploit virtual hardware device to create an NPU hardware device for user to select from.
-      // Such case happens for older WoS devices (e.g., Makena) that ORT Core's device discovery logic could not detect
-      // NPU through DXCore.
+    bool synthesize_npu = qnn::soc::GetSocId() != 0;
+
+#if !defined(_WIN32) && defined(__aarch64__)
+    // Qualcomm Linux/Android arm64: ORT Core doesn't enumerate Hexagon NPUs.
+    // Detect via any fastRPC compute-DSP char device.
+    glob_t g{};
+    if (glob("/dev/fastrpc-cdsp*", 0, nullptr, &g) == 0 && g.gl_pathc > 0) {
+      synthesize_npu = true;
+    }
+    globfree(&g);
+#endif
+
+    if (synthesize_npu) {
+      // ORT Core didn't enumerate an NPU OrtHardwareDevice; synthesize one.
+      // Triggers: WoS without DXCore enumeration (Makena), or Qualcomm Linux/Android arm64.
       OrtHardwareDevice* undetected_npu_hw_device = nullptr;
       RETURN_IF_NOT_NULL(create_hw_device(OrtHardwareDeviceType_NPU, undetected_npu_hw_device, false));
       factory->undetected_npu_hw_device_ = HardwareDeviceUniquePtr(

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -11,11 +11,6 @@
 #include <iostream>
 #include <optional>
 
-#if !defined(_WIN32)
-#include <cstring>
-#include <dirent.h>
-#endif
-
 #include "onnxruntime_c_api.h"
 #include "onnxruntime_ep_device_ep_metadata_keys.h"
 #include "QnnCommon.h"
@@ -190,21 +185,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this
   }
 
   if (!has_npu_hw_device && num_ep_devices < max_ep_devices) {
-    bool synthesize_npu = qnn::soc::GetSocId() != 0;
-
-#if !defined(_WIN32) && defined(__aarch64__)
-    // Qualcomm Linux/Android arm64: ORT Core doesn't enumerate Hexagon NPUs.
-    // Detect via any fastRPC compute-DSP char device.
-    if (DIR* d = opendir("/dev")) {
-      while (dirent* e = readdir(d)) {
-        if (std::strncmp(e->d_name, "fastrpc-cdsp", 12) == 0) {
-          synthesize_npu = true;
-          break;
-        }
-      }
-      closedir(d);
-    }
-#endif
+    bool synthesize_npu = qnn::soc::GetSocId() != 0 || qnn::soc::HasFastRpcCdspDevice();
 
     if (synthesize_npu) {
       // ORT Core didn't enumerate an NPU OrtHardwareDevice; synthesize one.

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -12,7 +12,8 @@
 #include <optional>
 
 #if !defined(_WIN32)
-#include <glob.h>
+#include <cstring>
+#include <dirent.h>
 #endif
 
 #include "onnxruntime_c_api.h"
@@ -194,11 +195,15 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this
 #if !defined(_WIN32) && defined(__aarch64__)
     // Qualcomm Linux/Android arm64: ORT Core doesn't enumerate Hexagon NPUs.
     // Detect via any fastRPC compute-DSP char device.
-    glob_t g{};
-    if (glob("/dev/fastrpc-cdsp*", 0, nullptr, &g) == 0 && g.gl_pathc > 0) {
-      synthesize_npu = true;
+    if (DIR* d = opendir("/dev")) {
+      while (dirent* e = readdir(d)) {
+        if (std::strncmp(e->d_name, "fastrpc-cdsp", 12) == 0) {
+          synthesize_npu = true;
+          break;
+        }
+      }
+      closedir(d);
     }
-    globfree(&g);
 #endif
 
     if (synthesize_npu) {

--- a/onnxruntime/core/providers/qnn/soc_utils.cc
+++ b/onnxruntime/core/providers/qnn/soc_utils.cc
@@ -6,6 +6,10 @@
 #ifdef _WIN32
 #include <windows.h>
 #endif
+#if !defined(_WIN32) && defined(__aarch64__)
+#include <cstring>
+#include <dirent.h>
+#endif
 
 #include "core/providers/qnn/soc_utils.h"
 
@@ -178,6 +182,28 @@ int getSocId() {
 int GetSocId() {
   static int cached_soc_id = getSocId();
   return cached_soc_id;
+}
+
+bool HasFastRpcCdspDevice() {
+#if !defined(_WIN32) && defined(__aarch64__)
+  // Qualcomm Linux/Android arm64: ORT Core doesn't enumerate Hexagon NPUs.
+  // Detect via any fastRPC compute-DSP char device.
+  DIR* d = opendir("/dev");
+  if (!d) {
+    return false;
+  }
+  bool found = false;
+  while (dirent* e = readdir(d)) {
+    if (std::strncmp(e->d_name, "fastrpc-cdsp", 12) == 0) {
+      found = true;
+      break;
+    }
+  }
+  closedir(d);
+  return found;
+#else
+  return false;
+#endif
 }
 
 }  // namespace soc

--- a/onnxruntime/core/providers/qnn/soc_utils.h
+++ b/onnxruntime/core/providers/qnn/soc_utils.h
@@ -9,6 +9,10 @@ namespace soc {
 
 int GetSocId();
 
+// Returns true on Linux/Android arm64 if a Hexagon fastRPC compute-DSP char device
+// (/dev/fastrpc-cdsp*) is present. Always false elsewhere.
+bool HasFastRpcCdspDevice();
+
 }  // namespace soc
 }  // namespace qnn
 }  // namespace onnxruntime


### PR DESCRIPTION
### Description

Register a QNN NPU device on Linux ARM64. Checks `/dev/fastrpc-cdsp*` and advertises an NPU if found. Same fallback we already use for older WoS devices.

### Motivation and Context

After #500, Linux ARM64 users get `No QNN EP devices found`. ORT Core doesn't enumerate the Hexagon on Linux, and #500 removed the CPU placeholder that used to fill in. 

Verified on CI Linux ARM64 runner