### PR TITLE
Fix softmax output enc not in [0, 1] range

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/softmax_op_builder.cc
@@ -39,6 +39,135 @@ constexpr int32_t GetDefaultAxisAttribute(int opset_version) {
   return opset_version < 13 ? 1 : -1;
 }
 
+// Returns true if the Softmax output uses a non-natural quantized encoding that should be
+// decoupled from the consumer's encoding via an explicit Convert.
+//
+// Softmax output is in [0, 1] (strictly non-negative), so its natural quantized encoding is
+// asymmetric with offset (zero-point) 0. However, when the output feeds an op that requires a
+// symmetric encoding on that input (e.g. an HTP MatMul RHS on older HTP archs), aimet assigns the softmax
+// output a symmetric encoding (zero-point != 0). At 8-bit HTP softmax kernel mishandles the symmetric
+// output encoding producing garbage and near-zero accuracy
+//
+// The fix emits Softmax with its natural (zero-point 0) encoding and then a QNN_OP_CONVERT to the
+// original (symmetric) encoding the consumer expects, satisfying both the constraints
+
+static bool NeedsBoundedOutputSplit(const std::string& op_type, const TensorInfo& output_info,
+                                    QnnBackendType backend_type) {
+  // Limiting to Softmax for now, will scale to other ops next
+  if (op_type != "Softmax") {
+    return false;
+  }
+  if (!IsNpuBackend(backend_type)) {
+    return false;
+  }
+  if (!output_info.quant_param.IsPerTensor(/*include_bw*/ false)) {
+    return false;
+  }
+
+  // Only split when the encoding is symmetric (zero-point at the midpoint of the unsigned integer
+  // range), which is what aimet assigns when the [0, 1] output must feed a symmetric-input
+  // consumer (e.g. an HTP MatMul RHS)
+  const bool is_unsigned = output_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+                           output_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16;
+  if (!is_unsigned) {
+    return false;
+  }
+  const size_t bitwidth = utils::GetElementSizeByType(output_info.qnn_data_type) * 8;
+  const int32_t symmetric_offset = -(static_cast<int32_t>(uint64_t{1} << (bitwidth - 1)));
+  return output_info.quant_param.Get().scaleOffsetEncoding.offset == symmetric_offset;
+}
+
+// Builds the natural (zero-point 0) quantized encoding for an output bounded to the unit interval
+// [0, 1] -- e.g. Softmax, Sigmoid, HardSigmoid. Uses a power-of-two scale so the requant on HTP is
+// an exact bit-shift: scale = 1 / 2^bitwidth maps the unsigned range [0, 2^bitwidth - 1] to [0, ~1).
+static QnnQuantParamsWrapper BuildUnitRangeQuantParams(Qnn_DataType_t qnn_data_type) {
+  const size_t bitwidth = utils::GetElementSizeByType(qnn_data_type) * 8;
+  const float scale = 1.0f / static_cast<float>(uint64_t{1} << bitwidth);
+  return QnnQuantParamsWrapper(scale, /*offset*/ 0);
+}
+
+// Creates the QNN Softmax node and wires its output to `output_name`
+//
+// Normally this is a single Softmax node writing directly to `output_name` with the output's
+// (consumer-demanded) quantization params. When NeedsBoundedOutputSplit() is true, it instead
+// emits:  Softmax (natural offset-0 encoding) -> QNN_OP_CONVERT -> output_name (original encoding).
+// The Convert bridges the natural softmax encoding to the encoding the consumer expects
+//
+static Ort::Status CreateSoftmaxOutputNodes(QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit,
+                                            std::vector<std::string>&& input_names,
+                                            std::vector<std::string>&& param_tensor_names,
+                                            const std::string& output_name,
+                                            Qnn_DataType_t qnn_data_type,
+                                            const QnnQuantParamsWrapper& output_quant_param,
+                                            std::vector<uint32_t> output_shape,
+                                            bool is_graph_output,
+                                            const std::string& qnn_op_type,
+                                            bool do_op_validation) {
+  TensorInfo output_info = {};
+  output_info.shape = output_shape;
+  output_info.qnn_data_type = qnn_data_type;
+  output_info.quant_param = output_quant_param.Copy();
+
+  const Qnn_TensorType_t output_tensor_type =
+      is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+
+  if (!NeedsBoundedOutputSplit(node_unit.OpType(), output_info, qnn_model_wrapper.GetQnnBackendType())) {
+    // No split: single Softmax node writing directly to output_name. Reached only for the
+    // reshape/transpose-path intermediate tensors (the direct path's no-split case goes through
+    // ProcessOutputs in the caller)
+    QnnTensorWrapper output_tensorwrapper(output_name, output_tensor_type, qnn_data_type,
+                                          output_quant_param.Copy(), std::vector<uint32_t>(output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                  "Failed to add (Log)Softmax output tensor.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  qnn_op_type,
+                                                  std::move(input_names),
+                                                  {output_name},
+                                                  std::move(param_tensor_names),
+                                                  do_op_validation),
+                  "Failed to add (Log)Softmax node.");
+    return Ort::Status();
+  }
+
+  // Split path: Softmax (natural encoding) -> Convert -> output_name (original encoding)
+  QnnQuantParamsWrapper natural_quant_param = BuildUnitRangeQuantParams(qnn_data_type);
+  const std::string natural_name = utils::UniqueNameGenerator().New(output_name, "_natural");
+
+  // 1) Intermediate softmax output with the natural zero-point=0 encoding.
+  QnnTensorWrapper natural_tensor_wrapper(natural_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type,
+                                          natural_quant_param.Copy(), std::vector<uint32_t>(output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(natural_tensor_wrapper)),
+                "Failed to add natural-encoding (Log)Softmax output tensor.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                qnn_op_type,
+                                                std::move(input_names),
+                                                {natural_name},
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
+                "Failed to add (Log)Softmax node (split path).");
+
+  // 2) Output tensor with the original encoding
+  QnnTensorWrapper output_tensor_wrapper(output_name, output_tensor_type, qnn_data_type,
+                                         output_quant_param.Copy(), std::vector<uint32_t>(output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensor_wrapper)),
+                "Failed to add (Log)Softmax converted output tensor.");
+
+  // 3) Convert: natural encoding -> original encoding. Single in/out, no params
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_CONVERT),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_CONVERT,
+                                                {natural_name},
+                                                {output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to add Convert node for (Log)Softmax bounded-output split.");
+
+  return Ort::Status();
+}
+
 std::vector<uint32_t> FlattenShapeFromAxis(const std::vector<uint32_t>& input_shape, int32_t axis) {
   /*
   Return the shape with all dimensions multiplied onward from the specified axis. If axis is 0, the returned shape
@@ -182,16 +311,19 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-    QnnTensorWrapper output_tensorwrapper(reshape_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
-                                          output_info.quant_param.Copy(), std::vector<uint32_t>(reshape_input_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  GetQnnOpType(node_unit.OpType()),
-                                                  std::move(input_names),
-                                                  {reshape_input_name},
-                                                  std::move(param_tensor_names)),
-                  "Failed to add node.");
+    // Softmax writes the (flattened) result to reshape_input_name; the subsequent Reshape restores
+    // the original shape. The bounded-output split (if needed) is applied here on reshape_input_name,
+    // which is never a graph output (the Reshape produces the graph output).
+    RETURN_IF_ERROR(CreateSoftmaxOutputNodes(qnn_model_wrapper, node_unit,
+                                             std::move(input_names),
+                                             std::move(param_tensor_names),
+                                             reshape_input_name,
+                                             output_info.qnn_data_type,
+                                             output_info.quant_param,
+                                             reshape_input_shape,
+                                             /*is_graph_output*/ false,
+                                             GetQnnOpType(node_unit.OpType()),
+                                             do_op_validation));
 
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(reshape_input_name,
@@ -218,16 +350,19 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-    QnnTensorWrapper output_tensorwrapper(transpose_input_name, QNN_TENSOR_TYPE_NATIVE, output_info.qnn_data_type,
-                                          output_info.quant_param.Copy(), std::vector<uint32_t>(transpose_input_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  GetQnnOpType(node_unit.OpType()),
-                                                  std::move(input_names),
-                                                  {transpose_input_name},
-                                                  std::move(param_tensor_names)),
-                  "Failed to add node.");
+    // Softmax writes the result (axis transposed to last) to transpose_input_name; the subsequent
+    // Transpose restores the original layout. The bounded-output split (if needed) is applied here
+    // on transpose_input_name, which is never a graph output (the Transpose produces the output).
+    RETURN_IF_ERROR(CreateSoftmaxOutputNodes(qnn_model_wrapper, node_unit,
+                                             std::move(input_names),
+                                             std::move(param_tensor_names),
+                                             transpose_input_name,
+                                             output_info.qnn_data_type,
+                                             output_info.quant_param,
+                                             transpose_input_shape,
+                                             /*is_graph_output*/ false,
+                                             GetQnnOpType(node_unit.OpType()),
+                                             do_op_validation));
 
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);
     std::vector<uint32_t> transpose_perm;
