### PR TITLE
Add convert for mixed-bitwidth quantized conv

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -3,6 +3,8 @@
 
 #include <gsl/gsl>
 
+#include <cmath>
+
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
@@ -1061,6 +1063,41 @@ Ort::Status ConvOpBuilder::ProcessConv1DInputs(QnnModelWrapper& qnn_model_wrappe
   return Ort::Status();
 }
 
+// Re-encode a per-tensor quantization param at a different bitwidth, preserving the dequantized
+// range. The source encoding (scale, offset, orig_bitwidth) represents the range
+// [scale*offset, scale*(2^orig_bitwidth - 1 + offset)]; this writes a fresh per-tensor encoding
+// covering the same range at new_bitwidth. Direction-agnostic: new_bitwidth may be larger
+// (widen) or smaller (narrow) than orig_bitwidth.
+//
+// Used to build the intermediate output of a mixed-bitwidth quantized Conv whose downstream
+// consumer expects a different bitwidth (e.g. uint16 Conv output feeding a uint8 KV-cache),
+// with a Convert bridging the two encodings.
+//
+// Both bitwidths must be in (0, 32] so `(1 << bw) - 1` fits in uint64 and the result fits in
+// float; `src` must be a per-tensor encoding.
+static Ort::Status RequantizePerTensorAtBitwidth(const QnnQuantParamsWrapper& src,
+                                                 size_t orig_bitwidth,
+                                                 size_t new_bitwidth,
+                                                 /*out*/ QnnQuantParamsWrapper& out) {
+  RETURN_IF_NOT(orig_bitwidth > 0 && orig_bitwidth <= 32 &&
+                    new_bitwidth > 0 && new_bitwidth <= 32,
+                "RequantizePerTensorAtBitwidth: bitwidth must be in (0, 32].");
+  float src_scale = 0.0f;
+  int32_t src_offset = 0;
+  RETURN_IF_ERROR(src.GetPerTensorScaleOffset(src_scale, src_offset));
+  const double q_max_orig = static_cast<double>((uint64_t{1} << orig_bitwidth) - 1);
+  const double f_min = static_cast<double>(src_scale) * static_cast<double>(src_offset);
+  const double f_max = static_cast<double>(src_scale) *
+                       (q_max_orig + static_cast<double>(src_offset));
+  const double q_max_new = static_cast<double>((uint64_t{1} << new_bitwidth) - 1);
+  const float new_scale = static_cast<float>((f_max - f_min) / q_max_new);
+  const int32_t new_offset = (new_scale != 0.0f)
+                                 ? static_cast<int32_t>(std::lround(f_min / new_scale))
+                                 : 0;
+  out = QnnQuantParamsWrapper(new_scale, new_offset);
+  return Ort::Status();
+}
+
 Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                        const OrtNodeUnit& node_unit,
                                                        std::vector<std::string>&& input_names,
