### PR TITLE
Tanh gelu fusion and test case

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -519,6 +519,7 @@ QNN EP recognizes the following multi-op patterns and fuses them into a single Q
 | Pattern | Fused QNN op | Notes |
 |---|---|---|
 | `[Div/Mul(√2)] → Erf → [Mul(0.5) →] Add(1) → Mul → [Mul(0.5)]` | `QNN_OP_GELU` | Matches two common Gelu decomposition variants (ErfAdd and ErfMul). Surrounding DQ nodes are also handled. |
+| `Mul(x,x) → Mul(x²,x) → Mul(0.044715) → Add(x) → Mul(√(2/π)) → Tanh → Add(1) → Mul(x) → Mul(0.5)` | `QNN_OP_GELU` | Tanh-based GELU approximation. SingleNode (non-QDQ) only. The QNN GELU op uses the exact-erf definition; max substitution error is ~4.7e-4 over [-10, 10]. |
 | `HardSigmoid(α=1/6, β=0.5) → Mul` (shared input) | `QNN_OP_ELEMENT_WISE_NEURON` (HardSwish) | Both inputs to Mul must originate from the same source tensor. |
 | `ReduceMean → Sub → Pow(2) → ReduceMean → Add(ε) → Sqrt → Div → Mul(γ) → Add(β)` | `QNN_OP_LAYER_NORM` | Matches the manual LayerNorm decomposition. Gamma and beta must be constants. |
 | `Mul(scalar constant) → Softmax` | `QNN_OP_SOFTMAX` | The scalar multiplier is folded into the beta parameter of QNN's Softmax. |

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -29,6 +29,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_rank5.h"
 #include "core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/transpose_reshape_transpose_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/udo_fusion.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
@@ -98,6 +99,7 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"Mul", {ScaleSoftmaxFusion::TryFusion}},
     {"Cast", {CastLoneQFusion::TryFusion}},
     {"Erf", {GeluFusion::TryFusion}},
+    {"Tanh", {TanhGeluFusion::TryFusion}},
     {"ReduceMean", {LayerNormFusion::TryFusion}},
     {"Einsum", {ReshapeEinsumReshapeNodeGroup::TryFusion}},
     {"Reshape", {SpaceToDepthFusion::TryFusion, Rank6ToRank5Fusion::TryFusion}},
