### PR TITLE
[QNN EP] Support FP16/BFP16 scale initializers in UnpackScales

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qlinear_matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qlinear_matmul_op_builder.cc
@@ -108,37 +108,10 @@ class QLinearMatMulOpBuilder : public BaseOpBuilder {
 Ort::Status QLinearMatMulOpBuilder::ReadScaleAsFloat32(const QnnModelWrapper& qnn_model_wrapper,
                                                        const OrtValueInfo* scale_tensor,
                                                        float& out_scale) {
-  RETURN_IF(scale_tensor == nullptr, "QLinearMatMul: scale initializer is null.");
-
-  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
-
-  const OrtTypeInfo* type_info = nullptr;
-  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetValueInfoTypeInfo(scale_tensor, &type_info));
-  const OrtTensorTypeAndShapeInfo* tinfo = nullptr;
-  ORT_CXX_RETURN_ON_API_FAIL(ort_api.CastTypeInfoToTensorInfo(type_info, &tinfo));
-  ONNXTensorElementDataType dtype = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-  ORT_CXX_RETURN_ON_API_FAIL(ort_api.GetTensorElementType(tinfo, &dtype));
-
-  std::vector<uint8_t> raw;
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_tensor, raw));
-
-  if (dtype == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
-    RETURN_IF(raw.size() < sizeof(float), "QLinearMatMul: scale tensor has insufficient bytes for float32.");
-    memcpy(&out_scale, raw.data(), sizeof(float));
-  } else if (dtype == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
-    RETURN_IF(raw.size() < sizeof(uint16_t), "QLinearMatMul: scale tensor has insufficient bytes for float16.");
-    uint16_t fp16_bits = 0;
-    memcpy(&fp16_bits, raw.data(), sizeof(uint16_t));
-    out_scale = Ort::Float16_t::FromBits(fp16_bits).ToFloat();
-  } else if (dtype == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
-    RETURN_IF(raw.size() < sizeof(uint16_t), "QLinearMatMul: scale tensor has insufficient bytes for bfloat16.");
-    uint16_t bf16_bits = 0;
-    memcpy(&bf16_bits, raw.data(), sizeof(uint16_t));
-    out_scale = Ort::BFloat16_t::FromBits(bf16_bits).ToFloat();
-  } else {
-    return MAKE_EP_FAIL("QLinearMatMul: scale must be float32, float16, or bfloat16.");
-  }
-
+  std::vector<float> scales;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(scale_tensor, scales));
+  RETURN_IF(scales.empty(), "QLinearMatMul: scale initializer unpacked to empty vector.");
+  out_scale = scales[0];
   return Ort::Status();
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -385,17 +385,26 @@ class QnnModelWrapper {
 
     // Handle float scales
     if constexpr (std::is_same_v<T, float>) {
-      // Verify data type for float scales
-      RETURN_IF_NOT(onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
-                    "Expected scale initializer to be of type FLOAT");
-
       std::vector<uint8_t> initializer_bytes;
       RETURN_IF_ERROR(UnpackInitializerData(scale_tensor, initializer_bytes));
 
-      gsl::span<const float> src = gsl::make_span(reinterpret_cast<const float*>(initializer_bytes.data()),
-                                                  initializer_bytes.size() / sizeof(float));
-
-      scales.insert(scales.end(), src.begin(), src.end());
+      if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        gsl::span<const float> src = gsl::make_span(reinterpret_cast<const float*>(initializer_bytes.data()),
+                                                    initializer_bytes.size() / sizeof(float));
+        scales.insert(scales.end(), src.begin(), src.end());
+      } else if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+        // fp16 scale initializers are produced by quantization tools that match the scale dtype to
+        // the activation dtype (e.g. fp16 models). QNN quantization structs use float, so decode here.
+        gsl::span<const Ort::Float16_t> src =
+            gsl::make_span(reinterpret_cast<const Ort::Float16_t*>(initializer_bytes.data()),
+                           initializer_bytes.size() / sizeof(Ort::Float16_t));
+        scales.reserve(scales.size() + src.size());
+        for (const auto& fp16_val : src) {
+          scales.push_back(fp16_val.ToFloat());
+        }
+      } else {
+        return MAKE_EP_FAIL("Expected scale initializer to be of type FLOAT or FLOAT16");
+      }
     }
     // Handle uint8_t scales (for block quantization)
     else if constexpr (std::is_same_v<T, uint8_t>) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -388,16 +388,17 @@ class QnnModelWrapper {
       // Validate dtype up front so an unsupported type returns before any (potentially external)
       // initializer read, mirroring the early RETURN_IF_NOT guard in the uint8_t branch below.
       RETURN_IF_NOT(onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
-                        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
-                    "Expected scale initializer to be of type FLOAT or FLOAT16");
+                        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 ||
+                        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16,
+                    "Expected scale initializer to be of type FLOAT, FLOAT16, or BFLOAT16");
 
       std::vector<uint8_t> initializer_bytes;
       RETURN_IF_ERROR(UnpackInitializerData(scale_tensor, initializer_bytes));
 
       // Reinterpret the raw bytes as SrcT and append each element as a float. static_cast covers