@@ -1306,6 +1343,18 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   const auto& output_name = outputs[0].name;
   if (is_1d_conv) {
+    // The 1D path emits Conv2d → Reshape with no Convert insertion, so it does
+    // not support mixed-bitwidth quantized I/O. The selector only loosens the
+    // matched-dtype requirement for the uint8<->uint16 case that the 2D/3D
+    // path handles below; fail loudly here if a 1D Conv reaches this branch
+    // with mismatched bitwidths, rather than silently emitting an HTP-invalid
+    // Conv2d.
+    if (is_quantized_tensor && qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[0])) {
+      const Qnn_DataType_t input_qnn_data_type_1d =
+          qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]).GetTensorDataType();
+      RETURN_IF(input_qnn_data_type_1d != qnn_data_type,
+                "QNN EP: 1D quantized Conv with mismatched input/output bitwidth is not supported.");
+    }
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
     std::vector<uint32_t> output_shape_2d = {
         output_shape[0],  // N
@@ -1340,6 +1389,28 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
     Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
+    // Detect a quantized Conv whose input and output activation use different unsigned
+    // bitwidths (e.g. uint16 in → uint8 out when the output feeds an 8-bit KV-cache). HTP's
+    // Conv2d itself requires matched I/O bitwidth, so we decompose into:
+    //   Conv (output @ input_bitwidth, output range re-encoded at input_bitwidth)
+    //     → Convert → output (at the user-authored output bitwidth/encoding)
+    // This mirrors the legacy QAIRT converter's lowering for the same pattern. The selector
+    // (qnn_ep_utils.cc OrtConvNodeGroupSelector) admits only uint8<->uint16 mismatch, which
+    // matches the predicate below.
+    Qnn_DataType_t input_qnn_data_type = qnn_data_type;
+    if (is_quantized_tensor && qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[0])) {
+      input_qnn_data_type =
+          qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]).GetTensorDataType();
+    }
+    const bool is_mixed_bitwidth_quantized =
+        is_quantized_tensor && !is_bq_conv &&
+        (input_qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+         input_qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+        (qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
+         qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
+        input_qnn_data_type != qnn_data_type &&
+        output_quantize_param.IsPerTensor(/*include_bw*/ true);
+
     if (is_bq_conv && is_quantized_tensor) {
       // BQ Conv outputs FP16; downstream QDQ expects INT16.
       // Emit: Conv (FP16 output) → Quantize (FP16 → INT16 quantized output).
@@ -1372,6 +1443,39 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                         QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
                         {conv_fp16_out}, {output_name}, {}, do_op_validation),
                     "Failed to add FP16→INT16 Quantize node for BQ Conv output.");
+    } else if (is_mixed_bitwidth_quantized) {
+      const size_t input_bw = utils::GetElementSizeByType(input_qnn_data_type) * 8;
+      const size_t output_bw = utils::GetElementSizeByType(qnn_data_type) * 8;
+      QnnQuantParamsWrapper widened_qp;
+      RETURN_IF_ERROR(RequantizePerTensorAtBitwidth(output_quantize_param, output_bw, input_bw,
+                                                    widened_qp));
+
+      const std::string conv_widened_out =
+          utils::UniqueNameGenerator().New(output_name, "_widened");
+      QnnTensorWrapper widened_out_wrapper(conv_widened_out, QNN_TENSOR_TYPE_NATIVE,
+                                           input_qnn_data_type, std::move(widened_qp),
+                                           std::vector<uint32_t>(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(widened_out_wrapper)),
+                    "Failed to add widened Conv output tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                    output_node_type,
+                                                    std::move(input_names),
+                                                    {conv_widened_out},
+                                                    std::move(param_tensor_names),
+                                                    do_op_validation),
+                    "Failed to add mixed-bitwidth Conv node.");
+
+      QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
+                                            std::move(output_quantize_param),
+                                            std::move(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                    "Failed to add narrowed Conv output tensor.");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                        utils::UniqueNameGenerator().New(node_unit, QNN_OP_CONVERT),
+                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CONVERT,
+                        {conv_widened_out}, {output_name}, {}, do_op_validation),
+                    "Failed to add Convert node bridging mixed-bitwidth Conv output.");
     } else {
       QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
                                             std::move(output_quantize_param), std::move(output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -1063,18 +1063,12 @@ Ort::Status ConvOpBuilder::ProcessConv1DInputs(QnnModelWrapper& qnn_model_wrappe
   return Ort::Status();
 }
 
-// Re-encode a per-tensor quantization param at a different bitwidth, preserving the dequantized
-// range. The source encoding (scale, offset, orig_bitwidth) represents the range
-// [scale*offset, scale*(2^orig_bitwidth - 1 + offset)]; this writes a fresh per-tensor encoding
-// covering the same range at new_bitwidth. Direction-agnostic: new_bitwidth may be larger
-// (widen) or smaller (narrow) than orig_bitwidth.
-//
-// Used to build the intermediate output of a mixed-bitwidth quantized Conv whose downstream
-// consumer expects a different bitwidth (e.g. uint16 Conv output feeding a uint8 KV-cache),
-// with a Convert bridging the two encodings.
-//
-// Both bitwidths must be in (0, 32] so `(1 << bw) - 1` fits in uint64 and the result fits in
-// float; `src` must be a per-tensor encoding.
+// Re-encode a per-tensor quantization param at `new_bitwidth` as a SYMMETRIC encoding (zero-point
+// at the unsigned mid-point) whose range covers the source's dequantized range
+// [scale*offset, scale*(2^orig_bitwidth - 1 + offset)]. A symmetric intermediate matches what the
+// legacy QAIRT converter emits for the widened Conv output and is what HTP's Conv2d expects; an
+// asymmetric intermediate is rejected at graph validation (error 3110).
+// Both bitwidths must be in (0, 32]; `src` must be a per-tensor encoding.
 static Ort::Status RequantizePerTensorAtBitwidth(const QnnQuantParamsWrapper& src,
                                                  size_t orig_bitwidth,
                                                  size_t new_bitwidth,
@@ -1089,11 +1083,12 @@ static Ort::Status RequantizePerTensorAtBitwidth(const QnnQuantParamsWrapper& sr
   const double f_min = static_cast<double>(src_scale) * static_cast<double>(src_offset);
   const double f_max = static_cast<double>(src_scale) *
                        (q_max_orig + static_cast<double>(src_offset));
-  const double q_max_new = static_cast<double>((uint64_t{1} << new_bitwidth) - 1);
-  const float new_scale = static_cast<float>((f_max - f_min) / q_max_new);
-  const int32_t new_offset = (new_scale != 0.0f)
-                                 ? static_cast<int32_t>(std::lround(f_min / new_scale))
-                                 : 0;
+  // Symmetric encoding: cover [-A, +A] where A bounds the source range, with zero-point at the
+  // unsigned mid-point (-2^(new_bw-1)). scale = A / 2^(new_bw-1).
+  const double abs_max = std::max(std::abs(f_min), std::abs(f_max));
+  const double half_levels = static_cast<double>(uint64_t{1} << (new_bitwidth - 1));
+  const float new_scale = static_cast<float>(abs_max / half_levels);
+  const int32_t new_offset = -static_cast<int32_t>(half_levels);
   out = QnnQuantParamsWrapper(new_scale, new_offset);
   return Ort::Status();
 }
@@ -1343,16 +1338,12 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
 
   const auto& output_name = outputs[0].name;
   if (is_1d_conv) {
-    // The 1D path emits Conv2d → Reshape with no Convert insertion, so it does
-    // not support mixed-bitwidth quantized I/O. The selector only loosens the
-    // matched-dtype requirement for the uint8<->uint16 case that the 2D/3D
-    // path handles below; fail loudly here if a 1D Conv reaches this branch
-    // with mismatched bitwidths, rather than silently emitting an HTP-invalid
-    // Conv2d.
-    if (is_quantized_tensor && qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[0])) {
-      const Qnn_DataType_t input_qnn_data_type_1d =
-          qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]).GetTensorDataType();
-      RETURN_IF(input_qnn_data_type_1d != qnn_data_type,
+    // The 1D path (Conv2d → Reshape) has no Convert insertion, so reject mixed-bitwidth I/O
+    // here rather than silently emitting an HTP-invalid Conv2d.
+    if (is_quantized_tensor) {
+      TensorInfo input0_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_0, input0_info));
+      RETURN_IF(input0_info.qnn_data_type != qnn_data_type,
                 "QNN EP: 1D quantized Conv with mismatched input/output bitwidth is not supported.");
     }
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
@@ -1389,19 +1380,14 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
     Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-    // Detect a quantized Conv whose input and output activation use different unsigned
-    // bitwidths (e.g. uint16 in → uint8 out when the output feeds an 8-bit KV-cache). HTP's
-    // Conv2d itself requires matched I/O bitwidth, so we decompose into:
-    //   Conv (output @ input_bitwidth, output range re-encoded at input_bitwidth)
-    //     → Convert → output (at the user-authored output bitwidth/encoding)
-    // This mirrors the legacy QAIRT converter's lowering for the same pattern. The selector
-    // (qnn_ep_utils.cc OrtConvNodeGroupSelector) admits only uint8<->uint16 mismatch, which
-    // matches the predicate below.
-    Qnn_DataType_t input_qnn_data_type = qnn_data_type;
-    if (is_quantized_tensor && qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[0])) {
-      input_qnn_data_type =
-          qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]).GetTensorDataType();
-    }
+    // Quantized Conv whose input/output activations differ in unsigned bitwidth (e.g. u16 in →
+    // u8 out feeding a KV-cache). Decomposed as Conv(@input bw) → Convert → output(@output bw)
+    // since HTP Conv2d requires matched I/O bitwidth. Predicate matches the selector gate.
+    // Read the input dtype from the node unit (not the tensor wrapper, which is absent during
+    // op validation in GetCapability).
+    TensorInfo input0_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_0, input0_info));
+    const Qnn_DataType_t input_qnn_data_type = input0_info.qnn_data_type;
     const bool is_mixed_bitwidth_quantized =
         is_quantized_tensor && !is_bq_conv &&
         (input_qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -862,12 +862,8 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     return false;
   }
 