@@ -142,6 +144,7 @@ static std::unique_ptr<IQnnNodeGroup> TryQnnFusions(
       starting_node_unit.OpType() != "Gather" &&
       starting_node_unit.OpType() != "MatMul" &&
       starting_node_unit.OpType() != "Erf" &&
+      starting_node_unit.OpType() != "Tanh" &&
       starting_node_unit.OpType() != "Reshape") {
     return nullptr;
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
@@ -39,6 +39,10 @@ bool HasSingleOutputConsumer(const OrtNodeUnit& node_unit) {
 }
 
 // Returns true if `node_unit` is a standalone (non-QDQ) SingleNode with the given op type.
+// QDQ support is intentionally out of scope for this fusion: in a quantized tanh-GELU model
+// every Mul/Add/Tanh is a QDQGroup, and the DQ/Q unwrap logic needed to fuse across QDQ
+// boundaries (see GeluFusion::TryFusion) adds significant complexity. That work is left as a
+// follow-up; for now only float32/float16 non-QDQ graphs are fused.
 bool IsSingleNode(const OrtNodeUnit* node_unit, std::string_view op_type) {
   return node_unit != nullptr &&
          node_unit->UnitType() == OrtNodeUnit::Type::SingleNode &&

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
@@ -1,11 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h"
 
-#include <algorithm>
-#include <cassert>
-#include <cmath>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -23,51 +20,125 @@
 namespace onnxruntime {
 namespace qnn {
 
-// Returns true if the named input is a scalar constant approximately equal to `expected`.
-static bool IsScalarConstantApprox(const QnnModelWrapper& qmw,
-                                   const std::string& input_name,
-                                   float expected,
-                                   float tol = 1e-3f) {
-  if (!qmw.IsConstantInput(input_name)) {
-    return false;
-  }
-  const OrtValueInfo* vi = qmw.GetConstantTensor(input_name);
-  if (!vi) {
-    return false;
-  }
-  Ort::ConstValueInfo ort_vi(vi);
-  Ort::ConstValue ort_val;
-  if (!ort_vi.GetInitializer(ort_val).IsOK()) {
-    return false;
-  }
-  auto type_info = ort_vi.TypeInfo();
-  auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
-  const size_t count = tensor_info.GetElementCount();
-  if (count != 1) {
-    return false;
-  }
-  const auto elem_type = tensor_info.GetElementType();
-  float val = 0.0f;
-  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
-    const float* data = ort_val.GetTensorData<float>();
-    if (!data) return false;
-    val = *data;
-  } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
-    const Ort::Float16_t* data = ort_val.GetTensorData<Ort::Float16_t>();
-    if (!data) return false;
-    val = data->ToFloat();
-  } else {
-    return false;
-  }
-  return std::abs(val - expected) <= tol;
+namespace {
+
+// GELU approximation constants.
+constexpr float kGeluCubicCoeff = 0.044715f;  // coefficient on x³ term
+constexpr float kGeluSqrt2OverPi = 0.7978845608f;  // sqrt(2/pi)
+constexpr float kGeluOne = 1.0f;
+constexpr float kGeluHalf = 0.5f;
+
+// Returns true if the first output of `node_unit` has exactly one consumer in the graph.
+// Used to guard backward-walk fusions: if an intermediate is consumed by more than one op,
+// fusing it would leave those other consumers with a dangling input.
+bool HasSingleOutputConsumer(const OrtNodeUnit& node_unit) {
+  const Ort::ConstNode node(&node_unit.GetNode());
+  const auto outputs = node.GetOutputs();
+  if (outputs.empty()) return false;
+  return outputs[0].GetConsumers().size() == 1;
 }
 
 // Returns true if `node_unit` is a standalone (non-QDQ) SingleNode with the given op type.
-static bool IsSingleNode(const OrtNodeUnit* node_unit, std::string_view op_type) {
+bool IsSingleNode(const OrtNodeUnit* node_unit, std::string_view op_type) {
   return node_unit != nullptr &&
          node_unit->UnitType() == OrtNodeUnit::Type::SingleNode &&
          node_unit->OpType() == op_type;
 }
+
+// For a commutative 2-input node, returns a pointer to the non-constant input when exactly
+// one input is a scalar constant matching `constant_val`. Returns nullptr otherwise.
+// Requiring exactly one match avoids false-positives when both inputs happen to equal
+// the constant (e.g., Mul(0.5, 0.5)) or neither matches.
+// The caller must keep `inputs` alive for the duration of any use of the returned pointer.
+const OrtNodeUnitIODef* NonConstInput(const QnnModelWrapper& qmw,
+                                      const std::vector<OrtNodeUnitIODef>& inputs,
+                                      float constant_val) {
+  if (inputs.size() < 2) return nullptr;
+  const bool is0 = IsScalarConstantApprox(qmw, inputs[0].name, constant_val);
+  const bool is1 = IsScalarConstantApprox(qmw, inputs[1].name, constant_val);
+  if (is1 && !is0) return &inputs[0];  // input[1] is the constant → return input[0]
+  if (is0 && !is1) return &inputs[1];  // input[0] is the constant → return input[1]
+  return nullptr;                       // both or neither match — ambiguous, reject
+}
+
+// Returns true if both inputs of a 2-input node share the same name (i.e., Mul(x, x)).
+bool BothInputsAreNamed(const std::vector<OrtNodeUnitIODef>& inputs, const std::string& name) {
+  return inputs.size() >= 2 && inputs[0].name == name && inputs[1].name == name;
+}
+
+struct CubicSubtreeMatch {
+  const OrtNodeUnit* mul_cubic_coeff = nullptr;  // Mul(x³, kGeluCubicCoeff)
+  const OrtNodeUnit* mul_x3 = nullptr;           // Mul(x², x)  — or Mul(x, x²) when swapped
+  const OrtNodeUnit* mul_x2 = nullptr;           // Mul(x, x)
+  std::string root_name;                         // name of the x tensor; empty signals no match
+
+  bool IsValid() const { return !root_name.empty(); }
+};
+
+// Tries to match the cubic sub-expression  0.044715 * x³  rooted at
+// add_inner.inputs[branch_idx], verifying that add_inner.inputs[1-branch_idx] is the
+// same root tensor x.  The `for i` loop in TryFusion calls this twice (branch_idx=0,1)
+// to handle both orderings of the Add(x, 0.044715*x³) node.
+//
+// Expected sub-graph (ignoring commutative orderings within each Mul):
+//
+//   add_inner.inputs[branch_idx]
+//         |
+//         v
+//   Mul(kGeluCubicCoeff, x³)       ← mul_cubic_coeff
+//                         |
+//                         v
+//                   Mul(x², x)     ← mul_x3  (either input may be x or x²)
+//                       |
+//                       v
+//                   Mul(x, x)      ← mul_x2
+//
+// Returns a populated CubicSubtreeMatch (IsValid()==true) on success, empty otherwise.
+CubicSubtreeMatch TryMatchCubicSubtree(
+    QnnModelWrapper& qmw,
+    const OrtNodeUnit& add_inner,
+    int branch_idx,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  const auto& add_inner_inputs = add_inner.Inputs();
+
+  // Step 1: add_inner.inputs[branch_idx] must come from Mul(kGeluCubicCoeff, x³).
+  const OrtNodeUnit* mul_cubic_coeff = GetParentOfInput(qmw, add_inner, add_inner_inputs[branch_idx],
+                                                        node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(mul_cubic_coeff, "Mul") || !HasSingleOutputConsumer(*mul_cubic_coeff)) return {};
+
+  // Step 2: identify which input of mul_cubic_coeff is the constant and which feeds x³.
+  const OrtNodeUnitIODef* x3_def = NonConstInput(qmw, mul_cubic_coeff->Inputs(), kGeluCubicCoeff);
+  if (!x3_def) return {};
+
+  // Step 3: x³ must come from Mul(x², x) — either input ordering.
+  const OrtNodeUnit* mul_x3 = GetParentOfInputByName(qmw, *mul_cubic_coeff, x3_def->name,
+                                                     node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(mul_x3, "Mul") || !HasSingleOutputConsumer(*mul_x3)) return {};
+  const auto& x3_inputs = mul_x3->Inputs();
+  if (x3_inputs.size() < 2) return {};
+
+  // Step 4: `for j` — try both slots of mul_x3 as the candidate root x.
+  //   j=0: x3_inputs[0] is x,  x3_inputs[1] comes from Mul(x,x)
+  //   j=1: x3_inputs[1] is x,  x3_inputs[0] comes from Mul(x,x)
+  for (int j = 0; j < 2; ++j) {
+    const std::string& root_candidate = x3_inputs[j].name;
+
+    // The other input of mul_x3 must come from Mul(root_candidate, root_candidate) = x².
+    const OrtNodeUnit* mul_x2 = GetParentOfInputByName(qmw, *mul_x3, x3_inputs[1 - j].name,
+                                                       node_to_node_unit, node_unit_to_qnn_node_group);
+    if (!IsSingleNode(mul_x2, "Mul") || !HasSingleOutputConsumer(*mul_x2)) continue;
+    if (!BothInputsAreNamed(mul_x2->Inputs(), root_candidate)) continue;
+
+    // Step 5: the straight-through input of add_inner (the non-cubic arm) must also be root x.
+    if (add_inner_inputs[1 - branch_idx].name != root_candidate) continue;
+
+    return CubicSubtreeMatch{mul_cubic_coeff, mul_x3, mul_x2, root_candidate};
+  }
+  return {};
+}
+
+}  // namespace
 
 std::unique_ptr<IQnnNodeGroup> TanhGeluFusion::TryFusion(
     QnnModelWrapper& qmw,
@@ -75,227 +146,127 @@ std::unique_ptr<IQnnNodeGroup> TanhGeluFusion::TryFusion(
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& /*logger*/) {
-  // Entry point: must be a standalone Tanh node.
   if (tanh_node_unit.OpType() != "Tanh" ||
       tanh_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
     return nullptr;
   }
 
-  // ---- Walk backwards through the pattern ----
+  //        +-> Mul(x,x) --+
+  //        |              v
+  //   [x] -+-----------> Mul(x²,x) --> Mul(0.044715) --+
+  //        |                                            v
+  //        +-------------------------------------------> Add --> Mul(sqrt(2/pi)) --> Tanh
   //
-  // Pattern (x³ via two Muls, as produced by ORT optimizers):
+  // ... then forward from Tanh:
   //
-  //  [x] --+-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) -> Add --+-> Mul(sqrt2pi) -> Tanh
-  //        |                                                     |
-  //        +-----------------------------------------------------+
+  //   Tanh --> Add(1) --> Mul(x) --> Mul(0.5) ==>
+  //                          ^
+  //                   (x fan-out)
 
   const auto& tanh_inputs = tanh_node_unit.Inputs();
-  if (tanh_inputs.empty()) {
-    return nullptr;
-  }
+  if (tanh_inputs.empty()) return nullptr;
 
-  // Tanh <- Mul_coeff  (multiplies by sqrt(2/pi) ≈ 0.7978845608)
+  // ---- Backward walk: Tanh ← Mul(sqrt2pi) ← Add(x, 0.044715*x³) ----
+
+  // tanh_inputs[0] must come from Mul(sqrt(2/pi), Add_inner).
   const OrtNodeUnit* mul_coeff = GetParentOfInput(qmw, tanh_node_unit, tanh_inputs[0],
                                                   node_to_node_unit, node_unit_to_qnn_node_group);
-  if (!IsSingleNode(mul_coeff, "Mul")) {
-    return nullptr;
-  }
+  if (!IsSingleNode(mul_coeff, "Mul") || !HasSingleOutputConsumer(*mul_coeff)) return nullptr;
 
-  const auto& mul_coeff_inputs = mul_coeff->Inputs();
-  if (mul_coeff_inputs.size() < 2) {
-    return nullptr;
-  }
+  // One input of mul_coeff is the sqrt(2/pi) scalar; the other feeds from add_inner.
+  const OrtNodeUnitIODef* add_inner_out = NonConstInput(qmw, mul_coeff->Inputs(), kGeluSqrt2OverPi);
+  if (!add_inner_out) return nullptr;
 
-  // One input of Mul_coeff must be the sqrt(2/pi) constant; the other feeds from Add_inner.
-  constexpr float kSqrt2OverPi = 0.7978845608f;
-  bool coeff_is_input1 = IsScalarConstantApprox(qmw, mul_coeff_inputs[1].name, kSqrt2OverPi);
-  bool coeff_is_input0 = IsScalarConstantApprox(qmw, mul_coeff_inputs[0].name, kSqrt2OverPi);
-  if (!coeff_is_input0 && !coeff_is_input1) {
-    return nullptr;
-  }
-  const OrtNodeUnitIODef& add_inner_output_def = coeff_is_input1 ? mul_coeff_inputs[0] : mul_coeff_inputs[1];
-
-  // Mul_coeff <- Add_inner  (adds x and 0.044715*x^3)
-  const OrtNodeUnit* add_inner = GetParentOfInputByName(qmw, *mul_coeff, add_inner_output_def.name,
+  const OrtNodeUnit* add_inner = GetParentOfInputByName(qmw, *mul_coeff, add_inner_out->name,
                                                         node_to_node_unit, node_unit_to_qnn_node_group);
-  if (!IsSingleNode(add_inner, "Add")) {
-    return nullptr;
+  if (!IsSingleNode(add_inner, "Add") || !HasSingleOutputConsumer(*add_inner)) return nullptr;
+  if (add_inner->Inputs().size() < 2) return nullptr;
+
+  // Try add_inner with the cubic arm in slot 0 (i=0) then slot 1 (i=1).
+  CubicSubtreeMatch cubic;
+  for (int i = 0; i < 2 && !cubic.IsValid(); ++i) {
+    cubic = TryMatchCubicSubtree(qmw, *add_inner, i, node_to_node_unit, node_unit_to_qnn_node_group);
   }
+  if (!cubic.IsValid()) return nullptr;
 
-  const auto& add_inner_inputs = add_inner->Inputs();
-  if (add_inner_inputs.size() < 2) {
-    return nullptr;
-  }
-
-  // One input of Add_inner is [x] (root); the other is Mul(0.044715, x³).
-  // x³ is computed as Mul(Mul(x,x), x) — no Pow node.
-  // Try both input orderings.
-  constexpr float k0044715 = 0.044715f;
-  const OrtNodeUnit* mul_0044715 = nullptr;  // Mul(0.044715, x³)
-  const OrtNodeUnit* mul_x2 = nullptr;  // Mul(x, x)  — produces x²
-  const OrtNodeUnit* mul_x3 = nullptr;  // Mul(x², x) — produces x³
-  std::string root_name;
-
-  for (int i = 0; i < 2; ++i) {
-    const OrtNodeUnit* candidate = GetParentOfInput(qmw, *add_inner, add_inner_inputs[i],
-                                                    node_to_node_unit, node_unit_to_qnn_node_group);
-    if (!IsSingleNode(candidate, "Mul")) {
-      continue;
-    }
-    const auto& ci = candidate->Inputs();
-    if (ci.size() < 2) continue;
-    if (!IsScalarConstantApprox(qmw, ci[0].name, k0044715) &&
-        !IsScalarConstantApprox(qmw, ci[1].name, k0044715)) {
-      continue;
-    }
-    // candidate is Mul(0.044715, x³); find x³ = Mul(x²,x)
-    bool c_const_is1 = IsScalarConstantApprox(qmw, ci[1].name, k0044715);
-    const OrtNodeUnitIODef& x3_def = c_const_is1 ? ci[0] : ci[1];
-    const OrtNodeUnit* x3_node = GetParentOfInputByName(qmw, *candidate, x3_def.name,
-                                                        node_to_node_unit, node_unit_to_qnn_node_group);
-    if (!IsSingleNode(x3_node, "Mul")) {
-      continue;
-    }
-    // x3_node = Mul(x², x): one input must be x, the other is Mul(x,x).
-    const auto& x3i = x3_node->Inputs();
-    if (x3i.size() < 2) continue;
-
-    // Try to identify which input of x3_node is x and which is x².
-    for (int j = 0; j < 2; ++j) {
-      const std::string& candidate_root = x3i[j].name;
-      const OrtNodeUnit* sq_candidate = GetParentOfInputByName(qmw, *x3_node, x3i[1 - j].name,
-                                                               node_to_node_unit, node_unit_to_qnn_node_group);
-      if (!IsSingleNode(sq_candidate, "Mul")) continue;
-      // sq_candidate = Mul(x,x): both inputs must be candidate_root.
-      const auto& sqi = sq_candidate->Inputs();
-      if (sqi.size() < 2) continue;
-      if (sqi[0].name != candidate_root && sqi[1].name != candidate_root) continue;
-
-      // All checks passed — record the match.
-      mul_0044715 = candidate;
-      mul_x3 = x3_node;
-      mul_x2 = sq_candidate;
-      root_name = candidate_root;
-      // Also verify the other Add_inner input is root [x].
-      if (add_inner_inputs[1 - i].name != root_name) {
-        // Reset — different root
-        mul_0044715 = nullptr;
-        mul_x3 = nullptr;
-        mul_x2 = nullptr;
-        root_name.clear();
-        continue;
-      }
-      break;
-    }
-    if (mul_0044715 != nullptr) break;
-  }
-
-  if (mul_0044715 == nullptr || root_name.empty()) {
-    return nullptr;
-  }
-
-  // ---- Walk forwards from Tanh ----
-  //
-  // Tanh -> Add(1) -> Mul(x)[Mul_4] -> Mul(0.5)[Mul_5]  [final output]
-  // (ORT emits Add_1 → Mul(Add_1_out, x) → Mul(result, 0.5))
+  // ---- Forward walk: Tanh → Add(1) → Mul(x) → Mul(0.5) ----
 
   const auto& tanh_outputs = tanh_node_unit.Outputs();
-  if (tanh_outputs.empty()) {
-    return nullptr;
-  }
+  if (tanh_outputs.empty()) return nullptr;
 
+  // tanh_out → Add(1) — shifts the Tanh range from [-1,1] to [0,2].
   const OrtNodeUnit* add_one = GetOnlyChildOfOutput(qmw, tanh_node_unit, tanh_outputs[0],
                                                     node_to_node_unit, node_unit_to_qnn_node_group);
-  if (!IsSingleNode(add_one, "Add")) {
-    return nullptr;
-  }
-
-  // Add(1): one input must be constant 1.0.
+  if (!IsSingleNode(add_one, "Add")) return nullptr;
   const auto& add_one_inputs = add_one->Inputs();
-  if (add_one_inputs.size() < 2) {
+  if (add_one_inputs.size() < 2) return nullptr;
+  if (!IsScalarConstantApprox(qmw, add_one_inputs[0].name, kGeluOne) &&
+      !IsScalarConstantApprox(qmw, add_one_inputs[1].name, kGeluOne)) {
     return nullptr;
   }
-  if (!IsScalarConstantApprox(qmw, add_one_inputs[0].name, 1.0f) &&
-      !IsScalarConstantApprox(qmw, add_one_inputs[1].name, 1.0f)) {
-    return nullptr;
-  }
-
   const auto& add_one_outputs = add_one->Outputs();
-  if (add_one_outputs.empty()) {
-    return nullptr;
-  }
+  if (add_one_outputs.empty()) return nullptr;
 
-  // Add_1 -> Mul(x) — multiplies (1+Tanh) by root [x]
+  // add_one_out → Mul(x) — multiplies (1 + tanh(...)) by the root input x.
+  // Confirms the same x flows into the tail as the one identified in the cubic sub-tree.
   const OrtNodeUnit* mul_x = GetOnlyChildOfOutput(qmw, *add_one, add_one_outputs[0],
                                                   node_to_node_unit, node_unit_to_qnn_node_group);
-  if (!IsSingleNode(mul_x, "Mul")) {
-    return nullptr;
-  }
+  if (!IsSingleNode(mul_x, "Mul")) return nullptr;
   const auto& mul_x_inputs = mul_x->Inputs();
-  if (mul_x_inputs.size() < 2) {
+  if (mul_x_inputs.size() < 2) return nullptr;
+  if (mul_x_inputs[0].name != cubic.root_name && mul_x_inputs[1].name != cubic.root_name) {
     return nullptr;
   }
-  if (mul_x_inputs[0].name != root_name && mul_x_inputs[1].name != root_name) {
-    return nullptr;
-  }
-
   const auto& mul_x_outputs = mul_x->Outputs();
-  if (mul_x_outputs.empty()) {
-    return nullptr;
-  }
+  if (mul_x_outputs.empty()) return nullptr;
 
-  // Mul(x) -> Mul(0.5) — final scaling
+  // mul_x_out → Mul(0.5) — applies the final ½ factor.
   const OrtNodeUnit* mul_half = GetOnlyChildOfOutput(qmw, *mul_x, mul_x_outputs[0],
                                                      node_to_node_unit, node_unit_to_qnn_node_group);
-  if (!IsSingleNode(mul_half, "Mul")) {
-    return nullptr;
-  }
+  if (!IsSingleNode(mul_half, "Mul")) return nullptr;
   const auto& mul_half_inputs = mul_half->Inputs();
-  if (mul_half_inputs.size() < 2) {
+  if (mul_half_inputs.size() < 2) return nullptr;
+  if (!IsScalarConstantApprox(qmw, mul_half_inputs[0].name, kGeluHalf) &&
+      !IsScalarConstantApprox(qmw, mul_half_inputs[1].name, kGeluHalf)) {
     return nullptr;
   }
-  if (!IsScalarConstantApprox(qmw, mul_half_inputs[0].name, 0.5f) &&
-      !IsScalarConstantApprox(qmw, mul_half_inputs[1].name, 0.5f)) {
-    return nullptr;
-  }
-
   const auto& mul_half_outputs = mul_half->Outputs();
-  if (mul_half_outputs.empty()) {
-    return nullptr;
-  }
+  if (mul_half_outputs.empty()) return nullptr;
 
-  // Collect root IODef from add_inner's inputs.
+  // Re-derive the root IODef from add_inner so we carry its full type/shape metadata
+  // into the fused node, not just the tensor name string from cubic.root_name.
   OrtNodeUnitIODef root_input;
-  for (const auto& inp : add_inner_inputs) {
-    if (inp.name == root_name) {
+  for (const auto& inp : add_inner->Inputs()) {
+    if (inp.name == cubic.root_name) {
       root_input = inp;
       break;
     }
   }
   OrtNodeUnitIODef final_output = mul_half_outputs[0];
 
-  // Validate QNN Gelu accepts these tensor types.
+  // Validate QNN ElementWiseNeuron(Gelu) accepts these tensor types.
   QnnTensorWrapper input_tensor;
   QnnTensorWrapper output_tensor;
-  if (!qmw.MakeTensorWrapper(root_input, input_tensor).IsOK()) {
-    return nullptr;
-  }
-  if (!qmw.MakeTensorWrapper(final_output, output_tensor).IsOK()) {
-    return nullptr;
-  }
+  if (!qmw.MakeTensorWrapper(root_input, input_tensor).IsOK()) return nullptr;
+  if (!qmw.MakeTensorWrapper(final_output, output_tensor).IsOK()) return nullptr;
   const std::string node_name = utils::UniqueNameGenerator().New(tanh_node_unit);
+  Qnn_Scalar_t neuron_op = QNN_SCALAR_INIT;
+  neuron_op.dataType = QNN_DATATYPE_UINT_32;
+  neuron_op.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_GELU;
+  QnnParamWrapper op_param(tanh_node_unit.Index(), node_name,
+                           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, neuron_op);
   if (!qmw.ValidateQnnNode(node_name,
                            QNN_OP_PACKAGE_NAME_QTI_AISW,
-                           QNN_OP_GELU,
+                           QNN_OP_ELEMENT_WISE_NEURON,
                            {input_tensor.GetQnnTensor()},
                            {output_tensor.GetQnnTensor()},
-                           {})
+                           {op_param.GetQnnParam()})
            .IsOK()) {
     return nullptr;
   }
 
   std::vector<const OrtNodeUnit*> node_units = {
-      mul_x2, mul_x3, mul_0044715, add_inner, mul_coeff,
+      cubic.mul_x2, cubic.mul_x3, cubic.mul_cubic_coeff, add_inner, mul_coeff,
       &tanh_node_unit, add_one, mul_x, mul_half};
 
   return std::make_unique<TanhGeluFusion>(std::move(node_units),
@@ -320,12 +291,17 @@ Ort::Status TanhGeluFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger&
   RETURN_IF_ERROR(qmw.MakeTensorWrapper(gelu_root_input_, input_tensor));
   RETURN_IF_ERROR(qmw.MakeTensorWrapper(gelu_final_output_, output_tensor));
   const std::string node_name = utils::UniqueNameGenerator().New(*target_node_unit_);
+  Qnn_Scalar_t neuron_op = QNN_SCALAR_INIT;
+  neuron_op.dataType = QNN_DATATYPE_UINT_32;
+  neuron_op.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_GELU;
+  QnnParamWrapper op_param(target_node_unit_->Index(), node_name,
+                           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, neuron_op);
   return qmw.ValidateQnnNode(node_name,
                              QNN_OP_PACKAGE_NAME_QTI_AISW,
-                             QNN_OP_GELU,
+                             QNN_OP_ELEMENT_WISE_NEURON,
                              {input_tensor.GetQnnTensor()},
                              {output_tensor.GetQnnTensor()},
-                             {});
+                             {op_param.GetQnnParam()});
 }
 
 Ort::Status TanhGeluFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& /*logger*/) const {
@@ -341,12 +317,21 @@ Ort::Status TanhGeluFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::L
   }
 
   const std::string node_name = utils::UniqueNameGenerator().New(*target_node_unit_);
+  // QNN GELU uses the exact-erf definition; the tanh approximation differs by at most ~4.7e-4
+  // over [-10, 10], which is within the test tolerances (2e-3 to 6e-3) and acceptable for HTP.
+  Qnn_Scalar_t neuron_op = QNN_SCALAR_INIT;
+  neuron_op.dataType = QNN_DATATYPE_UINT_32;
+  neuron_op.uint32Value = QNN_OP_ELEMENT_WISE_NEURON_OPERATION_GELU;
+  QnnParamWrapper op_param(target_node_unit_->Index(), node_name,
+                           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION, neuron_op);
+  const std::string op_param_name = op_param.GetParamTensorName();
+  RETURN_IF_NOT(qmw.AddParamWrapper(std::move(op_param)), "Failed to add TanhGelu operation param.");
   RETURN_IF_NOT(qmw.CreateQnnNode(node_name,
                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                  QNN_OP_GELU,
+                                  QNN_OP_ELEMENT_WISE_NEURON,
                                   {gelu_root_input_.name},
                                   {gelu_final_output_.name},
-                                  {},
+                                  {op_param_name},
                                   /*do_op_validation=*/false),
                 "Failed to add fused TanhGelu node.");
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
@@ -23,7 +23,7 @@ namespace qnn {
 namespace {
 
 // GELU approximation constants.
-constexpr float kGeluCubicCoeff = 0.044715f;  // coefficient on x³ term
+constexpr float kGeluCubicCoeff = 0.044715f;       // coefficient on x³ term
 constexpr float kGeluSqrt2OverPi = 0.7978845608f;  // sqrt(2/pi)
 constexpr float kGeluOne = 1.0f;
 constexpr float kGeluHalf = 0.5f;
@@ -58,7 +58,7 @@ const OrtNodeUnitIODef* NonConstInput(const QnnModelWrapper& qmw,
   const bool is1 = IsScalarConstantApprox(qmw, inputs[1].name, constant_val);
   if (is1 && !is0) return &inputs[0];  // input[1] is the constant → return input[0]
   if (is0 && !is1) return &inputs[1];  // input[0] is the constant → return input[1]
-  return nullptr;                       // both or neither match — ambiguous, reject
+  return nullptr;                      // both or neither match — ambiguous, reject
 }
 
 // Returns true if both inputs of a 2-input node share the same name (i.e., Mul(x, x)).

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
@@ -1,0 +1,361 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <gsl/gsl>
+
+#include "core/providers/qnn/ort_api.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Returns true if the named input is a scalar constant approximately equal to `expected`.
+static bool IsScalarConstantApprox(const QnnModelWrapper& qmw,
+                                   const std::string& input_name,
+                                   float expected,
+                                   float tol = 1e-3f) {
+  if (!qmw.IsConstantInput(input_name)) {
+    return false;
+  }
+  const OrtValueInfo* vi = qmw.GetConstantTensor(input_name);
+  if (!vi) {
+    return false;
+  }
+  Ort::ConstValueInfo ort_vi(vi);
+  Ort::ConstValue ort_val;
+  if (!ort_vi.GetInitializer(ort_val).IsOK()) {
+    return false;
+  }
+  auto type_info = ort_vi.TypeInfo();
+  auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+  const size_t count = tensor_info.GetElementCount();
+  if (count != 1) {
+    return false;
+  }
+  const auto elem_type = tensor_info.GetElementType();
+  float val = 0.0f;
+  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    const float* data = ort_val.GetTensorData<float>();
+    if (!data) return false;
+    val = *data;
+  } else if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+    const Ort::Float16_t* data = ort_val.GetTensorData<Ort::Float16_t>();
+    if (!data) return false;
+    val = data->ToFloat();
+  } else {
+    return false;
+  }
+  return std::abs(val - expected) <= tol;
+}
+
+// Returns true if `node_unit` is a standalone (non-QDQ) SingleNode with the given op type.
+static bool IsSingleNode(const OrtNodeUnit* node_unit, std::string_view op_type) {
+  return node_unit != nullptr &&
+         node_unit->UnitType() == OrtNodeUnit::Type::SingleNode &&
+         node_unit->OpType() == op_type;
+}
+
+std::unique_ptr<IQnnNodeGroup> TanhGeluFusion::TryFusion(
+    QnnModelWrapper& qmw,
+    const OrtNodeUnit& tanh_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const Ort::Logger& /*logger*/) {
+  // Entry point: must be a standalone Tanh node.
+  if (tanh_node_unit.OpType() != "Tanh" ||
+      tanh_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return nullptr;
+  }
+
+  // ---- Walk backwards through the pattern ----
+  //
+  // Pattern (x³ via two Muls, as produced by ORT optimizers):
+  //
+  //  [x] --+-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) -> Add --+-> Mul(sqrt2pi) -> Tanh
+  //        |                                                     |
+  //        +-----------------------------------------------------+
+
+  const auto& tanh_inputs = tanh_node_unit.Inputs();
+  if (tanh_inputs.empty()) {
+    return nullptr;
+  }
+
+  // Tanh <- Mul_coeff  (multiplies by sqrt(2/pi) ≈ 0.7978845608)
+  const OrtNodeUnit* mul_coeff = GetParentOfInput(qmw, tanh_node_unit, tanh_inputs[0],
+                                                  node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(mul_coeff, "Mul")) {
+    return nullptr;
+  }
+
+  const auto& mul_coeff_inputs = mul_coeff->Inputs();
+  if (mul_coeff_inputs.size() < 2) {
+    return nullptr;
+  }
+
+  // One input of Mul_coeff must be the sqrt(2/pi) constant; the other feeds from Add_inner.
+  constexpr float kSqrt2OverPi = 0.7978845608f;
+  bool coeff_is_input1 = IsScalarConstantApprox(qmw, mul_coeff_inputs[1].name, kSqrt2OverPi);
+  bool coeff_is_input0 = IsScalarConstantApprox(qmw, mul_coeff_inputs[0].name, kSqrt2OverPi);
+  if (!coeff_is_input0 && !coeff_is_input1) {
+    return nullptr;
+  }
+  const OrtNodeUnitIODef& add_inner_output_def = coeff_is_input1 ? mul_coeff_inputs[0] : mul_coeff_inputs[1];
+
+  // Mul_coeff <- Add_inner  (adds x and 0.044715*x^3)
+  const OrtNodeUnit* add_inner = GetParentOfInputByName(qmw, *mul_coeff, add_inner_output_def.name,
+                                                        node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(add_inner, "Add")) {
+    return nullptr;
+  }
+
+  const auto& add_inner_inputs = add_inner->Inputs();
+  if (add_inner_inputs.size() < 2) {
+    return nullptr;
+  }
+
+  // One input of Add_inner is [x] (root); the other is Mul(0.044715, x³).
+  // x³ is computed as Mul(Mul(x,x), x) — no Pow node.
+  // Try both input orderings.
+  constexpr float k0044715 = 0.044715f;
+  const OrtNodeUnit* mul_0044715 = nullptr;  // Mul(0.044715, x³)
+  const OrtNodeUnit* mul_x2 = nullptr;        // Mul(x, x)  — produces x²
+  const OrtNodeUnit* mul_x3 = nullptr;        // Mul(x², x) — produces x³
+  std::string root_name;
+
+  for (int i = 0; i < 2; ++i) {
+    const OrtNodeUnit* candidate = GetParentOfInput(qmw, *add_inner, add_inner_inputs[i],
+                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+    if (!IsSingleNode(candidate, "Mul")) {
+      continue;
+    }
+    const auto& ci = candidate->Inputs();
+    if (ci.size() < 2) continue;
+    if (!IsScalarConstantApprox(qmw, ci[0].name, k0044715) &&
+        !IsScalarConstantApprox(qmw, ci[1].name, k0044715)) {
+      continue;
+    }
+    // candidate is Mul(0.044715, x³); find x³ = Mul(x²,x)
+    bool c_const_is1 = IsScalarConstantApprox(qmw, ci[1].name, k0044715);
+    const OrtNodeUnitIODef& x3_def = c_const_is1 ? ci[0] : ci[1];
+    const OrtNodeUnit* x3_node = GetParentOfInputByName(qmw, *candidate, x3_def.name,
+                                                        node_to_node_unit, node_unit_to_qnn_node_group);
+    if (!IsSingleNode(x3_node, "Mul")) {
+      continue;
+    }
+    // x3_node = Mul(x², x): one input must be x, the other is Mul(x,x).
+    const auto& x3i = x3_node->Inputs();
+    if (x3i.size() < 2) continue;
+
+    // Try to identify which input of x3_node is x and which is x².
+    for (int j = 0; j < 2; ++j) {
+      const std::string& candidate_root = x3i[j].name;
+      const OrtNodeUnit* sq_candidate = GetParentOfInputByName(qmw, *x3_node, x3i[1 - j].name,
+                                                               node_to_node_unit, node_unit_to_qnn_node_group);
+      if (!IsSingleNode(sq_candidate, "Mul")) continue;
+      // sq_candidate = Mul(x,x): both inputs must be candidate_root.
+      const auto& sqi = sq_candidate->Inputs();
+      if (sqi.size() < 2) continue;
+      if (sqi[0].name != candidate_root && sqi[1].name != candidate_root) continue;
+
+      // All checks passed — record the match.
+      mul_0044715 = candidate;
+      mul_x3 = x3_node;
+      mul_x2 = sq_candidate;
+      root_name = candidate_root;
+      // Also verify the other Add_inner input is root [x].
+      if (add_inner_inputs[1 - i].name != root_name) {
+        // Reset — different root
+        mul_0044715 = nullptr; mul_x3 = nullptr; mul_x2 = nullptr; root_name.clear();
+        continue;
+      }
+      break;
+    }
+    if (mul_0044715 != nullptr) break;
+  }
+
+  if (mul_0044715 == nullptr || root_name.empty()) {
+    return nullptr;
+  }
+
+  // ---- Walk forwards from Tanh ----
+  //
+  // Tanh -> Add(1) -> Mul(x)[Mul_4] -> Mul(0.5)[Mul_5]  [final output]
+  // (ORT emits Add_1 → Mul(Add_1_out, x) → Mul(result, 0.5))
+
+  const auto& tanh_outputs = tanh_node_unit.Outputs();
+  if (tanh_outputs.empty()) {
+    return nullptr;
+  }
+
+  const OrtNodeUnit* add_one = GetOnlyChildOfOutput(qmw, tanh_node_unit, tanh_outputs[0],
+                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(add_one, "Add")) {
+    return nullptr;
+  }
+
+  // Add(1): one input must be constant 1.0.
+  const auto& add_one_inputs = add_one->Inputs();
+  if (add_one_inputs.size() < 2) {
+    return nullptr;
+  }
+  if (!IsScalarConstantApprox(qmw, add_one_inputs[0].name, 1.0f) &&
+      !IsScalarConstantApprox(qmw, add_one_inputs[1].name, 1.0f)) {
+    return nullptr;
+  }
+
+  const auto& add_one_outputs = add_one->Outputs();
+  if (add_one_outputs.empty()) {
+    return nullptr;
+  }
+
+  // Add_1 -> Mul(x) — multiplies (1+Tanh) by root [x]
+  const OrtNodeUnit* mul_x = GetOnlyChildOfOutput(qmw, *add_one, add_one_outputs[0],
+                                                  node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(mul_x, "Mul")) {
+    return nullptr;
+  }
+  const auto& mul_x_inputs = mul_x->Inputs();
+  if (mul_x_inputs.size() < 2) {
+    return nullptr;
+  }
+  if (mul_x_inputs[0].name != root_name && mul_x_inputs[1].name != root_name) {
+    return nullptr;
+  }
+
+  const auto& mul_x_outputs = mul_x->Outputs();
+  if (mul_x_outputs.empty()) {
+    return nullptr;
+  }
+
+  // Mul(x) -> Mul(0.5) — final scaling
+  const OrtNodeUnit* mul_half = GetOnlyChildOfOutput(qmw, *mul_x, mul_x_outputs[0],
+                                                     node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!IsSingleNode(mul_half, "Mul")) {
+    return nullptr;
+  }
+  const auto& mul_half_inputs = mul_half->Inputs();
+  if (mul_half_inputs.size() < 2) {
+    return nullptr;
+  }
+  if (!IsScalarConstantApprox(qmw, mul_half_inputs[0].name, 0.5f) &&
+      !IsScalarConstantApprox(qmw, mul_half_inputs[1].name, 0.5f)) {
+    return nullptr;
+  }
+
+  const auto& mul_half_outputs = mul_half->Outputs();
+  if (mul_half_outputs.empty()) {
+    return nullptr;
+  }
+
+  // Collect root IODef from add_inner's inputs.
+  OrtNodeUnitIODef root_input;
+  for (const auto& inp : add_inner_inputs) {
+    if (inp.name == root_name) {
+      root_input = inp;
+      break;
+    }
+  }
+  OrtNodeUnitIODef final_output = mul_half_outputs[0];
+
+  // Validate QNN Gelu accepts these tensor types.
+  QnnTensorWrapper input_tensor;
+  QnnTensorWrapper output_tensor;
+  if (!qmw.MakeTensorWrapper(root_input, input_tensor).IsOK()) {
+    return nullptr;
+  }
+  if (!qmw.MakeTensorWrapper(final_output, output_tensor).IsOK()) {
+    return nullptr;
+  }
+  const std::string node_name = utils::UniqueNameGenerator().New(tanh_node_unit);
+  if (!qmw.ValidateQnnNode(node_name,
+                           QNN_OP_PACKAGE_NAME_QTI_AISW,
+                           QNN_OP_GELU,
+                           {input_tensor.GetQnnTensor()},
+                           {output_tensor.GetQnnTensor()},
+                           {})
+           .IsOK()) {
+    return nullptr;
+  }
+
+  std::vector<const OrtNodeUnit*> node_units = {
+      mul_x2, mul_x3, mul_0044715, add_inner, mul_coeff,
+      &tanh_node_unit, add_one, mul_x, mul_half};
+
+  return std::make_unique<TanhGeluFusion>(std::move(node_units),
+                                          &tanh_node_unit,
+                                          std::move(root_input),
+                                          std::move(final_output));
+}
+
+TanhGeluFusion::TanhGeluFusion(std::vector<const OrtNodeUnit*>&& node_units,
+                               const OrtNodeUnit* target_node_unit,
+                               OrtNodeUnitIODef gelu_root_input,
+                               OrtNodeUnitIODef gelu_final_output)
+    : node_units_(std::move(node_units)),
+      target_node_unit_(target_node_unit),
+      gelu_root_input_(std::move(gelu_root_input)),
+      gelu_final_output_(std::move(gelu_final_output)) {
+}
+
+Ort::Status TanhGeluFusion::IsSupported(QnnModelWrapper& qmw, const Ort::Logger& /*logger*/) const {
+  QnnTensorWrapper input_tensor;
+  QnnTensorWrapper output_tensor;
+  RETURN_IF_ERROR(qmw.MakeTensorWrapper(gelu_root_input_, input_tensor));
+  RETURN_IF_ERROR(qmw.MakeTensorWrapper(gelu_final_output_, output_tensor));
+  const std::string node_name = utils::UniqueNameGenerator().New(*target_node_unit_);
+  return qmw.ValidateQnnNode(node_name,
+                             QNN_OP_PACKAGE_NAME_QTI_AISW,
+                             QNN_OP_GELU,
+                             {input_tensor.GetQnnTensor()},
+                             {output_tensor.GetQnnTensor()},
+                             {});
+}
+
+Ort::Status TanhGeluFusion::AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& /*logger*/) const {
+  if (!qmw.IsQnnTensorWrapperExist(gelu_root_input_.name)) {
+    QnnTensorWrapper input_tensor;
+    RETURN_IF_ERROR(qmw.MakeTensorWrapper(gelu_root_input_, input_tensor));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(input_tensor)), "Failed to add TanhGelu input tensor.");
+  }
+  if (!qmw.IsQnnTensorWrapperExist(gelu_final_output_.name)) {
+    QnnTensorWrapper output_tensor;
+    RETURN_IF_ERROR(qmw.MakeTensorWrapper(gelu_final_output_, output_tensor));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(output_tensor)), "Failed to add TanhGelu output tensor.");
+  }
+
+  const std::string node_name = utils::UniqueNameGenerator().New(*target_node_unit_);
+  RETURN_IF_NOT(qmw.CreateQnnNode(node_name,
+                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                  QNN_OP_GELU,
+                                  {gelu_root_input_.name},
+                                  {gelu_final_output_.name},
+                                  {},
+                                  /*do_op_validation=*/false),
+                "Failed to add fused TanhGelu node.");
+  return Ort::Status();
+}
+
+gsl::span<const OrtNodeUnit* const> TanhGeluFusion::GetNodeUnits() const {
+  return gsl::make_span(node_units_);
+}
+
+const OrtNodeUnit* TanhGeluFusion::GetTargetNodeUnit() const {
+  return target_node_unit_;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.cc
@@ -132,8 +132,8 @@ std::unique_ptr<IQnnNodeGroup> TanhGeluFusion::TryFusion(
   // Try both input orderings.
   constexpr float k0044715 = 0.044715f;
   const OrtNodeUnit* mul_0044715 = nullptr;  // Mul(0.044715, x³)
-  const OrtNodeUnit* mul_x2 = nullptr;        // Mul(x, x)  — produces x²
-  const OrtNodeUnit* mul_x3 = nullptr;        // Mul(x², x) — produces x³
+  const OrtNodeUnit* mul_x2 = nullptr;  // Mul(x, x)  — produces x²
+  const OrtNodeUnit* mul_x3 = nullptr;  // Mul(x², x) — produces x³
   std::string root_name;
 
   for (int i = 0; i < 2; ++i) {
@@ -179,7 +179,10 @@ std::unique_ptr<IQnnNodeGroup> TanhGeluFusion::TryFusion(
       // Also verify the other Add_inner input is root [x].
       if (add_inner_inputs[1 - i].name != root_name) {
         // Reset — different root
-        mul_0044715 = nullptr; mul_x3 = nullptr; mul_x2 = nullptr; root_name.clear();
+        mul_0044715 = nullptr;
+        mul_x3 = nullptr;
+        mul_x2 = nullptr;
+        root_name.clear();
         continue;
       }
       break;

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h
@@ -29,7 +29,9 @@ class QnnModelWrapper;
 ///
 /// Equation: x * 0.5 * (1 + Tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 ///
-/// All contained NodeUnits must be SingleNode (non-QDQ).
+/// All contained NodeUnits must be SingleNode (non-QDQ). QDQ support is out of scope for this
+/// PR: fusing across QDQ boundaries requires DQ/Q unwrap logic (see GeluFusion) that adds
+/// significant complexity. Quantized tanh-GELU will silently fall back to individual ops.
 /// </summary>
 class TanhGeluFusion : public IQnnNodeGroup {
  public:

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 
@@ -19,15 +19,13 @@ class QnnModelWrapper;
 /// <summary>
 /// Fuses the tanh-based GELU approximation into a single QNN Gelu op.
 ///
-/// Pattern (entry point is Tanh):
+/// Pattern (entry point is Tanh; ORT lowers Pow(x,3) to Mul(Mul(x,x),x) before QNN EP sees the graph):
 ///
-///                                                   +----------------------------+
-///                                                   |                            |
-///                                                   v                            |
-///   [x] --> Pow(3) --> Mul(0.044715) --> Add --> Mul(sqrt(2/pi)) --> Tanh --> Add(1) --> Mul(0.5) --> Mul ==>
-///                                         ^
-///                                         |
-///                                        [x]
+///        +-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) --+
+///        |                   ^                          v
+///   [x] -+-------------------+------------------------> Add --> Mul(sqrt(2/pi)) --> Tanh --> Add(1) --> Mul --> Mul(0.5) ==>
+///        |                                                                                              ^
+///        +----------------------------------------------------------------------------------------------+
 ///
 /// Equation: x * 0.5 * (1 + Tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 ///

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+/// <summary>
+/// Fuses the tanh-based GELU approximation into a single QNN Gelu op.
+///
+/// Pattern (entry point is Tanh):
+///
+///                                                   +----------------------------+
+///                                                   |                            |
+///                                                   v                            |
+///   [x] --> Pow(3) --> Mul(0.044715) --> Add --> Mul(sqrt(2/pi)) --> Tanh --> Add(1) --> Mul(0.5) --> Mul ==>
+///                                         ^
+///                                         |
+///                                        [x]
+///
+/// Equation: x * 0.5 * (1 + Tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+///
+/// All contained NodeUnits must be SingleNode (non-QDQ).
+/// </summary>
+class TanhGeluFusion : public IQnnNodeGroup {
+ public:
+  TanhGeluFusion(std::vector<const OrtNodeUnit*>&& node_units,
+                 const OrtNodeUnit* target_node_unit,
+                 OrtNodeUnitIODef gelu_root_input,
+                 OrtNodeUnitIODef gelu_final_output);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(TanhGeluFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override;
+  std::string_view Type() const override { return "TanhGeluFusion"; }
+
+  /// <summary>
+  /// Tries to match the tanh-GELU pattern starting from the given Tanh NodeUnit.
+  /// Returns a TanhGeluFusion on success, nullptr otherwise.
+  /// </summary>
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& tanh_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::vector<const OrtNodeUnit*> node_units_;
+  const OrtNodeUnit* target_node_unit_;
+  OrtNodeUnitIODef gelu_root_input_;
+  OrtNodeUnitIODef gelu_final_output_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -4,6 +4,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/utils.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <gsl/gsl>
 #include <cstdint>
@@ -453,9 +454,10 @@ const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& /*qnn_model_wra
                                           const std::string& input_name,
                                           const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                           const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
-  // Iterate through all nodes in the group
+  // Walk every node in the group looking for one that consumes `input_name`, then
+  // return the NodeUnit that produces it — subject to the same fusion-safety checks
+  // used by the other Get*Parent* helpers (not a graph output, not already fused, standalone).
   for (const OrtNode* node : node_unit.GetAllNodesInGroup()) {
-    // Check if this node has the input we're looking for
     for (const Ort::ConstValueInfo& input_info : Ort::ConstNode(node).GetInputs()) {
       if (input_info.GetName() != input_name) {
         continue;
@@ -464,13 +466,13 @@ const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& /*qnn_model_wra
       const Ort::ConstNode parent_node = input_info.GetProducerNode().node;
 
       if (static_cast<const OrtNode*>(parent_node) == nullptr) {
-        // Node is not in this graph
+        // input_name is a graph input or initializer — no producer node.
         return nullptr;
       }
 
       for (const Ort::ConstValueInfo& parent_output_info : parent_node.GetOutputs()) {
         if (parent_output_info.IsGraphOutput()) {
-          // Node is producing a graph output
+          // Producer also feeds a graph output; fusing it would drop that output.
           return nullptr;
         }
       }
@@ -481,13 +483,12 @@ const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& /*qnn_model_wra
       }
       const OrtNodeUnit* p_parent_node_unit = parent_node_unit_it->second;
 
-      // Check if parent node has already been handled. Should not be the case if the calling
-      // fusion function has been called in topological order, but check to be safe.
+      // Guard against races when fusion dispatch is not perfectly topological.
       if (qnn_node_group_map.count(p_parent_node_unit) != 0) {
         return nullptr;
       }
 
-      // parent must not already be part of a QDQ NodeUnit (i.e., be standalone).
+      // Only fuse standalone (non-QDQ) nodes — QDQ groups are handled separately.
       if (p_parent_node_unit->UnitType() != OrtNodeUnit::Type::SingleNode) {
         return nullptr;
       }
@@ -496,6 +497,38 @@ const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& /*qnn_model_wra
     }
   }
   return nullptr;
+}
+
+std::optional<float> GetScalarConstantValue(const QnnModelWrapper& qmw,
+                                             const std::string& input_name) {
+  if (!qmw.IsConstantInput(input_name)) return std::nullopt;
+  const OrtValueInfo* vi = qmw.GetConstantTensor(input_name);
+  if (!vi) return std::nullopt;
+  Ort::ConstValueInfo ort_vi(vi);
+  Ort::ConstValue ort_val;
+  if (!ort_vi.GetInitializer(ort_val).IsOK()) return std::nullopt;
+  auto tensor_info = ort_vi.TypeInfo().GetTensorTypeAndShapeInfo();
+  if (tensor_info.GetElementCount() != 1) return std::nullopt;
+  const auto elem_type = tensor_info.GetElementType();
+  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    const float* data = ort_val.GetTensorData<float>();
+    if (!data) return std::nullopt;
+    return *data;
+  }
+  if (elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+    const Ort::Float16_t* data = ort_val.GetTensorData<Ort::Float16_t>();
+    if (!data) return std::nullopt;
+    return data->ToFloat();
+  }
+  return std::nullopt;
+}
+
+bool IsScalarConstantApprox(const QnnModelWrapper& qmw,
+                             const std::string& input_name,
+                             float expected,
+                             float tol) {
+  const auto val = GetScalarConstantValue(qmw, input_name);
+  return val.has_value() && std::abs(*val - expected) <= tol;
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -500,7 +500,7 @@ const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& /*qnn_model_wra
 }
 
 std::optional<float> GetScalarConstantValue(const QnnModelWrapper& qmw,
-                                             const std::string& input_name) {
+                                            const std::string& input_name) {
   if (!qmw.IsConstantInput(input_name)) return std::nullopt;
   const OrtValueInfo* vi = qmw.GetConstantTensor(input_name);
   if (!vi) return std::nullopt;
@@ -524,9 +524,9 @@ std::optional<float> GetScalarConstantValue(const QnnModelWrapper& qmw,
 }
 
 bool IsScalarConstantApprox(const QnnModelWrapper& qmw,
-                             const std::string& input_name,
-                             float expected,
-                             float tol) {
+                            const std::string& input_name,
+                            float expected,
+                            float tol) {
   const auto val = GetScalarConstantValue(qmw, input_name);
   return val.has_value() && std::abs(*val - expected) <= tol;
 }

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
@@ -96,7 +96,7 @@ std::optional<std::vector<int64_t>> GetInitializerDataAsInt64(const QnnModelWrap
 /// constant, not a scalar (element count != 1), or has an unsupported element type.
 /// </summary>
 std::optional<float> GetScalarConstantValue(const QnnModelWrapper& qnn_model_wrapper,
-                                             const std::string& input_name);
+                                            const std::string& input_name);
 
 /// <summary>
 /// Returns true if the named input is a scalar constant approximately equal to `expected`.
@@ -105,9 +105,9 @@ std::optional<float> GetScalarConstantValue(const QnnModelWrapper& qnn_model_wra
 /// tol defaults to 1e-3f (~2% relative error for the GELU cubic coefficient 0.044715).
 /// </summary>
 bool IsScalarConstantApprox(const QnnModelWrapper& qnn_model_wrapper,
-                             const std::string& input_name,
-                             float expected,
-                             float tol = 1e-3f);
+                            const std::string& input_name,
+                            float expected,
+                            float tol = 1e-3f);
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
@@ -90,5 +90,24 @@ const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& qnn_model_wrapp
 std::optional<std::vector<int64_t>> GetInitializerDataAsInt64(const QnnModelWrapper& qnn_model_wrapper,
                                                               const OrtNodeUnitIODef& shape_input);
 
+/// <summary>
+/// Reads a scalar constant initializer by tensor name and returns its value as float.
+/// Supports float32 and float16 element types. Returns nullopt if the input is not a
+/// constant, not a scalar (element count != 1), or has an unsupported element type.
+/// </summary>
+std::optional<float> GetScalarConstantValue(const QnnModelWrapper& qnn_model_wrapper,
+                                             const std::string& input_name);
+
+/// <summary>
+/// Returns true if the named input is a scalar constant approximately equal to `expected`.
+/// Tolerance is applied as abs(val - expected) <= tol.
+/// Supports float32 and float16 element types.
+/// tol defaults to 1e-3f (~2% relative error for the GELU cubic coefficient 0.044715).
+/// </summary>
+bool IsScalarConstantApprox(const QnnModelWrapper& qnn_model_wrapper,
+                             const std::string& input_name,
+                             float expected,
+                             float tol = 1e-3f);
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
@@ -217,10 +217,21 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float16) {
                         6e-3f);
 }
 
+// Peak substitution error: input range [-3, 3] covers |x|≈2 where the divergence between the
+// tanh approximation and the exact-erf GELU is largest (~4.7e-4). Verifies the fused QNN GELU
+// output still matches CPU tanh-GELU within the documented tolerance.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_PeakSubstitutionError) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunTanhGeluFusionTest("TanhGeluFusion_Float32_PeakSubstitutionError",
+                        BuildTanhGeluTestCase(TestInputDef<float>({1, 2, 3, 4}, false, -3.0f, 3.0f)),
+                        6e-3f);
+}
+
 // ---- Negative tests --------------------------------------------------------
+// Fusion is rejected but Mul/Add/Tanh are individually supported on HTP, so
+// individual ops still run on QNN EP → ExpectedEPNodeAssignment::Some.
 
 // Wrong cubic coefficient (0.1 instead of 0.044715) — matcher must reject.
-// When fusion does not fire, all nodes fall back to CPU, so we expect None on the QNN EP.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
@@ -253,12 +264,11 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   RunQnnModelTest(bad_model,
                   GetProviderOptions(),
                   /*opset_version=*/13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::None, ElementwiseAbsoluteVerifier(6e-3f)});
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(6e-3f)});
 }
 
-// Shared intermediate: x² is also consumed by an extra Relu outside the pattern.
-// Fusing would leave Relu with a dangling input, so the matcher must reject.
-// When fusion does not fire, all nodes fall back to CPU, so we expect None on the QNN EP.
+// Shared backward intermediate: x² is also consumed by an extra Relu outside the pattern.
+// HasSingleOutputConsumer rejects it, so the matcher must reject the full pattern.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_SharedIntermediate_ShouldNotFuse) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
@@ -297,7 +307,49 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_SharedIntermediate_ShouldNotFuse) {
   RunQnnModelTest(shared_model,
                   GetProviderOptions(),
                   /*opset_version=*/13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::None, ElementwiseAbsoluteVerifier(6e-3f)});
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(6e-3f)});
+}
+
+// Shared forward intermediate: add_one_out has a second consumer (an extra Relu) outside the pattern.
+// GetOnlyChildOfOutput rejects multi-consumer outputs, so the forward walk fails.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_SharedForwardIntermediate_ShouldNotFuse) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
+  GetTestModelFn forward_shared_model = [&input_def](ModelTestBuilder& builder) -> void {
+    constexpr float k0044715 = 0.044715f;
+    constexpr float kSqrt2OverPi = 0.7978845608f;
+    constexpr float kOne = 1.0f;
+    constexpr float kHalf = 0.5f;
+
+    builder.graph_->set_name("tanh_gelu_forward_shared_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
+    builder.AddNode("Mul_x3", "Mul", {"x2_out", "input"}, {"x3_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("c0044715", k0044715);
+    builder.AddNode("Mul_0044715", "Mul", {"x3_out", "c0044715"}, {"mul_0044715_out"}, kOnnxDomain);
+    builder.AddNode("Add_inner", "Add", {"input", "mul_0044715_out"}, {"add_inner_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("sqrt2pi", kSqrt2OverPi);
+    builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
+    builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("one", kOne);
+    builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
+
+    // Extra consumer of add_one_out — prevents fusion of the forward tail.
+    builder.AddNode("Relu_extra", "Relu", {"add_one_out"}, {"extra_out"}, kOnnxDomain);
+    builder.MakeOutput("extra_out");
+
+    builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("half", kHalf);
+    builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+
+  RunQnnModelTest(forward_shared_model,
+                  GetProviderOptions(),
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(6e-3f)});
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
@@ -18,11 +18,6 @@ namespace test {
 
 namespace {
 
-void ResetQnnGraphDir(const std::filesystem::path& json_qnn_graph_dir) {
-  std::filesystem::remove_all(json_qnn_graph_dir);
-  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
-}
-
 // Builds the tanh-GELU approximation pattern:
 //
 //  [x] --+-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) -> Add --+-> Mul(sqrt2pi) -> Tanh -> Add(1) -> Mul(x) -> Mul(0.5) ==>

--- a/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #if !defined(ORT_MINIMAL_BUILD)
 
@@ -18,55 +18,123 @@ namespace test {
 
 namespace {
 
-// Builds the tanh-GELU approximation pattern:
+// Builds the canonical tanh-GELU approximation pattern (float32):
 //
-//  [x] --+-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) -> Add --+-> Mul(sqrt2pi) -> Tanh -> Add(1) -> Mul(x) -> Mul(0.5) ==>
-//        |                                                     |
-//        +-----------------------------------------------------+
+//  [x] --+-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) --+
+//        |                                              v
+//        +--------------------------------------------> Add -> Mul(sqrt2pi) -> Tanh -> Add(1) -> Mul(x) -> Mul(0.5) ==>
 //
-// This matches what ORT's optimizer produces (Pow(x,3) is lowered to Mul(Mul(x,x),x)).
+// Equation: 0.5 * x * (1 + Tanh(sqrt(2/pi) * (x + 0.044715 * x³)))
 GetTestModelFn BuildTanhGeluTestCase(const TestInputDef<float>& input_def) {
   return [input_def](ModelTestBuilder& builder) -> void {
     constexpr float k0044715 = 0.044715f;
-    constexpr float kSqrt2OverPi = 0.7978845608f;  // sqrt(2/pi)
+    constexpr float kSqrt2OverPi = 0.7978845608f;
     constexpr float kOne = 1.0f;
     constexpr float kHalf = 0.5f;
 
     builder.graph_->set_name("tanh_gelu_graph");
-
     MakeTestInput<float>(builder, "input", input_def);
 
-    // x² = Mul(x, x)
     builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
-
-    // x³ = Mul(x², x)
     builder.AddNode("Mul_x3", "Mul", {"x2_out", "input"}, {"x3_out"}, kOnnxDomain);
 
-    // 0.044715 * x³
     builder.MakeScalarInitializer<float>("c0044715", k0044715);
     builder.AddNode("Mul_0044715", "Mul", {"x3_out", "c0044715"}, {"mul_0044715_out"}, kOnnxDomain);
 
-    // x + 0.044715*x³
+    // Canonical Add: Add(input, 0.044715*x³)  — x is input[0], cubic branch is input[1]
     builder.AddNode("Add_inner", "Add", {"input", "mul_0044715_out"}, {"add_inner_out"}, kOnnxDomain);
 
-    // sqrt(2/pi) * (x + 0.044715*x³)
     builder.MakeScalarInitializer<float>("sqrt2pi", kSqrt2OverPi);
     builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
 
-    // Tanh
     builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
 
-    // 1 + Tanh(...)
     builder.MakeScalarInitializer<float>("one", kOne);
     builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
 
-    // x * (1 + Tanh(...))
     builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
 
-    // 0.5 * x * (1 + Tanh(...))
     builder.MakeScalarInitializer<float>("half", kHalf);
     builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+}
 
+// Same as BuildTanhGeluTestCase but with commutative-input orderings swapped at two places
+// that exercise the matcher's `for i` (add_inner branch index) and `for j` (mul_x3 child order):
+//
+//  add_inner   : Add(0.044715*x³, x)  — cubic branch is input[0] instead of input[1]  (for i loop)
+//  mul_x3      : Mul(x, x²)           — x is input[0] instead of input[1]              (for j loop)
+GetTestModelFn BuildTanhGeluTestCaseSwappedInputs(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) -> void {
+    constexpr float k0044715 = 0.044715f;
+    constexpr float kSqrt2OverPi = 0.7978845608f;
+    constexpr float kOne = 1.0f;
+    constexpr float kHalf = 0.5f;
+
+    builder.graph_->set_name("tanh_gelu_swapped_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
+
+    // for j: Mul(x, x²) — x in slot 0, x² in slot 1 (swapped vs canonical Mul(x²,x))
+    builder.AddNode("Mul_x3", "Mul", {"input", "x2_out"}, {"x3_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<float>("c0044715", k0044715);
+    builder.AddNode("Mul_0044715", "Mul", {"x3_out", "c0044715"}, {"mul_0044715_out"}, kOnnxDomain);
+
+    // for i: Add(0.044715*x³, x) — cubic branch is input[0] (swapped vs canonical Add(x, 0.044715*x³))
+    builder.AddNode("Add_inner", "Add", {"mul_0044715_out", "input"}, {"add_inner_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<float>("sqrt2pi", kSqrt2OverPi);
+    builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
+
+    builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<float>("one", kOne);
+    builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
+
+    builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<float>("half", kHalf);
+    builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+}
+
+// Builds the tanh-GELU pattern using fp16 scalar constants.
+// GetScalarConstantValue supports FLOAT16 element type, so fusion must also fire for fp16 models.
+GetTestModelFn BuildTanhGeluTestCaseFp16(const TestInputDef<float>& float_input_def) {
+  return [float_input_def](ModelTestBuilder& builder) -> void {
+    const Ort::Float16_t k0044715 = static_cast<Ort::Float16_t>(0.044715f);
+    const Ort::Float16_t kSqrt2OverPi = static_cast<Ort::Float16_t>(0.7978845608f);
+    const Ort::Float16_t kOne = static_cast<Ort::Float16_t>(1.0f);
+    const Ort::Float16_t kHalf = static_cast<Ort::Float16_t>(0.5f);
+
+    builder.graph_->set_name("tanh_gelu_fp16_graph");
+    const TestInputDef<Ort::Float16_t> input_def = ConvertToFP16InputDef(float_input_def);
+    MakeTestInput<Ort::Float16_t>(builder, "input", input_def);
+
+    builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
+    builder.AddNode("Mul_x3", "Mul", {"x2_out", "input"}, {"x3_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<Ort::Float16_t>("c0044715", k0044715);
+    builder.AddNode("Mul_0044715", "Mul", {"x3_out", "c0044715"}, {"mul_0044715_out"}, kOnnxDomain);
+
+    builder.AddNode("Add_inner", "Add", {"input", "mul_0044715_out"}, {"add_inner_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<Ort::Float16_t>("sqrt2pi", kSqrt2OverPi);
+    builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
+
+    builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<Ort::Float16_t>("one", kOne);
+    builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
+
+    builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
+
+    builder.MakeScalarInitializer<Ort::Float16_t>("half", kHalf);
+    builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
     builder.MakeOutput("output");
   };
 }
@@ -81,78 +149,78 @@ ProviderOptions GetProviderOptions() {
   return provider_options;
 }
 
+// Runs a positive fusion test: verifies fusion fires (one ElementWiseNeuron in the QNN graph)
+// and that QNN output matches CPU EP within abs_err.
+void RunTanhGeluFusionTest(const std::string& test_name,
+                           const GetTestModelFn& build_fn,
+                           float abs_err) {
+  const std::filesystem::path json_qnn_graph_dir = test_name;
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(build_fn,
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(abs_err)});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseNeuron");
+}
+
 }  // namespace
 
-// Basic pattern: verifies fusion fires and produces a single QNN Gelu node.
+// ---- Positive tests --------------------------------------------------------
+
+// 4D input: typical batch * channel * H * W layout.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_4D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
-
-  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_Float32_4D";
-  std::filesystem::remove_all(json_qnn_graph_dir);
-  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
-  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
-
-  ProviderOptions provider_options = GetProviderOptions();
-  provider_options["dump_json_qnn_graph"] = "1";
-  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-
-  RunQnnModelTest(BuildTanhGeluTestCase(input_def),
-                  provider_options,
-                  /*opset_version=*/13,
-                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/6e-3f);
-
-  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+  RunTanhGeluFusionTest("TanhGeluFusion_Float32_4D",
+                        BuildTanhGeluTestCase(TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f)),
+                        6e-3f);
 }
 
-// Typical transformer hidden-size shape {1, 128, 768}.
+// 3D input: typical transformer hidden-size shape {batch, seq, hidden}.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_3D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  auto input_def = TestInputDef<float>({1, 128, 768}, false, -1.5f, 1.5f);
-
-  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_Float32_3D";
-  std::filesystem::remove_all(json_qnn_graph_dir);
-  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
-  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
-
-  ProviderOptions provider_options = GetProviderOptions();
-  provider_options["dump_json_qnn_graph"] = "1";
-  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-
-  RunQnnModelTest(BuildTanhGeluTestCase(input_def),
-                  provider_options,
-                  /*opset_version=*/13,
-                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/2e-3f);
-
-  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+  RunTanhGeluFusionTest("TanhGeluFusion_Float32_3D",
+                        BuildTanhGeluTestCase(TestInputDef<float>({1, 128, 768}, false, -1.5f, 1.5f)),
+                        2e-3f);
 }
 
-// 2D shape (e.g., after flatten in a linear layer).
+// 2D input: typical post-flatten shape in a linear layer.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_2D) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-  auto input_def = TestInputDef<float>({32, 512}, false, -1.5f, 1.5f);
-
-  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_Float32_2D";
-  std::filesystem::remove_all(json_qnn_graph_dir);
-  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
-  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
-
-  ProviderOptions provider_options = GetProviderOptions();
-  provider_options["dump_json_qnn_graph"] = "1";
-  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
-
-  RunQnnModelTest(BuildTanhGeluTestCase(input_def),
-                  provider_options,
-                  /*opset_version=*/13,
-                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/6e-3f);
-
-  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+  RunTanhGeluFusionTest("TanhGeluFusion_Float32_2D",
+                        BuildTanhGeluTestCase(TestInputDef<float>({32, 512}, false, -1.5f, 1.5f)),
+                        6e-3f);
 }
 
-// Negative test: a broken pattern (wrong coefficient) must NOT fuse.
+// Commutative-input-ordering test:
+//   add_inner  = Add(0.044715*x³, x)   — cubic arm in slot 0  → exercises `for i` in TryMatchCubicSubtree
+//   mul_x3     = Mul(x, x²)            — x in slot 0          → exercises `for j` inside TryMatchCubicSubtree
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_SwappedInputs) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunTanhGeluFusionTest("TanhGeluFusion_Float32_SwappedInputs",
+                        BuildTanhGeluTestCaseSwappedInputs(TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f)),
+                        6e-3f);
+}
+
+// fp16 test: scalar constants are FLOAT16 initializers.
+// GetScalarConstantValue handles FLOAT16 via Ort::Float16_t::ToFloat(), so fusion must fire.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunTanhGeluFusionTest("TanhGeluFusion_Float16",
+                        BuildTanhGeluTestCaseFp16(TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f)),
+                        6e-3f);
+}
+
+// ---- Negative tests --------------------------------------------------------
+
+// Wrong cubic coefficient (0.1 instead of 0.044715) — matcher must reject.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
@@ -166,9 +234,8 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
 
-  // Build pattern with wrong coefficient (0.1 instead of 0.044715).
   GetTestModelFn bad_model = [&input_def](ModelTestBuilder& builder) -> void {
-    constexpr float kWrongCoeff = 0.1f;  // Should be 0.044715
+    constexpr float kWrongCoeff = 0.1f;
     constexpr float kSqrt2OverPi = 0.7978845608f;
     constexpr float kOne = 1.0f;
     constexpr float kHalf = 0.5f;
@@ -195,11 +262,63 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   RunQnnModelTest(bad_model,
                   provider_options,
                   /*opset_version=*/13,
-                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
-                  /*fp32_abs_err=*/6e-3f);
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(6e-3f)});
 
-  // No Gelu should appear in the QNN graph.
-  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu", 0);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseNeuron", 0);
+}
+
+// Shared intermediate: x² is also consumed by an extra Relu outside the pattern.
+// Fusing would leave Relu with a dangling input, so the matcher must reject.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_SharedIntermediate_ShouldNotFuse) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
+  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_SharedIntermediate";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  GetTestModelFn shared_model = [&input_def](ModelTestBuilder& builder) -> void {
+    constexpr float k0044715 = 0.044715f;
+    constexpr float kSqrt2OverPi = 0.7978845608f;
+    constexpr float kOne = 1.0f;
+    constexpr float kHalf = 0.5f;
+
+    builder.graph_->set_name("tanh_gelu_shared_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // x² is shared: consumed by both Mul(x²,x) and the extra Relu below.
+    builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
+
+    // Extra consumer of x² — prevents fusion.
+    builder.AddNode("Relu_extra", "Relu", {"x2_out"}, {"extra_out"}, kOnnxDomain);
+    builder.MakeOutput("extra_out");
+
+    builder.AddNode("Mul_x3", "Mul", {"x2_out", "input"}, {"x3_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("c0044715", k0044715);
+    builder.AddNode("Mul_0044715", "Mul", {"x3_out", "c0044715"}, {"mul_0044715_out"}, kOnnxDomain);
+    builder.AddNode("Add_inner", "Add", {"input", "mul_0044715_out"}, {"add_inner_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("sqrt2pi", kSqrt2OverPi);
+    builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
+    builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("one", kOne);
+    builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
+    builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("half", kHalf);
+    builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+
+  RunQnnModelTest(shared_model,
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(6e-3f)});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseNeuron", 0);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+namespace {
+
+void ResetQnnGraphDir(const std::filesystem::path& json_qnn_graph_dir) {
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+}
+
+// Builds the tanh-GELU approximation pattern:
+//
+//  [x] --+-> Mul(x,x) -> Mul(x²,x) -> Mul(0.044715) -> Add --+-> Mul(sqrt2pi) -> Tanh -> Add(1) -> Mul(x) -> Mul(0.5) ==>
+//        |                                                     |
+//        +-----------------------------------------------------+
+//
+// This matches what ORT's optimizer produces (Pow(x,3) is lowered to Mul(Mul(x,x),x)).
+GetTestModelFn BuildTanhGeluTestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) -> void {
+    constexpr float k0044715 = 0.044715f;
+    constexpr float kSqrt2OverPi = 0.7978845608f;  // sqrt(2/pi)
+    constexpr float kOne = 1.0f;
+    constexpr float kHalf = 0.5f;
+
+    builder.graph_->set_name("tanh_gelu_graph");
+
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // x² = Mul(x, x)
+    builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
+
+    // x³ = Mul(x², x)
+    builder.AddNode("Mul_x3", "Mul", {"x2_out", "input"}, {"x3_out"}, kOnnxDomain);
+
+    // 0.044715 * x³
+    builder.MakeScalarInitializer<float>("c0044715", k0044715);
+    builder.AddNode("Mul_0044715", "Mul", {"x3_out", "c0044715"}, {"mul_0044715_out"}, kOnnxDomain);
+
+    // x + 0.044715*x³
+    builder.AddNode("Add_inner", "Add", {"input", "mul_0044715_out"}, {"add_inner_out"}, kOnnxDomain);
+
+    // sqrt(2/pi) * (x + 0.044715*x³)
+    builder.MakeScalarInitializer<float>("sqrt2pi", kSqrt2OverPi);
+    builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
+
+    // Tanh
+    builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
+
+    // 1 + Tanh(...)
+    builder.MakeScalarInitializer<float>("one", kOne);
+    builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
+
+    // x * (1 + Tanh(...))
+    builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
+
+    // 0.5 * x * (1 + Tanh(...))
+    builder.MakeScalarInitializer<float>("half", kHalf);
+    builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return provider_options;
+}
+
+}  // namespace
+
+// Basic pattern: verifies fusion fires and produces a single QNN Gelu node.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_4D) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
+  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_Float32_4D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildTanhGeluTestCase(input_def),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/6e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+}
+
+// Typical transformer hidden-size shape {1, 128, 768}.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_3D) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 128, 768}, false, -1.5f, 1.5f);
+
+  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_Float32_3D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildTanhGeluTestCase(input_def),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/2e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+}
+
+// 2D shape (e.g., after flatten in a linear layer).
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float32_2D) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({32, 512}, false, -1.5f, 1.5f);
+
+  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_Float32_2D";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildTanhGeluTestCase(input_def),
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/6e-3f);
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu");
+}
+
+// Negative test: a broken pattern (wrong coefficient) must NOT fuse.
+TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
+
+  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_WrongCoeff";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  // Build pattern with wrong coefficient (0.1 instead of 0.044715).
+  GetTestModelFn bad_model = [&input_def](ModelTestBuilder& builder) -> void {
+    constexpr float kWrongCoeff = 0.1f;  // Should be 0.044715
+    constexpr float kSqrt2OverPi = 0.7978845608f;
+    constexpr float kOne = 1.0f;
+    constexpr float kHalf = 0.5f;
+
+    builder.graph_->set_name("tanh_gelu_wrong_coeff_graph");
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.AddNode("Mul_x2", "Mul", {"input", "input"}, {"x2_out"}, kOnnxDomain);
+    builder.AddNode("Mul_x3", "Mul", {"x2_out", "input"}, {"x3_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("wrong_coeff", kWrongCoeff);
+    builder.AddNode("Mul_wrong", "Mul", {"x3_out", "wrong_coeff"}, {"mul_wrong_out"}, kOnnxDomain);
+    builder.AddNode("Add_inner", "Add", {"input", "mul_wrong_out"}, {"add_inner_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("sqrt2pi", kSqrt2OverPi);
+    builder.AddNode("Mul_coeff", "Mul", {"add_inner_out", "sqrt2pi"}, {"mul_coeff_out"}, kOnnxDomain);
+    builder.AddNode("Tanh", "Tanh", {"mul_coeff_out"}, {"tanh_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("one", kOne);
+    builder.AddNode("Add_one", "Add", {"tanh_out", "one"}, {"add_one_out"}, kOnnxDomain);
+    builder.AddNode("Mul_x", "Mul", {"input", "add_one_out"}, {"mul_x_out"}, kOnnxDomain);
+    builder.MakeScalarInitializer<float>("half", kHalf);
+    builder.AddNode("Mul_half", "Mul", {"mul_x_out", "half"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+
+  RunQnnModelTest(bad_model,
+                  provider_options,
+                  /*opset_version=*/13,
+                  /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
+                  /*fp32_abs_err=*/6e-3f);
+
+  // No Gelu should appear in the QNN graph.
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Gelu", 0);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/tanh_gelu_fusion_test.cc
@@ -14,8 +14,6 @@
 namespace onnxruntime {
 namespace test {
 
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
-
 namespace {
 
 // Builds the canonical tanh-GELU approximation pattern (float32):
@@ -173,6 +171,7 @@ void RunTanhGeluFusionTest(const std::string& test_name,
 
 }  // namespace
 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 // ---- Positive tests --------------------------------------------------------
 
 // 4D input: typical batch * channel * H * W layout.
@@ -221,18 +220,10 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_Float16) {
 // ---- Negative tests --------------------------------------------------------
 
 // Wrong cubic coefficient (0.1 instead of 0.044715) — matcher must reject.
+// When fusion does not fire, all nodes fall back to CPU, so we expect None on the QNN EP.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
-
-  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_WrongCoeff";
-  std::filesystem::remove_all(json_qnn_graph_dir);
-  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
-  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
-
-  ProviderOptions provider_options = GetProviderOptions();
-  provider_options["dump_json_qnn_graph"] = "1";
-  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
 
   GetTestModelFn bad_model = [&input_def](ModelTestBuilder& builder) -> void {
     constexpr float kWrongCoeff = 0.1f;
@@ -260,27 +251,17 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_WrongCoeff_ShouldNotFuse) {
   };
 
   RunQnnModelTest(bad_model,
-                  provider_options,
+                  GetProviderOptions(),
                   /*opset_version=*/13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(6e-3f)});
-
-  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseNeuron", 0);
+                  EPVerificationParams{ExpectedEPNodeAssignment::None, ElementwiseAbsoluteVerifier(6e-3f)});
 }
 
 // Shared intermediate: x² is also consumed by an extra Relu outside the pattern.
 // Fusing would leave Relu with a dangling input, so the matcher must reject.
+// When fusion does not fire, all nodes fall back to CPU, so we expect None on the QNN EP.
 TEST_F(QnnHTPBackendTests, TanhGeluFusion_SharedIntermediate_ShouldNotFuse) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   auto input_def = TestInputDef<float>({1, 2, 3, 4}, false, -1.0f, 1.0f);
-
-  const std::filesystem::path json_qnn_graph_dir = "TanhGeluFusion_SharedIntermediate";
-  std::filesystem::remove_all(json_qnn_graph_dir);
-  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
-  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
-
-  ProviderOptions provider_options = GetProviderOptions();
-  provider_options["dump_json_qnn_graph"] = "1";
-  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
 
   GetTestModelFn shared_model = [&input_def](ModelTestBuilder& builder) -> void {
     constexpr float k0044715 = 0.044715f;
@@ -314,11 +295,9 @@ TEST_F(QnnHTPBackendTests, TanhGeluFusion_SharedIntermediate_ShouldNotFuse) {
   };
 
   RunQnnModelTest(shared_model,
-                  provider_options,
+                  GetProviderOptions(),
                   /*opset_version=*/13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(6e-3f)});
-
-  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseNeuron", 0);
+                  EPVerificationParams{ExpectedEPNodeAssignment::None, ElementwiseAbsoluteVerifier(6e-3f)});
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Added support for Gelu Tanh Fusion in ORT-QNNEP code. This merges many ops to one op increasing model performance. This is similar to QNN converter fusion.    


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
QNN only has one Gelu op. The tanh-GELU approximation expands as:
x * 0.5 * (1 + Tanh(sqrt(2/π) * (x + 0.044715 * x³)))
which can be written in ONNX ops as:
x -> Pow(3) -> Mul(0.044715) -> Add(x) -> Mul(sqrt(2/π)) -> Tanh -> Add(1) -> Mul(0.5) -> Mul(x) ==>
The starting node for fusion discovery needs to be Tanh.
The total fused node list is 9 nodes: mul_x2, mul_x3, mul_0044715, add_inner, mul_coeff, tanh, add_one, mul_x, mul_half
Added the test case as well.