-      // both float (identity) and Ort::Float16_t (via its float conversion operator). fp16 scale
-      // initializers are produced by quantization tools that match the scale dtype to the activation
-      // dtype (e.g. fp16 models); QNN quantization structs use float, so decode them here too.
+      // float (identity), Ort::Float16_t, and Ort::BFloat16_t (both have operator float()). fp16/bf16
+      // scale initializers are produced by quantization tools that match the scale dtype to the
+      // activation dtype (e.g. fp16 models); QNN quantization structs use float, so decode here.
       auto append_scales = [&scales, &initializer_bytes](auto src_type_tag) {
         using SrcT = decltype(src_type_tag);
         gsl::span<const SrcT> src = gsl::make_span(reinterpret_cast<const SrcT*>(initializer_bytes.data()),
@@ -410,8 +411,10 @@ class QnnModelWrapper {
 
       if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
         append_scales(float{});
-      } else {
+      } else if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
         append_scales(Ort::Float16_t{});
+      } else {
+        append_scales(Ort::BFloat16_t{});
       }
     }
     // Handle uint8_t scales (for block quantization)

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -385,25 +385,33 @@ class QnnModelWrapper {
 
     // Handle float scales
     if constexpr (std::is_same_v<T, float>) {
+      // Validate dtype up front so an unsupported type returns before any (potentially external)
+      // initializer read, mirroring the early RETURN_IF_NOT guard in the uint8_t branch below.
+      RETURN_IF_NOT(onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
+                        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16,
+                    "Expected scale initializer to be of type FLOAT or FLOAT16");
+
       std::vector<uint8_t> initializer_bytes;
       RETURN_IF_ERROR(UnpackInitializerData(scale_tensor, initializer_bytes));
 
-      if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
-        gsl::span<const float> src = gsl::make_span(reinterpret_cast<const float*>(initializer_bytes.data()),
-                                                    initializer_bytes.size() / sizeof(float));
-        scales.insert(scales.end(), src.begin(), src.end());
-      } else if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
-        // fp16 scale initializers are produced by quantization tools that match the scale dtype to
-        // the activation dtype (e.g. fp16 models). QNN quantization structs use float, so decode here.
-        gsl::span<const Ort::Float16_t> src =
-            gsl::make_span(reinterpret_cast<const Ort::Float16_t*>(initializer_bytes.data()),
-                           initializer_bytes.size() / sizeof(Ort::Float16_t));
+      // Reinterpret the raw bytes as SrcT and append each element as a float. static_cast covers
+      // both float (identity) and Ort::Float16_t (via its float conversion operator). fp16 scale
+      // initializers are produced by quantization tools that match the scale dtype to the activation
+      // dtype (e.g. fp16 models); QNN quantization structs use float, so decode them here too.
+      auto append_scales = [&scales, &initializer_bytes](auto src_type_tag) {
+        using SrcT = decltype(src_type_tag);
+        gsl::span<const SrcT> src = gsl::make_span(reinterpret_cast<const SrcT*>(initializer_bytes.data()),
+                                                   initializer_bytes.size() / sizeof(SrcT));
         scales.reserve(scales.size() + src.size());
-        for (const auto& fp16_val : src) {
-          scales.push_back(fp16_val.ToFloat());
+        for (const auto& val : src) {
+          scales.push_back(static_cast<float>(val));
         }
+      };
+
+      if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        append_scales(float{});
       } else {
-        return MAKE_EP_FAIL("Expected scale initializer to be of type FLOAT or FLOAT16");
+        append_scales(Ort::Float16_t{});
       }
     }
     // Handle uint8_t scales (for block quantization)

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -413,7 +413,9 @@ class QnnModelWrapper {
         append_scales(float{});
       } else if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
         append_scales(Ort::Float16_t{});