@@ -252,10 +387,27 @@ Ort::Status SoftmaxOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_m
     param_tensor_names.push_back(axis_param.GetParamTensorName());
     qnn_model_wrapper.AddParamWrapper(std::move(axis_param));
 
-    return ProcessOutputs(qnn_model_wrapper, node_unit,
-                          std::move(input_names),
-                          std::move(param_tensor_names),
-                          logger, do_op_validation, GetQnnOpType(op_type));
+    // Direct path: Softmax output is the node's ONNX output. When the bounded-output split is not
+    // needed, defer to ProcessOutputs() which handles graph-output wiring and other generic logic.
+    // When the split is needed, emit Softmax(natural) -> Convert -> output directly.
+    if (!NeedsBoundedOutputSplit(op_type, output_info, qnn_model_wrapper.GetQnnBackendType())) {
+      return ProcessOutputs(qnn_model_wrapper, node_unit,
+                            std::move(input_names),
+                            std::move(param_tensor_names),
+                            logger, do_op_validation, GetQnnOpType(op_type));
+    }
+
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);
+    RETURN_IF_ERROR(CreateSoftmaxOutputNodes(qnn_model_wrapper, node_unit,
+                                             std::move(input_names),
+                                             std::move(param_tensor_names),
+                                             orig_output_name,
+                                             output_info.qnn_data_type,
+                                             output_info.quant_param,
+                                             output_info.shape,
+                                             is_graph_output,
+                                             GetQnnOpType(op_type),
+                                             do_op_validation));
   }
 
   return Ort::Status();

