### PR TITLE
[QNN EP] Consolidate duplicated BQ helpers across op builders

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -5,36 +5,13 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_bq_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/qnn_graph_utils.h"
 
 namespace onnxruntime {
 namespace qnn {
-
-namespace {
-// HTP BQ Conv: supported bitwidths and their block_size divisor constraints.
-// block_size must be a multiple of the corresponding value (same as MatMulNBits HTP constraints).
-const std::unordered_map<uint32_t, int64_t> kHtpConvBQBitsAndBlockSizeMultipliers{
-    {2, 16}, {4, 8}, {8, 4}};
-
-// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
-static uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
-  switch (onnx_type) {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
-      return 2;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
-      return 4;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      return 8;
-    default:
-      return 0;
-  }
-}
-}  // namespace
 
 // ONNX convolution types supported by this builder.
 // We translate node_unit.OpType() into this enum to avoid repeated string comparisons.
@@ -155,24 +132,13 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                      weight_scale_shape[1] < weight_shape[1]);
         if (is_block_quant) {
           const int64_t num_blocks_per_oc = weight_scale_shape[1];
-          RETURN_IF(num_blocks_per_oc <= 0, "QNN EP: BQ num_blocks must be positive");
           const int64_t ic = static_cast<int64_t>(weight_shape[1]);
-          RETURN_IF(ic % num_blocks_per_oc != 0,
-                    "QNN EP: Conv BQ: IC must be divisible by num_blocks_per_oc");
 
           // Validate bitwidth (from weight element type) and block_size against HTP constraints.
-          const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
-          const int64_t block_size = ic / num_blocks_per_oc;
-          auto bq_it = kHtpConvBQBitsAndBlockSizeMultipliers.find(bitwidth);
-          RETURN_IF(bq_it == kHtpConvBQBitsAndBlockSizeMultipliers.end(),
-                    ("QNN HTP Conv BQ: unsupported weight bitwidth=" +
-                     std::to_string(bitwidth))
-                        .c_str());
-          RETURN_IF(block_size % bq_it->second != 0,
-                    ("QNN HTP Conv BQ: block_size=" + std::to_string(block_size) +
-                     " must be a multiple of " + std::to_string(bq_it->second) +
-                     " for " + std::to_string(bitwidth) + "-bit weight")
-                        .c_str());
+          const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
+          int64_t block_size = 0;
+          RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], ic, num_blocks_per_oc, "Conv", block_size));
+          RETURN_IF_ERROR(bq::ValidateBQBitwidthAndBlockSize(bitwidth, block_size, "Conv"));
 
           // Return success; full QNN validation is done in the NHWC IsOpSupported path.
           return Ort::Status();
@@ -287,22 +253,11 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
       const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
       if (act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16) {
-        // Reuse the original DequantizeLinear node's output name (the target Conv's input[0]) for the
-        // FP16 tensor. That tensor is conceptually the dequantized activation — exactly what this
-        // INT16→FP16 Dequantize produces — and QNN EP otherwise skips it, so the name is free and
-        // keeps the QNN graph aligned with the ONNX graph naming.
+        // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
+        // stays aligned with the ONNX graph naming.
         const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-        std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
-        QnnTensorWrapper fp16_act_wrapper(fp16_act_name, QNN_TENSOR_TYPE_NATIVE,
-                                          QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                          std::vector<uint32_t>(act_shape));
-        RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_act_wrapper)),
-                      "Failed to add FP16 activation tensor for BQ Conv.");
-        RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                          utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
-                          QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
-                          {act_name}, {fp16_act_name}, {}, do_op_validation),
-                      "Failed to add INT16→FP16 Dequantize node for BQ Conv activation.");
+        RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
+                                                               fp16_act_name, do_op_validation, "Conv"));
         input_names[0] = fp16_act_name;
       }
     }
@@ -352,21 +307,13 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       // BQ path: manually build QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK quant params.
       const int64_t OC = static_cast<int64_t>(input_info.shape[0]);
       const int64_t IC = static_cast<int64_t>(input_info.shape[1]);
-      const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc (validated: IC % nb == 0)
-      const int64_t block_size = IC / nb;
-      const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
+      const int64_t nb = bq_scale_shape[1];  // num_blocks_per_oc
+      int64_t block_size = 0;
+      RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], IC, nb, "Conv", block_size));
+      const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
 
       // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain.
-      // QNN BW_FLOAT_BLOCK only supports SFIXED_POINT_8 (signed); unsigned data must be converted.
-      // TransformUnsignedToSignedFixedPoint XORs the MSB of each packed element:
-      //   - UINT8 (bitwidth=8, mask=0x80): 1 byte/element — directly converts [0,255] → [-128,127].
-      //   - UINT4 (bitwidth=4, mask=0x88): after TransposeFromNchwToHwcn unpack, each byte holds
-      //     a UINT4 value in its lower nibble (upper nibble=0). XOR with 0x88 flips bits 3 and 7;
-      //     QNN reads only the lower nibble for bitwidth=4, so the result is equivalent to
-      //     flipping bit 3, which shifts [0,15] → signed-nibble-interpreted [-8,7] correctly.
-      const bool is_unsigned_weight = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
-                                       inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
-                                       inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+      const bool is_unsigned_weight = bq::IsUnsignedBQType(inputs[1].type);
       if (is_unsigned_weight) {
         RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor,
                                                                    static_cast<int64_t>(bitwidth)));
@@ -377,28 +324,16 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
       const std::vector<uint32_t> block_size_arr = {1u, 1u, static_cast<uint32_t>(block_size), 1u};
 
       // Read ONNX per-block float scales: flat [OC * nb] in OC-major order.
+      // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
       std::vector<float> scales_qnn;
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, scales_qnn));
       RETURN_IF_NOT(static_cast<int64_t>(scales_qnn.size()) == OC * nb,
                     "QNN EP: BQ Conv scale size mismatch");
-      // QNN BW_FLOAT_BLOCK expects scales in [OC, nb] order — same as ONNX, no reordering needed.
 
       // Float offsets in [OC, nb] order.
-      // Signed:   offset = -onnx_zp
-      // Unsigned: offset = (1 << (bits-1)) - onnx_zp   (compensates for unsigned→signed shift above)
-      const float unsigned_bias = is_unsigned_weight ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
-      std::vector<float> offsets_qnn(static_cast<size_t>(OC * nb), unsigned_bias);
-      if (inputs[1].quant_param->zero_point != nullptr) {
-        std::vector<int32_t> zp_values;
-        ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-        RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point,
-                                                           zp_values, zp_onnx_type));
-        RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == OC * nb,
-                      "QNN EP: BQ Conv zero_point size must match OC * num_blocks");
-        for (size_t idx = 0; idx < static_cast<size_t>(OC * nb); ++idx) {
-          offsets_qnn[idx] = unsigned_bias - static_cast<float>(zp_values[idx]);
-        }
-      }
+      std::vector<float> offsets_qnn;
+      RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
+                                           is_unsigned_weight, bitwidth, OC * nb, offsets_qnn));
 
       QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
                                             gsl::span<const float>(offsets_qnn),
@@ -1343,10 +1278,8 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     if (is_bq_conv && is_quantized_tensor) {
       // BQ Conv outputs FP16; downstream QDQ expects INT16.
       // Emit: Conv (FP16 output) → Quantize (FP16 → INT16 quantized output).
-      // Reuse the original QuantizeLinear node's input name (the target Conv's output[0]) for the
-      // FP16 tensor. That tensor is conceptually the un-quantized Conv output — exactly what this
-      // BQ Conv produces — and QNN EP otherwise skips it, so the name is free and keeps the QNN
-      // graph aligned with the ONNX graph naming.
+      // Reuse the original QuantizeLinear input name for the FP16 tensor so the QNN graph
+      // stays aligned with the ONNX graph naming.
       const std::string conv_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
       QnnTensorWrapper fp16_out_wrapper(conv_fp16_out, QNN_TENSOR_TYPE_NATIVE,
                                         QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
@@ -1361,17 +1294,11 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                     std::move(param_tensor_names),
                                                     do_op_validation),
                     "Failed to add BQ Conv node.");
