### PR TITLE
[QNN EP] Fix if_test.cc to use new RunQnnModelTest EPVerificationParams signature

### DIFF
--- a/onnxruntime/test/providers/qnn/if_test.cc
+++ b/onnxruntime/test/providers/qnn/if_test.cc
@@ -383,8 +383,7 @@ static void RunIfTest(const GetTestModelFn& model_fn,
   RunQnnModelTest(model_fn,
                   provider_options,
                   opset,
-                  expected_ep_assignment,
-                  fp32_abs_err);
+                  EPVerificationParams{expected_ep_assignment, ElementwiseAbsoluteVerifier(fp32_abs_err)});
 }
 
 //


### PR DESCRIPTION
### Description
`if_test.cc` failed to compile (linux-aarch64, android, windows-arm64ec) after #504 changed `RunQnnModelTest`'s 4th arg to a single `const EPVerificationParams&`, while #409 was authored against the old signature and merged in parallel. 

Fix wraps the args as
  `EPVerificationParams{expected_ep_assignment, ElementwiseAbsoluteVerifier(fp32_abs_err)}`, matching every other caller.