--- a/onnxruntime/test/providers/qnn/softmax_test.cc
+++ b/onnxruntime/test/providers/qnn/softmax_test.cc
@@ -7,9 +7,13 @@
 #include <string>
 #include <vector>
 
+#include <filesystem>
+
 #include "test/providers/qnn/qnn_test_utils.h"
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
+#include "gsl/gsl"
 #include "gtest/gtest.h"
 
 namespace onnxruntime {
@@ -272,16 +276,39 @@ static void RunQDQSoftmaxSymmetricOutputTest(const TestInputDef<float>& input_de
                                              const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                                              int opset_version,
                                              ExpectedEPNodeAssignment expected_ep_assignment,
-                                             bool use_contrib_qdq = false) {
+                                             bool use_contrib_qdq = false,
+                                             bool assert_convert_in_graph = false) {
+  namespace fs = std::filesystem;
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
+
+  // When asserting, dump the lowered QNN graph JSON so we can check it contains exactly one
+  // Convert, i.e. the bounded-output split emitted Softmax(natural) -> Convert -> output(symmetric).
+
+  const bool check_graph = assert_convert_in_graph;
+  const auto* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+  const fs::path graph_dir = fs::temp_directory_path() /
+                             (std::string("softmax_split_qnn_graph_") + test_info->name());
+  if (check_graph) {
+    fs::remove_all(graph_dir);
+    fs::create_directories(graph_dir);
+    provider_options["dump_json_qnn_graph"] = "1";
+    provider_options["json_qnn_graph_dir"] = graph_dir.string();
+  }
+  auto cleanup = gsl::finally([&]() {
+    if (check_graph) fs::remove_all(graph_dir);
+  });
 
   TestQDQModelAccuracy(BuildOpTestCase<float>("Softmax_node", "Softmax", {input_def}, {}, attrs),
                        BuildQDQSoftmaxSymmetricOutputTestCase<QType>(input_def, attrs, use_contrib_qdq),
                        provider_options,
                        opset_version,
                        expected_ep_assignment);
+
+  if (check_graph && !::testing::Test::IsSkipped()) {
+    AssertOpInQnnGraph(graph_dir, "Convert", 1);
+  }
 }
 }  // namespace
 