-      // INT16 quantized output tensor consumed by downstream nodes.
-      QnnTensorWrapper int16_out_wrapper(output_name, tensor_type, qnn_data_type,
-                                         std::move(output_quantize_param),
-                                         std::move(output_shape));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                    "Failed to add INT16 BQ Conv output tensor.");
-      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                        utils::UniqueNameGenerator().New(output_name, "_fp16_quantize"),
-                        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                        {conv_fp16_out}, {output_name}, {}, do_op_validation),
-                    "Failed to add FP16→INT16 Quantize node for BQ Conv output.");
+      RETURN_IF_ERROR(bq::AddFp16ToInt16QuantizeOutput(qnn_model_wrapper,
+                                                       conv_fp16_out, output_name,
+                                                       tensor_type, qnn_data_type,
+                                                       std::move(output_quantize_param),
+                                                       std::move(output_shape), do_op_validation));
     } else {
       QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
                                             std::move(output_quantize_param), std::move(output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -332,8 +332,8 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
   std::vector<float> scales_qnn, offsets_qnn;
   if (trans_b == 0) {
     // Transpose from [num_blocks, N] to [N, num_blocks].
-    bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn);
-    bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn);
+    RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn));
+    RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn));
   } else {
     scales_qnn = std::move(onnx_scales);
     offsets_qnn = std::move(onnx_offsets);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -37,8 +37,8 @@ bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitI
   }
   // For transB=0: B=[K,N], blocked on axis 0 → scale=[num_blocks, N], scale_shape[0] < weight_shape[0].
   // For transB=1: B=[N,K], blocked on axis 1 → scale=[N, num_blocks], scale_shape[1] < weight_shape[1].
-  const size_t blocked_axis = (trans_b == 0) ? 0 : 1;
-  return bq::IsBlockedScale(scale_shape, weight_shape, blocked_axis);
+  const size_t block_axis = (trans_b == 0) ? 0 : 1;
+  return bq::IsBQScale(scale_shape, weight_shape, block_axis);
 }
 
 }  // namespace
@@ -332,8 +332,9 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
   std::vector<float> scales_qnn, offsets_qnn;
   if (trans_b == 0) {
     // Transpose from [num_blocks, N] to [N, num_blocks].
-    RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn));
-    RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn));
+    const std::vector<uint32_t> transpose_shape = {static_cast<uint32_t>(num_blocks), static_cast<uint32_t>(N)};
+    RETURN_IF_ERROR(utils::TwoDimensionTranspose<float>(onnx_scales, transpose_shape, scales_qnn, logger));
+    RETURN_IF_ERROR(utils::TwoDimensionTranspose<float>(onnx_offsets, transpose_shape, offsets_qnn, logger));
   } else {
     scales_qnn = std::move(onnx_scales);
     offsets_qnn = std::move(onnx_offsets);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <unordered_map>
-
 #include <gsl/gsl>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_bq_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -15,27 +14,6 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
-
-// HTP BQ Gemm/FC: supported weight bitwidths and their block_size divisor constraints.
-const std::unordered_map<uint32_t, int64_t> kHtpGemmBQBitsAndBlockSizeMultipliers{
-    {2, 16}, {4, 8}, {8, 4}};
-
-// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
-uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
-  switch (onnx_type) {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
-      return 2;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
-      return 4;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      return 8;
-    default:
-      return 0;
-  }
-}
 
 // Detects a block-quantized Gemm weight B, accounting for transB.
 // For transB=0: B is [K, N], scale is [K/block_size, N], blocked on axis 0.
@@ -59,15 +37,8 @@ bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitI
   }
   // For transB=0: B=[K,N], blocked on axis 0 → scale=[num_blocks, N], scale_shape[0] < weight_shape[0].
   // For transB=1: B=[N,K], blocked on axis 1 → scale=[N, num_blocks], scale_shape[1] < weight_shape[1].
-  const int blocked_axis = (trans_b == 0) ? 0 : 1;
-  if (scale_shape[blocked_axis] >= static_cast<int64_t>(weight_shape[blocked_axis])) {
-    return false;
-  }
-  const int64_t num_blocks = scale_shape[blocked_axis];
-  if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[blocked_axis]) % num_blocks != 0) {
-    return false;
-  }
-  return true;
+  const size_t blocked_axis = (trans_b == 0) ? 0 : 1;
+  return bq::IsBlockedScale(scale_shape, weight_shape, blocked_axis);
 }
 
 }  // namespace
@@ -281,24 +252,14 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
   {
     const std::string act_name = input_names[0];
     const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
-    const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
-    // BW_FLOAT_BLOCK FC requires FP16 activation. The only activation dtype reaching this
-    // path through the QDQ selector is INT16 (SFIXED or UFIXED), so anything else is unexpected.
-    RETURN_IF_NOT(act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16,
-                  "QNN EP: BQ Gemm activation must be INT16-quantized for the BW_FLOAT_BLOCK kernel");
-    // Reuse the original DequantizeLinear node's output name for the FP16 tensor.
-    const std::string fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
     const std::vector<uint32_t> act_shape_2d = act_wrapper.GetTensorDims();
-    QnnTensorWrapper fp16_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
-                                  QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                  std::vector<uint32_t>(act_shape_2d));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
-                  "Failed to add FP16 activation tensor for BQ Gemm.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
-                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
-                      {act_name}, {fp16_name}, {}, do_op_validation),
-                  "Failed to add INT16→FP16 Dequantize node for BQ Gemm activation.");
+
+    // BW_FLOAT_BLOCK FC requires FP16 activation; dequantize the INT16 activation to FP16.
+    // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
+    // stays aligned with the ONNX graph naming.
+    const std::string fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+    RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
+                                                           fp16_name, do_op_validation, "Gemm"));
     input_names[0] = fp16_name;
 
     // transA=1: the FP16 activation is [K, M]; transpose to [M, K] for QNN FullyConnected.
@@ -326,28 +287,20 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
 
   // num_blocks is the number of blocks along K.
   const int64_t num_blocks = (trans_b == 0) ? scale_shape[0] : scale_shape[1];
-  RETURN_IF(num_blocks <= 0 || K % num_blocks != 0, "QNN EP: BQ Gemm K must be divisible by num_blocks");
-  const int64_t block_size = K / num_blocks;
-  const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
-  auto bq_it = kHtpGemmBQBitsAndBlockSizeMultipliers.find(bitwidth);
-  RETURN_IF(bq_it == kHtpGemmBQBitsAndBlockSizeMultipliers.end(),
-            ("QNN HTP Gemm BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
-  RETURN_IF(block_size % bq_it->second != 0,
-            ("QNN HTP Gemm BQ: block_size=" + std::to_string(block_size) +
-             " must be a multiple of " + std::to_string(bq_it->second) +
-             " for " + std::to_string(bitwidth) + "-bit weight")
-                .c_str());
+  int64_t block_size = 0;
+  RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], K, num_blocks, "Gemm", block_size));
+  const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
+  RETURN_IF_ERROR(bq::ValidateBQBitwidthAndBlockSize(bitwidth, block_size, "Gemm"));
 
   // Unpack weight to one byte per element (sub-byte INT2/INT4 expanded to INT8).
   std::vector<uint8_t> unpacked_weight;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(weight_info.initializer_tensor, unpacked_weight));
 
   // For unsigned types, shift to signed domain.
-  const bool is_unsigned = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
-                            inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
-                            inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+  const bool is_unsigned = bq::IsUnsignedBQType(inputs[1].type);
   if (is_unsigned) {
-    RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_weight, static_cast<int64_t>(bitwidth)));
+    RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_weight,
+                                                               static_cast<int64_t>(bitwidth)));
   }
 
   // Transpose B to [N, K] if transB=0 (ONNX B is [K, N]).
@@ -372,32 +325,15 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
                 "QNN EP: BQ Gemm scale size mismatch");
 
   // Float offsets: unsigned_bias - onnx_zp (matching Conv BQ convention).
