### PR TITLE
[QNN EP] Fix ReshapeGemmFusion claiming shared Reshape with multiple consumers

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -119,6 +119,18 @@ bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape
   return total_input == total_output;
 }
 
+// Returns true if the input Reshape's output has more than one consumer.
+// If a graph-level CSE pass merges two Reshape nodes into one, claiming the
+// shared Reshape would remove it from the graph and break the other consumers.
+// TODO: Revisit — in principle each consumer could be fused independently by
+// duplicating the Reshape; for now we conservatively skip to keep correctness.
+static bool InputReshapeIsShared(const OrtNodeUnit* input_reshape) {
+  if (input_reshape == nullptr) return false;
+  const Ort::ConstNode reshape_node(&input_reshape->GetNode());
+  auto reshape_outputs = reshape_node.GetOutputs();
+  return !reshape_outputs.empty() && reshape_outputs[0].GetConsumers().size() > 1;
+}
+
 // Get the input Reshape node unit that feeds into the Gemm node
 const OrtNodeUnit* GetInputReshapeNodeUnit(
     const QnnModelWrapper& qnn_model_wrapper,
@@ -412,6 +424,10 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion2(
     return nullptr;
   }
 
+  if (InputReshapeIsShared(input_reshape)) {
+    return nullptr;
+  }
+
   // Get weight's input channel (K dimension)
   const OrtNodeUnitIODef& weight_input = gemm_node_unit.Inputs()[1];
   int64_t weight_k = GetWeightInputChannel(qnn_model_wrapper, weight_input);
@@ -444,6 +460,10 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion3(
   const OrtNodeUnit* input_reshape = GetInputReshapeNodeUnit(
       qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
   if (!input_reshape) {
+    return nullptr;
+  }
+
+  if (InputReshapeIsShared(input_reshape)) {
     return nullptr;
   }
 
@@ -486,6 +506,10 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion4(
   const OrtNodeUnit* input_reshape = GetInputReshapeNodeUnit(
       qnn_model_wrapper, gemm_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
   if (!input_reshape) {
+    return nullptr;
+  }
+
+  if (InputReshapeIsShared(input_reshape)) {
     return nullptr;
   }
 

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc
@@ -358,6 +358,50 @@ TEST_F(QnnHTPBackendTests, ReshapeGemmReshapeFusion_Transformer) {
 // Negative Tests - Fusion should NOT happen
 // ============================================================================
 
+// Build a test case where input Reshape has two consumers (fusion should not happen).
+// Graph: Input -> Reshape -> Gemm1 (output1)
+//                        \-> Gemm2 (output2)
+// Claiming the shared Reshape for Gemm1 would break Gemm2, so fusion must not fire.
+GetTestModelFn BuildReshapeSharedByTwoGemmsTestCase() {
+  return [](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_shared_two_gemms_graph");
+
+    auto input_def = TestInputDef<float>({1, 4, 8}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    // Shared Reshape: [1, 4, 8] -> [4, 8]
+    builder.Make1DInitializer<int64_t>("reshape_shape", {4, 8});
+    builder.AddNode("reshape", "Reshape", {"input", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // Gemm1: [4, 8] x [8, 16] -> [4, 16]
+    builder.MakeInitializer<float>("weight1", {8, 16}, -0.5f, 0.5f);
+    builder.MakeInitializer<float>("bias1", {16}, -0.1f, 0.1f);
+    builder.AddNode("gemm1", "Gemm", {"reshape_out", "weight1", "bias1"}, {"output1"}, kOnnxDomain);
+
+    // Gemm2: [4, 8] x [8, 32] -> [4, 32]  — shares reshape_out
+    builder.MakeInitializer<float>("weight2", {8, 32}, -0.5f, 0.5f);
+    builder.MakeInitializer<float>("bias2", {32}, -0.1f, 0.1f);
+    builder.AddNode("gemm2", "Gemm", {"reshape_out", "weight2", "bias2"}, {"output2"}, kOnnxDomain);
+
+    builder.MakeOutput("output1");
+    builder.MakeOutput("output2");
+  };
+}
+
+// Test: Fusion should NOT happen when the input Reshape has two consumers.
+// If fusion incorrectly claimed the shared Reshape for one Gemm, the other Gemm
+// would lose its input and the model would fail. All nodes must still run on QNN EP.
+TEST_F(QnnHTPBackendTests, ReshapeGemmFusion_Negative_SharedReshape) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  ProviderOptions provider_options = GetProviderOptions();
+
+  RunQnnModelTest(BuildReshapeSharedByTwoGemmsTestCase(),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+}
+
 // Build a test case where Gemm has transA=1 (fusion should not happen)
 GetTestModelFn BuildReshapeGemmWithTransATestCase(const std::vector<int64_t>& input_shape,
                                                   int64_t hidden_size,


### PR DESCRIPTION
### Description

In ReshapeGemmFusionGroup::TryFusion2/3/4, add a guard to skip fusion when the input Reshape's output has more than one consumer.

When ORT's CSE (Common Subexpression Elimination) optimization runs before graph partitioning, it can merge two structurally-identical Reshape nodes
into one shared node. If such a shared Reshape feeds multiple Gemm nodes, the fusion logic would incorrectly claim it — removing the shared Reshape
from the graph and breaking every other consumer's input edge.

The fix conservatively skips fusion in this case. A future optimization could duplicate the Reshape per consumer to re-enable fusion.

**Files changed:**
- onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc — single-consumer guard in TryFusion2, TryFusion3, TryFusion4
- onnxruntime/test/providers/qnn/qnn_node_group/reshape_gemm_fusion_test.cc — negative test ReshapeGemmFusion_Negative_SharedReshape

**Kill-test fence:** 
ReshapeGemmFusion_Negative_SharedReshape was verified to fail when the InputReshapeIsShared guard is temporarily removed — the second Gemm's input tensor has already been claimed by the first fusion group, causing a Compile error. This confirms the test is not vacuously passing.

### Motivation and Context

This is an edge case missed in the initial implementation of ReshapeGemmFusionGroup (introduced in #232). The fusion logic did not account for the
possibility that ORT graph optimizations (e.g., CSE) could produce a shared Reshape consumed by multiple Gemms. Without this fix, such a model would
produce a broken QNN graph during Compile because the second Gemm's input tensor has already been claimed and removed by the first fusion group.