-      } else {
+      } else if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16) {
+        // Spelled out (rather than a bare else) so a future dtype added to the guard above
+        // without a matching branch here fails to compile instead of silently aliasing BFLOAT16.
         append_scales(Ort::BFloat16_t{});
       }
     }

--- a/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
+++ b/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
@@ -133,6 +133,19 @@ struct MockInitRegistry {
     }
     return Add(name, std::move(s));
   }
+  const OrtValueInfo* AddTensorFloat16(const std::string& name,
+                                       std::vector<int64_t> dims,
+                                       const std::vector<float>& data) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+    s.dims = std::move(dims);
+    s.raw_bytes.resize(data.size() * sizeof(Ort::Float16_t));
+    auto* dst = reinterpret_cast<Ort::Float16_t*>(s.raw_bytes.data());
+    for (size_t i = 0; i < data.size(); ++i) {
+      dst[i] = static_cast<Ort::Float16_t>(data[i]);
+    }
+    return Add(name, std::move(s));
+  }
   const OrtValueInfo* AddTensorUint8(const std::string& name,
                                      std::vector<int64_t> dims,
                                      const std::vector<uint8_t>& data) {

--- a/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
+++ b/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
@@ -146,6 +146,19 @@ struct MockInitRegistry {
     }
     return Add(name, std::move(s));
   }
+  const OrtValueInfo* AddTensorBFloat16(const std::string& name,
+                                        std::vector<int64_t> dims,
+                                        const std::vector<float>& data) {
+    MockInitSpec s;
+    s.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
+    s.dims = std::move(dims);
+    s.raw_bytes.resize(data.size() * sizeof(Ort::BFloat16_t));
+    auto* dst = reinterpret_cast<Ort::BFloat16_t*>(s.raw_bytes.data());
+    for (size_t i = 0; i < data.size(); ++i) {
+      dst[i] = static_cast<Ort::BFloat16_t>(data[i]);
+    }
+    return Add(name, std::move(s));
+  }
   const OrtValueInfo* AddTensorUint8(const std::string& name,
                                      std::vector<int64_t> dims,
                                      const std::vector<uint8_t>& data) {

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -902,8 +902,8 @@ TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_MultiZp_Return
 
 // =============================================================================
 // QnnModelWrapper::UnpackScales — header-defined template, exercised directly.
-// Covers the float-scale dtype dispatch: FLOAT (existing), FLOAT16 (new decode
-// path), and an unsupported dtype (error). fp16 scale initializers appear in
+// Covers the float-scale dtype dispatch: FLOAT (existing), FLOAT16 and BFLOAT16
+// (new decode paths), and an unsupported dtype (error). fp16/bf16 scale initializers appear in
 // fp16 models where the quantization tool matches the scale dtype to the
 // activation dtype; QNN quant structs store float, so UnpackScales decodes them.
 // =============================================================================
@@ -950,6 +950,15 @@ TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_BFloat16_DecodesToFloat) {
   EXPECT_FLOAT_EQ(scales[1], 0.25f);
 }
 
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_BFloat16_PerTensorScalar) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorBFloat16("scale", {}, {0.125f});
+  std::vector<float> scales;
+  ASSERT_TRUE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());
+  ASSERT_EQ(scales.size(), 1u);
+  EXPECT_FLOAT_EQ(scales[0], 0.125f);
+}
+
 TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_UnsupportedDtype_ReturnsError) {
   PerTensorIODefFixture fx;
   // INT32 is none of FLOAT / FLOAT16 / BFLOAT16 — must hit the up-front guard.
@@ -969,6 +978,19 @@ TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_NullTensor_ReturnsError) {
 TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Float16Scale_SetsScaleOffsetEncoding) {
   PerTensorIODefFixture fx;
   auto scale_vi = g_mock_init_reg.AddTensorFloat16("scale", {}, {0.5f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {}, {static_cast<uint8_t>(5)});
+  auto io_def = MakeIODef("in", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4}, scale_vi, zp_vi);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.5f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -5);
+}
+
+// Same integration path as the fp16 case above, for a bf16 per-tensor scale.
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_BFloat16Scale_SetsScaleOffsetEncoding) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorBFloat16("scale", {}, {0.5f});
   auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {}, {static_cast<uint8_t>(5)});
   auto io_def = MakeIODef("in", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4}, scale_vi, zp_vi);
   QnnQuantParamsWrapper q;

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -901,6 +901,73 @@ TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Int4_MultiZp_Return
 }
 
 // =============================================================================