-  const float unsigned_bias = is_unsigned ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
-  std::vector<float> onnx_offsets(static_cast<size_t>(N * num_blocks), unsigned_bias);
-  if (inputs[1].quant_param->zero_point != nullptr) {
-    std::vector<int32_t> zp_values;
-    ONNXTensorElementDataType zp_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point, zp_values, zp_type));
-    RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == N * num_blocks,
-                  "QNN EP: BQ Gemm zero_point size must match N * num_blocks");
-    for (size_t i = 0; i < zp_values.size(); ++i) {
-      onnx_offsets[i] = unsigned_bias - static_cast<float>(zp_values[i]);
-    }
-  }
+  std::vector<float> onnx_offsets;
+  RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
+                                       is_unsigned, bitwidth, N * num_blocks, onnx_offsets));
 
   std::vector<float> scales_qnn, offsets_qnn;
   if (trans_b == 0) {
     // Transpose from [num_blocks, N] to [N, num_blocks].
-    scales_qnn.resize(static_cast<size_t>(N * num_blocks));
-    offsets_qnn.resize(static_cast<size_t>(N * num_blocks));
-    for (int64_t b = 0; b < num_blocks; ++b) {
-      for (int64_t n = 0; n < N; ++n) {
-        const size_t src = static_cast<size_t>(b * N + n);
-        const size_t dst = static_cast<size_t>(n * num_blocks + b);
-        scales_qnn[dst] = onnx_scales[src];
-        offsets_qnn[dst] = onnx_offsets[src];
-      }
-    }
+    bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn);
+    bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn);
   } else {
     scales_qnn = std::move(onnx_scales);
     offsets_qnn = std::move(onnx_offsets);
@@ -505,30 +441,25 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(org_output_name);
     const Qnn_TensorType_t out_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-    // FullyConnected → 2-D FP16 intermediate tensor. Reuse the original QL node's input name
-    // to keep the QNN graph aligned with the ONNX graph naming.
+    // FullyConnected → 2-D FP16 intermediate tensor, then Quantize to INT16.
+    // Reuse the original QuantizeLinear input name for the FP16 tensor so the QNN graph
+    // stays aligned with the ONNX graph naming.
     const std::string fc_fp16_out = Ort::ConstNode(&node_unit.GetNode()).GetOutputs()[0].GetName();
-    QnnTensorWrapper fc_fp16_wrapper(fc_fp16_out, QNN_TENSOR_TYPE_NATIVE,
-                                     QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                     std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_fp16_wrapper)),
+    QnnTensorWrapper fp16_wrapper(fc_fp16_out, QNN_TENSOR_TYPE_NATIVE,
+                                  QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                  std::vector<uint32_t>(output_shape));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
                   "Failed to add FP16 BQ Gemm FC output tensor.");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_FULLY_CONNECTED,
                                                   std::move(input_names), {fc_fp16_out},
                                                   {}, do_op_validation),
                   "Failed to add BQ FullyConnected node.");
-
-    // FP16 → INT16 quantized output.
-    QnnTensorWrapper int16_out_wrapper(org_output_name, out_tensor_type, output_info.qnn_data_type,
-                                       output_info.quant_param.Copy(), std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                  "Failed to add INT16 BQ Gemm output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::UniqueNameGenerator().New(org_output_name, "_fp16_quantize"),
-                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                      {fc_fp16_out}, {org_output_name}, {}, do_op_validation),
-                  "Failed to add FP16→INT16 Quantize node for BQ Gemm output.");
+    RETURN_IF_ERROR(bq::AddFp16ToInt16QuantizeOutput(qnn_model_wrapper,
+                                                     fc_fp16_out, org_output_name,
+                                                     out_tensor_type, output_info.qnn_data_type,
+                                                     output_info.quant_param.Copy(),
+                                                     output_shape, do_op_validation));
     return Ort::Status();
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -868,7 +868,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                                      matmul_fp16_out, op_output_name,
                                                      op_output_tensor_type, output_info.qnn_data_type,
                                                      op_output_quant_param.Copy(),
-                                                     std::move(op_output_shape), do_op_validation));
+                                                     op_output_shape, do_op_validation));
   } else {
     QnnTensorWrapper op_output_tensor_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
                                               op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -708,8 +708,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
 
   // Transpose scales/offsets [num_blocks, N] → [N, num_blocks].
   std::vector<float> scales_qnn, offsets_qnn;
-  bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn);
-  bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn);
+  RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn));
+  RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn));
 
   QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
                                         gsl::span<const float>(offsets_qnn),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -4,12 +4,12 @@
 #include <functional>
 #include <limits>
 #include <numeric>
-#include <unordered_map>
 
 #include <gsl/gsl>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_bq_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
@@ -20,28 +20,6 @@ namespace qnn {
 namespace {
 inline bool IsQuant16bit(Qnn_DataType_t qnn_data_type) {
   return qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 || qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16;
-}
-
-// HTP BQ MatMul: supported weight bitwidths and their block_size divisor constraints.
-// block_size must be a multiple of the corresponding value (same as Conv BQ / MatMulNBits HTP constraints).
-const std::unordered_map<uint32_t, int64_t> kHtpMatMulBQBitsAndBlockSizeMultipliers{
-    {2, 16}, {4, 8}, {8, 4}};
-
-// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
-uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
-  switch (onnx_type) {
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
-      return 2;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
-      return 4;
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
-    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
-      return 8;
-    default:
-      return 0;
-  }
 }
 
 // Detects a block-quantized MatMul weight (ONNX MatMul input[1]).
@@ -82,14 +60,7 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   }
   // Blocked axis is rank-2 (K dimension). scale_shape[rank-2] < weight_shape[rank-2].
   const size_t k_axis = rank - 2;
-  if (scale_shape[k_axis] >= static_cast<int64_t>(weight_shape[k_axis])) {
-    return false;
-  }
-  const int64_t num_blocks = scale_shape[k_axis];
-  if (num_blocks <= 0 || static_cast<int64_t>(weight_shape[k_axis]) % num_blocks != 0) {
-    return false;
-  }
-  return true;
+  return bq::IsBlockedScale(scale_shape, weight_shape, k_axis);
 }
 
 // Flattens the leading dims of `shape` (all but the last `n_trailing` dims) into a single
@@ -668,29 +639,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
   {
     const std::string act_name = input_names[0];
     const auto& act_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(act_name);
-    const Qnn_DataType_t act_dtype = act_wrapper.GetTensorDataType();
     std::vector<uint32_t> act_shape = act_wrapper.GetTensorDims();
 
-    std::string fp16_name = act_name;
-    // BW_FLOAT_BLOCK MatMul requires FP16 activation. The only activation dtype reaching this
-    // path through the QDQ selector is INT16 (SFIXED or UFIXED), so anything else is unexpected.
-    RETURN_IF_NOT(act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16,
-                  "QNN EP: BQ MatMul activation must be INT16-quantized for the BW_FLOAT_BLOCK kernel");
-    // Reuse the original DequantizeLinear node's output name (the target MatMul's input[0]) for the
-    // FP16 tensor. That tensor is conceptually the dequantized activation — exactly what this
-    // INT16→FP16 Dequantize produces — and QNN EP otherwise skips it, so the name is free and keeps
-    // the QNN graph aligned with the ONNX graph naming.
-    fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-    QnnTensorWrapper fp16_act_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
-                                      QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                      std::vector<uint32_t>(act_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_act_wrapper)),
-                  "Failed to add FP16 activation tensor for BQ MatMul.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
-                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
-                      {act_name}, {fp16_name}, {}, do_op_validation),
-                  "Failed to add INT16→FP16 Dequantize node for BQ MatMul activation.");
+    // BW_FLOAT_BLOCK MatMul requires FP16 activation; dequantize the INT16 activation to FP16.
+    // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
+    // stays aligned with the ONNX graph naming.
+    const std::string fp16_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+    RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
+                                                           fp16_name, do_op_validation, "MatMul"));
 
     // Reshape the FP16 activation [..., M, K] to 4-D [batch, 1, M, K] for the QNN HTP BQ MatMul.
     const uint32_t k_dim = act_shape.back();
@@ -717,29 +673,20 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
   RETURN_IF_NOT(scale_shape.size() == w_rank,
                 "QNN EP: BQ MatMul scale rank must match weight rank");
   const int64_t num_blocks = scale_shape[w_rank - 2];