@@ -292,7 +319,9 @@ TEST_F(QnnHTPBackendTests, Softmax_SymmetricOutput_U8_Split) {
   RunQDQSoftmaxSymmetricOutputTest<uint8_t>({TestInputDef<float>({1, 2, 3}, false, input_data)},
                                             {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                             13,
-                                            ExpectedEPNodeAssignment::All);
+                                            ExpectedEPNodeAssignment::All,
+                                            /*use_contrib_qdq*/ false,
+                                            /*assert_convert_in_graph*/ true);
 }
 
 // (2) Symmetric uint8 Softmax output that is also a graph output -> split path with the converted
@@ -302,7 +331,9 @@ TEST_F(QnnHTPBackendTests, Softmax_SymmetricOutput_U8_GraphOutput_Split) {
   RunQDQSoftmaxSymmetricOutputTest<uint8_t>({TestInputDef<float>({1, 2, 3, 4}, false, input_data)},
                                             {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
                                             13,
-                                            ExpectedEPNodeAssignment::All);
+                                            ExpectedEPNodeAssignment::All,
+                                            /*use_contrib_qdq*/ false,
+                                            /*assert_convert_in_graph*/ true);
 }
 
 // (3) Natural (zero-point 0) uint8 Softmax output -> NO split. Standard QDQ harness derives a

--- a/onnxruntime/test/providers/qnn/softmax_test.cc
+++ b/onnxruntime/test/providers/qnn/softmax_test.cc
@@ -182,6 +182,174 @@ TEST_F(QnnHTPBackendTests, Softmax13NonLastAxisAfterMatMulAddFusion) {
                   /*fp32_abs_err=*/2e-3f);
 }
 
