### PR TITLE
Support Clip with DequantizeLinear-wrapped constant min/max

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -6,6 +6,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
@@ -39,6 +40,17 @@ static Ort::Status ProcessClipMinMax(QnnModelWrapper& qnn_model_wrapper,
   TensorInfo input_info = {};
   std::vector<uint8_t> val_bytes;
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, input_info));
+
+  // A standalone DQ-of-constant feeding Clip is folded to a STATIC fp32 tensor by
+  // FoldConstantDequantizeLinear before this builder runs, so the dequantized scalar
+  // is already available in the QnnTensorWrapper registry.
+  if (!input_info.is_initializer && qnn_model_wrapper.IsFoldedConstant(input.name)) {
+    RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input.name, val_bytes));
+    RETURN_IF(val_bytes.size() != sizeof(float), "Clip min/max must be a scalar.");
+    float_value = *reinterpret_cast<const float*>(val_bytes.data());
+    return Ort::Status();
+  }
+
   assert(input_info.is_initializer);  // Checked by ExplicitOpCheck().
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info.initializer_tensor, val_bytes));
 
@@ -148,12 +160,12 @@ static Ort::Status ProcessClipMinMax(QnnModelWrapper& qnn_model_wrapper,
 Ort::Status ClipOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const {
   if (node_unit.Inputs().size() > 1) {
     const auto& min_input_name = node_unit.Inputs()[1].name;
-    RETURN_IF(!min_input_name.empty() && !qnn_model_wrapper.IsConstantInput(min_input_name),
+    RETURN_IF(!min_input_name.empty() && !qnn_model_wrapper.IsEffectivelyConstantInput(min_input_name),
               "QNN doesn't support dynamic min/max.");
   }
   if (node_unit.Inputs().size() > 2) {
     const auto& max_input_name = node_unit.Inputs()[2].name;
-    RETURN_IF(!max_input_name.empty() && !qnn_model_wrapper.IsConstantInput(max_input_name),
+    RETURN_IF(!max_input_name.empty() && !qnn_model_wrapper.IsEffectivelyConstantInput(max_input_name),
               "QNN doesn't support dynamic min/max.");
   }
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <cassert>
 #include <limits>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
@@ -41,17 +40,17 @@ static Ort::Status ProcessClipMinMax(QnnModelWrapper& qnn_model_wrapper,
   std::vector<uint8_t> val_bytes;
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, input_info));
 
-  // A standalone DQ-of-constant feeding Clip is folded to a STATIC fp32 tensor by
-  // FoldConstantDequantizeLinear before this builder runs, so the dequantized scalar
-  // is already available in the QnnTensorWrapper registry.
-  if (!input_info.is_initializer && qnn_model_wrapper.IsFoldedConstant(input.name)) {
+  // ExplicitOpCheck() accepts either a real initializer or a DQ-of-constant folded to a STATIC
+  // fp32 tensor. A folded input is not an initializer; read its bytes from the registry instead.
+  if (!input_info.is_initializer) {
+    RETURN_IF_NOT(qnn_model_wrapper.IsFoldedConstant(input.name),
+                  "QNN EP: Clip min/max must be a constant initializer or a folded constant.");
     RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input.name, val_bytes));
     RETURN_IF(val_bytes.size() != sizeof(float), "Clip min/max must be a scalar.");
     float_value = *reinterpret_cast<const float*>(val_bytes.data());
     return Ort::Status();
   }
 
-  assert(input_info.is_initializer);  // Checked by ExplicitOpCheck().
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info.initializer_tensor, val_bytes));
 
   // If the input is quantized, we need to dequantize it

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -18,12 +18,9 @@
 namespace onnxruntime {
 namespace qnn {
 
-namespace {
-
-// Accepts either a real initializer or a previously-folded STATIC tensor.
-Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
-                                   const std::string& tensor_name,
-                                   /*out*/ std::vector<uint8_t>& bytes) {
+Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
+                                           const std::string& tensor_name,
+                                           /*out*/ std::vector<uint8_t>& bytes) {
   if (qnn_model_wrapper.IsConstantInput(tensor_name)) {
     const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(tensor_name);
     RETURN_IF(init == nullptr, "Constant initializer not found for tensor.");
@@ -39,6 +36,8 @@ Ort::Status GetConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
   }
   return MAKE_EP_FAIL("Tensor is not a constant initializer or folded constant.");
 }
+
+namespace {
 
 // SafeInt guards against overflow from an adversarial shape before allocation.
 Ort::Status ComputeNumElements(gsl::span<const uint32_t> shape, /*out*/ size_t& num_elems) {
@@ -108,7 +107,7 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
             "Folded DequantizeLinear only supports float32 output.");
 
   std::vector<uint8_t> quant_bytes;
-  RETURN_IF_ERROR(GetConstantTensorBytes(qnn_model_wrapper, input_def.name, quant_bytes));
+  RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input_def.name, quant_bytes));
 
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));
@@ -148,7 +147,7 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF(!output_def.quant_param.has_value(), "Q output has no quant param.");
 
   std::vector<uint8_t> input_bytes;
