### PR TITLE
Fix arm64ReproDir to use CACHE PATH in cmake/arm64x.cmake

### DIFF
--- a/cmake/arm64x.cmake
+++ b/cmake/arm64x.cmake
@@ -1,4 +1,5 @@
-set(arm64ReproDir "${CMAKE_CURRENT_SOURCE_DIR}/repros")
+set(arm64ReproDir "${CMAKE_CURRENT_SOURCE_DIR}/repros" CACHE PATH "Path to the ARM64 repro directory for ARM64X build")
+message(STATUS "Using arm64ReproDir: " ${arm64ReproDir})
 
 function(set_arm64_dependencies n)
 	set(ARM64_LIBS)


### PR DESCRIPTION
### Description
Make arm64ReproDir a CMake cache variable so that passing `-Darm64ReproDir=<path>` at configure time is respected.


### Motivation and Context
`cmake/arm64x.cmake` declared `arm64ReproDir` with a plain `set()` call, which CMake does not expose as a cache variable. As a result, passing `-Darm64ReproDir=<path>` at configure time was silently ignored — CMake's `-D` flag only overrides `CACHE` variables.

Patch `0003` already applied the correct fix to the ort_core dependency's copy of the same file. This PR applies the matching fix to the fork's own `cmake/arm64x.cmake`, which is included directly when building with `BUILD_AS_ARM64X`.