-  RETURN_IF(num_blocks <= 0 || K % num_blocks != 0, "QNN EP: BQ MatMul K must be divisible by num_blocks");
-  const int64_t block_size = K / num_blocks;
-  const uint32_t bitwidth = GetBQBitwidth(inputs[1].type);
-  auto bq_it = kHtpMatMulBQBitsAndBlockSizeMultipliers.find(bitwidth);
-  RETURN_IF(bq_it == kHtpMatMulBQBitsAndBlockSizeMultipliers.end(),
-            ("QNN HTP MatMul BQ: unsupported weight bitwidth=" + std::to_string(bitwidth)).c_str());
-  RETURN_IF(block_size % bq_it->second != 0,
-            ("QNN HTP MatMul BQ: block_size=" + std::to_string(block_size) +
-             " must be a multiple of " + std::to_string(bq_it->second) +
-             " for " + std::to_string(bitwidth) + "-bit weight")
-                .c_str());
+  int64_t block_size = 0;
+  RETURN_IF_ERROR(bq::ResolveBlockSize(inputs[1], K, num_blocks, "MatMul", block_size));
+  const uint32_t bitwidth = bq::GetBQBitwidth(inputs[1].type);
+  RETURN_IF_ERROR(bq::ValidateBQBitwidthAndBlockSize(bitwidth, block_size, "MatMul"));
 
   // Unpack the weight to one byte per element (sub-byte INT2/INT4 expanded to INT8).
   std::vector<uint8_t> unpacked_tensor;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info_1.initializer_tensor, unpacked_tensor));
 
-  // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain. QNN BW_FLOAT_BLOCK
-  // only supports SFIXED_POINT_8 (signed); unsigned data must be converted (see conv_op_builder.cc).
-  const bool is_unsigned_weight = (inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
-                                   inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
-                                   inputs[1].type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8);
+  // For unsigned types (UINT2/UINT4/UINT8), shift weight data to the signed domain.
+  const bool is_unsigned_weight = bq::IsUnsignedBQType(inputs[1].type);
   if (is_unsigned_weight) {
-    RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor, static_cast<int64_t>(bitwidth)));
+    RETURN_IF_ERROR(utils::TransformUnsignedToSignedFixedPoint(unpacked_tensor,
+                                                               static_cast<int64_t>(bitwidth)));
   }
 
   // QNN HTP requires a BQ MatMul to be expressed with 4-D activation, 4-D weight, and a 4-D blockSize.
@@ -749,41 +696,20 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
 
   // ONNX per-block float scales are laid out [..., num_blocks, N] (block-major along K-axis).
   // QNN expects the scale/offset array output-channel-major: [N, num_blocks].
-  // Transpose from [num_blocks, N] → [N, num_blocks] (leading dims are always 1, so we just
-  // look at the last two dims of the flat scale array).
   std::vector<float> onnx_scales;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackScales(inputs[1].quant_param->scale, onnx_scales));
   RETURN_IF_NOT(static_cast<int64_t>(onnx_scales.size()) == num_blocks * N,
                 "QNN EP: BQ MatMul scale size mismatch");
 
-  // Float offsets in ONNX [num_blocks, N] order before transpose. Matches the Conv BQ formula:
-  //   offsets_qnn[idx] = unsigned_bias - zp_values[idx]
-  // where zp_values come from UnpackZeroPoints and unsigned_bias = (1 << (bits-1)) for unsigned weights
-  // (compensating for the unsigned→signed shift above), 0 for signed weights.
-  const float unsigned_bias = is_unsigned_weight ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
-  std::vector<float> onnx_offsets(static_cast<size_t>(num_blocks * N), unsigned_bias);
-  if (inputs[1].quant_param->zero_point != nullptr) {
-    std::vector<int32_t> zp_values;
-    ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(inputs[1].quant_param->zero_point, zp_values, zp_onnx_type));
-    RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == num_blocks * N,
-                  "QNN EP: BQ MatMul zero_point size must match num_blocks * N");
-    for (size_t idx = 0; idx < zp_values.size(); ++idx) {
-      onnx_offsets[idx] = unsigned_bias - static_cast<float>(zp_values[idx]);
-    }
-  }
+  // Float offsets in ONNX [num_blocks, N] order before transpose.
+  std::vector<float> onnx_offsets;
+  RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
+                                       is_unsigned_weight, bitwidth, num_blocks * N, onnx_offsets));
 
   // Transpose scales/offsets [num_blocks, N] → [N, num_blocks].
-  std::vector<float> scales_qnn(static_cast<size_t>(N * num_blocks));
-  std::vector<float> offsets_qnn(static_cast<size_t>(N * num_blocks));
-  for (int64_t b = 0; b < num_blocks; ++b) {
-    for (int64_t n = 0; n < N; ++n) {
-      const size_t src = static_cast<size_t>(b * N + n);
-      const size_t dst = static_cast<size_t>(n * num_blocks + b);
-      scales_qnn[dst] = onnx_scales[src];
-      offsets_qnn[dst] = onnx_offsets[src];
-    }
-  }
+  std::vector<float> scales_qnn, offsets_qnn;
+  bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn);
+  bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn);
 
   QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
                                         gsl::span<const float>(offsets_qnn),
@@ -937,16 +863,11 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                                      QnnQuantParamsWrapper(), do_op_validation,
                                                      /*is_for_input=*/false, /*is_for_output=*/false));
 
-    // INT16 quantized output tensor consumed by downstream nodes (or the graph output).
-    QnnTensorWrapper int16_out_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
-                                       op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_out_wrapper)),
-                  "Failed to add INT16 BQ MatMul output tensor.");
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                      utils::UniqueNameGenerator().New(op_output_name, "_fp16_quantize"),
-                      QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                      {matmul_fp16_out}, {op_output_name}, {}, do_op_validation),
-                  "Failed to add FP16→INT16 Quantize node for BQ MatMul output.");
+    RETURN_IF_ERROR(bq::AddFp16ToInt16QuantizeOutput(qnn_model_wrapper,
+                                                     matmul_fp16_out, op_output_name,
+                                                     op_output_tensor_type, output_info.qnn_data_type,
+                                                     op_output_quant_param.Copy(),
+                                                     std::move(op_output_shape), do_op_validation));
   } else {
     QnnTensorWrapper op_output_tensor_wrapper(op_output_name, op_output_tensor_type, output_info.qnn_data_type,
                                               op_output_quant_param.Copy(), std::vector<uint32_t>(op_output_shape));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -60,7 +60,7 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   }
   // Blocked axis is rank-2 (K dimension). scale_shape[rank-2] < weight_shape[rank-2].
   const size_t k_axis = rank - 2;
-  return bq::IsBlockedScale(scale_shape, weight_shape, k_axis);
+  return bq::IsBQScale(scale_shape, weight_shape, k_axis);
 }
 
 // Flattens the leading dims of `shape` (all but the last `n_trailing` dims) into a single
@@ -707,9 +707,10 @@ Ort::Status MatMulOpBuilder::ProcessInputsForBQMatMul(QnnModelWrapper& qnn_model
                                        is_unsigned_weight, bitwidth, num_blocks * N, onnx_offsets));
 
   // Transpose scales/offsets [num_blocks, N] → [N, num_blocks].
+  const std::vector<uint32_t> transpose_shape = {static_cast<uint32_t>(num_blocks), static_cast<uint32_t>(N)};
   std::vector<float> scales_qnn, offsets_qnn;