-  RETURN_IF_ERROR(GetConstantTensorBytes(qnn_model_wrapper, input_def.name, input_bytes));
+  RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input_def.name, input_bytes));
 
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -19,8 +19,8 @@ namespace onnxruntime {
 namespace qnn {
 
 Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
-                                           const std::string& tensor_name,
-                                           /*out*/ std::vector<uint8_t>& bytes) {
+                                              const std::string& tensor_name,
+                                              /*out*/ std::vector<uint8_t>& bytes) {
   if (qnn_model_wrapper.IsConstantInput(tensor_name)) {
     const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(tensor_name);
     RETURN_IF(init == nullptr, "Constant initializer not found for tensor.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -20,5 +20,10 @@ bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
 Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
                                const OrtNodeUnit& node_unit) ORT_MUST_USE_RESULT;
 
+// Reads the raw bytes of a real initializer or a previously-folded STATIC tensor.
+Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
+                                              const std::string& tensor_name,
+                                              /*out*/ std::vector<uint8_t>& bytes) ORT_MUST_USE_RESULT;
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -370,6 +370,69 @@ TEST_F(QnnHTPBackendTests, Clip_U8_QuantizedMinMax) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 
+// Clip with a bare-float data input and Q/DQ-wrapped constant min/max. Asymmetric
+// zero_point exercises the dequant sign convention.
+TEST_F(QnnHTPBackendTests, Clip_U16_FloatData_QDQConstMinMax) {
+  GetTestModelFn model_fn = [](ModelTestBuilder& builder) {
+    const float scale = 10.0f / 65535.0f;
+    const float min_value = -10.0f;
+    const float max_value = 10.0f;
+    const uint16_t min_zp = 65535;
+    const uint16_t max_zp = 0;
+    uint16_t min_q = static_cast<uint16_t>(std::round(min_value / scale) + min_zp);
+    uint16_t max_q = static_cast<uint16_t>(std::round(max_value / scale) + max_zp);
+
+    builder.MakeInitializer<uint16_t>("min_q", {}, {min_q});
+    builder.AddDequantizeLinearNode<uint16_t>("min_dq", "min_q", scale, min_zp, "min_dq_out");
+    builder.MakeInitializer<uint16_t>("max_q", {}, {max_q});
+    builder.AddDequantizeLinearNode<uint16_t>("max_dq", "max_q", scale, max_zp, "max_dq_out");
+
+    builder.MakeInput<float>("X", {1, 8}, GetFloatDataInRange(-20.0f, 20.0f, 8));
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("clip", "Clip", {"X", "min_dq_out", "max_dq_out"}, {"Y"}, "", attributes);
+    builder.MakeOutput("Y");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(model_fn,
+                  provider_options,
+                  13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
+TEST_F(QnnHTPBackendTests, Clip_U8_FloatData_QDQConstMinMax) {
+  GetTestModelFn model_fn = [](ModelTestBuilder& builder) {
+    const float scale = 0.1f;
+    const uint8_t zp = 128;
+    const float min_value = -5.0f;
+    const float max_value = 5.0f;
+    uint8_t min_q = static_cast<uint8_t>(std::round(min_value / scale) + zp);
+    uint8_t max_q = static_cast<uint8_t>(std::round(max_value / scale) + zp);
+
+    builder.MakeInitializer<uint8_t>("min_q", {}, {min_q});
+    builder.AddDequantizeLinearNode<uint8_t>("min_dq", "min_q", scale, zp, "min_dq_out");
+    builder.MakeInitializer<uint8_t>("max_q", {}, {max_q});
+    builder.AddDequantizeLinearNode<uint8_t>("max_dq", "max_q", scale, zp, "max_dq_out");
+
+    builder.MakeInput<float>("X", {1, 8}, GetFloatDataInRange(-10.0f, 10.0f, 8));
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("clip", "Clip", {"X", "min_dq_out", "max_dq_out"}, {"Y"}, "", attributes);
+    builder.MakeOutput("Y");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(model_fn,
+                  provider_options,
+                  13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
 // Test FP16 Clip with min (FP16)
 TEST_F(QnnHTPBackendTests, Clip_FP16) {
 #if defined(_WIN32)

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -399,7 +399,7 @@ TEST_F(QnnHTPBackendTests, Clip_U16_FloatData_QDQConstMinMax) {
 
   RunQnnModelTest(model_fn,
                   provider_options,
-                  13,
+                  21,  // 16-bit DequantizeLinear requires opset >= 21.
                   EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -400,7 +400,8 @@ TEST_F(QnnHTPBackendTests, Clip_U16_FloatData_QDQConstMinMax) {
   RunQnnModelTest(model_fn,
                   provider_options,
                   21,  // 16-bit DequantizeLinear requires opset >= 21.
-                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier{5e-3f}});
 }
 
 TEST_F(QnnHTPBackendTests, Clip_U8_FloatData_QDQConstMinMax) {
@@ -430,7 +431,8 @@ TEST_F(QnnHTPBackendTests, Clip_U8_FloatData_QDQConstMinMax) {
   RunQnnModelTest(model_fn,
                   provider_options,
                   13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier{5e-3f}});
 }
 
 // Test FP16 Clip with min (FP16)


### PR DESCRIPTION
## Summary
- ClipOpBuilder now accepts Clip nodes whose min/max inputs come from a standalone `DequantizeLinear` over a constant initializer (a common AIMET-export pattern where the data input is bare-float and so the Clip is not formed into a QDQ NodeUnit).
- The existing `FoldConstantDequantizeLinear` pass already folds those DQs into STATIC fp32 tensors before the Clip op builder runs, so the fix is: replace `IsConstantInput` with `IsEffectivelyConstantInput` in `ExplicitOpCheck`, and read the dequantised scalar from the folded `QnnTensorWrapper` in `ProcessClipMinMax`.
- Exports `GetEffectivelyConstantTensorBytes` from `qdq_constant_folding.h` for the new read path.
- Adds two HTP regression tests (uint16 zp=65535 and uint8 zp=128) that exercise asymmetric zero_point so the dequant-sign convention can't silently regress.