+// QnnModelWrapper::UnpackScales — header-defined template, exercised directly.
+// Covers the float-scale dtype dispatch: FLOAT (existing), FLOAT16 (new decode
+// path), and an unsupported dtype (error). fp16 scale initializers appear in
+// fp16 models where the quantization tool matches the scale dtype to the
+// activation dtype; QNN quant structs store float, so UnpackScales decodes them.
+// =============================================================================
+
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_Float_DecodesAllValues) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat("scale", {3}, {0.1f, 0.2f, 0.3f});
+  std::vector<float> scales;
+  ASSERT_TRUE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());
+  ASSERT_EQ(scales.size(), 3u);
+  EXPECT_FLOAT_EQ(scales[0], 0.1f);
+  EXPECT_FLOAT_EQ(scales[1], 0.2f);
+  EXPECT_FLOAT_EQ(scales[2], 0.3f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_Float16_DecodesToFloat) {
+  PerTensorIODefFixture fx;
+  // 0.5 and 0.25 are exactly representable in fp16, so the round-trip is exact.
+  auto scale_vi = g_mock_init_reg.AddTensorFloat16("scale", {2}, {0.5f, 0.25f});
+  std::vector<float> scales;
+  ASSERT_TRUE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());
+  ASSERT_EQ(scales.size(), 2u);
+  EXPECT_FLOAT_EQ(scales[0], 0.5f);
+  EXPECT_FLOAT_EQ(scales[1], 0.25f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_Float16_PerTensorScalar) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat16("scale", {}, {0.125f});
+  std::vector<float> scales;
+  ASSERT_TRUE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());
+  ASSERT_EQ(scales.size(), 1u);
+  EXPECT_FLOAT_EQ(scales[0], 0.125f);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_UnsupportedDtype_ReturnsError) {
+  PerTensorIODefFixture fx;
+  // INT32 is neither FLOAT nor FLOAT16 — must fall into the error branch.
+  auto scale_vi = g_mock_init_reg.AddTensorInt32("scale", {1}, {1});
+  std::vector<float> scales;
+  EXPECT_FALSE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_NullTensor_ReturnsError) {
+  PerTensorIODefFixture fx;
+  std::vector<float> scales;
+  EXPECT_FALSE(fx.wrapper->UnpackScales(nullptr, scales).IsOK());
+}
+
+// Integration: a per-tensor fp16 scale flowing through Init(io_def) must reach
+// the SCALE_OFFSET encoding with the decoded float value.
+TEST(QnnUnit_QuantParamsWrapperTest, InitFromIODef_PerTensor_Float16Scale_SetsScaleOffsetEncoding) {
+  PerTensorIODefFixture fx;
+  auto scale_vi = g_mock_init_reg.AddTensorFloat16("scale", {}, {0.5f});
+  auto zp_vi = g_mock_init_reg.AddTensorUint8("zp", {}, {static_cast<uint8_t>(5)});
+  auto io_def = MakeIODef("in", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 3, 4, 4}, scale_vi, zp_vi);
+  QnnQuantParamsWrapper q;
+  ASSERT_TRUE(q.Init(*fx.wrapper, io_def).IsOK());
+  EXPECT_EQ(q.Get().quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(q.Get().scaleOffsetEncoding.scale, 0.5f);
+  EXPECT_EQ(q.Get().scaleOffsetEncoding.offset, -5);
+}
+
+// =============================================================================
 // Templated handlers — header-defined, NOT counted toward .cc coverage but
 // tested for behavioural completeness.
 //

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -939,9 +939,20 @@ TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_Float16_PerTensorScalar) {
   EXPECT_FLOAT_EQ(scales[0], 0.125f);
 }
 
+TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_BFloat16_DecodesToFloat) {
+  PerTensorIODefFixture fx;
+  // 0.5 and 0.25 are exactly representable in bf16 as well.
+  auto scale_vi = g_mock_init_reg.AddTensorBFloat16("scale", {2}, {0.5f, 0.25f});
+  std::vector<float> scales;
+  ASSERT_TRUE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());
+  ASSERT_EQ(scales.size(), 2u);
+  EXPECT_FLOAT_EQ(scales[0], 0.5f);
+  EXPECT_FLOAT_EQ(scales[1], 0.25f);
+}
+
 TEST(QnnUnit_QuantParamsWrapperTest, UnpackScales_UnsupportedDtype_ReturnsError) {
   PerTensorIODefFixture fx;
-  // INT32 is neither FLOAT nor FLOAT16 — must fall into the error branch.
+  // INT32 is none of FLOAT / FLOAT16 / BFLOAT16 — must hit the up-front guard.
   auto scale_vi = g_mock_init_reg.AddTensorInt32("scale", {1}, {1});
   std::vector<float> scales;
   EXPECT_FALSE(fx.wrapper->UnpackScales(scale_vi, scales).IsOK());


### PR DESCRIPTION
### Description

`QnnModelWrapper::UnpackScales` previously accepted only `FLOAT` scale initializers. This change adds `FLOAT16` and `BFLOAT16` decode branches: values are read as `Ort::Float16_t` / `Ort::BFloat16_t` and converted to `float` (the type QNN's quantization structs use) before being appended to the output. A dtype guard is placed before `UnpackInitializerData` so unsupported types return early without performing any initializer I/O, matching the existing guard pattern in the `uint8_t` branch.

`QLinearMatMulOpBuilder::ReadScaleAsFloat32`, which previously duplicated the same float/fp16/bf16 decode logic inline, is refactored to delegate to `UnpackScales`.

Unit tests are added (`onnxruntime_provider_test`, run under the `coverage-linux-x86_64` CI job) covering:
- `FLOAT` decode (regression)
- `FLOAT16` decode — per-axis and per-tensor scalar
- `BFLOAT16` decode — per-axis
- unsupported dtype → early error (no I/O performed)
- null tensor → error
- per-tensor `FLOAT16` scale flowing through `QnnQuantParamsWrapper::Init` to a `SCALE_OFFSET` encoding

`AddTensorFloat16` and `AddTensorBFloat16` helpers are added to the test-only `mock_init_registry.h`.

### Motivation and Context

In fp16 models, quantization tooling matches the scale initializer's dtype to the activation dtype, so the `scale` input of `QuantizeLinear` / `DequantizeLinear` (and the weight/bias scales consumed by Conv/Gemm/MatMul builders) is emitted as `FLOAT16` rather than `FLOAT`. The old code rejected these initializers, forcing the affected Q/DQ node onto the CPU EP. This had a cascading effect — downstream ops that depend on the dequantized tensor's shape then failed with `Cannot get shape`. QNN itself supports these scales (its quantization param structs store `scale` as `float`); the gap was purely a missing decode branch on the ONNX side.

`BFLOAT16` support is added at the same time for completeness, matching the dtype set already handled by `QLinearMatMulOpBuilder::ReadScaleAsFloat32`.