-  RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_scales, num_blocks, N, scales_qnn));
-  RETURN_IF_ERROR(bq::TransposeBlockMajorToChannelMajor(onnx_offsets, num_blocks, N, offsets_qnn));
+  RETURN_IF_ERROR(utils::TwoDimensionTranspose<float>(onnx_scales, transpose_shape, scales_qnn, logger));
+  RETURN_IF_ERROR(utils::TwoDimensionTranspose<float>(onnx_offsets, transpose_shape, offsets_qnn, logger));
 
   QnnQuantParamsWrapper bq_quant_params(gsl::span<const float>(scales_qnn),
                                         gsl::span<const float>(offsets_qnn),

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -1,0 +1,190 @@
+// Copyright (c) Qualcomm. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/qnn_bq_utils.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "QnnOpDef.h"
+
+#include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/common/inlined_containers.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+// HTP BQ: supported weight bitwidths (2/4/8) mapped to their block_size divisor
+// constraint — block_size must be a multiple of the corresponding value (same as
+// the MatMulNBits HTP constraints).
+const InlinedHashMap<uint32_t, int64_t> kHtpBQBitsAndBlockSizeMultipliers{
+    {2, 16}, {4, 8}, {8, 4}};
+}  // namespace
+
+namespace bq {
+uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type) {
+  switch (onnx_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+bool IsUnsignedBQType(ONNXTensorElementDataType onnx_type) {
+  return onnx_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2 ||
+         onnx_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 ||
+         onnx_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+}
+
+Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size, const char* op_tag) {
+  auto bq_it = kHtpBQBitsAndBlockSizeMultipliers.find(bitwidth);
+  RETURN_IF(bq_it == kHtpBQBitsAndBlockSizeMultipliers.end(),
+            ("QNN HTP " + std::string(op_tag) + " BQ: unsupported weight bitwidth=" +
+             std::to_string(bitwidth))
+                .c_str());
+  RETURN_IF(block_size % bq_it->second != 0,
+            ("QNN HTP " + std::string(op_tag) + " BQ: block_size=" + std::to_string(block_size) +
+             " must be a multiple of " + std::to_string(bq_it->second) +
+             " for " + std::to_string(bitwidth) + "-bit weight")
+                .c_str());
+  return Ort::Status();
+}
+
+Ort::Status ResolveBlockSize(const OrtNodeUnitIODef& weight, int64_t contraction_dim,
+                             int64_t num_blocks, const char* op_tag,
+                             /*out*/ int64_t& block_size) {
+  RETURN_IF(num_blocks <= 0 || contraction_dim % num_blocks != 0,
+            ("QNN EP: BQ " + std::string(op_tag) +
+             ": contraction dim must be a positive multiple of num_blocks")
+                .c_str());
+  block_size = contraction_dim / num_blocks;
+
+  // Since PR307 the DQ/Q "block_size" attribute is surfaced on quant_param->block_size. When
+  // present, cross-check it against the value derived from the scale shape; reject a malformed
+  // model where the two disagree. When absent, the derived value stands.
+  if (weight.quant_param.has_value() && weight.quant_param->block_size.has_value()) {
+    const int64_t attr_block_size = weight.quant_param->block_size.value();
+    RETURN_IF(attr_block_size != block_size,
+              ("QNN EP: BQ " + std::string(op_tag) + ": block_size attribute (" +
+               std::to_string(attr_block_size) + ") disagrees with scale-derived block_size (" +
+               std::to_string(block_size) + ")")
+                  .c_str());
+  }
+  return Ort::Status();
+}
+
+bool IsBlockedScale(gsl::span<const int64_t> scale_shape,
+                    gsl::span<const uint32_t> weight_shape,
+                    size_t blocked_axis) {
+  if (blocked_axis >= scale_shape.size() || blocked_axis >= weight_shape.size()) {
+    return false;
+  }
+  const int64_t num_blocks = scale_shape[blocked_axis];
+  const int64_t weight_dim = static_cast<int64_t>(weight_shape[blocked_axis]);
+  if (num_blocks <= 0 || num_blocks >= weight_dim) {
+    return false;
+  }
+  return weight_dim % num_blocks == 0;
+}
+
+Ort::Status ComputeBQOffsets(const QnnModelWrapper& qnn_model_wrapper,
+                             const OrtValueInfo* zero_point,
+                             bool is_unsigned_weight,
+                             uint32_t bitwidth,
+                             int64_t count,
+                             /*out*/ std::vector<float>& offsets) {
+  RETURN_IF(count <= 0, "QNN EP: BQ ComputeBQOffsets: count must be positive");
+  // Signed:   offset = -onnx_zp
+  // Unsigned: offset = (1 << (bits-1)) - onnx_zp   (compensates the unsigned→signed shift)
+  const float unsigned_bias = is_unsigned_weight ? static_cast<float>(1u << (bitwidth - 1)) : 0.0f;
+  offsets.assign(static_cast<size_t>(count), unsigned_bias);
+  if (zero_point != nullptr) {
+    std::vector<int32_t> zp_values;
+    ONNXTensorElementDataType zp_onnx_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackZeroPoints(zero_point, zp_values, zp_onnx_type));
+    RETURN_IF_NOT(static_cast<int64_t>(zp_values.size()) == count,
+                  "QNN EP: BQ zero_point size mismatch");
+    for (size_t idx = 0; idx < zp_values.size(); ++idx) {
+      offsets[idx] = unsigned_bias - static_cast<float>(zp_values[idx]);
+    }
+  }
+  return Ort::Status();
+}
+
+void TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
+                                       /*out*/ std::vector<float>& out) {
+  // Caller is responsible for ensuring in.size() == num_blocks * N with both > 0.
+  assert(num_blocks > 0 && N > 0 && in.size() == static_cast<size_t>(num_blocks * N));
+  out.resize(static_cast<size_t>(N * num_blocks));
+  for (int64_t b = 0; b < num_blocks; ++b) {
+    for (int64_t n = 0; n < N; ++n) {
+      const size_t src = static_cast<size_t>(b * N + n);
+      const size_t dst = static_cast<size_t>(n * num_blocks + b);
+      out[dst] = in[src];
+    }
+  }
+}
+
+Ort::Status AddInt16ToFp16DequantForActivation(QnnModelWrapper& qnn_model_wrapper,
+                                               const std::string& act_name,
+                                               const std::string& fp16_name,
+                                               bool do_op_validation,
+                                               const char* op_tag) {
+  const Qnn_DataType_t act_dtype = qnn_model_wrapper.GetQnnTensorWrapper(act_name).GetTensorDataType();
+  // The BW_FLOAT_BLOCK kernels compute in FP16. The only activation dtype reaching this path
+  // through the QDQ selector is INT16 (SFIXED or UFIXED), so anything else is unexpected.
+  RETURN_IF_NOT(act_dtype == QNN_DATATYPE_SFIXED_POINT_16 || act_dtype == QNN_DATATYPE_UFIXED_POINT_16,
+                ("QNN EP: BQ " + std::string(op_tag) +
+                 " activation must be INT16-quantized for the BW_FLOAT_BLOCK kernel")
+                    .c_str());
+  const std::vector<uint32_t> act_shape = qnn_model_wrapper.GetQnnTensorWrapper(act_name).GetTensorDims();
+  QnnTensorWrapper fp16_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
+                                QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
+                                std::vector<uint32_t>(act_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
+                ("Failed to add FP16 activation tensor for BQ " + std::string(op_tag) + ".").c_str());
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                    utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
+                    QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                    {act_name}, {fp16_name}, {}, do_op_validation),
+                ("Failed to add INT16→FP16 Dequantize node for BQ " + std::string(op_tag) +
+                 " activation.")
+                    .c_str());
+  return Ort::Status();
+}
+
+Ort::Status AddFp16ToInt16QuantizeOutput(QnnModelWrapper& qnn_model_wrapper,
+                                         const std::string& fp16_out_name,
+                                         const std::string& int16_out_name,
+                                         Qnn_TensorType_t int16_tensor_type,
+                                         Qnn_DataType_t int16_qnn_data_type,
+                                         QnnQuantParamsWrapper int16_quant_param,
+                                         std::vector<uint32_t> output_shape,
+                                         bool do_op_validation) {
+  QnnTensorWrapper int16_wrapper(int16_out_name, int16_tensor_type, int16_qnn_data_type,
+                                 std::move(int16_quant_param), std::vector<uint32_t>(output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_wrapper)),
+                "Failed to add INT16 BQ op output tensor.");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
+                    utils::UniqueNameGenerator().New(fp16_out_name, "_fp16_quantize"),
+                    QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                    {fp16_out_name}, {int16_out_name}, {}, do_op_validation),
+                "Failed to add FP16→INT16 Quantize node for BQ op output.");
+  return Ort::Status();
+}
+
+}  // namespace bq
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -4,6 +4,7 @@
 #include "core/providers/qnn/builder/qnn_bq_utils.h"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
@@ -43,7 +44,7 @@ bool IsUnsignedBQType(ONNXTensorElementDataType onnx_type) {
          onnx_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
 }
 
-Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size, const char* op_tag) {
+Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size, std::string_view op_tag) {
   auto bq_it = kHtpBQBitsAndBlockSizeMultipliers.find(bitwidth);
   RETURN_IF(bq_it == kHtpBQBitsAndBlockSizeMultipliers.end(),
             ("QNN HTP " + std::string(op_tag) + " BQ: unsupported weight bitwidth=" +
@@ -58,7 +59,7 @@ Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size
 }
 
 Ort::Status ResolveBlockSize(const OrtNodeUnitIODef& weight, int64_t contraction_dim,
-                             int64_t num_blocks, const char* op_tag,
+                             int64_t num_blocks, std::string_view op_tag,
                              /*out*/ int64_t& block_size) {
   RETURN_IF(num_blocks <= 0 || contraction_dim % num_blocks != 0,
             ("QNN EP: BQ " + std::string(op_tag) +
@@ -80,14 +81,14 @@ Ort::Status ResolveBlockSize(const OrtNodeUnitIODef& weight, int64_t contraction
   return Ort::Status();
 }
 
-bool IsBlockedScale(gsl::span<const int64_t> scale_shape,
-                    gsl::span<const uint32_t> weight_shape,
-                    size_t blocked_axis) {
-  if (blocked_axis >= scale_shape.size() || blocked_axis >= weight_shape.size()) {
+bool IsBQScale(gsl::span<const int64_t> scale_shape,
+               gsl::span<const uint32_t> weight_shape,
+               size_t block_axis) {
+  if (block_axis >= scale_shape.size() || block_axis >= weight_shape.size()) {
     return false;
   }
-  const int64_t num_blocks = scale_shape[blocked_axis];
-  const int64_t weight_dim = static_cast<int64_t>(weight_shape[blocked_axis]);
+  const int64_t num_blocks = scale_shape[block_axis];
+  const int64_t weight_dim = static_cast<int64_t>(weight_shape[block_axis]);
   if (num_blocks <= 0 || num_blocks >= weight_dim) {
     return false;
   }
@@ -118,27 +119,11 @@ Ort::Status ComputeBQOffsets(const QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-Ort::Status TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
-                                              /*out*/ std::vector<float>& out) {
-  RETURN_IF_NOT(num_blocks > 0 && N > 0 && in.size() == static_cast<size_t>(num_blocks * N),
-                "TransposeBlockMajorToChannelMajor: num_blocks and N must be positive and "
-                "in.size() must equal num_blocks * N");
-  out.resize(static_cast<size_t>(N * num_blocks));
-  for (int64_t b = 0; b < num_blocks; ++b) {
-    for (int64_t n = 0; n < N; ++n) {
-      const size_t src = static_cast<size_t>(b * N + n);
-      const size_t dst = static_cast<size_t>(n * num_blocks + b);
-      out[dst] = in[src];
-    }
-  }
-  return Ort::Status();
-}
-
 Ort::Status AddInt16ToFp16DequantForActivation(QnnModelWrapper& qnn_model_wrapper,
                                                const std::string& act_name,
                                                const std::string& fp16_name,
                                                bool do_op_validation,
-                                               const char* op_tag) {
+                                               std::string_view op_tag) {
   const Qnn_DataType_t act_dtype = qnn_model_wrapper.GetQnnTensorWrapper(act_name).GetTensorDataType();
   // The BW_FLOAT_BLOCK kernels compute in FP16. The only activation dtype reaching this path
   // through the QDQ selector is INT16 (SFIXED or UFIXED), so anything else is unexpected.

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -3,15 +3,10 @@
 
 #include "core/providers/qnn/builder/qnn_bq_utils.h"
 
-#include <cassert>
 #include <string>
 #include <vector>
 
-#include "QnnOpDef.h"
-
-#include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
-#include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/inlined_containers.h"
 
 namespace onnxruntime {
@@ -123,10 +118,11 @@ Ort::Status ComputeBQOffsets(const QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-void TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
-                                       /*out*/ std::vector<float>& out) {
-  // Caller is responsible for ensuring in.size() == num_blocks * N with both > 0.
-  assert(num_blocks > 0 && N > 0 && in.size() == static_cast<size_t>(num_blocks * N));
+Ort::Status TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
+                                              /*out*/ std::vector<float>& out) {
+  RETURN_IF_NOT(num_blocks > 0 && N > 0 && in.size() == static_cast<size_t>(num_blocks * N),
+                "TransposeBlockMajorToChannelMajor: num_blocks and N must be positive and "
+                "in.size() must equal num_blocks * N");
   out.resize(static_cast<size_t>(N * num_blocks));
   for (int64_t b = 0; b < num_blocks; ++b) {
     for (int64_t n = 0; n < N; ++n) {
@@ -135,6 +131,7 @@ void TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_bl
       out[dst] = in[src];
     }
   }
+  return Ort::Status();
 }
 
 Ort::Status AddInt16ToFp16DequantForActivation(QnnModelWrapper& qnn_model_wrapper,
@@ -150,19 +147,8 @@ Ort::Status AddInt16ToFp16DequantForActivation(QnnModelWrapper& qnn_model_wrappe
                  " activation must be INT16-quantized for the BW_FLOAT_BLOCK kernel")
                     .c_str());
   const std::vector<uint32_t> act_shape = qnn_model_wrapper.GetQnnTensorWrapper(act_name).GetTensorDims();
-  QnnTensorWrapper fp16_wrapper(fp16_name, QNN_TENSOR_TYPE_NATIVE,
-                                QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                                std::vector<uint32_t>(act_shape));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_wrapper)),
-                ("Failed to add FP16 activation tensor for BQ " + std::string(op_tag) + ".").c_str());
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                    utils::UniqueNameGenerator().New(act_name, "_int16_dequantize"),
-                    QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
-                    {act_name}, {fp16_name}, {}, do_op_validation),
-                ("Failed to add INT16→FP16 Dequantize node for BQ " + std::string(op_tag) +
-                 " activation.")
-                    .c_str());
-  return Ort::Status();
+  return qnn_model_wrapper.AddDequantizeNode(act_name, fp16_name,
+                                             QNN_DATATYPE_FLOAT_16, act_shape, do_op_validation);
 }
 
 Ort::Status AddFp16ToInt16QuantizeOutput(QnnModelWrapper& qnn_model_wrapper,
@@ -173,16 +159,10 @@ Ort::Status AddFp16ToInt16QuantizeOutput(QnnModelWrapper& qnn_model_wrapper,
                                          QnnQuantParamsWrapper int16_quant_param,
                                          std::vector<uint32_t> output_shape,
                                          bool do_op_validation) {
-  QnnTensorWrapper int16_wrapper(int16_out_name, int16_tensor_type, int16_qnn_data_type,
-                                 std::move(int16_quant_param), std::vector<uint32_t>(output_shape));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(int16_wrapper)),
-                "Failed to add INT16 BQ op output tensor.");
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(
-                    utils::UniqueNameGenerator().New(fp16_out_name, "_fp16_quantize"),
-                    QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
-                    {fp16_out_name}, {int16_out_name}, {}, do_op_validation),
-                "Failed to add FP16→INT16 Quantize node for BQ op output.");
-  return Ort::Status();
+  return qnn_model_wrapper.AddQuantizeNode(fp16_out_name, int16_out_name,
+                                           int16_tensor_type, int16_qnn_data_type,
+                                           std::move(int16_quant_param),
+                                           std::move(output_shape), do_op_validation);
 }
 
 }  // namespace bq

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Qualcomm. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "core/providers/qnn/builder/qnn_bq_utils.h"
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
@@ -68,8 +68,8 @@ Ort::Status ComputeBQOffsets(const QnnModelWrapper& qnn_model_wrapper,
 // Transposes a flat [num_blocks, N] scale/offset array into QNN's output-channel-major
 // [N, num_blocks] layout. `in` must have exactly num_blocks*N elements (asserted);
 // `out` is resized to the same count.
-void TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
-                                       /*out*/ std::vector<float>& out);
+Ort::Status TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
+                                              /*out*/ std::vector<float>& out);
 
 // Inserts a QNN_OP_DEQUANTIZE node in front of the BQ activation input.
 // The BW_FLOAT_BLOCK kernels compute in FP16, so the (only expected) INT16 activation must be

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <gsl/gsl>
@@ -33,7 +34,7 @@ bool IsUnsignedBQType(ONNXTensorElementDataType onnx_type);
 
 // Validates a BQ weight bitwidth and block_size against the HTP constraints above.
 // `op_tag` is used in the error messages (e.g. "Conv", "MatMul", "Gemm").
-Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size, const char* op_tag);
+Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size, std::string_view op_tag);
 
 // Resolves the BQ block_size along the contraction axis. The block_size = contraction_dim /
 // num_blocks (the value the QNN BW_FLOAT_BLOCK encoding needs) is always derivable from the
@@ -42,16 +43,16 @@ Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size
 // model where they disagree is rejected) and otherwise ignored. `op_tag` names the op in the
 // error message. Returns the resolved block_size via `block_size`.
 Ort::Status ResolveBlockSize(const OrtNodeUnitIODef& weight, int64_t contraction_dim,
-                             int64_t num_blocks, const char* op_tag,
+                             int64_t num_blocks, std::string_view op_tag,
                              /*out*/ int64_t& block_size);
 
 // Returns true if `scale_shape` describes a block-quantized scale for `weight_shape`
-// blocked along `blocked_axis`: the scale dim is positive, strictly smaller than the
+// blocked along `block_axis`: the scale dim is positive, strictly smaller than the
 // weight dim, and divides it evenly. Caller is responsible for the op-specific rank and
 // leading-dim checks.
-bool IsBlockedScale(gsl::span<const int64_t> scale_shape,
-                    gsl::span<const uint32_t> weight_shape,
-                    size_t blocked_axis);
+bool IsBQScale(gsl::span<const int64_t> scale_shape,
+               gsl::span<const uint32_t> weight_shape,
+               size_t block_axis);
 
 // Computes per-block float offsets from optional ONNX zero-points, matching the shared
 // BQ convention: offset = unsigned_bias - onnx_zp, where unsigned_bias = (1 << (bits-1))
@@ -65,12 +66,6 @@ Ort::Status ComputeBQOffsets(const QnnModelWrapper& qnn_model_wrapper,
                              int64_t count,
                              /*out*/ std::vector<float>& offsets);
 
-// Transposes a flat [num_blocks, N] scale/offset array into QNN's output-channel-major
-// [N, num_blocks] layout. `in` must have exactly num_blocks*N elements (asserted);
-// `out` is resized to the same count.
-Ort::Status TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
-                                              /*out*/ std::vector<float>& out);
-
 // Inserts a QNN_OP_DEQUANTIZE node in front of the BQ activation input.
 // The BW_FLOAT_BLOCK kernels compute in FP16, so the (only expected) INT16 activation must be
 // dequantized first. Verifies `act_name`'s QNN dtype is SFIXED/UFIXED_POINT_16, registers the
@@ -81,7 +76,7 @@ Ort::Status AddInt16ToFp16DequantForActivation(QnnModelWrapper& qnn_model_wrappe
                                                const std::string& act_name,
                                                const std::string& fp16_name,
                                                bool do_op_validation,
-                                               const char* op_tag);
+                                               std::string_view op_tag);
 
 // Adds the FP16→INT16 output tail for a BW_FLOAT_BLOCK op. Registers the INT16 output tensor
 // and adds a QNN_OP_QUANTIZE node (fp16_out_name → int16_out_name).

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
@@ -1,0 +1,102 @@
+// Copyright (c) Qualcomm. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gsl/gsl>
+
+#include "QnnTypes.h"
+
+#include "core/providers/qnn/builder/qnn_quant_params_wrapper.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// Shared helpers for block-quantized (BQ) weight handling in the QNN HTP
+// BW_FLOAT_BLOCK op-builder paths (Conv, MatMul, Gemm).
+// These were previously duplicated verbatim across the individual op builders.
+namespace bq {
+
+// Returns BQ weight bitwidth (2/4/8) from an ONNX element data type, or 0 if unsupported.
+uint32_t GetBQBitwidth(ONNXTensorElementDataType onnx_type);
+
+// Returns true for the unsigned BQ weight element types (UINT2/UINT4/UINT8), which must be
+// shifted to the signed domain before being registered as SFIXED_POINT_8.
+bool IsUnsignedBQType(ONNXTensorElementDataType onnx_type);
+
+// Validates a BQ weight bitwidth and block_size against the HTP constraints above.
+// `op_tag` is used in the error messages (e.g. "Conv", "MatMul", "Gemm").
+Ort::Status ValidateBQBitwidthAndBlockSize(uint32_t bitwidth, int64_t block_size, const char* op_tag);
+
+// Resolves the BQ block_size along the contraction axis. The block_size = contraction_dim /
+// num_blocks (the value the QNN BW_FLOAT_BLOCK encoding needs) is always derivable from the
+// scale shape. Since PR307 the DQ/Q "block_size" attribute is also surfaced on
+// quant_param->block_size; when present it is validated to equal the derived value (a malformed
+// model where they disagree is rejected) and otherwise ignored. `op_tag` names the op in the
+// error message. Returns the resolved block_size via `block_size`.
+Ort::Status ResolveBlockSize(const OrtNodeUnitIODef& weight, int64_t contraction_dim,
+                             int64_t num_blocks, const char* op_tag,
+                             /*out*/ int64_t& block_size);
+
+// Returns true if `scale_shape` describes a block-quantized scale for `weight_shape`
+// blocked along `blocked_axis`: the scale dim is positive, strictly smaller than the
+// weight dim, and divides it evenly. Caller is responsible for the op-specific rank and
+// leading-dim checks.
+bool IsBlockedScale(gsl::span<const int64_t> scale_shape,
+                    gsl::span<const uint32_t> weight_shape,
+                    size_t blocked_axis);
+
+// Computes per-block float offsets from optional ONNX zero-points, matching the shared
+// BQ convention: offset = unsigned_bias - onnx_zp, where unsigned_bias = (1 << (bits-1))
+// for unsigned weights (compensating the unsigned→signed shift) and 0 for signed weights.
+// `zero_point` may be null (all offsets = unsigned_bias). `count` is the expected element
+// count (e.g. OC*num_blocks or num_blocks*N); validated against the unpacked zero-points.
+Ort::Status ComputeBQOffsets(const QnnModelWrapper& qnn_model_wrapper,
+                             const OrtValueInfo* zero_point,
+                             bool is_unsigned_weight,
+                             uint32_t bitwidth,
+                             int64_t count,
+                             /*out*/ std::vector<float>& offsets);
+
+// Transposes a flat [num_blocks, N] scale/offset array into QNN's output-channel-major
+// [N, num_blocks] layout. `in` must have exactly num_blocks*N elements (asserted);
+// `out` is resized to the same count.
+void TransposeBlockMajorToChannelMajor(gsl::span<const float> in, int64_t num_blocks, int64_t N,
+                                       /*out*/ std::vector<float>& out);
+
+// Inserts a QNN_OP_DEQUANTIZE node in front of the BQ activation input.
+// The BW_FLOAT_BLOCK kernels compute in FP16, so the (only expected) INT16 activation must be
+// dequantized first. Verifies `act_name`'s QNN dtype is SFIXED/UFIXED_POINT_16, registers the
+// FP16 output tensor at `fp16_name`, and adds the Dequantize node.
+// The caller derives `fp16_name` (typically by reusing the original DequantizeLinear output name).
+// `op_tag` is used in error messages.
+Ort::Status AddInt16ToFp16DequantForActivation(QnnModelWrapper& qnn_model_wrapper,
+                                               const std::string& act_name,
+                                               const std::string& fp16_name,
+                                               bool do_op_validation,
+                                               const char* op_tag);
+
+// Adds the FP16→INT16 output tail for a BW_FLOAT_BLOCK op. Registers the INT16 output tensor
+// and adds a QNN_OP_QUANTIZE node (fp16_out_name → int16_out_name).
+// IMPORTANT: The FP16 tensor (`fp16_out_name`) must be registered and the main BQ op node that
+// produces it must be created BEFORE calling this function. QNN graph composition requires a
+// tensor's producer node to exist before any consumer node is added.
+Ort::Status AddFp16ToInt16QuantizeOutput(QnnModelWrapper& qnn_model_wrapper,
+                                         const std::string& fp16_out_name,
+                                         const std::string& int16_out_name,
+                                         Qnn_TensorType_t int16_tensor_type,
+                                         Qnn_DataType_t int16_qnn_data_type,
+                                         QnnQuantParamsWrapper int16_quant_param,
+                                         std::vector<uint32_t> output_shape,
+                                         bool do_op_validation);
+
+}  // namespace bq
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
@@ -1,5 +1,5 @@
-// Copyright (c) Qualcomm. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -905,6 +905,16 @@ Ort::Status QnnModelWrapper::AddCastNode(const std::string& cast_node_name,
   return Ort::Status();
 }
 