-  // Input and output activation dtypes must match, except for the specific
-  // unsigned uint8<->uint16 case that conv_op_builder lowers as
-  // Conv@input_bw + Convert(input_bw -> output_bw). HTP's Conv2d itself requires
-  // matched I/O bitwidth; any other mismatch combination (signed types,
-  // per-channel output, etc.) has no op-builder decomposition and would fail
-  // at HTP graph finalize, so reject it here.
+  // I/O activation dtypes must match, except for unsigned uint8<->uint16 which conv_op_builder
+  // lowers as Conv + Convert (HTP Conv2d itself requires matched I/O bitwidth).
   const auto in_dt = dt_input.value();
   const auto out_dt = dt_output.value();
   const bool is_uint8_uint16_mixed =

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -854,7 +854,6 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     return false;
   }
 
-  // Input and output types need to be same
   auto dt_input = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
   auto dt_weight = GetNodeInputDataType(dq_nodes[1], ort_api, 0);
   auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
@@ -863,7 +862,20 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     return false;
   }
 
-  if (dt_input.value() != dt_output.value()) {
+  // Input and output activation dtypes must match, except for the specific
+  // unsigned uint8<->uint16 case that conv_op_builder lowers as
+  // Conv@input_bw + Convert(input_bw -> output_bw). HTP's Conv2d itself requires
+  // matched I/O bitwidth; any other mismatch combination (signed types,
+  // per-channel output, etc.) has no op-builder decomposition and would fail
+  // at HTP graph finalize, so reject it here.
+  const auto in_dt = dt_input.value();
+  const auto out_dt = dt_output.value();
+  const bool is_uint8_uint16_mixed =
+      (in_dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8 &&
+       out_dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16) ||
+      (in_dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16 &&
+       out_dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+  if (in_dt != out_dt && !is_uint8_uint16_mixed) {
     return false;
   }
 
@@ -884,8 +896,9 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     }
   }
 
