### PR TITLE
Add unit tests for qnn_ep_utils.cc 

### DIFF
--- a/onnxruntime/test/providers/qnn/unit/README.md
+++ b/onnxruntime/test/providers/qnn/unit/README.md
@@ -24,6 +24,11 @@ All test code in this directory is guarded by `#if !defined(ORT_MINIMAL_BUILD) &
 |---|---|---|
 | `qnn_def_test.cc` | `QnnUnit_DefTest` | `builder/qnn_def.cc` |
 | `qnn_model_wrapper_test.cc` | `QnnUnit_ModelWrapperTest` | `builder/qnn_model_wrapper.cc` |
+| `qnn_quant_params_wrapper_test.cc` | `QnnUnit_QuantParamsWrapperTest` | `builder/qnn_quant_params_wrapper.cc` |
+| `qnn_model_test.cc` | `QnnUnit_ModelTest` | `builder/qnn_model.cc` |
+| `qnn_utils_test.cc` | `QnnUnit_UtilsTest` | `builder/qnn_utils.cc` |
+| `qnn_ep_utils_test.cc` | `QnnUnit_EpUtilsTest` | `qnn_ep_utils.cc` |
+| `ort_api_test.cc` | `QnnUnit_OrtApiTest` | `ort_api.cc` |
 
 ## Benefits
 
@@ -100,6 +105,38 @@ Pick the lowest-cost layer that lets you write the test. Cost increases top to b
 | Needs a real `Qnn_BackendHandle_t` (e.g., `backendValidateOpConfig`) | Use `QnnRealHtpBackendContext`: `dlopen` `libQnnHtp.so` + `backendCreate`. **Does not create a QNN context/session** — the validation path does not need one. Use `GTEST_SKIP()` when the SDK is unavailable |
 | Needs a real QNN context/session, graph operations | **No helper today.** Please raise it — we need a fixture-shared session (avoid rebuilding per test) before adding such tests |
 | Needs a real `OrtGraph` or `Ort::Logger` object | **Not currently possible** — public ORT headers are insufficient and private ORT headers are forbidden. Redesign the test to remove this dependency |
+
+**Fake graph infrastructure (`qnn_fake_ort_graph.h`)**
+
+ORT's graph types (`OrtGraph`, `OrtNode`, `OrtValueInfo`, etc.) are opaque C handles — the EP
+never dereferences these pointers directly, only passes them to `OrtApi` function pointers.
+This means tests can substitute lightweight POD structs (`FakeNode`, `FakeValueInfo`,
+`FakeGraph`, `FakeOrtValue`) and install stub lambdas that cast back to the fake type:
+
+```
+Test:  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&input}, {}};
+       passes dq.AsNode() [= reinterpret_cast<const OrtNode*>(&dq)] to EP code
+         ↓
+EP:    api.Node_GetOperatorType(node, &out)   // EP never dereferences `node`
+         ↓
+Stub:  reinterpret_cast<const FakeNode*>(node)->op_type  →  "DequantizeLinear"
+```
+
+The pointer round-trips safely because only the original type (`FakeNode*`) is used to
+read memory — the opaque handle is just a passthrough token.
+
+| Type | Acts as | Key detail |
+|------|---------|------------|
+| `FakeValueInfo` | `OrtValueInfo*`, `OrtTypeInfo*`, `OrtTensorTypeAndShapeInfo*` | One struct serves three handle roles |
+| `FakeOrtValue` | `OrtValue*`, `OrtTensorTypeAndShapeInfo*` | First 3 fields layout-compatible with `FakeValueInfo` (verified by `static_assert`) |
+| `FakeNode` | `OrtNode*` | Holds input/output `FakeValueInfo*` vectors |
+| `FakeGraph` | `OrtGraph*` | Owns nodes; observes inputs/outputs/initializers |
+
+`InstallFakeGraphApiStubs(api)` installs all stubs at once. Override individual stubs
+afterward for test-specific behaviour (e.g., `api.ValueInfo_GetValueProducer = ...`).
+
+For tests that use `Ort::ConstNode` wrappers (which call `Ort::GetApi()` internally),
+wrap with `OrtGlobalApiOverride` from `qnn_unit_test_utils.h` to redirect the global API.
 
 **Constraints — common traps to avoid**
 - **No private ORT headers.** Only the public C API (`onnxruntime_c_api.h`) and the EP's own headers under `core/providers/qnn/` are allowed. ORT's internal source tree (`core/graph/...`, `core/framework/...`) and ORT's internal test infrastructure (`test/util/include/...`) are off-limits.

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -1739,4 +1739,155 @@ TEST(QnnUnit_EpUtilsTest, MatMul_QLinearCheckQDQNodesFails_ReturnsFalse) {
                          {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
 }
 
+// =============================================================================
+// Additional selector Check() branches — targeted coverage for
+// qnn_ep_utils.cc L736/1037/1065/1093/1192/1206/1267
+// =============================================================================
+
+// OrtGemmNodeGroupSelector: dq_nodes.size() < 2 → returns false (L1037).
+// CheckQDQNodes passes because is_empty_q_nodes_allowed=true and node has 1 input.
+TEST(QnnUnit_EpUtilsTest, Gemm_RejectsFewerThan2Dq) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"a", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_a{"dq_a", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"gemm", "Gemm", "", 11, {&dummy}, {&main_out}};
+
+  OrtGemmNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_a.AsNode()}, {}));
+}
+
+// OrtGemmNodeGroupSelector: IsDisallowedType(dt_A|dt_B, allow_16bit_, allow_4bit_)
+// gate → returns false (L1065). Both inputs UINT16 with allow_16bit=false.
+TEST(QnnUnit_EpUtilsTest, Gemm_Rejects16BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16, {}};
+  FakeNode dq_a{"dq_a", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_b{"dq_b", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"gemm", "Gemm", "", 11, {&dummy, &dummy}, {&main_out}};
+
+  OrtGemmNodeGroupSelector sel(/*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_a.AsNode(), dq_b.AsNode()}, {}));
+}
+
+// OrtWhereNodeGroupSelector: CheckQDQNodes with num_dq_inputs=2 fails because
+// dq_nodes.size()=3 → returns false (L1093).
+TEST(QnnUnit_EpUtilsTest, Where_RejectsWrongDqCount) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq3{"dq3", "DequantizeLinear", "", 13, {&dq_in}, {}};  // extra
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"where", "Where", "", 9, {&dummy, &dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtWhereNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode(), dq3.AsNode()}, {q.AsNode()}));
+}
+
+// OrtBatchNormalizationNodeGroupSelector: CheckQDQNodes fails because
+// num_outputs (2) != q_nodes.size() (1) → returns false (L1192).
+TEST(QnnUnit_EpUtilsTest, BatchNorm_CheckQDQNodesFails_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_scale{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out1{"y1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo main_out2{"y2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};  // extra output
+  FakeNode main_node{"bn", "BatchNormalization", "", 15, {&dummy, &dummy}, {&main_out1, &main_out2}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};  // only 1 Q for 2 outputs
+
+  OrtBatchNormalizationNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
+}
+
+// OrtBatchNormalizationNodeGroupSelector: !has_float_output path,
+// dt_output.value() != dt_input.value() → returns false (L1206).
+TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInputOutputTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_data_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo dq_scale_in{"s", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_data_in}, {}};
+  FakeNode dq_scale{"dq1", "DequantizeLinear", "", 13, {&dq_scale_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"bn", "BatchNormalization", "", 15, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // ≠ UINT8 input
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtBatchNormalizationNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
+}
+
+// OrtTopKNodeGroupSelector: dt_input.value() != dt_output.value() → returns
+// false (L1267). Requires CanCreateNodeGroup to pass first.
+TEST(QnnUnit_EpUtilsTest, TopK_RejectsInputOutputTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"topk", "TopK", "", 11, {&dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // ≠ UINT8 input
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtTopKNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq.AsNode()}, {q.AsNode()}));
+}
+
+// File-scope handle for the Clip producer test stub — non-capturing lambdas
+// cannot bind to a specific DQ node, so we thread it through a static.
+namespace {
+const OrtNode* g_clip_producer_dq = nullptr;
+OrtStatus* FakeClipProducerStub(const OrtValueInfo* /*value_info*/,
+                                const OrtNode** producer,
+                                size_t* output_index) noexcept {
+  if (producer) *producer = g_clip_producer_dq;
+  if (output_index) *output_index = 0;
+  return nullptr;
+}
+}  // namespace
+
+// OrtClipNodeGroupSelector: CheckQuantTypes fails when input/output types
+// are UINT16 and allow_16bit_=false → returns false (L736).
+// Reaches L736 by installing a producer stub that returns the DQ node so
+// the L718 producer==nullptr guard passes.
+TEST(QnnUnit_EpUtilsTest, Clip_Rejects16BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16, {}};
+  FakeValueInfo clip_in{"ci", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"clip", "Clip", "", 11, {&clip_in}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+
+  g_clip_producer_dq = dq.AsNode();
+  ctx.api.ValueInfo_GetValueProducer = &FakeClipProducerStub;
+
+  // Ort::ConstNode(producer).GetOperatorType() uses the global api.
+  OrtGlobalApiOverride global_guard(&ctx.api);
+  OrtClipNodeGroupSelector sel(/*allow_16bit=*/false);
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                          {dq.AsNode()}, {q.AsNode()}));
+  g_clip_producer_dq = nullptr;
+}
+
 #endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -1,0 +1,1742 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Function-level unit tests for qnn_ep_utils.cc.
+//
+// Tests the OrtNodeGroupSelector::Check() family using FakeGraph / FakeNode /
+// FakeValueInfo from qnn_fake_ort_graph.h — no real QNN backend required.
+
+#include "gtest/gtest.h"
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <vector>
+
+#include "core/providers/qnn/qnn_ep_utils.h"
+#include "test/providers/qnn/unit/qnn_fake_ort_graph.h"
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+using namespace onnxruntime::QDQ;
+using namespace onnxruntime::test;
+
+// =============================================================================
+// EpUtilsTestContext
+//
+// Installs FakeGraph stubs plus the two extras that CheckQDQNodes uses:
+//   - ValueInfo_IsGraphOutput  → always false (not a graph output)
+//   - ValueInfo_GetValueNumConsumers → always 1 (exactly one consumer)
+//
+// These two are ORT_CONTINUE_ON_ERROR — the node-group check will return
+// false without them if the function pointer is null and crashes, so they
+// must always be installed.
+// =============================================================================
+struct EpUtilsTestContext {
+  OrtApi api{};
+
+  EpUtilsTestContext() {
+    InstallFakeGraphApiStubs(api);
+    api.ValueInfo_IsGraphOutput = [](const OrtValueInfo*, bool* out) noexcept -> OrtStatus* {
+      *out = false;
+      return nullptr;
+    };
+    api.ValueInfo_GetValueNumConsumers = [](const OrtValueInfo*, size_t* count) noexcept -> OrtStatus* {
+      *count = 1;
+      return nullptr;
+    };
+  }
+};
+
+// =============================================================================
+// OrtDropDQNodeGroupSelector::Check
+//
+// Signature: (graph/*unused*/, ort_api, node/*unused*/, redundant_clip_node,
+//             dq_nodes, q_nodes/*unused*/)
+//
+// Logic:
+//   1. Reject if redundant_clip_node != nullptr
+//   2. Reject if dq_nodes.size() != 1
+//   3. Read dq_nodes[0]->inputs[0] element type
+//   4. Reject if IsDisallowedType(elem_type, allow_16bit_, allow_4bit_)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_RejectsRedundantClipNode) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode clip{"clip", "Clip", "", 13, {}, {}};
+
+  OrtDropDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, clip.AsNode(), {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_RejectsEmptyDqNodes) {
+  EpUtilsTestContext ctx;
+  OrtDropDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_RejectsTwoDqNodes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtDropDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_AcceptsUint8) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtDropDQNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_AcceptsInt8) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtDropDQNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_AcceptsInt16WhenAllowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtDropDQNodeGroupSelector sel(/*allow_16bit=*/true);
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_RejectsInt16WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtDropDQNodeGroupSelector sel(/*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropDQ_RejectsInt4WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtDropDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+// =============================================================================
+// OrtUnaryNodeGroupSelector::Check
+//
+// Logic:
+//   1. CheckQDQNodes(node, 1 dq, 1 q) — node must have 1 output, 1 consumer
+//   2. Read dq_nodes[0]->inputs[0] and q_nodes[0]->outputs[0] element types
+//   3. CheckQuantTypes(both types must match and be allowed)
+//
+// For CheckQDQNodes to pass we need:
+//   - dq_nodes.size() == 1
+//   - node has 1 output (FakeNode with 1 element in outputs)
+//   - q_nodes.size() == 1 == num_outputs == total_consumers
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Unary_RejectsWrongDqCount) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {}, {&main_out}};
+
+  OrtUnaryNodeGroupSelector sel;
+  // dq_nodes empty → CheckQDQNodes fails (0 != 1)
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr, {}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Unary_AcceptsUint8) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtUnaryNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Unary_RejectsTypeMismatch) {
+  EpUtilsTestContext ctx;
+  // DQ input = UINT8, Q output = INT8 — types differ, CheckQuantTypes fails
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtUnaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Unary_RejectsInt16WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtUnaryNodeGroupSelector sel(/*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Unary_AcceptsInt16WhenAllowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtUnaryNodeGroupSelector sel(/*allow_16bit=*/true);
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtBinaryNodeGroupSelector::Check
+//
+// Needs 2 DQ inputs. Both must have the same allowed type, plus 1 Q output.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Binary_RejectsOnlyOneDq) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"add", "Add", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtBinaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Binary_AcceptsTwoUint8Dqs) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"add", "Add", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtBinaryNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Binary_RejectsMixedTypes) {
+  EpUtilsTestContext ctx;
+  // dq1 = UINT8, dq2 = INT8 — types mismatch
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"add", "Add", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtBinaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtPadNodeGroupSelector::Check
+//
+// 1 or 2 DQ inputs allowed; input/output types must match.
+// No allow_16bit/allow_4bit flags — all types accepted.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Pad_RejectsThreeDqNodes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq3{"dq3", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"pad", "Pad", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtPadNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode(), dq3.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Pad_AcceptsOneDqMatchingType) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"pad", "Pad", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtPadNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Pad_RejectsOneDqMismatchedType) {
+  EpUtilsTestContext ctx;
+  // DQ input = UINT8, Q output = INT8 — mismatch
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"pad", "Pad", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtPadNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Pad_AcceptsTwoDqSameType) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"pad", "Pad", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtPadNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Pad_RejectsTwoDqDifferentTypes) {
+  EpUtilsTestContext ctx;
+  // dq1 = UINT8, dq2 = INT8 — mismatch
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"pad", "Pad", "", 13, {}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtPadNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtSelectors::RegisterSelector
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, RegisterSelector_IncreasesSize) {
+  OrtSelectors selectors;
+  EXPECT_EQ(selectors.SelectorsSet().size(), 0u);
+  selectors.RegisterSelector({{"Relu", {1, 6, 13}}},
+                             std::make_unique<OrtUnaryNodeGroupSelector>());
+  EXPECT_EQ(selectors.SelectorsSet().size(), 1u);
+}
+
+// =============================================================================
+// OrtVariadicNodeGroupSelector::Check
+//
+// All DQ inputs must share the same type; all Q outputs must share a type.
+// Node_GetNumInputs is used by CheckQDQNodes (num_dq_inputs=-1), so
+// main_node.inputs.size() must equal dq_nodes.size().
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Variadic_Accepts2DqSameType) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  // inputs.size() == dq_nodes.size() == 2 for CheckQDQNodes
+  FakeNode main_node{"concat", "Concat", "", 13, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtVariadicNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Variadic_RejectsMixedDqTypes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"concat", "Concat", "", 13, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtVariadicNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Variadic_RejectsInt16WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"concat", "Concat", "", 13, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtVariadicNodeGroupSelector sel(/*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtSplitNodeGroupSelector::Check
+//
+// 1 DQ input → Split → N Q outputs.  All Q output types must match the DQ.
+// main_node.outputs.size() must equal q_nodes.size() for CheckQDQNodes.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Split_RejectsRedundantClipNode) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode clip{"clip", "Clip", "", 13, {}, {}};
+
+  OrtSplitNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, clip.AsNode(), {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Split_Accepts1DqWith2Q) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 8}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo out1{"y1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo out2{"y2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  // 1 input (dq_nodes.size=1), 2 outputs (q_nodes.size=2)
+  FakeNode main_node{"split", "Split", "", 13, {&dummy}, {&out1, &out2}};
+
+  FakeValueInfo q_out1{"z1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo q_out2{"z2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q1{"q1", "QuantizeLinear", "", 13, {}, {&q_out1}};
+  FakeNode q2{"q2", "QuantizeLinear", "", 13, {}, {&q_out2}};
+
+  OrtSplitNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {q1.AsNode(), q2.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Split_RejectsQTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 8}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo out1{"y1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo out2{"y2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"split", "Split", "", 13, {&dummy}, {&out1, &out2}};
+
+  FakeValueInfo q_out1{"z1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo q_out2{"z2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q1{"q1", "QuantizeLinear", "", 13, {}, {&q_out1}};
+  FakeNode q2{"q2", "QuantizeLinear", "", 13, {}, {&q_out2}};
+
+  OrtSplitNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q1.AsNode(), q2.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Split_Rejects4BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"split", "Split", "", 13, {&dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtSplitNodeGroupSelector sel(/*req_equal_quant_params=*/false, /*allow_4bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtConvNodeGroupSelector::Check
+//
+// dq[0]=input, dq[1]=weight, dq[2]=bias (optional INT32).
+// int8_allowed controls whether INT8 data is accepted.
+// allow_4bit_weight controls whether 4-bit weights are accepted.
+// main_node.inputs.size() must equal dq_nodes.size() for CheckQDQNodes.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Conv_Accepts2DqUint8) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Conv_RejectsInt8WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel(/*int8_allowed=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Conv_AcceptsInt8WhenAllowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel(/*int8_allowed=*/true);
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Conv_Rejects3DqWithNonInt32Bias) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeValueInfo dq_bias_in{"b", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {4}};  // wrong — must be INT32
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_bias{"dq2", "DequantizeLinear", "", 13, {&dq_bias_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode(), dq_bias.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtMatMulNodeGroupSelector::Check
+//
+// 2 DQ inputs required.  Q node optional (matmulintegertofloat path).
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, MatMul_Accepts2DqWithQ) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {4, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"mm", "MatMul", "", 13, {&dummy, &dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtMatMulNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, MatMul_AcceptsNoQWhenMmIntToFloatAllowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {4, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true, /*matmulintegertofloat_allowed=*/true);
+  // qlinear=false → directly returns matmulintegertofloat_allowed_
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
+                        {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, MatMul_RejectsNoQWhenMmIntToFloatDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {4, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true, /*matmulintegertofloat_allowed=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+// =============================================================================
+// OrtLogicalComparisonNodeGroupSelector::Check
+//
+// 2 DQ inputs, no Q output.  Both DQ types must match.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, LogicalComparison_AcceptsMatchingTypes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  // 2 inputs, is_empty_q_nodes_allowed=true so CheckQDQNodes returns true without checking outputs
+  FakeNode main_node{"equal", "Equal", "", 13, {&dummy, &dummy}, {}};
+
+  OrtLogicalComparisonNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_TRUE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, LogicalComparison_RejectsMismatchedTypes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+
+  FakeNode main_node{"equal", "Equal", "", 13, {&dummy, &dummy}, {}};
+
+  OrtLogicalComparisonNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+// =============================================================================
+// OrtDropQDQNodeGroupSelector::Check — early exits only
+// Happy path requires IsQDQPairSupported (reads scale OrtValue), skipped.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, DropQDQ_RejectsRedundantClipNode) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode clip{"clip", "Clip", "", 13, {}, {}};
+
+  OrtDropQDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, clip.AsNode(), {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, DropQDQ_RejectsZeroDqNodes) {
+  EpUtilsTestContext ctx;
+  OrtDropQDQNodeGroupSelector sel;
+  // CheckQDQNodes expects 1 DQ but gets 0 → false
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {}, {}));
+}
+
+// =============================================================================
+// CheckQDQNodes — produces_graph_output=true path (L573-574)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, CheckQDQNodes_RejectsWhenOutputIsGraphOutput) {
+  EpUtilsTestContext ctx;
+  // Override: any output IS a graph output
+  ctx.api.ValueInfo_IsGraphOutput = [](const OrtValueInfo*, bool* out) noexcept -> OrtStatus* {
+    *out = true;
+    return nullptr;
+  };
+
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {&dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtUnaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtDropQDQNodeGroupSelector — type-mismatch path (reaches CheckQuantTypes)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, DropQDQ_RejectsTypeMismatchAfterCheckQDQNodes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"id", "Identity", "", 13, {&dummy}, {&main_out}};
+
+  // Q output INT8 ≠ DQ input UINT8 — CheckQuantTypes fails
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtDropQDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtConvNodeGroupSelector — additional rejection paths
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Conv_RejectsInputOutputTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  // Q output INT8 ≠ input UINT8
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Conv_Rejects4BitWeightWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_data_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo dq_wt_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_data_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_wt_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel(/*int8_allowed=*/true, /*allow_16bit=*/true,
+                               /*allow_4bit_weight=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Conv_RejectsInt8DataWithUint8Weight) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_data_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeValueInfo dq_wt_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};  // mismatch
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_data_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_wt_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel(/*int8_allowed=*/true);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Conv_Rejects16BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtConvNodeGroupSelector sel(/*int8_allowed=*/true, /*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtMatMulNodeGroupSelector — INT8 mismatch and 16-bit paths
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, MatMul_RejectsInt8DataWithUint8Weight) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_data_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeValueInfo dq_wt_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};  // mismatch
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_data_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_wt_in}, {}};
+
+  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, MatMul_Rejects16BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true, /*mmtof=*/false,
+                                 /*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {}));
+}
+
+// =============================================================================
+// OrtGemmNodeGroupSelector — INT8/Q-type mismatch
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Gemm_RejectsInt8AWithUint8B) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_a_in{"a", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeValueInfo dq_b_in{"b", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};  // mismatch
+  FakeNode dq_a{"dq_a", "DequantizeLinear", "", 13, {&dq_a_in}, {}};
+  FakeNode dq_b{"dq_b", "DequantizeLinear", "", 13, {&dq_b_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"gemm", "Gemm", "", 11, {&dummy, &dummy}, {&main_out}};
+
+  OrtGemmNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_a.AsNode(), dq_b.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Gemm_RejectsQOutputTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_a{"dq_a", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_b{"dq_b", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"gemm", "Gemm", "", 11, {&dummy, &dummy}, {&main_out}};
+
+  // Q output INT8 ≠ A input UINT8
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtGemmNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_a.AsNode(), dq_b.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtEinsumNodeGroupSelector — acceptance + rejection paths
+// (is_empty_q_nodes_allowed=true → CheckQDQNodes passes with empty Q)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Einsum_AcceptsUint8NoQ) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"einsum", "Einsum", "", 12, {&dummy}, {}};
+
+  OrtEinsumNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Einsum_RejectsInt8WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"einsum", "Einsum", "", 12, {&dummy}, {}};
+
+  OrtEinsumNodeGroupSelector sel(/*allow_int8=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Einsum_RejectsInt16WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"einsum", "Einsum", "", 12, {&dummy}, {}};
+
+  OrtEinsumNodeGroupSelector sel(/*allow_int8=*/true, /*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Einsum_RejectsQOutputTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"einsum", "Einsum", "", 12, {&dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtEinsumNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtReciprocalNodeGroupSelector — same pattern as Einsum
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Reciprocal_AcceptsUint8NoQ) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"recip", "Reciprocal", "", 13, {&dummy}, {}};
+
+  OrtReciprocalNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Reciprocal_RejectsInt8WhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"recip", "Reciprocal", "", 13, {&dummy}, {}};
+
+  OrtReciprocalNodeGroupSelector sel(/*allow_int8=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
+}
+
+// =============================================================================
+// OrtWhereNodeGroupSelector — type mismatch paths
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, Where_RejectsDqTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"where", "Where", "", 9, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtWhereNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+TEST(QnnUnit_EpUtilsTest, Where_Rejects16BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"where", "Where", "", 9, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtWhereNodeGroupSelector sel(/*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtInstanceAndLayerNormalizationNodeGroupSelector — type mismatch (private)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, InstanceNorm_RejectsTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_scale{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"ln", "LayerNorm", "", 17, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtInstanceAndLayerNormalizationNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtBatchNormalizationNodeGroupSelector — too few DQ + INT8 mismatch
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsTooFewDq) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  OrtBatchNormalizationNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInt8WithMixedScale) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_data_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
+  FakeValueInfo dq_scale_in{"s", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};  // scale ≠ input type
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_data_in}, {}};
+  FakeNode dq_scale{"dq1", "DequantizeLinear", "", 13, {&dq_scale_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"bn", "BatchNormalization", "", 15, {&dummy, &dummy}, {&main_out}};
+
+  OrtBatchNormalizationNodeGroupSelector sel(/*int8_allowed=*/true);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_scale.AsNode()}, {}));
+}
+
+// =============================================================================
+// OrtCumSumNodeGroupSelector — type mismatch (private)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, CumSum_RejectsTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"cumsum", "CumSum", "", 14, {&dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtCumSumNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtScatterElementsNodeGroupSelector — type mismatch (private)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, ScatterElements_RejectsMixedDqTypes) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in1{"x1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo dq_in2{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in1}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in2}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"scatter", "ScatterElements", "", 11, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtScatterElementsNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtRMSNormalizationNodeGroupSelector — type mismatch (private)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, RMSNorm_RejectsTypeMismatch) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode dq_scale{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"rms", "RMSNormalization", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtRMSNormalizationNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtTopKNodeGroupSelector — early exits + CanCreateNodeGroup path (private)
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, TopK_RejectsRedundantClipNode) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode clip{"clip", "Clip", "", 13, {}, {}};
+
+  OrtTopKNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, nullptr, clip.AsNode(),
+                          {dq.AsNode()}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, TopK_RejectsWrongDqCount) {
+  EpUtilsTestContext ctx;
+  OrtTopKNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, nullptr, nullptr, {}, {}));
+}
+
+TEST(QnnUnit_EpUtilsTest, TopK_CoversCanCreateNodeGroupPath) {
+  // CanCreateNodeGroup is exercised here. IsQDQPairSupported will return false
+  // (no scale initializer) so the final result is false, but the internal
+  // CanCreateNodeGroup + type-check code paths are covered.
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"topk", "TopK", "", 11, {&dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtTopKNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  // Result is false because the Q node has no scale initializer (no inputs[1]),
+  // so IsQDQPairSupported returns false. CanCreateNodeGroup and type-check paths
+  // are covered.
+  EXPECT_FALSE(base.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                          {dq.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// IsQOrDQScalePositiveConstantScalar + IsQDQPairSupported
+// (exercised through OrtDropQDQNodeGroupSelector::Check with real scale
+//  initializers backed by FakeOrtValue)
+//
+// Graph pattern for all tests below:
+//   DQ(inputs[0]=dq_in, inputs[1]=<scale_vi>) ->
+//   Identity(outputs={main_out}) ->
+//   Q(inputs[0]=main_out, inputs[1]=<scale_vi>, outputs={q_out})
+// =============================================================================
+
+// Shared fixture: builds the minimum fake graph for a DropQDQ scale test.
+// Scale values and which scale_vi each node uses are set per test.
+struct DropQdqScaleFixture {
+  FakeValueInfo q_scale_vi{"q_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_scale_vi{"dq_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"dq_in", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeValueInfo main_out{"main_out", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeValueInfo q_out{"q_out", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeOrtValue q_scale_val;
+  FakeOrtValue dq_scale_val;
+  // Both nodes default to the same q_scale_vi (same-name path).
+  FakeNode dq_node{"dq", "DequantizeLinear", "", 13, {&dq_in, &q_scale_vi}, {}};
+  FakeNode main_node{"id", "Identity", "", 13, {}, {&main_out}};
+  FakeNode q_node{"q", "QuantizeLinear", "", 13, {&main_out, &q_scale_vi}, {&q_out}};
+  FakeGraph graph{{}, {}, {}, {&q_scale_vi}};
+};
+
+// IsQOrDQScalePositiveConstantScalar: positive float scale → returns true.
+// IsQDQPairSupported: same scale name → same_scale=true → returns true.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_PositiveScale_SameName_CheckReturnsTrue) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(0.5f);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_TRUE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                        {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQOrDQScalePositiveConstantScalar: negative scale → returns false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_NegativeScale_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(-0.5f);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQOrDQScalePositiveConstantScalar: zero scale → returns false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_ZeroScale_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(0.0f);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// allow_nonpositive_scale=true: IsQOrDQScalePositiveConstantScalar is skipped;
+// IsQDQPairSupported (same name) returns true even for a negative scale.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_AllowNonpositiveScale_NegativeScaleOk) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(-1.0f);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/true);
+  EXPECT_TRUE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                        {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQOrDQScalePositiveConstantScalar: scale not in graph.initializers →
+// GetConstantInitializer returns nullptr → returns false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_ScaleNotInitializer_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.graph.initializers = {};  // scale_vi absent from graph initializers
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQDQPairSupported: different scale names, same float value → same_scale=true.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_DiffScaleName_SameValue_CheckReturnsTrue) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(0.5f);
+  f.dq_scale_val = FakeOrtValue::MakeFloat(0.5f);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+  f.dq_scale_vi.initializer_value = &f.dq_scale_val;
+  // Q uses q_scale_vi ("q_scale"), DQ uses dq_scale_vi ("dq_scale").
+  f.dq_node.inputs = {&f.dq_in, &f.dq_scale_vi};
+  f.graph.initializers = {&f.q_scale_vi, &f.dq_scale_vi};
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_TRUE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                        {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQDQPairSupported: different scale names, different float values → false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_DiffScaleName_DiffValue_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(0.5f);
+  f.dq_scale_val = FakeOrtValue::MakeFloat(1.0f);  // different value
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+  f.dq_scale_vi.initializer_value = &f.dq_scale_val;
+  f.dq_node.inputs = {&f.dq_in, &f.dq_scale_vi};
+  f.graph.initializers = {&f.q_scale_vi, &f.dq_scale_vi};
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQOrDQScalePositiveConstantScalar: Q node has < 2 inputs →
+// num_inputs < 2 guard fires → returns false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_QNodeHasNoScaleInput_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  // Q node has only 1 input (no scale at index 1).
+  f.q_node.inputs = {&f.main_out};
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQOrDQScalePositiveConstantScalar: double-precision scale, positive →
+// element_type==DOUBLE path executed, returns true.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_DoubleScale_Positive_CheckReturnsTrue) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeDouble(0.5);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_TRUE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                        {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQOrDQScalePositiveConstantScalar: scale is INT32 type (neither float nor
+// double) → falls through to the final return false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_IntTypeScale_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQDQPairSupported: different scale names, Q=FLOAT vs DQ=DOUBLE →
+// q_element_type != dq_element_type → returns false.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_DiffScaleName_TypeMismatch_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(0.5f);   // FLOAT
+  f.dq_scale_val = FakeOrtValue::MakeDouble(0.5);  // DOUBLE
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+  f.dq_scale_vi.initializer_value = &f.dq_scale_val;
+  f.dq_node.inputs = {&f.dq_in, &f.dq_scale_vi};
+  f.graph.initializers = {&f.q_scale_vi, &f.dq_scale_vi};
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// IsQDQPairSupported: different scale names, both DOUBLE, same value →
+// double-precision comparison path executed, same_scale=true → returns true.
+TEST(QnnUnit_EpUtilsTest, DropQDQ_DiffScaleName_BothDouble_SameValue_CheckReturnsTrue) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeDouble(0.5);
+  f.dq_scale_val = FakeOrtValue::MakeDouble(0.5);
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+  f.dq_scale_vi.initializer_value = &f.dq_scale_val;
+  f.dq_node.inputs = {&f.dq_in, &f.dq_scale_vi};
+  f.graph.initializers = {&f.q_scale_vi, &f.dq_scale_vi};
+
+  OrtDropQDQNodeGroupSelector sel(/*allow_16bit=*/true, /*allow_4bit=*/true,
+                                  /*allow_nonpositive_scale=*/false);
+  EXPECT_TRUE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                        {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// =============================================================================
+// "DQ has no inputs" early-exit tests
+//
+// Covers the !dt_input.has_value() guards in multiple selector Check() methods.
+// When the first DQ node has no inputs, GetNodeInputDataType(dq_node, 0) returns
+// nullopt (index 0 >= num_inputs == 0), triggering the return-false path.
+// =============================================================================
+
+// DropQDQ: dt_input or dt_output not has_value → returns false (L609).
+TEST(QnnUnit_EpUtilsTest, DropQDQ_DQHasNoInputs_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode main_node{"id", "Identity", "", 13, {}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtDropQDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// DropDQ: DQ node has no inputs → !dt_input.has_value() → returns false (L650).
+TEST(QnnUnit_EpUtilsTest, DropDQ_DQHasNoInputs_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {}, {}};
+  OrtDropDQNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
+}
+
+// Unary: DQ node has no inputs → !dt_input.has_value() → returns false (L675).
+TEST(QnnUnit_EpUtilsTest, Unary_DQHasNoInputs_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode main_node{"relu", "Relu", "", 13, {}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtUnaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// Variadic: zero DQ nodes → CheckQDQNodes fails → returns false (L699).
+TEST(QnnUnit_EpUtilsTest, Variadic_ZeroDqNodes_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  // Add node needs 2 inputs so num_dq_inputs=2; dq_nodes.size()=0 → mismatch → false.
+  FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo in2{"in2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeNode main_node{"add", "Add", "", 13, {&in1, &in2}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtVariadicNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {}, {q.AsNode()}));
+}
+
+// Variadic: DQ node has no inputs → !dt_input.has_value() → returns false (L781).
+TEST(QnnUnit_EpUtilsTest, Variadic_DQHasNoInputs_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo in2{"in2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {}, {}};
+  FakeNode main_node{"add", "Add", "", 13, {&in1, &in2}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtVariadicNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// Split: DQ node has no inputs → !dt_input.has_value() → returns false (L825).
+TEST(QnnUnit_EpUtilsTest, Split_DQHasNoInputs_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode main_node{"split", "Split", "", 13, {}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtSplitNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// Split: req_equal_quant_params=true + Q and DQ have different scale values →
+// IsQDQPairSupported returns false → returns false (L842).
+TEST(QnnUnit_EpUtilsTest, Split_ReqEqualQuant_DiffScaleValues_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  DropQdqScaleFixture f;
+  f.q_scale_val = FakeOrtValue::MakeFloat(0.5f);
+  f.dq_scale_val = FakeOrtValue::MakeFloat(1.0f);  // different value
+  f.q_scale_vi.initializer_value = &f.q_scale_val;
+  f.dq_scale_vi.initializer_value = &f.dq_scale_val;
+  f.dq_node.inputs = {&f.dq_in, &f.dq_scale_vi};
+  f.graph.initializers = {&f.q_scale_vi, &f.dq_scale_vi};
+
+  OrtSplitNodeGroupSelector sel(/*req_equal_quant_params=*/true);
+  EXPECT_FALSE(sel.Check(f.graph.AsGraph(), ctx.api, f.main_node.AsNode(), nullptr,
+                         {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
+}
+
+// Conv: first DQ node has no inputs → !dt_input.has_value() → returns false (L863).
+TEST(QnnUnit_EpUtilsTest, Conv_FirstDQHasNoInputs_CheckReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_wt_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_wt_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtConvNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
+}
+
+// =============================================================================
+// OrtSelectorManager::GetOrtQDQSelections — version-check path (L1808-1809)
+//
+// Uses OrtGlobalApiOverride to make Ort::ConstNode(node).GetOperatorType() call
+// the test stub (FakeNode::op_type). MaxPool has a non-empty version list {12},
+// so the if(!versions.empty()) block is entered, covering L1808-1809.
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, GetOrtQDQSelections_MaxPoolVersionCheck_CoversVersionPath) {
+  EpUtilsTestContext ctx;
+  // MaxPool is registered with versions={12}. A MaxPool node with since_version=12
+  // is within range → the version-check block (L1808-1809) is entered.
+  FakeNode maxpool_node{"mp", "MaxPool", "", 12, {}, {}};
+  FakeGraph graph{{maxpool_node}};
+
+  OrtGlobalApiOverride global_guard(&ctx.api);
+  OrtSelectorManager selector_mgr;
+  auto logger = MakeNullLogger();
+  auto selections = selector_mgr.GetOrtQDQSelections(graph.AsGraph(), ctx.api, logger);
+  // No DQ/Q nodes → GetOrtQDQSelection finds no pattern → result is empty.
+  EXPECT_TRUE(selections.empty());
+}
+
+// =============================================================================
+// =============================================================================
+// Selector "return false" branch coverage — additional simple tests
+//
+// Each test covers a specific !has_value() or type-check return path that was
+// not reached by existing tests.
+// =============================================================================
+
+// OrtClipNodeGroupSelector: CheckQDQNodes fails when q_nodes is empty and
+// is_empty_q_nodes_allowed=false (the Clip default) → returns false (L699).
+TEST(QnnUnit_EpUtilsTest, Clip_CheckQDQNodesFails_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"clip", "Clip", "", 11, {}, {&main_out}};
+  FakeGraph graph{};
+  OrtClipNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  // Empty q_nodes → CheckQDQNodes returns is_empty_q_nodes_allowed=false → L699.
+  EXPECT_FALSE(base.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                          {dq.AsNode()}, {}));
+}
+
+// OrtClipNodeGroupSelector: data_producer is nullptr (ValueInfo_GetValueProducer
+// default stub returns nullptr) → returns false before dt_input check.
+TEST(QnnUnit_EpUtilsTest, Clip_NullProducer_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo clip_in{"ci", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {}, {}};
+  FakeNode main_node{"clip", "Clip", "", 11, {&clip_in}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  // OrtGlobalApiOverride needed because Clip Check calls Ort::ConstNode(producer)
+  // even though producer will be nullptr (short-circuits before GetOperatorType).
+  OrtGlobalApiOverride global_guard(&ctx.api);
+  OrtClipNodeGroupSelector sel;
+  OrtNodeGroupSelector& base = sel;
+  EXPECT_FALSE(base.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                          {dq.AsNode()}, {q.AsNode()}));
+}
+
+// OrtBinaryNodeGroupSelector: first DQ has no inputs → !dt_input.has_value() (L758).
+TEST(QnnUnit_EpUtilsTest, Binary_FirstDQHasNoInputs_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq2_in{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq2_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"add", "Add", "", 13, {}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtBinaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// OrtVariadicNodeGroupSelector: Q node has no outputs →
+// !dt_output.has_value() → returns false (L793).
+TEST(QnnUnit_EpUtilsTest, Variadic_QHasNoOutputs_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo in2{"in2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&in1}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&in2}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
+  FakeNode main_node{"add", "Add", "", 13, {&in1, &in2}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {}};  // no outputs
+  FakeGraph graph{};
+  OrtVariadicNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// OrtEinsumNodeGroupSelector: 4-bit input disallowed → returns false (L923).
+TEST(QnnUnit_EpUtilsTest, Einsum_Rejects4BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"einsum", "Einsum", "", 12, {&dummy}, {}};
+  OrtEinsumNodeGroupSelector sel(/*allow_int8=*/true, /*allow_16bit=*/true,
+                                 /*allow_4bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
+}
+
+// OrtReciprocalNodeGroupSelector: 16-bit input disallowed → returns false (L962).
+// main_node has 1 input so CheckQDQNodes passes (num_dq_inputs=1).
+TEST(QnnUnit_EpUtilsTest, Reciprocal_Rejects16BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"reciprocal", "Reciprocal", "", 13, {&dummy}, {}};
+  OrtReciprocalNodeGroupSelector sel(/*allow_int8=*/true, /*allow_16bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
+}
+
+// OrtReciprocalNodeGroupSelector: 4-bit input disallowed → returns false (L965).
+TEST(QnnUnit_EpUtilsTest, Reciprocal_Rejects4BitWhenDisallowed) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"reciprocal", "Reciprocal", "", 13, {&dummy}, {}};
+  OrtReciprocalNodeGroupSelector sel(/*allow_int8=*/true, /*allow_16bit=*/true,
+                                     /*allow_4bit=*/false);
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
+}
+
+// OrtReciprocalNodeGroupSelector: Q node has no outputs →
+// !dt_output.has_value() → returns false (L972).
+TEST(QnnUnit_EpUtilsTest, Reciprocal_QHasNoOutputs_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"reciprocal", "Reciprocal", "", 13, {&dummy}, {&main_out}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {}};  // no outputs
+  OrtReciprocalNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// OrtReciprocalNodeGroupSelector: DQ UINT8 but Q output INT8 →
+// type mismatch → returns false (L975).
+TEST(QnnUnit_EpUtilsTest, Reciprocal_QOutputTypeMismatch_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+  FakeNode main_node{"reciprocal", "Reciprocal", "", 13, {&dummy}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  OrtReciprocalNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// OrtMatMulNodeGroupSelector: first DQ has no inputs →
+// !dt_input.has_value() → returns false (L994).
+TEST(QnnUnit_EpUtilsTest, MatMul_FirstDQHasNoInputs_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq2_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {}, {}};  // no inputs
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq2_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"matmul", "MatMul", "", 13, {}, {&main_out}};
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtMatMulNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+// OrtVariadicNodeGroupSelector: second Q node has mismatched output type →
+// dt_o.value() != dt_output.value() → returns false (L796-798).
+TEST(QnnUnit_EpUtilsTest, Variadic_SecondQTypeMismatch_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo in2{"in2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&in1}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&in2}, {}};
+  FakeValueInfo main_out1{"y1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeValueInfo main_out2{"y2", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"add", "Add", "", 13, {&in1, &in2}, {&main_out1, &main_out2}};
+  FakeValueInfo q1_out{"z1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo q2_out{"z2", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};  // mismatch
+  FakeNode q1{"q1", "QuantizeLinear", "", 13, {}, {&q1_out}};
+  FakeNode q2{"q2", "QuantizeLinear", "", 13, {}, {&q2_out}};
+  FakeGraph graph{};
+  OrtVariadicNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q1.AsNode(), q2.AsNode()}));
+}
+
+// OrtMatMulNodeGroupSelector: QLinearMatMul path, CheckQDQNodes fails because
+// main_node has 0 inputs → num_dq_inputs=0 ≠ 2 → returns false (L1015).
+TEST(QnnUnit_EpUtilsTest, MatMul_QLinearCheckQDQNodesFails_ReturnsFalse) {
+  EpUtilsTestContext ctx;
+  FakeValueInfo dq1_in{"a", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeValueInfo dq2_in{"b", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq1_in}, {}};
+  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq2_in}, {}};
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
+  FakeNode main_node{"matmul", "MatMul", "", 13, {}, {&main_out}};  // 0 inputs
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+  FakeGraph graph{};
+  OrtMatMulNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
+}
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -715,7 +715,7 @@ TEST(QnnUnit_EpUtilsTest, DropQDQ_RejectsZeroDqNodes) {
 }
 
 // =============================================================================
-// CheckQDQNodes — produces_graph_output=true path (L573-574)
+// CheckQDQNodes — produces_graph_output=true path
 // =============================================================================
 
 TEST(QnnUnit_EpUtilsTest, CheckQDQNodes_RejectsWhenOutputIsGraphOutput) {
@@ -732,6 +732,31 @@ TEST(QnnUnit_EpUtilsTest, CheckQDQNodes_RejectsWhenOutputIsGraphOutput) {
 
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
   FakeNode main_node{"relu", "Relu", "", 13, {&dummy}, {&main_out}};
+
+  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
+
+  OrtUnaryNodeGroupSelector sel;
+  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {q.AsNode()}));
+}
+
+// CheckQDQNodes — total_consumers != q_nodes.size() path
+// =============================================================================
+
+TEST(QnnUnit_EpUtilsTest, CheckQDQNodes_RejectsWhenConsumerCountExceedsQNodes) {
+  EpUtilsTestContext ctx;
+  // Override: each output has 2 consumers, but only 1 Q node → mismatch
+  ctx.api.ValueInfo_GetValueNumConsumers = [](const OrtValueInfo*, size_t* count) noexcept -> OrtStatus* {
+    *count = 2;
+    return nullptr;
+  };
+
+  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
+  FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
+
+  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1, 4}};
+  FakeNode main_node{"relu", "Relu", "", 13, {&dq_in}, {&main_out}};
 
   FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {1, 4}};
   FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
@@ -1396,7 +1421,7 @@ TEST(QnnUnit_EpUtilsTest, DropQDQ_DiffScaleName_BothDouble_SameValue_CheckReturn
 // nullopt (index 0 >= num_inputs == 0), triggering the return-false path.
 // =============================================================================
 
-// DropQDQ: dt_input or dt_output not has_value → returns false (L609).
+// DropQDQ: dt_input or dt_output not has_value → returns false.
 TEST(QnnUnit_EpUtilsTest, DropQDQ_DQHasNoInputs_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
@@ -1410,7 +1435,7 @@ TEST(QnnUnit_EpUtilsTest, DropQDQ_DQHasNoInputs_CheckReturnsFalse) {
                          {dq.AsNode()}, {q.AsNode()}));
 }
 
-// DropDQ: DQ node has no inputs → !dt_input.has_value() → returns false (L650).
+// DropDQ: DQ node has no inputs → !dt_input.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, DropDQ_DQHasNoInputs_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeNode dq{"dq", "DequantizeLinear", "", 13, {}, {}};
@@ -1418,7 +1443,7 @@ TEST(QnnUnit_EpUtilsTest, DropDQ_DQHasNoInputs_CheckReturnsFalse) {
   EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr, {dq.AsNode()}, {}));
 }
 
-// Unary: DQ node has no inputs → !dt_input.has_value() → returns false (L675).
+// Unary: DQ node has no inputs → !dt_input.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Unary_DQHasNoInputs_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
@@ -1432,7 +1457,7 @@ TEST(QnnUnit_EpUtilsTest, Unary_DQHasNoInputs_CheckReturnsFalse) {
                          {dq.AsNode()}, {q.AsNode()}));
 }
 
-// Variadic: zero DQ nodes → CheckQDQNodes fails → returns false (L699).
+// Variadic: zero DQ nodes → CheckQDQNodes fails → returns false.
 TEST(QnnUnit_EpUtilsTest, Variadic_ZeroDqNodes_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   // Add node needs 2 inputs so num_dq_inputs=2; dq_nodes.size()=0 → mismatch → false.
@@ -1448,7 +1473,7 @@ TEST(QnnUnit_EpUtilsTest, Variadic_ZeroDqNodes_CheckReturnsFalse) {
                          {}, {q.AsNode()}));
 }
 
-// Variadic: DQ node has no inputs → !dt_input.has_value() → returns false (L781).
+// Variadic: DQ node has no inputs → !dt_input.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Variadic_DQHasNoInputs_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
@@ -1465,7 +1490,7 @@ TEST(QnnUnit_EpUtilsTest, Variadic_DQHasNoInputs_CheckReturnsFalse) {
                          {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
 }
 
-// Split: DQ node has no inputs → !dt_input.has_value() → returns false (L825).
+// Split: DQ node has no inputs → !dt_input.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Split_DQHasNoInputs_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {1}};
@@ -1480,7 +1505,7 @@ TEST(QnnUnit_EpUtilsTest, Split_DQHasNoInputs_CheckReturnsFalse) {
 }
 
 // Split: req_equal_quant_params=true + Q and DQ have different scale values →
-// IsQDQPairSupported returns false → returns false (L842).
+// IsQDQPairSupported returns false → returns false.
 TEST(QnnUnit_EpUtilsTest, Split_ReqEqualQuant_DiffScaleValues_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   DropQdqScaleFixture f;
@@ -1496,7 +1521,7 @@ TEST(QnnUnit_EpUtilsTest, Split_ReqEqualQuant_DiffScaleValues_CheckReturnsFalse)
                          {f.dq_node.AsNode()}, {f.q_node.AsNode()}));
 }
 
-// Conv: first DQ node has no inputs → !dt_input.has_value() → returns false (L863).
+// Conv: first DQ node has no inputs → !dt_input.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Conv_FirstDQHasNoInputs_CheckReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1514,7 +1539,7 @@ TEST(QnnUnit_EpUtilsTest, Conv_FirstDQHasNoInputs_CheckReturnsFalse) {
 }
 
 // =============================================================================
-// OrtSelectorManager::GetOrtQDQSelections — version-check path (L1808-1809)
+// OrtSelectorManager::GetOrtQDQSelections — version-check path
 //
 // Uses OrtGlobalApiOverride to make Ort::ConstNode(node).GetOperatorType() call
 // the test stub (FakeNode::op_type). MaxPool has a non-empty version list {12},
@@ -1524,7 +1549,7 @@ TEST(QnnUnit_EpUtilsTest, Conv_FirstDQHasNoInputs_CheckReturnsFalse) {
 TEST(QnnUnit_EpUtilsTest, GetOrtQDQSelections_MaxPoolVersionCheck_CoversVersionPath) {
   EpUtilsTestContext ctx;
   // MaxPool is registered with versions={12}. A MaxPool node with since_version=12
-  // is within range → the version-check block (L1808-1809) is entered.
+  // is within range → the version-check block is entered.
   FakeNode maxpool_node{"mp", "MaxPool", "", 12, {}, {}};
   FakeGraph graph{{maxpool_node}};
 
@@ -1545,7 +1570,7 @@ TEST(QnnUnit_EpUtilsTest, GetOrtQDQSelections_MaxPoolVersionCheck_CoversVersionP
 // =============================================================================
 
 // OrtClipNodeGroupSelector: CheckQDQNodes fails when q_nodes is empty and
-// is_empty_q_nodes_allowed=false (the Clip default) → returns false (L699).
+// is_empty_q_nodes_allowed=false (the Clip default) → returns false.
 TEST(QnnUnit_EpUtilsTest, Clip_CheckQDQNodesFails_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1580,7 +1605,7 @@ TEST(QnnUnit_EpUtilsTest, Clip_NullProducer_ReturnsFalse) {
                           {dq.AsNode()}, {q.AsNode()}));
 }
 
-// OrtBinaryNodeGroupSelector: first DQ has no inputs → !dt_input.has_value() (L758).
+// OrtBinaryNodeGroupSelector: first DQ has no inputs → !dt_input.has_value().
 TEST(QnnUnit_EpUtilsTest, Binary_FirstDQHasNoInputs_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq2_in{"x2", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1597,7 +1622,7 @@ TEST(QnnUnit_EpUtilsTest, Binary_FirstDQHasNoInputs_ReturnsFalse) {
 }
 
 // OrtVariadicNodeGroupSelector: Q node has no outputs →
-// !dt_output.has_value() → returns false (L793).
+// !dt_output.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Variadic_QHasNoOutputs_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1613,7 +1638,7 @@ TEST(QnnUnit_EpUtilsTest, Variadic_QHasNoOutputs_ReturnsFalse) {
                          {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
 }
 
-// OrtEinsumNodeGroupSelector: 4-bit input disallowed → returns false (L923).
+// OrtEinsumNodeGroupSelector: 4-bit input disallowed → returns false.
 TEST(QnnUnit_EpUtilsTest, Einsum_Rejects4BitWhenDisallowed) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1626,7 +1651,7 @@ TEST(QnnUnit_EpUtilsTest, Einsum_Rejects4BitWhenDisallowed) {
                          {dq.AsNode()}, {}));
 }
 
-// OrtReciprocalNodeGroupSelector: 16-bit input disallowed → returns false (L962).
+// OrtReciprocalNodeGroupSelector: 16-bit input disallowed → returns false.
 // main_node has 1 input so CheckQDQNodes passes (num_dq_inputs=1).
 TEST(QnnUnit_EpUtilsTest, Reciprocal_Rejects16BitWhenDisallowed) {
   EpUtilsTestContext ctx;
@@ -1639,7 +1664,7 @@ TEST(QnnUnit_EpUtilsTest, Reciprocal_Rejects16BitWhenDisallowed) {
                          {dq.AsNode()}, {}));
 }
 
-// OrtReciprocalNodeGroupSelector: 4-bit input disallowed → returns false (L965).
+// OrtReciprocalNodeGroupSelector: 4-bit input disallowed → returns false.
 TEST(QnnUnit_EpUtilsTest, Reciprocal_Rejects4BitWhenDisallowed) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1653,7 +1678,7 @@ TEST(QnnUnit_EpUtilsTest, Reciprocal_Rejects4BitWhenDisallowed) {
 }
 
 // OrtReciprocalNodeGroupSelector: Q node has no outputs →
-// !dt_output.has_value() → returns false (L972).
+// !dt_output.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Reciprocal_QHasNoOutputs_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1668,7 +1693,7 @@ TEST(QnnUnit_EpUtilsTest, Reciprocal_QHasNoOutputs_ReturnsFalse) {
 }
 
 // OrtReciprocalNodeGroupSelector: DQ UINT8 but Q output INT8 →
-// type mismatch → returns false (L975).
+// type mismatch → returns false.
 TEST(QnnUnit_EpUtilsTest, Reciprocal_QOutputTypeMismatch_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1684,7 +1709,7 @@ TEST(QnnUnit_EpUtilsTest, Reciprocal_QOutputTypeMismatch_ReturnsFalse) {
 }
 
 // OrtMatMulNodeGroupSelector: first DQ has no inputs →
-// !dt_input.has_value() → returns false (L994).
+// !dt_input.has_value() → returns false.
 TEST(QnnUnit_EpUtilsTest, MatMul_FirstDQHasNoInputs_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq2_in{"w", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1701,7 +1726,7 @@ TEST(QnnUnit_EpUtilsTest, MatMul_FirstDQHasNoInputs_ReturnsFalse) {
 }
 
 // OrtVariadicNodeGroupSelector: second Q node has mismatched output type →
-// dt_o.value() != dt_output.value() → returns false (L796-798).
+// dt_o.value() != dt_output.value() → returns false.
 TEST(QnnUnit_EpUtilsTest, Variadic_SecondQTypeMismatch_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo in1{"in1", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1722,7 +1747,7 @@ TEST(QnnUnit_EpUtilsTest, Variadic_SecondQTypeMismatch_ReturnsFalse) {
 }
 
 // OrtMatMulNodeGroupSelector: QLinearMatMul path, CheckQDQNodes fails because
-// main_node has 0 inputs → num_dq_inputs=0 ≠ 2 → returns false (L1015).
+// main_node has 0 inputs → num_dq_inputs=0 ≠ 2 → returns false.
 TEST(QnnUnit_EpUtilsTest, MatMul_QLinearCheckQDQNodesFails_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq1_in{"a", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1744,7 +1769,7 @@ TEST(QnnUnit_EpUtilsTest, MatMul_QLinearCheckQDQNodesFails_ReturnsFalse) {
 // qnn_ep_utils.cc L736/1037/1065/1093/1192/1206/1267
 // =============================================================================
 
-// OrtGemmNodeGroupSelector: dq_nodes.size() < 2 → returns false (L1037).
+// OrtGemmNodeGroupSelector: dq_nodes.size() < 2 → returns false.
 // CheckQDQNodes passes because is_empty_q_nodes_allowed=true and node has 1 input.
 TEST(QnnUnit_EpUtilsTest, Gemm_RejectsFewerThan2Dq) {
   EpUtilsTestContext ctx;
@@ -1760,7 +1785,7 @@ TEST(QnnUnit_EpUtilsTest, Gemm_RejectsFewerThan2Dq) {
 }
 
 // OrtGemmNodeGroupSelector: IsDisallowedType(dt_A|dt_B, allow_16bit_, allow_4bit_)
-// gate → returns false (L1065). Both inputs UINT16 with allow_16bit=false.
+// gate → returns false. Both inputs UINT16 with allow_16bit=false.
 TEST(QnnUnit_EpUtilsTest, Gemm_Rejects16BitWhenDisallowed) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1776,7 +1801,7 @@ TEST(QnnUnit_EpUtilsTest, Gemm_Rejects16BitWhenDisallowed) {
 }
 
 // OrtWhereNodeGroupSelector: CheckQDQNodes with num_dq_inputs=2 fails because
-// dq_nodes.size()=3 → returns false (L1093).
+// dq_nodes.size()=3 → returns false.
 TEST(QnnUnit_EpUtilsTest, Where_RejectsWrongDqCount) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1795,7 +1820,7 @@ TEST(QnnUnit_EpUtilsTest, Where_RejectsWrongDqCount) {
 }
 
 // OrtBatchNormalizationNodeGroupSelector: CheckQDQNodes fails because
-// num_outputs (2) != q_nodes.size() (1) → returns false (L1192).
+// num_outputs (2) != q_nodes.size() (1) → returns false.
 TEST(QnnUnit_EpUtilsTest, BatchNorm_CheckQDQNodesFails_ReturnsFalse) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1814,7 +1839,7 @@ TEST(QnnUnit_EpUtilsTest, BatchNorm_CheckQDQNodesFails_ReturnsFalse) {
 }
 
 // OrtBatchNormalizationNodeGroupSelector: !has_float_output path,
-// dt_output.value() != dt_input.value() → returns false (L1206).
+// dt_output.value() != dt_input.value() → returns false.
 TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInputOutputTypeMismatch) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1833,7 +1858,7 @@ TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInputOutputTypeMismatch) {
 }
 
 // OrtTopKNodeGroupSelector: dt_input.value() != dt_output.value() → returns
-// false (L1267). Requires CanCreateNodeGroup to pass first.
+// false. Requires CanCreateNodeGroup to pass first.
 TEST(QnnUnit_EpUtilsTest, TopK_RejectsInputOutputTypeMismatch) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
@@ -1868,7 +1893,7 @@ struct ClipProducerGuard {
 }  // namespace
 
 // OrtClipNodeGroupSelector: CheckQuantTypes fails when input/output types
-// are UINT16 and allow_16bit_=false → returns false (L736).
+// are UINT16 and allow_16bit_=false → returns false.
 // Reaches L736 by installing a producer stub that returns the DQ node so
 // the L718 producer==nullptr guard passes.
 TEST(QnnUnit_EpUtilsTest, Clip_Rejects16BitWhenDisallowed) {

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -1861,6 +1861,10 @@ OrtStatus* FakeClipProducerStub(const OrtValueInfo* /*value_info*/,
   if (output_index) *output_index = 0;
   return nullptr;
 }
+struct ClipProducerGuard {
+  explicit ClipProducerGuard(const OrtNode* n) { g_clip_producer_dq = n; }
+  ~ClipProducerGuard() { g_clip_producer_dq = nullptr; }
+};
 }  // namespace
 
 // OrtClipNodeGroupSelector: CheckQuantTypes fails when input/output types
@@ -1878,7 +1882,7 @@ TEST(QnnUnit_EpUtilsTest, Clip_Rejects16BitWhenDisallowed) {
   FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
   FakeGraph graph{};
 
-  g_clip_producer_dq = dq.AsNode();
+  ClipProducerGuard guard(dq.AsNode());
   ctx.api.ValueInfo_GetValueProducer = &FakeClipProducerStub;
 
   // Ort::ConstNode(producer).GetOperatorType() uses the global api.
@@ -1887,7 +1891,6 @@ TEST(QnnUnit_EpUtilsTest, Clip_Rejects16BitWhenDisallowed) {
   OrtNodeGroupSelector& base = sel;
   EXPECT_FALSE(base.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
                           {dq.AsNode()}, {q.AsNode()}));
-  g_clip_producer_dq = nullptr;
 }
 
 #endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
@@ -38,6 +38,10 @@
 namespace onnxruntime {
 namespace test {
 
+// FakeOrtValue is declared here so FakeValueInfo can hold a pointer to it.
+// Full definition follows after FakeValueInfo.
+struct FakeOrtValue;
+
 // ---------------------------------------------------------------------------
 // FakeValueInfo
 //
@@ -51,6 +55,9 @@ struct FakeValueInfo {
   std::string name;
   ONNXTensorElementDataType elem_type;
   std::vector<int64_t> shape;
+  // Non-owning pointer to a FakeOrtValue for constant initializers.
+  // Null for non-initializer value infos. Used by ValueInfo_GetInitializerValue.
+  FakeOrtValue* initializer_value = nullptr;
 
   const OrtValueInfo* AsValueInfo() const {
     return reinterpret_cast<const OrtValueInfo*>(this);
@@ -60,6 +67,50 @@ struct FakeValueInfo {
   }
   const OrtTensorTypeAndShapeInfo* AsTensorInfo() const {
     return reinterpret_cast<const OrtTensorTypeAndShapeInfo*>(this);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// FakeOrtValue
+//
+// Acts as both OrtValue* and OrtTensorTypeAndShapeInfo* simultaneously.
+//
+// The first three fields (dummy_name, elem_type, shape) are layout-compatible
+// with FakeValueInfo so the existing GetTensorElementType / GetDimensionsCount
+// / GetDimensions stubs, which reinterpret_cast to FakeValueInfo, correctly
+// decode a FakeOrtValue* that has been cast to OrtTensorTypeAndShapeInfo*.
+// This avoids duplicating or overriding those stubs for the OrtValue code path.
+//
+// Keep FakeOrtValue objects on the stack (or as struct members with lifetimes
+// that enclose EP code calls); ReleaseTensorTypeAndShapeInfo is a no-op stub,
+// so no heap allocation or deallocation is performed.
+//
+// Usage:
+//   FakeOrtValue scale = FakeOrtValue::MakeFloat(0.5f);
+//   scale_vi.initializer_value = &scale;  // tie to a FakeValueInfo initializer
+// ---------------------------------------------------------------------------
+struct FakeOrtValue {
+  // Layout-compatible fields (same type and order as FakeValueInfo[0..2])
+  std::string dummy_name;                                                     // FakeValueInfo::name
+  ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;  // FakeValueInfo::elem_type
+  std::vector<int64_t> shape;                                                 // FakeValueInfo::shape (empty = scalar)
+  // Scalar payload (read by GetTensorMutableData)
+  float float_data = 0.0f;
+  double double_data = 0.0;
+
+  const OrtValue* AsOrtValue() const { return reinterpret_cast<const OrtValue*>(this); }
+
+  static FakeOrtValue MakeFloat(float v) {
+    FakeOrtValue r;
+    r.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    r.float_data = v;
+    return r;
+  }
+  static FakeOrtValue MakeDouble(double v) {
+    FakeOrtValue r;
+    r.elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE;
+    r.double_data = v;
+    return r;
   }
 };
 
@@ -314,6 +365,52 @@ inline void InstallFakeGraphApiStubs(OrtApi& api) {
   };
   api.Node_GetGraph = [](const OrtNode*, const OrtGraph** g) noexcept -> OrtStatus* {
     *g = nullptr;
+    return nullptr;
+  };
+
+  // ---- OrtValue (scalar constant initializer) ----
+  //
+  // ValueInfo_GetInitializerValue: return the FakeOrtValue stored in
+  // FakeValueInfo::initializer_value (null if not a constant initializer).
+  api.ValueInfo_GetInitializerValue = [](const OrtValueInfo* vi, const OrtValue** out) noexcept -> OrtStatus* {
+    auto* fov = reinterpret_cast<const FakeValueInfo*>(vi)->initializer_value;
+    *out = fov ? fov->AsOrtValue() : nullptr;
+    return nullptr;
+  };
+  // GetTensorTypeAndShape: the OrtValue* is a FakeOrtValue*; return it cast to
+  // OrtTensorTypeAndShapeInfo*. The layout-compatible FakeOrtValue fields
+  // (elem_type, shape) are read correctly by the existing GetTensorElementType
+  // and GetDimensionsCount stubs without any modification.
+  // ReleaseTensorTypeAndShapeInfo remains a no-op (no heap allocation here).
+  api.GetTensorTypeAndShape = [](const OrtValue* v, OrtTensorTypeAndShapeInfo** out) noexcept -> OrtStatus* {
+    *out = const_cast<OrtTensorTypeAndShapeInfo*>(
+        reinterpret_cast<const OrtTensorTypeAndShapeInfo*>(v));
+    return nullptr;
+  };
+  // GetTensorMutableData: return a pointer to float_data or double_data.
+  api.GetTensorMutableData = [](OrtValue* v, void** out) noexcept -> OrtStatus* {
+    auto* fov = reinterpret_cast<FakeOrtValue*>(v);
+    *out = (fov->elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT)
+               ? static_cast<void*>(&fov->float_data)
+               : static_cast<void*>(&fov->double_data);
+    return nullptr;
+  };
+
+  // ---- ValueInfo producer/consumer queries ----
+  // Return nullptr/empty by default. Tests that need a real producer can
+  // override this stub after calling InstallFakeGraphApiStubs.
+  api.ValueInfo_GetValueProducer = [](const OrtValueInfo*, const OrtNode** producer,
+                                      size_t* output_index) noexcept -> OrtStatus* {
+    if (producer) *producer = nullptr;
+    if (output_index) *output_index = 0;
+    return nullptr;
+  };
+  api.ValueInfo_GetValueConsumers = [](const OrtValueInfo*, const OrtNode** consumers,
+                                       int64_t* indices, size_t count) noexcept -> OrtStatus* {
+    for (size_t i = 0; i < count; ++i) {
+      consumers[i] = nullptr;
+      if (indices) indices[i] = 0;
+    }
     return nullptr;
   };
 }

--- a/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
@@ -113,6 +113,10 @@ struct FakeOrtValue {
     return r;
   }
 };
+static_assert(offsetof(FakeOrtValue, dummy_name) == offsetof(FakeValueInfo, name),
+              "FakeOrtValue/FakeValueInfo layout drift: name offset mismatch");
+static_assert(offsetof(FakeOrtValue, elem_type) == offsetof(FakeValueInfo, elem_type),
+              "FakeOrtValue/FakeValueInfo layout drift: elem_type offset mismatch");
 
 // ---------------------------------------------------------------------------
 // FakeNode
@@ -387,7 +391,7 @@ inline void InstallFakeGraphApiStubs(OrtApi& api) {
         reinterpret_cast<const OrtTensorTypeAndShapeInfo*>(v));
     return nullptr;
   };
-  // GetTensorMutableData: return a pointer to float_data or double_data.
+  // GetTensorMutableData: production code (qnn_ep_utils.cc) calls the mutable variant via api_ptrs_.
   api.GetTensorMutableData = [](OrtValue* v, void** out) noexcept -> OrtStatus* {
     auto* fov = reinterpret_cast<FakeOrtValue*>(v);
     *out = (fov->elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT)

--- a/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
+++ b/onnxruntime/test/providers/qnn/unit/qnn_fake_ort_graph.h
@@ -117,6 +117,8 @@ static_assert(offsetof(FakeOrtValue, dummy_name) == offsetof(FakeValueInfo, name
               "FakeOrtValue/FakeValueInfo layout drift: name offset mismatch");
 static_assert(offsetof(FakeOrtValue, elem_type) == offsetof(FakeValueInfo, elem_type),
               "FakeOrtValue/FakeValueInfo layout drift: elem_type offset mismatch");
+static_assert(offsetof(FakeOrtValue, shape) == offsetof(FakeValueInfo, shape),
+              "FakeOrtValue/FakeValueInfo layout drift: shape offset mismatch");
 
 // ---------------------------------------------------------------------------
 // FakeNode


### PR DESCRIPTION
## Summary

Adds `onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc` — function-level
unit tests for `qnn_ep_utils.cc`, exercising the `OrtNodeGroupSelector::Check()`
family using `FakeGraph` / `FakeNode` / `FakeValueInfo` stubs from
`qnn_fake_ort_graph.h`. No real QNN backend or ORT session is required.

**107 tests in `QnnUnit_EpUtilsTest`, covering all 22 selector classes in
`qnn_ep_utils.h`:**

| Selector class | Tests | Notable branches covered |
|---|---:|---|
| `OrtDropDQNodeGroupSelector` | 9 | redundant clip reject, empty/two-DQ reject, uint8/int8 accept, int16 gated by `allow_16bit_`, int4 gated by `allow_4bit_`, DQ-with-no-inputs |
| `OrtDropQDQNodeGroupSelector` | 16 | positive/negative/zero scale, `allow_nonpositive_scale_`, scale-not-initializer, diff-scale-name same/different value, double vs int scale types, Q-node no scale input |
| `OrtUnaryNodeGroupSelector` | 6 | wrong DQ count, uint8 accept, type mismatch, int16 gate, no-inputs DQ |
| `OrtBinaryNodeGroupSelector` | 4 | only-one-DQ reject, matching uint8 accept, mixed types reject, first-DQ-no-inputs |
| `OrtVariadicNodeGroupSelector` | 7 | 2-DQ same type accept, mixed types reject, int16 gate, zero DQ, no-inputs DQ, no-outputs Q, second-Q type mismatch |
| `OrtPadNodeGroupSelector` | 5 | 3-DQ reject, 1-DQ matching/mismatched, 2-DQ same/different types |
| `OrtSplitNodeGroupSelector` | 6 | redundant clip, 1-DQ-2-Q accept, Q type mismatch, int4 gate, no-inputs DQ, equal-quant scale value mismatch |
| `OrtConvNodeGroupSelector` | 9 | 2/3-DQ paths, int8 gate, int32 bias check, I/O type mismatch, int4 weight gate, weight/data type mismatch, 16-bit gate, first-DQ-no-inputs |
| `OrtMatMulNodeGroupSelector` | 7 | 2-DQ with/without Q, `allow_matmul_int_to_float_` gating, weight/data type mismatch, 16-bit gate, no-inputs DQ, QLinear check failure |
| `OrtGemmNodeGroupSelector` | 4 | int8-A/uint8-B mismatch, Q output type mismatch, **fewer-than-2-DQ reject, 16-bit gate on A/B** |
| `OrtEinsumNodeGroupSelector` | 5 | uint8 no-Q accept, int8/int16/int4 gates, Q output type mismatch |
| `OrtReciprocalNodeGroupSelector` | 6 | uint8 no-Q accept, int8/int16/int4 gates, no-outputs Q, Q output type mismatch |
| `OrtWhereNodeGroupSelector` | 3 | DQ type mismatch, 16-bit gate, **wrong DQ count** |
| `OrtInstanceAndLayerNormalizationNodeGroupSelector` | 1 | type mismatch reject |
| `OrtBatchNormalizationNodeGroupSelector` | 4 | too-few-DQ reject, int8 with mixed scale reject, **CheckQDQNodes fail, input/output type mismatch** |
| `OrtCumSumNodeGroupSelector` | 1 | type mismatch reject |
| `OrtScatterElementsNodeGroupSelector` | 1 | mixed DQ types reject |
| `OrtRMSNormalizationNodeGroupSelector` | 1 | type mismatch reject |
| `OrtTopKNodeGroupSelector` | 4 | redundant clip, wrong DQ count, CanCreateNodeGroup path, **input/output type mismatch** |
| `OrtClipNodeGroupSelector` | 3 | CheckQDQNodes failure, null producer, **16-bit gate (with producer stub)** |
| `OrtLogicalComparisonNodeGroupSelector` | 2 | matching types accept, mismatched reject |
| `CheckQDQNodes` (base helper) | 1 | rejects when output is a graph output |
| `OrtSelectors::RegisterSelector` | 1 | increases size |
| `GetOrtQDQSelections` (MaxPool version path) | 1 | version-gated selector registration |

(Bolded rows added in the follow-up commit that lifted coverage from 90.0% to 90.7%.)

## Coverage (`qnn_ep_utils.cc`, build/linux-x86_64, RelWithDebInfo)

| Filter | Lines | Functions | Branches |
|---|---|---|---|
| `QnnUnit_EpUtilsTest.*` (unit-only) | **614 / 999 = 61.5%** | 39 / 49 = 79.6% | 922 / 2367 = 39.0% |
| `*Qnn*` (combined with integration) | **906 / 999 = 90.7%** | 49 / 49 = 100% | 1253 / 2367 = 52.9% |

The 292-line gap between unit-only and combined comes from integration tests
(`QnnHTPBackendTests`, `QnnCPUBackendTests`) exercising three graph-traversal
functions that build/walk real `OrtNodeUnit` structures through
`qnn_execution_provider::GetCapability`:

- `GetOrtQDQSelection` Relu/Clip fusion detection (~89 lines)
- `CreateSupportedPartitionNodeGroups` (~72 lines)
- `GetAllOrtNodeUnits` (~34 lines)
- selector accept paths + helpers only reachable through real QDQ graphs (~97 lines)

## Test infrastructure

- **`FakeGraph` / `FakeNode` / `FakeValueInfo` / `FakeOrtValue`** (`qnn_fake_ort_graph.h`) —
  pure C++ stubs, no real ORT graph required.
- **`EpUtilsTestContext`** — installs `FakeGraph` API stubs plus two extras used
  by `CheckQDQNodes`: `ValueInfo_IsGraphOutput` (returns false) and
  `ValueInfo_GetValueNumConsumers` (returns 1). Without the latter two, the
  `ORT_CONTINUE_ON_ERROR` paths would silently fail.
- **`OrtGlobalApiOverride`** (`qnn_unit_test_utils.h`) — RAII scope guard used
  by tests that reach code calling `Ort::ConstNode(node).GetOperatorType()`,
  which routes through the global `Ort::detail::Global::Api()` pointer.
- **File-scope `g_clip_producer_dq` + `FakeClipProducerStub`** — used only by
  `Clip_Rejects16BitWhenDisallowed` to thread a specific DQ node pointer
  through a non-capturing lambda stub for `ValueInfo_GetValueProducer`.

## Test plan

- `./onnxruntime_provider_test --gtest_filter="QnnUnit_EpUtilsTest.*"` — all 107 tests pass
- Coverage build (`coverage_linux_x86_64`, RelWithDebInfo):
  - Unit-only: 61.5% lines
  - Combined: 90.7% lines / 100% functions
- Tests guarded by `QNN_EP_INTERNAL_SYMBOL_ACCESS` — no-op on non-coverage builds
