### PR TITLE
[QNN EP] Fix SpaceToDepth CRD fusion for dynamic batch models

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.cc
@@ -182,14 +182,18 @@ bool HasSpaceToDepthCoreSignature(
     return false;
   }
 
-  // check Reshape 'shape' dimensions to be positive.
-  for (int64_t v : *shape_6d) {
+  // check Reshape 'shape' dimensions to be positive (allow -1 only for the batch dim at index 0).
+  for (size_t i = 0; i < shape_6d->size(); ++i) {
+    const int64_t v = (*shape_6d)[i];
+    if (i == 0 && v == -1) continue;  // dynamic batch
     if (v <= 0) {
       return false;
     }
   }
 
-  for (int64_t v : *shape_4d) {
+  for (size_t i = 0; i < shape_4d->size(); ++i) {
+    const int64_t v = (*shape_4d)[i];
+    if (i == 0 && v == -1) continue;  // dynamic batch
     if (v <= 0) {
       return false;
     }
@@ -209,8 +213,8 @@ bool HasSpaceToDepthCoreSignature(
   const int64_t w_div = (*shape_6d)[4];
   const int64_t b1 = (*shape_6d)[5];
 
-  // r_ are expected to match input [N,C]
-  if (r_n != n || r_c != c || b0 < 1 || b1 < 1) {
+  // r_ are expected to match input [N,C]; allow r_n = -1 for dynamic batch.
+  if ((r_n != -1 && r_n != n) || r_c != c || b0 < 1 || b1 < 1) {
     return false;
   }
 
@@ -225,8 +229,12 @@ bool HasSpaceToDepthCoreSignature(
   // [N, C * b0 * b1, H / b0, W / b1]
   const int64_t expected_c = c * b0 * b1;
   const std::array<int64_t, 4> expected_shape_4d = {n, expected_c, h / b0, w / b1};
-  if (!std::equal(shape_4d->begin(), shape_4d->end(), expected_shape_4d.begin())) {
-    return false;
+  for (size_t i = 0; i < 4; ++i) {
+    // Allow -1 only for the batch dimension (index 0) in the output shape.
+    if (i == 0 && (*shape_4d)[i] == -1) continue;
+    if ((*shape_4d)[i] != expected_shape_4d[i]) {
+      return false;
+    }
   }
 
   // check transpose perm to be either {0,3,5,1,2,4} or {0,1,3,5,2,4}.

--- a/onnxruntime/test/providers/qnn/qnn_node_group/spacetodepth_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/spacetodepth_fusion_test.cc
@@ -30,7 +30,8 @@ GetTestModelFn BuildSpaceToDepthTestCase(const std::vector<int64_t>& input_shape
                                          int64_t block_width,
                                          const std::vector<int64_t>& perm,
                                          bool use_qdq,
-                                         bool use_contrib_qdq) {
+                                         bool use_contrib_qdq,
+                                         bool use_dynamic_batch = false) {
   return [=](ModelTestBuilder& builder) -> void {
     builder.graph_->set_name("spacetodepth_fusion_graph");
 
@@ -55,7 +56,7 @@ GetTestModelFn BuildSpaceToDepthTestCase(const std::vector<int64_t>& input_shape
                                                  use_contrib_qdq);
     }
 
-    const int64_t n = input_shape[0];
+    const int64_t n = use_dynamic_batch ? -1 : input_shape[0];
     const int64_t h = input_shape[2];
     const int64_t w = input_shape[3];
     const int64_t h_div = h / block_height;
@@ -261,7 +262,8 @@ void RunSpaceToDepthFusionTest(const std::filesystem::path& json_qnn_graph_dir,
                                bool use_qdq,
                                bool use_contrib_qdq,
                                const std::string& backend_type,
-                               float fp32_abs_err = 1e-2f) {
+                               float fp32_abs_err = 1e-2f,
+                               bool use_dynamic_batch = false) {
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
   const int uncaught_on_entry = std::uncaught_exceptions();
@@ -276,7 +278,7 @@ void RunSpaceToDepthFusionTest(const std::filesystem::path& json_qnn_graph_dir,
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
 
-  RunQnnModelTest(BuildSpaceToDepthTestCase<QuantType>(input_shape, block_height, block_width, perm, use_qdq, use_contrib_qdq),
+  RunQnnModelTest(BuildSpaceToDepthTestCase<QuantType>(input_shape, block_height, block_width, perm, use_qdq, use_contrib_qdq, use_dynamic_batch),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -552,6 +554,36 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_U16_CRD) {
                                       /*use_qdq=*/true,
                                       /*use_contrib_qdq=*/true,
                                       /*backend_type=*/"htp");
+}
+
+// Tests for dynamic batch size (-1 in Reshape shape initializer).
+// Regression test: HasSpaceToDepthCoreSignature was rejecting -1 (ONNX dynamic batch marker).
+TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Float_CRD_DynamicBatch) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunSpaceToDepthFusionTest("SpaceToDepthFusionFloatCRD_DynamicBatch",
+                            /*input_shape=*/{1, 2, 4, 4},
+                            /*block_height=*/2,
+                            /*block_width=*/2,
+                            /*perm=*/{0, 1, 3, 5, 2, 4},
+                            /*use_qdq=*/false,
+                            /*use_contrib_qdq=*/false,
+                            /*backend_type=*/"htp",
+                            /*fp32_abs_err=*/1e-2f,
+                            /*use_dynamic_batch=*/true);
+}
+
+TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_CRD_DynamicBatch) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunSpaceToDepthFusionTest("SpaceToDepthFusionQDQ_CRD_DynamicBatch",
+                            /*input_shape=*/{1, 2, 4, 4},
+                            /*block_height=*/2,
+                            /*block_width=*/2,
+                            /*perm=*/{0, 1, 3, 5, 2, 4},
+                            /*use_qdq=*/true,
+                            /*use_contrib_qdq=*/false,
+                            /*backend_type=*/"htp",
+                            /*fp32_abs_err=*/2.9e-2f,
+                            /*use_dynamic_batch=*/true);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/spacetodepth_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/spacetodepth_fusion_test.cc
@@ -30,12 +30,14 @@ GetTestModelFn BuildSpaceToDepthTestCase(const std::vector<int64_t>& input_shape
                                          int64_t block_width,
                                          const std::vector<int64_t>& perm,
                                          bool use_qdq,
-                                         bool use_contrib_qdq,
-                                         bool use_dynamic_batch = false) {
+                                         bool use_contrib_qdq) {
   return [=](ModelTestBuilder& builder) -> void {
     builder.graph_->set_name("spacetodepth_fusion_graph");
 
-    const auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    // input_shape[0] may be -1 (dynamic batch); replace with 1 for concrete test data allocation.
+    std::vector<int64_t> data_shape = input_shape;
+    std::replace(data_shape.begin(), data_shape.end(), static_cast<int64_t>(-1), static_cast<int64_t>(1));
+    const auto input_def = TestInputDef<float>(data_shape, false, -1.0f, 1.0f);
     MakeTestInput<float>(builder, "input", input_def);
 
     // Add layout-sensitive Conv around RTR so wrapped fusion can trigger.
@@ -56,7 +58,7 @@ GetTestModelFn BuildSpaceToDepthTestCase(const std::vector<int64_t>& input_shape
                                                  use_contrib_qdq);
     }
 
-    const int64_t n = use_dynamic_batch ? -1 : input_shape[0];
+    const int64_t n = input_shape[0];  // may be -1 for dynamic batch
     const int64_t h = input_shape[2];
     const int64_t w = input_shape[3];
     const int64_t h_div = h / block_height;
@@ -262,8 +264,7 @@ void RunSpaceToDepthFusionTest(const std::filesystem::path& json_qnn_graph_dir,
                                bool use_qdq,
                                bool use_contrib_qdq,
                                const std::string& backend_type,
-                               float fp32_abs_err = 1e-2f,
-                               bool use_dynamic_batch = false) {
+                               float fp32_abs_err = 1e-2f) {
   std::filesystem::remove_all(json_qnn_graph_dir);
   ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
   const int uncaught_on_entry = std::uncaught_exceptions();
@@ -278,7 +279,7 @@ void RunSpaceToDepthFusionTest(const std::filesystem::path& json_qnn_graph_dir,
   provider_options["dump_json_qnn_graph"] = "1";
   provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
 
-  RunQnnModelTest(BuildSpaceToDepthTestCase<QuantType>(input_shape, block_height, block_width, perm, use_qdq, use_contrib_qdq, use_dynamic_batch),
+  RunQnnModelTest(BuildSpaceToDepthTestCase<QuantType>(input_shape, block_height, block_width, perm, use_qdq, use_contrib_qdq),
                   provider_options,
                   /*opset_version=*/13,
                   /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All,
@@ -561,29 +562,27 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_UnequalBlockSize_QDQ_U16_CRD) {
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_Float_CRD_DynamicBatch) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest("SpaceToDepthFusionFloatCRD_DynamicBatch",
-                            /*input_shape=*/{1, 2, 4, 4},
+                            /*input_shape=*/{-1, 2, 4, 4},
                             /*block_height=*/2,
                             /*block_width=*/2,
                             /*perm=*/{0, 1, 3, 5, 2, 4},
                             /*use_qdq=*/false,
                             /*use_contrib_qdq=*/false,
                             /*backend_type=*/"htp",
-                            /*fp32_abs_err=*/1e-2f,
-                            /*use_dynamic_batch=*/true);
+                            /*fp32_abs_err=*/1e-2f);
 }
 
 TEST_F(QnnHTPBackendTests, SpaceToDepthFusion_QDQ_CRD_DynamicBatch) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   RunSpaceToDepthFusionTest("SpaceToDepthFusionQDQ_CRD_DynamicBatch",
-                            /*input_shape=*/{1, 2, 4, 4},
+                            /*input_shape=*/{-1, 2, 4, 4},
                             /*block_height=*/2,
                             /*block_width=*/2,
                             /*perm=*/{0, 1, 3, 5, 2, 4},
                             /*use_qdq=*/true,
                             /*use_contrib_qdq=*/false,
                             /*backend_type=*/"htp",
-                            /*fp32_abs_err=*/2.9e-2f,
-                            /*use_dynamic_batch=*/true);
+                            /*fp32_abs_err=*/2.9e-2f);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
## Summary

- Fix `HasSpaceToDepthCoreSignature` to handle dynamic batch dimension (`-1`) in
Reshape shape initializers, enabling SpaceToDepth CRD fusion for dynamic-batch models.

## Problem

Models exported with dynamic batch size use `-1` in Reshape shape initializers
(e.g., `[-1, 3, 64, 2, 64, 2]`). `HasSpaceToDepthCoreSignature` checked `v <= 0`
which rejects `-1`, causing `MatchPattern` to return `nullopt`. The RTR nodes then
fell through to standalone QNN validation where 6-D tensors are rejected with
**error code 3110**, resulting in CPU fallback.

Regression introduced by PR #171 (Reshape-Transpose-Reshape → SpaceToDepth fusion),
which was only tested with static batch-size models.

## Fix

Three changes in `HasSpaceToDepthCoreSignature`:
1. **Positive-dimension guard**: skip check when `v == -1`
2. **Batch-dim match**: treat `r_n == -1` as matching any actual batch size
3. **Output shape comparison**: treat `shape_4d[i] == -1` as a wildcard

The `node_count == 3` guard in `MatchPattern` is intentionally preserved —
it avoids redundant transposes in the DLC during the 1st `GetCapability` call.
In the 2nd call (after Layout Transform), the pattern matches as 4-node or 5-node
and the guard is never triggered.

## Test plan

- [ ] Existing SpaceToDepth fusion unit tests pass (static batch, HTP backend)
- [ ] `ImageSuperResolutionV100001` model: SpaceToDepth CRD op appears in QNN graph
	(confirmed via `ComposeQnnGraph` log: `fused_spacetodepth QNN_op_type: SpaceToDepth`)
- [ ] No regression on models with static batch size