+// Bounded-output split tests.
+//
+// A quantized Softmax output is in [0, 1] and is naturally encoded with zero-point 0. When the
+// quantizer instead assigns a symmetric output encoding (zero-point != 0) -- e.g. because the
+// output feeds an op that requires a symmetric input -- the QNN EP emits the Softmax with its
+// natural (zero-point 0) encoding followed by a QNN_OP_CONVERT to the original encoding. These
+// tests verify that the split is value-preserving (output matches the CPU reference) and does not
+// fragment the graph. (The underlying HTP softmax-kernel accuracy bug only manifests on real
+// hardware; here we guard that the fix is lossless and keeps the op on QNN.)
+namespace {
+// Builds a QDQ Softmax model whose output Q/DQ uses a forced SYMMETRIC encoding (zero-point at the
+// mid-point of the quantized range), which triggers the bounded-output split in the QNN EP.
+template <typename QType>
+static GetTestQDQModelFn<QType> BuildQDQSoftmaxSymmetricOutputTestCase(
+    const TestInputDef<float>& input_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    bool use_contrib_qdq = false) {
+  return [input_def, attrs, use_contrib_qdq](ModelTestBuilder& builder,
+                                             std::vector<QuantParams<QType>>& output_qparams) {
+    // input -> Q -> DQ
+    MakeTestInput<float>(builder, "X", input_def);
+    QuantParams<QType> input_qparams = GetTestInputQuantParams<QType>(input_def);
+    const std::string input_qdq = AddQDQNodePair<QType>(builder, "qdq_in", "X", input_qparams.scale,
+                                                        input_qparams.zero_point, use_contrib_qdq);
+
+    // DQ -> Softmax
+    builder.AddNode("Softmax_node", "Softmax", {input_qdq}, {"softmax_out"}, kOnnxDomain, attrs);
+
+    // Force a symmetric output encoding (zero-point != 0) over the [0, 1] softmax range. This is
+    // what triggers the EP's Softmax(natural) -> Convert -> output split.
+    // softmax_out -> Q(symmetric) -> DQ -> graph output
+    output_qparams[0] = QuantParams<QType>::Compute(0.0f, 1.0f, /*symmetric*/ true);
+    AddQDQNodePairWithOutputAsGraphOutput<QType>(builder, "qdq_out", "softmax_out",
+                                                 output_qparams[0].scale,
+                                                 output_qparams[0].zero_point, use_contrib_qdq);
+  };
+}
+
+// Builds a QDQ Softmax model whose output Q/DQ uses a forced CALIBRATED-ASYMMETRIC encoding: a
+// zero-point that is non-zero but NOT at the mid-point of the quantized range (e.g. derived from a
+// slightly-negative calibrated min)
+template <typename QType>
+static GetTestQDQModelFn<QType> BuildQDQSoftmaxAsymmetricOutputTestCase(
+    const TestInputDef<float>& input_def,
+    const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+    bool use_contrib_qdq = false) {
+  return [input_def, attrs, use_contrib_qdq](ModelTestBuilder& builder,
+                                             std::vector<QuantParams<QType>>& output_qparams) {
+    // input -> Q -> DQ
+    MakeTestInput<float>(builder, "X", input_def);
+    QuantParams<QType> input_qparams = GetTestInputQuantParams<QType>(input_def);
+    const std::string input_qdq = AddQDQNodePair<QType>(builder, "qdq_in", "X", input_qparams.scale,
+                                                        input_qparams.zero_point, use_contrib_qdq);
+
+    // DQ -> Softmax
+    builder.AddNode("Softmax_node", "Softmax", {input_qdq}, {"softmax_out"}, kOnnxDomain, attrs);
+
+    // Force a calibrated-asymmetric output encoding: a slightly-negative calibrated min yields a
+    // small non-zero zero-point that is NOT the symmetric mid-point (offset = -1, not -2^(bw-1)).
+    // This mirrors a terminal classification softmax. The EP must treat it as a normal QDQ output
+    // (no Convert split). softmax_out -> Q(asymmetric) -> DQ -> graph output.
+    output_qparams[0] = QuantParams<QType>::Compute(-0.004f, 1.0f, /*symmetric*/ false);
+    AddQDQNodePairWithOutputAsGraphOutput<QType>(builder, "qdq_out", "softmax_out",
+                                                 output_qparams[0].scale,
+                                                 output_qparams[0].zero_point, use_contrib_qdq);
+  };
+}
+
+template <typename QType>
+static void RunQDQSoftmaxAsymmetricOutputTest(const TestInputDef<float>& input_def,
+                                              const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                              int opset_version,
+                                              ExpectedEPNodeAssignment expected_ep_assignment,
+                                              bool use_contrib_qdq = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildOpTestCase<float>("Softmax_node", "Softmax", {input_def}, {}, attrs),
+                       BuildQDQSoftmaxAsymmetricOutputTestCase<QType>(input_def, attrs, use_contrib_qdq),
+                       provider_options,
+                       opset_version,
+                       expected_ep_assignment);
+}
+
+template <typename QType>
+static void RunQDQSoftmaxSymmetricOutputTest(const TestInputDef<float>& input_def,
+                                             const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                                             int opset_version,
+                                             ExpectedEPNodeAssignment expected_ep_assignment,
+                                             bool use_contrib_qdq = false) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildOpTestCase<float>("Softmax_node", "Softmax", {input_def}, {}, attrs),
+                       BuildQDQSoftmaxSymmetricOutputTestCase<QType>(input_def, attrs, use_contrib_qdq),
+                       provider_options,
+                       opset_version,
+                       expected_ep_assignment);
+}
+}  // namespace
+
+// (1) Symmetric (zero-point != 0) uint8 Softmax output -> split path. Last-axis (direct path).
+// Value-preserving + stays on QNN.
+TEST_F(QnnHTPBackendTests, Softmax_SymmetricOutput_U8_Split) {
+  const std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQSoftmaxSymmetricOutputTest<uint8_t>({TestInputDef<float>({1, 2, 3}, false, input_data)},
+                                            {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                            13,
+                                            ExpectedEPNodeAssignment::All);
+}
+
+// (2) Symmetric uint8 Softmax output that is also a graph output -> split path with the converted
+// output tensor as the graph output (APP_READ).
+TEST_F(QnnHTPBackendTests, Softmax_SymmetricOutput_U8_GraphOutput_Split) {
+  const std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 24);
+  RunQDQSoftmaxSymmetricOutputTest<uint8_t>({TestInputDef<float>({1, 2, 3, 4}, false, input_data)},
+                                            {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                            13,
+                                            ExpectedEPNodeAssignment::All);
+}
+
+// (3) Natural (zero-point 0) uint8 Softmax output -> NO split. Standard QDQ harness derives a
+// zero-point-0 encoding from the [0, 1] range, so the EP must not insert a Convert. Stays on QNN.
+TEST_F(QnnHTPBackendTests, Softmax_NaturalOutput_U8_NoSplit) {
+  const std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint8_t>("Softmax",
+                        {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                        {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                        13,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// (4) Symmetric uint16 Softmax output -> split path also applies at 16-bit (no bitwidth gate).
+TEST_F(QnnHTPBackendTests, Softmax_SymmetricOutput_U16_Split) {
+  const std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQSoftmaxSymmetricOutputTest<uint16_t>({TestInputDef<float>({1, 2, 3}, false, input_data)},
+                                             {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                             13,
+                                             ExpectedEPNodeAssignment::All,
+                                             /*use_contrib_qdq*/ true);
+}
+
+// (10) LogSoftmax is excluded from the split (its output is (-inf, 0], not [0, 1]). Even with a
+// symmetric output encoding it must NOT take the unit-range split path; it stays on QNN and is
+// value-preserving via the normal path.
+TEST_F(QnnHTPBackendTests, LogSoftmax_SymmetricOutput_U8_NoSplit) {
+  const std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQOpTest<uint8_t>("LogSoftmax",
+                        {TestInputDef<float>({1, 2, 3}, false, input_data)},
+                        {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                        13,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// (11) Calibrated-asymmetric uint8 Softmax output (zero-point != 0 but NOT the symmetric mid-point,
+// e.g. a terminal classification softmax with a slightly-negative calibrated min) -> NO split. Only
+// the symmetric mid-point encoding (zp at 2^(bw-1)) triggers the Convert; this guards against the
+// over-trigger that perturbed classification-model numerics.
+TEST_F(QnnHTPBackendTests, Softmax_AsymmetricOutput_U8_NoSplit) {
+  const std::vector<float> input_data = GetFloatDataInRange(-5.0f, 5.0f, 6);
+  RunQDQSoftmaxAsymmetricOutputTest<uint8_t>({TestInputDef<float>({1, 2, 3}, false, input_data)},
+                                             {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                             13,
+                                             ExpectedEPNodeAssignment::All);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test


### PR DESCRIPTION
### Description
This PR honors non-natural encoding populated at the output of softmax layer. 

<img width="734" height="570" alt="image" src="https://github.com/user-attachments/assets/f48c8873-f68e-48dc-8394-271deaac2a17" />

In the above network, the output of softmax is populated with an encoding of [Scale: 0.0078432, zp: 128] which translates to a min/max encodings of [-1.004, 0.996]. This is done by AIMET to satisfy older architectures where HTP only supports symmetric second input for Matmul. 

But Softmax output is mathematically between [0, 1]. When the above encodings generated by AIMET is directly populated at the output of softmax, HTP misbehaves because it expects the range to be [0, 1]. This PR fixes this issue by populating correct encodings at the output of softmax, and then by inserting a convert op to convert to the encodings generated by AIMET.

### Motivation and Context
YoloV10_det w8a8 precision shows an on-target accuracy of close to 0. With this change, the accuracy recovers to 34.257 (AIMET simulated is 34.8). PS: There is still a small gap which needs to be further investigated. YoloV11_det also has the same issue. 

Next step for this PR: Extend the solution to Sigmoid, HardSigmoid etc. 