### PR TITLE
[QNN EP] Fix GroupQueryAttention build on Linux x86_64

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/group_query_attention_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/group_query_attention_op_builder.cc
@@ -184,7 +184,7 @@ Ort::Status GroupQueryAttentionOpBuilder::ProcessAttributesAndOutputs(QnnModelWr
                                param_names));
 
   // do_rotary
-  const int64_t do_rotary = node_helper.Get("do_rotary", 0ll);
+  const int64_t do_rotary = node_helper.Get("do_rotary", static_cast<int64_t>(0));
   const uint32_t do_rotary_u32 = SafeInt<uint32_t>(do_rotary);
   RETURN_IF_ERROR(AddQnnScalar(qnn_model_wrapper,
                                node_unit.Index(),
@@ -201,7 +201,7 @@ Ort::Status GroupQueryAttentionOpBuilder::ProcessAttributesAndOutputs(QnnModelWr
   const size_t head_size = output_tensor_info.shape[2] / num_heads.value();
   RETURN_IF(head_size == 0, "head_size can't be zero!");
 
-  const float scale_default = 1.0f / std::sqrtf(static_cast<float>(head_size));
+  const float scale_default = 1.0f / std::sqrt(static_cast<float>(head_size));
   const float scale = node_helper.Get("scale", scale_default);
   RETURN_IF_ERROR(AddQnnScalar(qnn_model_wrapper,
                                node_unit.Index(),


### PR DESCRIPTION
## Summary
Two trivial portability fixes to `group_query_attention_op_builder.cc` that broke `-Werror` builds with GCC/libstdc++ on Linux x86_64 (Windows/MSVC builds happen to tolerate both):

- `node_helper.Get("do_rotary", 0ll)` — `0ll` is `long long`, but on Linux x86_64 `int64_t` is `long`, so the literal didn't uniquely match any of the overloaded `OrtNodeAttrHelper::Get(const std::string&, T)` candidates. Replaced with `static_cast<int64_t>(0)`.
- `std::sqrtf(...)` — `sqrtf` is a C function in `<math.h>`; the C++ standard does not put it in `std::`. libstdc++ enforces this. Replaced with `std::sqrt(...)` (the float overload picks the same implementation).

## Test plan
- [x] Build `linux-x86_64 Release` end-to-end — previously failed at the GQA TU, now produces `onnxruntime_qnn-2.5.0-cp310-cp310-linux_x86_64.whl`.
- [ ] Existing Windows builds remain green (no behavior change; both expressions resolve to the same call).