### PR TITLE
[QNN EP] Remove Dummy Bias tensor creation in RMS Norm

### DIFF
--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -30,6 +30,12 @@
   endif()
   message(STATUS "QNN SDK version ${QNN_SDK_VERSION}")
 
+  if(QNN_SDK_VERSION)
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _ "${QNN_SDK_VERSION}")
+    set(QNN_SDK_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(QNN_SDK_VERSION_MINOR "${CMAKE_MATCH_2}")
+  endif()
+
   source_group(TREE ${ONNXRUNTIME_ROOT}/core FILES ${onnxruntime_providers_qnn_ep_srcs})
 
   set(onnxruntime_providers_qnn_all_srcs ${onnxruntime_providers_qnn_ep_srcs})
@@ -76,6 +82,12 @@
 
     target_compile_definitions(onnxruntime_providers_qnn PRIVATE FILE_DESC=\"${QNN_DLL_FILE_DESCRIPTION}\")
     target_compile_definitions(onnxruntime_providers_qnn PRIVATE FILE_NAME=\"onnxruntime_providers_qnn.dll\")
+  endif()
+
+  if(QNN_SDK_VERSION_MAJOR AND QNN_SDK_VERSION_MINOR)
+    target_compile_definitions(onnxruntime_providers_qnn PRIVATE
+      QNN_SDK_VERSION_MAJOR=${QNN_SDK_VERSION_MAJOR}
+      QNN_SDK_VERSION_MINOR=${QNN_SDK_VERSION_MINOR})
   endif()
 
   # Set linker flags for function(s) exported by EP DLL

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -87,15 +87,15 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[X_IDX], logger, input_names));
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
 
-#if !defined(QNN_SDK_VERSION_MINOR) || QNN_SDK_VERSION_MINOR < 48
-  // QNN SDK < 2.48 requires an explicit beta/bias input for QNN_OP_RMS_NORM on NPU.
-  // SDK 2.48+ accepts beta as optional, so the dummy tensor is only needed for older SDKs.
+#if !defined(QNN_SDK_VERSION_MINOR) || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR < 49)
+  // QNN SDK < 2.49 requires an explicit beta/bias input for QNN_OP_RMS_NORM on NPU.
+  // SDK 2.49+ accepts beta as optional, so the dummy tensor is only needed for older SDKs.
   // Note: SDK 2.47 and 2.48 share the same QNN API version (2.36), so QNN_SDK_VERSION_MINOR
-  // derived from CMAKE is used here instead of QNN_API_VERSION_MINOR.
+  // derived from CMake is used here instead of QNN_API_VERSION_MINOR.
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                ("RMSNorm node " + node_unit.Name() + ": adding dummy beta tensor (SDK < 2.48).").c_str());
+                ("RMSNorm node " + node_unit.Name() + ": adding dummy beta tensor (SDK < 2.49).").c_str());
     TensorInfo scale_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_info));
 
@@ -133,9 +133,9 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
 #else
   if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                ("RMSNorm node " + node_unit.Name() + ": skipping dummy beta tensor (SDK >= 2.48).").c_str());
+                ("RMSNorm node " + node_unit.Name() + ": skipping dummy beta tensor (SDK >= 2.49).").c_str());
   }
-#endif  // !defined(QNN_SDK_VERSION_MINOR) || QNN_SDK_VERSION_MINOR < 48
+#endif  // !defined(QNN_SDK_VERSION_MINOR) || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR < 49)
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -87,9 +87,15 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[X_IDX], logger, input_names));
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
 
-  // Create dummy beta tensor for NPU backend
+#if !defined(QNN_SDK_VERSION_MINOR) || QNN_SDK_VERSION_MINOR < 48
+  // QNN SDK < 2.48 requires an explicit beta/bias input for QNN_OP_RMS_NORM on NPU.
+  // SDK 2.48+ accepts beta as optional, so the dummy tensor is only needed for older SDKs.
+  // Note: SDK 2.47 and 2.48 share the same QNN API version (2.36), so QNN_SDK_VERSION_MINOR
+  // derived from CMAKE is used here instead of QNN_API_VERSION_MINOR.
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("RMSNorm node " + node_unit.Name() + ": adding dummy beta tensor (SDK < 2.48).").c_str());
     TensorInfo scale_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_info));
 
@@ -124,6 +130,12 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
                   "Failed to add dummy beta tensor for QNN RMSNorm node.");
     input_names.push_back(beta_tensor_name);
   }
+#else
+  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("RMSNorm node " + node_unit.Name() + ": skipping dummy beta tensor (SDK >= 2.48).").c_str());
+  }
+#endif  // !defined(QNN_SDK_VERSION_MINOR) || QNN_SDK_VERSION_MINOR < 48
 
   return Ort::Status();
 }

--- a/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
@@ -129,7 +129,7 @@ static void RunRMSNormQDQTest(const TestInputDef<float>& input_def,
                   provider_options,
                   23,
                   EPVerificationParams{expected_ep_assignment, ElementwiseAbsoluteVerifier(1e-5)},
-                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR, false);
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE, false);
 }
 
 TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis) {


### PR DESCRIPTION
## Description

Removes the dummy all-zeros beta tensor that was unconditionally synthesized for `QNN_OP_RMS_NORM` on the HTP backend. SDK 2.49+ accepts beta as an optional input, so the workaround is only compiled in when building against SDK < 2.49.

---

## Motivation & Context

`QNN_OP_RMS_NORM` on the HTP backend previously required an explicit beta/bias input even though the ONNX `RMSNormalization` op has no bias parameter. To satisfy QNN's input contract, the op builder synthesized a dummy all-zeros beta tensor for every NPU graph build.

QAIRT SDK 2.49 relaxed this requirement, beta is now a truly optional input. The dummy tensor is no longer needed and adds unnecessary graph weight.

**Why `QNN_SDK_VERSION_MINOR` instead of `QNN_API_VERSION_MINOR`:**

SDK 2.47 and SDK 2.48 both define `QNN_API_VERSION_MINOR = 36`. The QNN API version did not increment between these two releases. `QNN_API_VERSION_MINOR` cannot distinguish them at compile time. Instead, `QNN_SDK_VERSION_MINOR` is injected by CMake by parsing the `version` field from `sdk.yaml` at configure time, which correctly resolves to `47` vs `48`.

The `!defined(QNN_SDK_VERSION_MINOR)` fallback in the `#if` guard preserves the old behavior (dummy tensor always added) when the SDK version cannot be determined at configure time.

---

## Files Changed

| File | Change |
|------|--------|
| `builder/opbuilder/rmsnormalization_op_builder.cc` | Wrapped dummy beta synthesis in `#if !defined(QNN_SDK_VERSION_MINOR) \|\| QNN_SDK_VERSION_MINOR < 48`. Added VERBOSE log on both paths indicating whether the dummy tensor is added or skipped. |
| `cmake/onnxruntime_providers_qnn.cmake` | Parse `QNN_SDK_VERSION` string (from `sdk.yaml`) into `QNN_SDK_VERSION_MAJOR` / `QNN_SDK_VERSION_MINOR` compile definitions on the `onnxruntime_providers_qnn` target. |