-  // 16-bit int types must be explicitly allowed
-  if (!allow_16bit_ && (Is16BitIntType(dt_input.value()) || Is16BitIntType(dt_weight.value()))) {
+  // 16-bit int types must be explicitly allowed.
+  if (!allow_16bit_ && (Is16BitIntType(dt_input.value()) || Is16BitIntType(dt_weight.value()) ||
+                        Is16BitIntType(dt_output.value()))) {
     return false;
   }
 

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3,9 +3,13 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
 #include <optional>
 #include <string>
 
+#include <gsl/gsl>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 
 #include "gtest/gtest.h"
@@ -3428,6 +3432,112 @@ TEST_F(QnnHTPBackendTests, ConvBQ_U16UInt8_1x1_BlockSize4) {
                   /*opset=*/21,
                   ExpectedEPNodeAssignment::All,
                   /*fp32_abs_err=*/2e-2f);
+}
+
+// Mixed-bitwidth quantized Conv lowering: when input activation Q and output activation Q
+// use different unsigned bitwidths (e.g. u16 in / u8 out, as in Llama v_proj heads whose output
+// feeds an 8-bit KV-cache), the EP must emit Conv@input_bw → Convert → output@output_bw because
+// HTP Conv2d itself requires matched I/O bitwidth.
+//
+// Mirrors the exact Llama-3.2 v_proj SHA-head pattern: u16 activation in, per-channel int4
+// constant weight, u8 activation out.
+static GetTestQDQModelFn<uint8_t> BuildMixedBitwidthConvU16InU8OutPerChannelInt4Weight(
+    const TestInputDef<float>& input_def,
+    const TestInputDef<float>& weight_def,
+    int64_t weight_quant_axis,
+    const std::vector<int64_t>& strides,
+    const std::vector<int64_t>& pads,
+    const std::vector<int64_t>& dilations,
+    int64_t group) {
+  return [input_def, weight_def, weight_quant_axis, strides, pads, dilations, group](
+             ModelTestBuilder& builder,
+             std::vector<QuantParams<uint8_t>>& output_qparams) {
+    std::vector<std::string> conv_input_names;
+
+    // input -> Q(u16) -> DQ -> (conv input)
+    MakeTestInput<float>(builder, "input", input_def);
+    const QuantParams<uint16_t> input_qparams = GetTestInputQuantParams<uint16_t>(input_def);
+    conv_input_names.push_back(AddQDQNodePair<uint16_t>(builder, "qdq_input", "input",
+                                                        input_qparams.scale, input_qparams.zero_point));
+
+    // weight: per-channel int4 quantized constant initializer -> DQ -> (conv weight)
+    QNN_ASSERT(weight_def.IsInitializer() && weight_def.IsRawData());
+    const auto weight_shape = weight_def.GetShape();
+    int64_t pos_weight_axis = weight_quant_axis < 0
+                                  ? weight_quant_axis + static_cast<int64_t>(weight_shape.size())
+                                  : weight_quant_axis;
+    std::vector<float> weight_scales;
+    std::vector<Int4x2> weight_zps;
+    GetTestInputQuantParamsPerChannel<Int4x2>(weight_def, weight_scales, weight_zps,
+                                              static_cast<size_t>(pos_weight_axis), true);
+    std::vector<Int4x2> q_weight(Int4x2::CalcNumInt4Pairs(SizeOfShape(weight_shape)));
+    QuantizeValues<float, Int4x2>(weight_def.GetRawData(), q_weight, weight_shape, weight_scales,
+                                  weight_zps, pos_weight_axis);
+    builder.MakeInitializer<Int4x2>("weights_q", weight_shape, q_weight);
+    std::vector<ONNX_NAMESPACE::AttributeProto> wdq_attrs{
+        builder.MakeScalarAttribute("axis", weight_quant_axis)};
+    builder.AddDequantizeLinearNode("WeightDQ", "weights_q", weight_scales, weight_zps, "weights_dq",
+                                    wdq_attrs, /*use_ms_domain=*/false);
+    conv_input_names.push_back("weights_dq");
+
+    // Conv
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs{
+        builder.MakeStringAttribute("auto_pad", "NOTSET"),
+        builder.MakeScalarAttribute("group", group),
+        builder.MakeIntsAttribute("pads", pads),
+        builder.MakeIntsAttribute("strides", strides),
+        builder.MakeIntsAttribute("dilations", dilations),
+    };
+    builder.AddNode("Conv", "Conv", conv_input_names, {"conv_out"}, kOnnxDomain, conv_attrs);
+
+    // conv_out -> Q(u8) -> DQ -> graph output. The Q here uses the NARROWER (u8) bitwidth,
+    // unlike the input's u16 — this is what triggers the mixed-bitwidth Conv + Convert split.
+    AddQDQNodePairWithOutputAsGraphOutput<uint8_t>(builder, "qdq_out", "conv_out",
+                                                   output_qparams[0].scale,
+                                                   output_qparams[0].zero_point);
+  };
+}
+
+// End-to-end test for the mixed-bitwidth Conv lowering. Asserts (1) the EP keeps the node on
+// HTP, (2) accuracy is within QDQ tolerance vs the f32 reference (i.e. the synthesized Convert
+// preserves semantics), and (3) the lowered QNN graph contains exactly one Convert (the bridge).
+TEST_F(QnnHTPBackendTests, ConvU16InU8OutPerChannelInt4WeightMixedBitwidthSplit) {
+  namespace fs = std::filesystem;
+
+  // u16 activation in (range covers a Llama-like activation), per-channel int4 weight,
+  // u8 activation out (range matches a Llama KV-cache value).
+  const std::vector<int64_t> input_shape = {1, 4, 4, 4};
+  const std::vector<int64_t> weight_shape = {8, 4, 1, 1};
+  TestInputDef<float> input_def(input_shape, /*is_initializer=*/false,
+                                GetFloatDataInRange(-3.5f, 4.25f, SizeOfShape(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, /*is_initializer=*/true,
+                                 GetFloatDataInRange(-0.05f, 0.05f, SizeOfShape(weight_shape)));
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  const auto* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+  const fs::path graph_dir = fs::temp_directory_path() /
+                             (std::string("ConvMixedBitwidthQnnGraph_") + test_info->name());
+  fs::remove_all(graph_dir);
+  fs::create_directories(graph_dir);
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = graph_dir.string();
+  auto cleanup = gsl::finally([&]() { fs::remove_all(graph_dir); });
+
+  TestQDQModelAccuracy<uint8_t>(
+      BuildF32ConvTestCase("Conv", input_def, weight_def, TestInputDef<float>(),
+                           /*strides=*/{1, 1}, /*pads=*/{0, 0, 0, 0}, /*dilations=*/{1, 1},
+                           /*group=*/1, "NOTSET"),
+      BuildMixedBitwidthConvU16InU8OutPerChannelInt4Weight(
+          input_def, weight_def, /*weight_quant_axis=*/0,
+          /*strides=*/{1, 1}, /*pads=*/{0, 0, 0, 0}, /*dilations=*/{1, 1}, /*group=*/1),
+      provider_options, /*opset=*/21, ExpectedEPNodeAssignment::All);
+
+  if (!::testing::Test::IsSkipped()) {
+    AssertOpInQnnGraph(graph_dir, "Convert", /*count=*/1);
+  }
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
## Summary

QNN HTP `Conv2d` requires matched input/output bitwidth. A quantized Conv whose output Q has a different bitwidth than the input (e.g. uint16 activations feeding a uint8 KV-cache, as in Llama-3.2 v_proj heads) was rejected by `OrtConvNodeGroupSelector` and silently fell back to a Conv with float weight, producing UNDEFINED weight encoding and an HTP finalize failure.

Two coordinated changes mirror the QAIRT converter's lowering:

- **`qnn_ep_utils.cc OrtConvNodeGroupSelector::Check`** — allow input/output dtype mismatch only for the unsigned uint8 <-> uint16 case the op-builder can decompose; reject all other mismatches. Extend the 16-bit allow guard to cover the output dtype.
- **`conv_op_builder.cc ProcessAttributesAndOutputs`** — for the mixed-bitwidth case emit `Conv (output @ input bitwidth, output range re-encoded at input bitwidth) -> QNN_OP_CONVERT -> output (at the user-authored bitwidth/encoding)`. The matched-bitwidth path is unchanged. The 1D Conv path (no Convert insertion there) explicitly rejects mixed-bitwidth I/O.

Adds a static `RequantizePerTensorAtBitwidth` helper that preserves the floating-point range across bitwidths.