+namespace {
+// Returns true when dt is any QNN SFIXED_POINT or UFIXED_POINT variant (4/8/16/32-bit).
+bool IsQnnFixedPointType(Qnn_DataType_t dt) {
+  return dt == QNN_DATATYPE_SFIXED_POINT_4 || dt == QNN_DATATYPE_UFIXED_POINT_4 ||
+         dt == QNN_DATATYPE_SFIXED_POINT_8 || dt == QNN_DATATYPE_UFIXED_POINT_8 ||
+         dt == QNN_DATATYPE_SFIXED_POINT_16 || dt == QNN_DATATYPE_UFIXED_POINT_16 ||
+         dt == QNN_DATATYPE_SFIXED_POINT_32 || dt == QNN_DATATYPE_UFIXED_POINT_32;
+}
+}  // namespace
+
 Ort::Status QnnModelWrapper::AddDequantizeNode(const std::string& input_name,
                                                const std::string& output_name,
                                                Qnn_DataType_t output_data_type,
@@ -929,14 +939,7 @@ Ort::Status QnnModelWrapper::AddQuantizeNode(const std::string& input_name,
                                              QnnQuantParamsWrapper output_quant_param,
                                              std::vector<uint32_t> output_shape,
                                              bool do_op_validation) {
-  RETURN_IF(output_data_type != QNN_DATATYPE_SFIXED_POINT_4 &&
-                output_data_type != QNN_DATATYPE_UFIXED_POINT_4 &&
-                output_data_type != QNN_DATATYPE_SFIXED_POINT_8 &&
-                output_data_type != QNN_DATATYPE_UFIXED_POINT_8 &&
-                output_data_type != QNN_DATATYPE_SFIXED_POINT_16 &&
-                output_data_type != QNN_DATATYPE_UFIXED_POINT_16 &&
-                output_data_type != QNN_DATATYPE_SFIXED_POINT_32 &&
-                output_data_type != QNN_DATATYPE_UFIXED_POINT_32,
+  RETURN_IF(!IsQnnFixedPointType(output_data_type),
             "AddQuantizeNode: output_data_type must be a SFIXED_POINT or UFIXED_POINT type");
   QnnTensorWrapper output_wrapper(output_name, output_tensor_type, output_data_type,
                                   std::move(output_quant_param), std::move(output_shape));

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -905,6 +905,49 @@ Ort::Status QnnModelWrapper::AddCastNode(const std::string& cast_node_name,
   return Ort::Status();
 }
 
+Ort::Status QnnModelWrapper::AddDequantizeNode(const std::string& input_name,
+                                               const std::string& output_name,
+                                               Qnn_DataType_t output_data_type,
+                                               std::vector<uint32_t> output_shape,
+                                               bool do_op_validation) {
+  RETURN_IF(output_data_type != QNN_DATATYPE_FLOAT_16 && output_data_type != QNN_DATATYPE_FLOAT_32,
+            "AddDequantizeNode: output_data_type must be FLOAT_16 or FLOAT_32");
+  QnnTensorWrapper output_wrapper(output_name, QNN_TENSOR_TYPE_NATIVE, output_data_type,
+                                  QnnQuantParamsWrapper(), std::move(output_shape));
+  RETURN_IF_NOT(AddTensorWrapper(std::move(output_wrapper)), "Failed to add Dequantize output tensor.");
+  RETURN_IF_NOT(CreateQnnNode(utils::UniqueNameGenerator().New(input_name, "_dequantize"),
+                              QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                              {input_name}, {output_name}, {}, do_op_validation),
+                "Failed to add Dequantize node.");
+  return Ort::Status();
+}
+
+Ort::Status QnnModelWrapper::AddQuantizeNode(const std::string& input_name,
+                                             const std::string& output_name,
+                                             Qnn_TensorType_t output_tensor_type,
+                                             Qnn_DataType_t output_data_type,
+                                             QnnQuantParamsWrapper output_quant_param,
+                                             std::vector<uint32_t> output_shape,
+                                             bool do_op_validation) {
+  RETURN_IF(output_data_type != QNN_DATATYPE_SFIXED_POINT_4 &&
+                output_data_type != QNN_DATATYPE_UFIXED_POINT_4 &&
+                output_data_type != QNN_DATATYPE_SFIXED_POINT_8 &&
+                output_data_type != QNN_DATATYPE_UFIXED_POINT_8 &&
+                output_data_type != QNN_DATATYPE_SFIXED_POINT_16 &&
+                output_data_type != QNN_DATATYPE_UFIXED_POINT_16 &&
+                output_data_type != QNN_DATATYPE_SFIXED_POINT_32 &&
+                output_data_type != QNN_DATATYPE_UFIXED_POINT_32,
+            "AddQuantizeNode: output_data_type must be a SFIXED_POINT or UFIXED_POINT type");
+  QnnTensorWrapper output_wrapper(output_name, output_tensor_type, output_data_type,
+                                  std::move(output_quant_param), std::move(output_shape));
+  RETURN_IF_NOT(AddTensorWrapper(std::move(output_wrapper)), "Failed to add Quantize output tensor.");
+  RETURN_IF_NOT(CreateQnnNode(utils::UniqueNameGenerator().New(input_name, "_quantize"),
+                              QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                              {input_name}, {output_name}, {}, do_op_validation),
+                "Failed to add Quantize node.");
+  return Ort::Status();
+}
+
 Ort::Status QnnModelWrapper::AddReshapeNode(const std::string& input_name, const std::string& output_name,
                                             const std::vector<uint32_t>& input_shape,
                                             const std::vector<uint32_t>& output_shape,

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -266,6 +266,25 @@ class QnnModelWrapper {
                           std::vector<uint32_t>&& output_shape,
                           bool do_op_validation);
 
+  // Adds a QNN_OP_DEQUANTIZE node: input (quantized) → output (float).
+  // output_data_type must be FLOAT_16 or FLOAT_32.
+  // Output tensor type is always QNN_TENSOR_TYPE_NATIVE.
+  Ort::Status AddDequantizeNode(const std::string& input_name,
+                                const std::string& output_name,
+                                Qnn_DataType_t output_data_type,
+                                std::vector<uint32_t> output_shape,
+                                bool do_op_validation);
+
+  // Adds a QNN_OP_QUANTIZE node: input (float) → output (fixed-point).
+  // output_data_type must be a SFIXED_POINT or UFIXED_POINT type.
+  Ort::Status AddQuantizeNode(const std::string& input_name,
+                              const std::string& output_name,
+                              Qnn_TensorType_t output_tensor_type,
+                              Qnn_DataType_t output_data_type,
+                              QnnQuantParamsWrapper output_quant_param,
+                              std::vector<uint32_t> output_shape,
+                              bool do_op_validation);
+
   Ort::Status AddReshapeNode(const std::string& input_name,
                              const std::string& output_name,
                              const std::vector<uint32_t>& input_shape,


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add a shared qnn::bq utility (qnn_bq_utils.{h,cc}) and route the conv, matmul, and gemm builders through it:
- GetBQBitwidth and the {2:16,4:8,8:4} bits/block-size constraint map
- ValidateBQBitwidthAndBlockSize (HTP block_size divisor check)
- ResolveBlockSize: derives block_size from the scale shape (contraction_dim / num_blocks) and cross-checks against the DQ/Q "block_size" attribute introduced by PR307 — rejects a malformed model where the two disagree, is a no-op when the attribute is absent
- IsUnsignedBQType / MaybeShiftUnsignedWeightToSigned
- ComputeBQOffsets (unsigned_bias - onnx_zp convention)
- TransposeBlockMajorToChannelMajor ([num_blocks,N] -> [N,num_blocks])
- IsBlockedScale (shared tail of the per-op weight detection)
- AddInt16ToFp16DequantForActivation (INT16 -> FP16 activation dequant)

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
The block-quantization PRs (Conv #429, MatMul #476, Gemm #477) each copy-pasted the same BW_FLOAT_BLOCK weight plumbing into their op builders, so a fix to a BQ constraint, dequant pattern, or scale layout had to be applied in three places.

