### PR TITLE
Fix QNN MatMul singleton weight lowering

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -18,17 +18,6 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
-template <typename Shape>
-bool LeadingDimsAllOne(const Shape& shape) {
-  for (size_t i = 0; i + 2 < shape.size(); ++i) {
-    if (shape[i] != 1) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 // Detects a block-quantized MatMul weight (ONNX MatMul input[1]).
 // Accepts weight rank 2–4: shape [..., K, N] where any leading dims beyond K/N must equal 1
 // (i.e. reshapeable to [1, 1, K, N]). Per ONNX opset 21 the scale has the same rank as the
@@ -50,13 +39,13 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   if (rank < 2 || rank > 4) {
     return false;  // BQ supports weight rank 2–4 (reshapeable to [1,1,K,N]).
   }
-  if (!LeadingDimsAllOne(weight_shape)) {
+  if (!utils::TrySqueezeLeadingOnesTo(weight_shape, 2).has_value()) {
     return false;
   }
   if (scale_shape.size() != rank) {
     return false;  // Scale must have the same rank as the weight.
   }
-  if (!LeadingDimsAllOne(scale_shape)) {
+  if (!utils::TrySqueezeLeadingOnesTo(scale_shape, 2).has_value()) {
     return false;
   }
   // Blocked axis is rank-2 (K dimension). scale_shape[rank-2] < weight_shape[rank-2].
@@ -105,11 +94,14 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
   // Just use QNN MatMul for these older QNN SDK versions.
   use_fully_connected = false;
 #else
-  // Static [1, ..., 1, K, N] weights are ONNX-broadcast-equivalent to [K, N].
+  // Static [1, ..., 1, K, N] weights are ONNX-broadcast-equivalent to [K, N]. The rank > 2 term is
+  // required (not just implied by the squeeze check, which is vacuously true at rank 2): it keeps
+  // rank-2 weights on the existing path, where no output reshape is needed.
   const bool is_rank2_static_weight = input_info_1.shape.size() == 2 && input_info_1.is_initializer;
   const bool is_rank1_input_1 = input_info_1.shape.size() == 1;
   squeeze_static_weight_to_2d =
-      input_info_1.is_initializer && input_info_1.shape.size() > 2 && LeadingDimsAllOne(input_info_1.shape) &&
+      input_info_1.is_initializer && input_info_1.shape.size() > 2 &&
+      utils::TrySqueezeLeadingOnesTo(input_info_1.shape, 2).has_value() &&
       input_info_0.shape.size() >= 2;
   // FullyConnected cannot pass the Op validation if keep_dims is true, so if input_0 is per-channel quantized tensor
   // with rank > 2, it's not easy to set the quantization parameters for the output reshaped rank 2 tensor.
@@ -454,6 +446,9 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   const std::string& org_input_1_name = inputs[1].name;
   std::string input_1_name = org_input_1_name;
   std::vector<uint32_t> shape_2d;
+  // input_1's [k, n] shape, i.e. its trailing two dims with any leading unit dims squeezed off.
+  // Unused when input_1 is rank 1. Not const: TwoDimensionTranspose rewrites it in place below.
+  std::vector<uint32_t> weight_shape_kn;
   QnnQuantParamsWrapper quant_param_2d = input_info_1.quant_param.Copy();
   if (reshape_input_1) {
     // Input[1] is a rank 1 tensor that needs to be reshaped.
@@ -467,11 +462,11 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_transpose");
     const size_t weight_k_dim_index = input_info_1.shape.size() - 2;
     const size_t weight_n_dim_index = input_info_1.shape.size() - 1;
-    const std::vector<uint32_t> squeezed_weight_shape = {input_info_1.shape[weight_k_dim_index],
-                                                         input_info_1.shape[weight_n_dim_index]};
-    shape_2d = {input_info_1.shape[weight_n_dim_index], input_info_1.shape[weight_k_dim_index]};
+    weight_shape_kn = {input_info_1.shape[weight_k_dim_index], input_info_1.shape[weight_n_dim_index]};
+    // FullyConnected requires input_1's shape to be [n, k].
+    shape_2d = {weight_shape_kn[1], weight_shape_kn[0]};
     if (squeeze_static_weight_to_2d) {
-      RETURN_IF_ERROR(quant_param_2d.HandleSqueeze<uint32_t>(input_info_1.shape, squeezed_weight_shape));
+      RETURN_IF_ERROR(quant_param_2d.HandleSqueeze<uint32_t>(input_info_1.shape, weight_shape_kn));
     }
     RETURN_IF_ERROR(quant_param_2d.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
   }
@@ -481,13 +476,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   if (input_info_1.is_initializer) {
     std::vector<uint8_t> unpacked_tensor;
     if (!reshape_input_1) {
-      const size_t input_1_rank = input_info_1.shape.size();
-      std::vector<uint32_t> weight_shape_for_transpose =
-          squeeze_static_weight_to_2d
-              ? std::vector<uint32_t>{input_info_1.shape[input_1_rank - 2], input_info_1.shape[input_1_rank - 1]}
-              : input_info_1.shape;
       RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper,
-                                                   weight_shape_for_transpose,  // Modified by TwoDimensionTranspose.
+                                                   weight_shape_kn,  // Modified by TwoDimensionTranspose.
                                                    input_info_1.initializer_tensor,
                                                    unpacked_tensor,
                                                    logger,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -18,11 +18,8 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
-bool HasOnlyLeadingUnitDimensions(const std::vector<uint32_t>& shape) {
-  if (shape.size() <= 2) {
-    return false;
-  }
-
+template <typename Shape>
+bool LeadingDimsAllOne(const Shape& shape) {
   for (size_t i = 0; i + 2 < shape.size(); ++i) {
     if (shape[i] != 1) {
       return false;
@@ -30,32 +27,6 @@ bool HasOnlyLeadingUnitDimensions(const std::vector<uint32_t>& shape) {
   }
 
   return true;
-}
-
-Ort::Status AdjustQuantAxisAfterSqueezingLeadingDimensions(QnnQuantParamsWrapper& quant_param,
-                                                           size_t num_squeezed_leading_dims) {
-  if (num_squeezed_leading_dims == 0 || (!quant_param.IsPerChannel() && !quant_param.IsLPBQ())) {
-    return Ort::Status();
-  }
-
-  Qnn_QuantizeParams_t& params = quant_param.Get();
-  int32_t* quant_axis = nullptr;
-  if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-    quant_axis = &params.axisScaleOffsetEncoding.axis;
-  } else if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-    quant_axis = &params.bwAxisScaleOffsetEncoding.axis;
-  } else if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION &&
-             params.blockwiseExpansion != nullptr) {
-    quant_axis = &params.blockwiseExpansion->axis;
-  } else {
-    return MAKE_EP_FAIL(("Unhandled quantization encoding: " + std::to_string(params.quantizationEncoding)).c_str());
-  }
-
-  RETURN_IF_NOT(*quant_axis >= static_cast<int32_t>(num_squeezed_leading_dims),
-                "Cannot squeeze leading unit dimensions that contain the quantization axis.");
-  *quant_axis -= static_cast<int32_t>(num_squeezed_leading_dims);
-
-  return Ort::Status();
 }
 
 // Detects a block-quantized MatMul weight (ONNX MatMul input[1]).
@@ -79,20 +50,14 @@ bool IsBQWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef
   if (rank < 2 || rank > 4) {
     return false;  // BQ supports weight rank 2–4 (reshapeable to [1,1,K,N]).
   }
-  // All leading dims (beyond the last two: K and N) must be 1.
-  for (size_t i = 0; i + 2 < rank; ++i) {
-    if (weight_shape[i] != 1) {
-      return false;
-    }
+  if (!LeadingDimsAllOne(weight_shape)) {
+    return false;
   }
   if (scale_shape.size() != rank) {
     return false;  // Scale must have the same rank as the weight.
   }
-  // All leading dims of the scale must also be 1.
-  for (size_t i = 0; i + 2 < rank; ++i) {
-    if (scale_shape[i] != 1) {
-      return false;
-    }
+  if (!LeadingDimsAllOne(scale_shape)) {
+    return false;
   }
   // Blocked axis is rank-2 (K dimension). scale_shape[rank-2] < weight_shape[rank-2].
   const size_t k_axis = rank - 2;
@@ -119,9 +84,10 @@ Ort::Status FlattenLeadingDims(const std::vector<uint32_t>& shape, uint32_t& bat
 // Both false                     -> lower to QNN MatMul
 Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitIODef& input_def_0,
                         const OrtNodeUnitIODef& input_def_1, TensorInfo& input_info_0, TensorInfo& input_info_1,
-                        bool& use_fully_connected, bool& use_conv2d) {
+                        bool& use_fully_connected, bool& use_conv2d, bool& squeeze_static_weight_to_2d) {
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def_0, input_info_0));
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def_1, input_info_1));
+  squeeze_static_weight_to_2d = false;
 
   // LPBQ weights require Conv2D lowering (1x1 filters) on NPU backends.
   // QNN Conv2D supports LPBQ (blockwise expansion) on the filter channel axis (axis 3 in HWCN format).
@@ -142,14 +108,14 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
   // Static [1, ..., 1, K, N] weights are ONNX-broadcast-equivalent to [K, N].
   const bool is_rank2_static_weight = input_info_1.shape.size() == 2 && input_info_1.is_initializer;
   const bool is_rank1_input_1 = input_info_1.shape.size() == 1;
-  const bool can_canonicalize_static_weight_to_2d =
-      input_info_1.is_initializer && HasOnlyLeadingUnitDimensions(input_info_1.shape) &&
-      input_info_0.shape.size() > 2;
+  squeeze_static_weight_to_2d =
+      input_info_1.is_initializer && input_info_1.shape.size() > 2 && LeadingDimsAllOne(input_info_1.shape) &&
+      input_info_0.shape.size() >= 2;
   // FullyConnected cannot pass the Op validation if keep_dims is true, so if input_0 is per-channel quantized tensor
   // with rank > 2, it's not easy to set the quantization parameters for the output reshaped rank 2 tensor.
   // In this case, we will not use FullyConnected.
   use_fully_connected =
-      is_rank2_static_weight || can_canonicalize_static_weight_to_2d || is_rank1_input_1;
+      is_rank2_static_weight || squeeze_static_weight_to_2d || is_rank1_input_1;
   use_fully_connected =
       use_fully_connected && !(input_info_0.quant_param.IsPerChannel() && input_info_0.shape.size() > 2);
   // Don't use FullyConnected if both inputs are dynamic and uint16 (quantized)
@@ -159,6 +125,7 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
                                                  !input_info_1.is_initializer);
   // Don't use FullyConnected for LPBQ weights.
   use_fully_connected = use_fully_connected && !use_conv2d && !input_info_1.quant_param.IsLPBQ();
+  squeeze_static_weight_to_2d = squeeze_static_weight_to_2d && use_fully_connected;
 #endif
   return Ort::Status();
 }
@@ -274,7 +241,8 @@ class MatMulOpBuilder : public BaseOpBuilder {
                                                 const TensorInfo& input_info_1,
                                                 const Ort::Logger& logger,
                                                 std::vector<std::string>& input_names,
-                                                bool do_op_validation) const ORT_MUST_USE_RESULT;
+                                                bool do_op_validation,
+                                                bool squeeze_static_weight_to_2d) const ORT_MUST_USE_RESULT;
   Ort::Status ProcessInputsForQnnConv2D(QnnModelWrapper& qnn_model_wrapper,
                                         const OrtNodeUnit& node_unit,
                                         const TensorInfo& input_info_0,
@@ -302,9 +270,10 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
   TensorInfo input_info_1{};
   bool use_fully_connected = false;
   bool use_conv2d = false;
+  bool squeeze_static_weight_to_2d = false;
   RETURN_IF_ERROR(
       CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1,
-                  use_fully_connected, use_conv2d));
+                  use_fully_connected, use_conv2d, squeeze_static_weight_to_2d));
 
   // Block-quantized weight: translate to a QNN MatMul with a BW_FLOAT_BLOCK weight.
   if (IsBQWeight(qnn_model_wrapper, inputs[1]) && !input_info_1.quant_param.IsLPBQ()) {
@@ -326,7 +295,8 @@ Ort::Status MatMulOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper, c
                                              input_info_1,
                                              logger,
                                              input_names,
-                                             do_op_validation);
+                                             do_op_validation,
+                                             squeeze_static_weight_to_2d);
   } else {
     return ProcessInputsForQnnMatMul(qnn_model_wrapper,
                                      node_unit,
@@ -471,7 +441,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
                                                                const TensorInfo& input_info_1,
                                                                const Ort::Logger& logger,
                                                                std::vector<std::string>& input_names,
-                                                               bool do_op_validation) const {
+                                                               bool do_op_validation,
+                                                               bool squeeze_static_weight_to_2d) const {
   const auto& inputs = node_unit.Inputs();
   const bool reshape_input_1 = input_info_1.shape.size() == 1;
 
@@ -482,27 +453,27 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   // Process input 1.
   const std::string& org_input_1_name = inputs[1].name;
   std::string input_1_name = org_input_1_name;
-  std::vector<uint32_t> fc_weight_shape;
-  QnnQuantParamsWrapper fc_weight_quant_param = input_info_1.quant_param.Copy();
-  const bool squeeze_static_weight_to_2d =
-      input_info_1.is_initializer && HasOnlyLeadingUnitDimensions(input_info_1.shape);
+  std::vector<uint32_t> shape_2d;
+  QnnQuantParamsWrapper quant_param_2d = input_info_1.quant_param.Copy();
   if (reshape_input_1) {
     // Input[1] is a rank 1 tensor that needs to be reshaped.
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
 
     // FullyConnected requires input_1's shape to be [n, k].
-    fc_weight_shape = {1, input_info_1.shape[0]};
-    RETURN_IF_ERROR(fc_weight_quant_param.HandleUnsqueeze<uint32_t>(input_info_1.shape, fc_weight_shape));
+    shape_2d = {1, input_info_1.shape[0]};
+    RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_info_1.shape, shape_2d));
   } else {
     assert(input_info_1.shape.size() == 2 || squeeze_static_weight_to_2d);
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_transpose");
     const size_t weight_k_dim_index = input_info_1.shape.size() - 2;
     const size_t weight_n_dim_index = input_info_1.shape.size() - 1;
-    fc_weight_shape = {input_info_1.shape[weight_n_dim_index], input_info_1.shape[weight_k_dim_index]};
+    const std::vector<uint32_t> squeezed_weight_shape = {input_info_1.shape[weight_k_dim_index],
+                                                         input_info_1.shape[weight_n_dim_index]};
+    shape_2d = {input_info_1.shape[weight_n_dim_index], input_info_1.shape[weight_k_dim_index]};
     if (squeeze_static_weight_to_2d) {
-      RETURN_IF_ERROR(AdjustQuantAxisAfterSqueezingLeadingDimensions(fc_weight_quant_param, weight_k_dim_index));
+      RETURN_IF_ERROR(quant_param_2d.HandleSqueeze<uint32_t>(input_info_1.shape, squeezed_weight_shape));
     }
-    RETURN_IF_ERROR(fc_weight_quant_param.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
+    RETURN_IF_ERROR(quant_param_2d.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
   }
 
   // If input_1 is initializer, unpack it and add the tensor with new quantization parameter and shape.
@@ -527,14 +498,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
 
     Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(org_input_1_name);
     QnnTensorWrapper input_tensorwrapper(input_1_name, tensor_type, input_info_1.qnn_data_type,
-                                         std::move(fc_weight_quant_param), std::move(fc_weight_shape),
+                                         std::move(quant_param_2d), std::move(shape_2d),
                                          std::move(unpacked_tensor));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
   } else {
     RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(org_input_1_name, input_1_name, input_info_1.shape,
-                                                     fc_weight_shape,
+                                                     shape_2d,
                                                      input_info_1.qnn_data_type, input_info_1.quant_param,
-                                                     fc_weight_quant_param, do_op_validation,
+                                                     quant_param_2d, do_op_validation,
                                                      qnn_model_wrapper.IsGraphInput(org_input_1_name), false));
   }
   input_names.emplace_back(input_1_name);
@@ -808,10 +779,11 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   TensorInfo input_info_1{};
   bool use_fully_connected = false;
   bool use_conv2d = false;
+  bool squeeze_static_weight_to_2d = false;
   std::string qnn_op_type;
   RETURN_IF_ERROR(
       CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1,
-                  use_fully_connected, use_conv2d));
+                  use_fully_connected, use_conv2d, squeeze_static_weight_to_2d));
 
   // A block-quantized weight is always emitted as a QNN MatMul (see ProcessInputsForBQMatMul), even
   // when CheckInputs would otherwise route a rank-2 initializer weight to FullyConnected. Force the
@@ -822,7 +794,8 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   bool reshape_input_0 = input_info_0.shape.size() == 1;
   bool reshape_input_1 = input_info_1.shape.size() == 1;
-  bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2) ||
+  bool reshape_output = reshape_input_0 || reshape_input_1 ||
+                        (use_fully_connected && (input_info_0.shape.size() > 2 || squeeze_static_weight_to_2d)) ||
                         (use_conv2d && input_info_0.shape.size() < 4);
 
   std::vector<std::string> param_tensor_names;
@@ -866,9 +839,13 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
       if (op_output_shape.size() < 4)
         op_output_shape.insert(op_output_shape.begin(), 1);
       RETURN_IF_ERROR(op_output_quant_param.HandleUnsqueeze<uint32_t>(output_info.shape, op_output_shape));
-    } else if (use_fully_connected && input_info_0.shape.size() > 2) {
+    } else if (use_fully_connected && (input_info_0.shape.size() > 2 || squeeze_static_weight_to_2d)) {
       uint32_t batch = 0;
-      RETURN_IF_ERROR(FlattenLeadingDims(input_info_0.shape, batch));
+      if (input_info_0.shape.size() > 2) {
+        RETURN_IF_ERROR(FlattenLeadingDims(input_info_0.shape, batch));
+      } else {
+        batch = input_info_0.shape[0];
+      }
       op_output_shape = {batch, reshape_input_1 ? 1 : input_info_1.shape.back()};
       RETURN_IF(op_output_quant_param.IsPerChannel(), "QNN FC output does not support per-channel quant.");
     } else {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -94,15 +94,27 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
   // Just use QNN MatMul for these older QNN SDK versions.
   use_fully_connected = false;
 #else
-  // Static [1, ..., 1, K, N] weights are ONNX-broadcast-equivalent to [K, N]. The rank > 2 term is
-  // required (not just implied by the squeeze check, which is vacuously true at rank 2): it keeps
-  // rank-2 weights on the existing path, where no output reshape is needed.
+  // A static [1, ..., 1, K, N] weight is ONNX-broadcast-equivalent to [K, N], so it can take the same
+  // FullyConnected lowering as a plain rank-2 weight. That matters because QNN MatMul on HTP fails
+  // graph finalization with QNN_COMMON_ERROR_MEM_ALLOC when input[1] carries a per-axis encoding and
+  // the batch dim is > 1; FullyConnected flattens the batch into rows and is unaffected.
+  // The rank > 2 term is required (not just implied by the squeeze check, which is vacuously true at
+  // rank 2): it keeps rank-2 weights on the existing path, where no output reshape is needed.
   const bool is_rank2_static_weight = input_info_1.shape.size() == 2 && input_info_1.is_initializer;
   const bool is_rank1_input_1 = input_info_1.shape.size() == 1;
-  squeeze_static_weight_to_2d =
-      input_info_1.is_initializer && input_info_1.shape.size() > 2 &&
-      utils::TrySqueezeLeadingOnesTo(input_info_1.shape, 2).has_value() &&
-      input_info_0.shape.size() >= 2;
+  const auto weight_shape_2d = utils::TrySqueezeLeadingOnesTo(input_info_1.shape, 2);
+  squeeze_static_weight_to_2d = input_info_1.is_initializer && input_info_1.shape.size() > 2 &&
+                                weight_shape_2d.has_value() && input_info_0.shape.size() >= 2;
+  if (squeeze_static_weight_to_2d) {
+    // The squeeze must also be able to remap the weight's quantization axis, which is not possible when
+    // that axis is one of the leading 1-dims. In practice only LPBQ hits this (its axis is forced to 0
+    // or 1); a per-axis encoding always has >= 2 scales, so its axis can never be a 1-dim. Trial-run
+    // the remap on a copy rather than restating the rule, and keep any weight it rejects on the QNN
+    // MatMul path -- which handles it today -- instead of failing the node.
+    squeeze_static_weight_to_2d = input_info_1.quant_param.Copy()
+                                      .HandleSqueeze<uint32_t>(input_info_1.shape, *weight_shape_2d)
+                                      .IsOK();
+  }
   // FullyConnected cannot pass the Op validation if keep_dims is true, so if input_0 is per-channel quantized tensor
   // with rank > 2, it's not easy to set the quantization parameters for the output reshaped rank 2 tensor.
   // In this case, we will not use FullyConnected.
@@ -115,8 +127,8 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
                                                  !input_info_0.is_initializer &&
                                                  utils::IsQuant16bit(input_info_1.qnn_data_type) &&
                                                  !input_info_1.is_initializer);
-  // Don't use FullyConnected for LPBQ weights.
-  use_fully_connected = use_fully_connected && !use_conv2d && !input_info_1.quant_param.IsLPBQ();
+  // Don't use FullyConnected for LPBQ weights
+  use_fully_connected = use_fully_connected && !use_conv2d;
   squeeze_static_weight_to_2d = squeeze_static_weight_to_2d && use_fully_connected;
 #endif
   return Ort::Status();
@@ -784,8 +796,12 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   bool reshape_input_0 = input_info_0.shape.size() == 1;
   bool reshape_input_1 = input_info_1.shape.size() == 1;
-  bool reshape_output = reshape_input_0 || reshape_input_1 ||
-                        (use_fully_connected && (input_info_0.shape.size() > 2 || squeeze_static_weight_to_2d)) ||
+  // FullyConnected always emits a rank-2 [batch, n] output, so it needs a reshape back to the ONNX
+  // output shape whenever that shape has rank > 2 -- either because input_0 does, or because the
+  // squeezed-away leading dims of input_1 do.
+  const bool reshape_fc_output =
+      use_fully_connected && (input_info_0.shape.size() > 2 || squeeze_static_weight_to_2d);
+  bool reshape_output = reshape_input_0 || reshape_input_1 || reshape_fc_output ||
                         (use_conv2d && input_info_0.shape.size() < 4);
 
   std::vector<std::string> param_tensor_names;
@@ -829,13 +845,10 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
       if (op_output_shape.size() < 4)
         op_output_shape.insert(op_output_shape.begin(), 1);
       RETURN_IF_ERROR(op_output_quant_param.HandleUnsqueeze<uint32_t>(output_info.shape, op_output_shape));
-    } else if (use_fully_connected && (input_info_0.shape.size() > 2 || squeeze_static_weight_to_2d)) {
+    } else if (reshape_fc_output) {
+      // input_0 is rank >= 2 here, so this reduces to input_0.shape[0] for a rank-2 input_0.
       uint32_t batch = 0;
-      if (input_info_0.shape.size() > 2) {
-        RETURN_IF_ERROR(FlattenLeadingDims(input_info_0.shape, batch));
-      } else {
-        batch = input_info_0.shape[0];
-      }
+      RETURN_IF_ERROR(FlattenLeadingDims(input_info_0.shape, batch));
       op_output_shape = {batch, reshape_input_1 ? 1 : input_info_1.shape.back()};
       RETURN_IF(op_output_quant_param.IsPerChannel(), "QNN FC output does not support per-channel quant.");
     } else {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -18,7 +18,7 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
-bool HasOnlyLeadingUnitDims(const std::vector<uint32_t>& shape) {
+bool HasOnlyLeadingUnitDimensions(const std::vector<uint32_t>& shape) {
   if (shape.size() <= 2) {
     return false;
   }
@@ -32,31 +32,32 @@ bool HasOnlyLeadingUnitDims(const std::vector<uint32_t>& shape) {
   return true;
 }
 
-bool IsStaticWeightWithOnlyLeadingUnitDims(const TensorInfo& input_info) {
-  return input_info.is_initializer && HasOnlyLeadingUnitDims(input_info.shape);
+bool IsStaticMatMulWeightWithOnlyLeadingUnitDimensions(const TensorInfo& input_info) {
+  return input_info.is_initializer && HasOnlyLeadingUnitDimensions(input_info.shape);
 }
 
-Ort::Status HandleSqueezeLeadingUnitDims(QnnQuantParamsWrapper& quant_param, size_t num_squeezed_dims) {
-  if (num_squeezed_dims == 0 || (!quant_param.IsPerChannel() && !quant_param.IsLPBQ())) {
+Ort::Status AdjustQuantAxisAfterSqueezingLeadingDimensions(QnnQuantParamsWrapper& quant_param,
+                                                           size_t num_squeezed_leading_dims) {
+  if (num_squeezed_leading_dims == 0 || (!quant_param.IsPerChannel() && !quant_param.IsLPBQ())) {
     return Ort::Status();
   }
 
   Qnn_QuantizeParams_t& params = quant_param.Get();
-  int32_t* axis = nullptr;
+  int32_t* quant_axis = nullptr;
   if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
-    axis = &params.axisScaleOffsetEncoding.axis;
+    quant_axis = &params.axisScaleOffsetEncoding.axis;
   } else if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
-    axis = &params.bwAxisScaleOffsetEncoding.axis;
+    quant_axis = &params.bwAxisScaleOffsetEncoding.axis;
   } else if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION &&
              params.blockwiseExpansion != nullptr) {
-    axis = &params.blockwiseExpansion->axis;
+    quant_axis = &params.blockwiseExpansion->axis;
   } else {
     return MAKE_EP_FAIL(("Unhandled quantization encoding: " + std::to_string(params.quantizationEncoding)).c_str());
   }
 
-  RETURN_IF_NOT(*axis >= static_cast<int32_t>(num_squeezed_dims),
+  RETURN_IF_NOT(*quant_axis >= static_cast<int32_t>(num_squeezed_leading_dims),
                 "Cannot squeeze leading unit dimensions that contain the quantization axis.");
-  *axis -= static_cast<int32_t>(num_squeezed_dims);
+  *quant_axis -= static_cast<int32_t>(num_squeezed_leading_dims);
 
   return Ort::Status();
 }
@@ -142,18 +143,16 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
   // Just use QNN MatMul for these older QNN SDK versions.
   use_fully_connected = false;
 #else
-  // Use FullyConnected if 2nd input is a rank 2 initializer, a rank 1 tensor, or a static weight
-  // with only leading unit dimensions that can use the existing rank>2 input/output reshape path.
-  // Static weights with only leading unit dimensions, e.g. [1, 1, K, N], are equivalent to
-  // rank-2 [K, N] weights after broadcasting. Lowering them through QNN MatMul can fail HTP graph
-  // finalization, so canonicalize them to FullyConnected when input 0 can be flattened and reshaped back safely.
+  // Static [1, ..., 1, K, N] weights are ONNX-broadcast-equivalent to [K, N].
+  const bool is_rank2_static_weight = input_info_1.shape.size() == 2 && input_info_1.is_initializer;
+  const bool is_rank1_input_1 = input_info_1.shape.size() == 1;
+  const bool can_canonicalize_static_weight_to_2d =
+      IsStaticMatMulWeightWithOnlyLeadingUnitDimensions(input_info_1) && input_info_0.shape.size() > 2;
   // FullyConnected cannot pass the Op validation if keep_dims is true, so if input_0 is per-channel quantized tensor
   // with rank > 2, it's not easy to set the quantization parameters for the output reshaped rank 2 tensor.
   // In this case, we will not use FullyConnected.
   use_fully_connected =
-      (input_info_1.shape.size() == 2 && input_info_1.is_initializer) ||
-      (IsStaticWeightWithOnlyLeadingUnitDims(input_info_1) && input_info_0.shape.size() > 2) ||
-      input_info_1.shape.size() == 1;
+      is_rank2_static_weight || can_canonicalize_static_weight_to_2d || is_rank1_input_1;
   use_fully_connected =
       use_fully_connected && !(input_info_0.quant_param.IsPerChannel() && input_info_0.shape.size() > 2);
   // Don't use FullyConnected if both inputs are dynamic and uint16 (quantized)
@@ -245,7 +244,7 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
  * FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op when:
  * 1. input_1 is a rank 2 initializer.
  * 2. input_1 is a rank 1 tensor.
- * 3. input_1 is a static weight with only leading unit dimensions, such as [1, 1, k, n].
+ * 3. input_1 is a static [1, ..., 1, k, n] weight and input_0 has rank > 2.
  * For LPBQ-quantized weights on NPU backends, Conv2D with 1x1 filters is used instead of MatMul.
  */
 class MatMulOpBuilder : public BaseOpBuilder {
@@ -486,26 +485,26 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   // Process input 1.
   const std::string& org_input_1_name = inputs[1].name;
   std::string input_1_name = org_input_1_name;
-  std::vector<uint32_t> shape_2d;
-  QnnQuantParamsWrapper quant_param_2d = input_info_1.quant_param.Copy();
-  const bool squeeze_leading_unit_dims = IsStaticWeightWithOnlyLeadingUnitDims(input_info_1);
+  std::vector<uint32_t> fc_weight_shape;
+  QnnQuantParamsWrapper fc_weight_quant_param = input_info_1.quant_param.Copy();
+  const bool squeeze_static_weight_to_2d = IsStaticMatMulWeightWithOnlyLeadingUnitDimensions(input_info_1);
   if (reshape_input_1) {
     // Input[1] is a rank 1 tensor that needs to be reshaped.
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
 
     // FullyConnected requires input_1's shape to be [n, k].
-    shape_2d = {1, input_info_1.shape[0]};
-    RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_info_1.shape, shape_2d));
+    fc_weight_shape = {1, input_info_1.shape[0]};
+    RETURN_IF_ERROR(fc_weight_quant_param.HandleUnsqueeze<uint32_t>(input_info_1.shape, fc_weight_shape));
   } else {
-    assert(input_info_1.shape.size() == 2 || squeeze_leading_unit_dims);
+    assert(input_info_1.shape.size() == 2 || squeeze_static_weight_to_2d);
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_transpose");
-    const size_t k_dim_index = input_info_1.shape.size() - 2;
-    const size_t n_dim_index = input_info_1.shape.size() - 1;
-    shape_2d = {input_info_1.shape[n_dim_index], input_info_1.shape[k_dim_index]};
-    if (squeeze_leading_unit_dims) {
-      RETURN_IF_ERROR(HandleSqueezeLeadingUnitDims(quant_param_2d, input_info_1.shape.size() - 2));
+    const size_t weight_k_dim_index = input_info_1.shape.size() - 2;
+    const size_t weight_n_dim_index = input_info_1.shape.size() - 1;
+    fc_weight_shape = {input_info_1.shape[weight_n_dim_index], input_info_1.shape[weight_k_dim_index]};
+    if (squeeze_static_weight_to_2d) {
+      RETURN_IF_ERROR(AdjustQuantAxisAfterSqueezingLeadingDimensions(fc_weight_quant_param, weight_k_dim_index));
     }
-    RETURN_IF_ERROR(quant_param_2d.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
+    RETURN_IF_ERROR(fc_weight_quant_param.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
   }
 
   // If input_1 is initializer, unpack it and add the tensor with new quantization parameter and shape.
@@ -513,15 +512,13 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   if (input_info_1.is_initializer) {
     std::vector<uint8_t> unpacked_tensor;
     if (!reshape_input_1) {
-      // 2D initializer should be transposed to [n, k]. A higher-rank initializer with only leading unit dims
-      // has identical storage order to its squeezed [k, n] shape.
       const size_t input_1_rank = input_info_1.shape.size();
-      std::vector<uint32_t> original_shape_copy = squeeze_leading_unit_dims
-                                                      ? std::vector<uint32_t>{input_info_1.shape[input_1_rank - 2],
-                                                                              input_info_1.shape[input_1_rank - 1]}
-                                                      : input_info_1.shape;
+      std::vector<uint32_t> weight_shape_for_transpose =
+          squeeze_static_weight_to_2d
+              ? std::vector<uint32_t>{input_info_1.shape[input_1_rank - 2], input_info_1.shape[input_1_rank - 1]}
+              : input_info_1.shape;
       RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper,
-                                                   original_shape_copy,  // Will be modified to new shape (unnecessary)
+                                                   weight_shape_for_transpose,  // Modified by TwoDimensionTranspose.
                                                    input_info_1.initializer_tensor,
                                                    unpacked_tensor,
                                                    logger,
@@ -532,12 +529,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
 
     Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(org_input_1_name);
     QnnTensorWrapper input_tensorwrapper(input_1_name, tensor_type, input_info_1.qnn_data_type,
-                                         std::move(quant_param_2d), std::move(shape_2d), std::move(unpacked_tensor));
+                                         std::move(fc_weight_quant_param), std::move(fc_weight_shape),
+                                         std::move(unpacked_tensor));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)), "Failed to add tensor.");
   } else {
-    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(org_input_1_name, input_1_name, input_info_1.shape, shape_2d,
+    RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(org_input_1_name, input_1_name, input_info_1.shape,
+                                                     fc_weight_shape,
                                                      input_info_1.qnn_data_type, input_info_1.quant_param,
-                                                     quant_param_2d, do_op_validation,
+                                                     fc_weight_quant_param, do_op_validation,
                                                      qnn_model_wrapper.IsGraphInput(org_input_1_name), false));
   }
   input_names.emplace_back(input_1_name);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -18,6 +18,49 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
+bool HasOnlyLeadingUnitDims(const std::vector<uint32_t>& shape) {
+  if (shape.size() <= 2) {
+    return false;
+  }
+
+  for (size_t i = 0; i + 2 < shape.size(); ++i) {
+    if (shape[i] != 1) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool IsStaticWeightWithOnlyLeadingUnitDims(const TensorInfo& input_info) {
+  return input_info.is_initializer && HasOnlyLeadingUnitDims(input_info.shape);
+}
+
+Ort::Status HandleSqueezeLeadingUnitDims(QnnQuantParamsWrapper& quant_param, size_t num_squeezed_dims) {
+  if (num_squeezed_dims == 0 || (!quant_param.IsPerChannel() && !quant_param.IsLPBQ())) {
+    return Ort::Status();
+  }
+
+  Qnn_QuantizeParams_t& params = quant_param.Get();
+  int32_t* axis = nullptr;
+  if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+    axis = &params.axisScaleOffsetEncoding.axis;
+  } else if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+    axis = &params.bwAxisScaleOffsetEncoding.axis;
+  } else if (params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION &&
+             params.blockwiseExpansion != nullptr) {
+    axis = &params.blockwiseExpansion->axis;
+  } else {
+    return MAKE_EP_FAIL(("Unhandled quantization encoding: " + std::to_string(params.quantizationEncoding)).c_str());
+  }
+
+  RETURN_IF_NOT(*axis >= static_cast<int32_t>(num_squeezed_dims),
+                "Cannot squeeze leading unit dimensions that contain the quantization axis.");
+  *axis -= static_cast<int32_t>(num_squeezed_dims);
+
+  return Ort::Status();
+}
+
 // Detects a block-quantized MatMul weight (ONNX MatMul input[1]).
 // Accepts weight rank 2–4: shape [..., K, N] where any leading dims beyond K/N must equal 1
 // (i.e. reshapeable to [1, 1, K, N]). Per ONNX opset 21 the scale has the same rank as the
@@ -99,12 +142,18 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
   // Just use QNN MatMul for these older QNN SDK versions.
   use_fully_connected = false;
 #else
-  // Use FullyConnected if 2nd input is a rank 2 initializer or a rank 1 tensor.
+  // Use FullyConnected if 2nd input is a rank 2 initializer, a rank 1 tensor, or a static weight
+  // with only leading unit dimensions that can use the existing rank>2 input/output reshape path.
+  // Static weights with only leading unit dimensions, e.g. [1, 1, K, N], are equivalent to
+  // rank-2 [K, N] weights after broadcasting. Lowering them through QNN MatMul can fail HTP graph
+  // finalization, so canonicalize them to FullyConnected when input 0 can be flattened and reshaped back safely.
   // FullyConnected cannot pass the Op validation if keep_dims is true, so if input_0 is per-channel quantized tensor
   // with rank > 2, it's not easy to set the quantization parameters for the output reshaped rank 2 tensor.
   // In this case, we will not use FullyConnected.
   use_fully_connected =
-      (input_info_1.shape.size() == 2 && input_info_1.is_initializer) || input_info_1.shape.size() == 1;
+      (input_info_1.shape.size() == 2 && input_info_1.is_initializer) ||
+      (IsStaticWeightWithOnlyLeadingUnitDims(input_info_1) && input_info_0.shape.size() > 2) ||
+      input_info_1.shape.size() == 1;
   use_fully_connected =
       use_fully_connected && !(input_info_0.quant_param.IsPerChannel() && input_info_0.shape.size() > 2);
   // Don't use FullyConnected if both inputs are dynamic and uint16 (quantized)
@@ -112,8 +161,8 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
                                                  !input_info_0.is_initializer &&
                                                  utils::IsQuant16bit(input_info_1.qnn_data_type) &&
                                                  !input_info_1.is_initializer);
-  // Don't use FullyConnected for LPBQ weights
-  use_fully_connected = use_fully_connected && !use_conv2d;
+  // Don't use FullyConnected for LPBQ weights.
+  use_fully_connected = use_fully_connected && !use_conv2d && !input_info_1.quant_param.IsLPBQ();
 #endif
   return Ort::Status();
 }
@@ -193,9 +242,10 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
  * An ONNX MatMul can be translated to either a QNN MatMul, a QNN FullyConnected, or a QNN Conv2D.
  * ONNX's MatMul supports inputs of rank 1, but neither QNN's MatMul nor FullyConnected support two rank 1 inputs.
  * So, we need to add Reshape Ops if necessary.
- * In two cases, FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op:
+ * FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op when:
  * 1. input_1 is a rank 2 initializer.
  * 2. input_1 is a rank 1 tensor.
+ * 3. input_1 is a static weight with only leading unit dimensions, such as [1, 1, k, n].
  * For LPBQ-quantized weights on NPU backends, Conv2D with 1x1 filters is used instead of MatMul.
  */
 class MatMulOpBuilder : public BaseOpBuilder {
@@ -438,6 +488,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   std::string input_1_name = org_input_1_name;
   std::vector<uint32_t> shape_2d;
   QnnQuantParamsWrapper quant_param_2d = input_info_1.quant_param.Copy();
+  const bool squeeze_leading_unit_dims = IsStaticWeightWithOnlyLeadingUnitDims(input_info_1);
   if (reshape_input_1) {
     // Input[1] is a rank 1 tensor that needs to be reshaped.
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
@@ -446,9 +497,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
     shape_2d = {1, input_info_1.shape[0]};
     RETURN_IF_ERROR(quant_param_2d.HandleUnsqueeze<uint32_t>(input_info_1.shape, shape_2d));
   } else {
-    assert(input_info_1.shape.size() == 2);
+    assert(input_info_1.shape.size() == 2 || squeeze_leading_unit_dims);
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_transpose");
-    shape_2d = {input_info_1.shape[1], input_info_1.shape[0]};
+    const size_t k_dim_index = input_info_1.shape.size() - 2;
+    const size_t n_dim_index = input_info_1.shape.size() - 1;
+    shape_2d = {input_info_1.shape[n_dim_index], input_info_1.shape[k_dim_index]};
+    if (squeeze_leading_unit_dims) {
+      RETURN_IF_ERROR(HandleSqueezeLeadingUnitDims(quant_param_2d, input_info_1.shape.size() - 2));
+    }
     RETURN_IF_ERROR(quant_param_2d.HandleTranspose<uint32_t>(std::vector<uint32_t>({1, 0})));
   }
 
@@ -457,8 +513,13 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   if (input_info_1.is_initializer) {
     std::vector<uint8_t> unpacked_tensor;
     if (!reshape_input_1) {
-      // 2D initializer should be transposed to [n, k].
-      std::vector<uint32_t> original_shape_copy = input_info_1.shape;
+      // 2D initializer should be transposed to [n, k]. A higher-rank initializer with only leading unit dims
+      // has identical storage order to its squeezed [k, n] shape.
+      const size_t input_1_rank = input_info_1.shape.size();
+      std::vector<uint32_t> original_shape_copy = squeeze_leading_unit_dims
+                                                      ? std::vector<uint32_t>{input_info_1.shape[input_1_rank - 2],
+                                                                              input_info_1.shape[input_1_rank - 1]}
+                                                      : input_info_1.shape;
       RETURN_IF_ERROR(utils::TwoDimensionTranspose(qnn_model_wrapper,
                                                    original_shape_copy,  // Will be modified to new shape (unnecessary)
                                                    input_info_1.initializer_tensor,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -32,10 +32,6 @@ bool HasOnlyLeadingUnitDimensions(const std::vector<uint32_t>& shape) {
   return true;
 }
 
-bool IsStaticMatMulWeightWithOnlyLeadingUnitDimensions(const TensorInfo& input_info) {
-  return input_info.is_initializer && HasOnlyLeadingUnitDimensions(input_info.shape);
-}
-
 Ort::Status AdjustQuantAxisAfterSqueezingLeadingDimensions(QnnQuantParamsWrapper& quant_param,
                                                            size_t num_squeezed_leading_dims) {
   if (num_squeezed_leading_dims == 0 || (!quant_param.IsPerChannel() && !quant_param.IsLPBQ())) {
@@ -147,7 +143,8 @@ Ort::Status CheckInputs(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeU
   const bool is_rank2_static_weight = input_info_1.shape.size() == 2 && input_info_1.is_initializer;
   const bool is_rank1_input_1 = input_info_1.shape.size() == 1;
   const bool can_canonicalize_static_weight_to_2d =
-      IsStaticMatMulWeightWithOnlyLeadingUnitDimensions(input_info_1) && input_info_0.shape.size() > 2;
+      input_info_1.is_initializer && HasOnlyLeadingUnitDimensions(input_info_1.shape) &&
+      input_info_0.shape.size() > 2;
   // FullyConnected cannot pass the Op validation if keep_dims is true, so if input_0 is per-channel quantized tensor
   // with rank > 2, it's not easy to set the quantization parameters for the output reshaped rank 2 tensor.
   // In this case, we will not use FullyConnected.
@@ -487,7 +484,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   std::string input_1_name = org_input_1_name;
   std::vector<uint32_t> fc_weight_shape;
   QnnQuantParamsWrapper fc_weight_quant_param = input_info_1.quant_param.Copy();
-  const bool squeeze_static_weight_to_2d = IsStaticMatMulWeightWithOnlyLeadingUnitDimensions(input_info_1);
+  const bool squeeze_static_weight_to_2d =
+      input_info_1.is_initializer && HasOnlyLeadingUnitDimensions(input_info_1.shape);
   if (reshape_input_1) {
     // Input[1] is a rank 1 tensor that needs to be reshaped.
     input_1_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -212,7 +212,7 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
  * FullyConnected (input_1's shape is [n, k]) is used instead of MatMul without extra Transpose Op when:
  * 1. input_1 is a rank 2 initializer.
  * 2. input_1 is a rank 1 tensor.
- * 3. input_1 is a static [1, ..., 1, k, n] weight and input_0 has rank > 2.
+ * 3. input_1 is a static [1, ..., 1, k, n] weight and input_0 has rank >= 2.
  * For LPBQ-quantized weights on NPU backends, Conv2D with 1x1 filters is used instead of MatMul.
  */
 class MatMulOpBuilder : public BaseOpBuilder {
@@ -790,8 +790,11 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   // A block-quantized weight is always emitted as a QNN MatMul (see ProcessInputsForBQMatMul), even
   // when CheckInputs would otherwise route a rank-2 initializer weight to FullyConnected. Force the
   // MatMul path here so the output handling matches how the inputs were built.
-  if (IsBQWeight(qnn_model_wrapper, inputs[1])) {
+  // Mirror the ProcessInputs predicate exactly; clear the squeeze flag as well so no downstream
+  // logic can observe a stale squeeze=true with use_fully_connected=false.
+  if (IsBQWeight(qnn_model_wrapper, inputs[1]) && !input_info_1.quant_param.IsLPBQ()) {
     use_fully_connected = false;
+    squeeze_static_weight_to_2d = false;
   }
 
   bool reshape_input_0 = input_info_0.shape.size() == 1;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Qualcomm. All rights reserved.
 // Licensed under the MIT License.
 
-#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <optional>
@@ -15,28 +14,6 @@
 
 namespace onnxruntime {
 namespace qnn {
-
-namespace {
-
-// QNN's RmsNorm OpDef requires gamma (and beta) to be rank size(axes), whereas ONNX
-// RMSNormalization lets `scale` be any shape unidirectionally broadcastable to X, e.g. scale
-// [1, 1, C] against X [1, S, C]. Returns `shape` with leading 1-dims dropped to reach
-// `target_rank`, or std::nullopt if a non-1 dim would have to be dropped. A shape already at or
-// below `target_rank` is returned unchanged, leaving QNN to validate it as before.
-std::optional<std::vector<uint32_t>> TrySqueezeLeadingOnesTo(const std::vector<uint32_t>& shape,
-                                                             size_t target_rank) {
-  if (shape.size() <= target_rank) {
-    return shape;
-  }
-
-  const size_t num_leading_dims = shape.size() - target_rank;
-  if (std::any_of(shape.begin(), shape.begin() + num_leading_dims, [](uint32_t dim) { return dim != 1; })) {
-    return std::nullopt;
-  }
-  return std::vector<uint32_t>(shape.begin() + num_leading_dims, shape.end());
-}
-
-}  // namespace
 
 class RMSNormalizationOpBuilder : public BaseOpBuilder {
  public:
@@ -139,8 +116,10 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
   size_t axes_rank = 0;
   RETURN_IF_ERROR(GetAxesRank(qnn_model_wrapper, node_unit, axes_rank));
 
+  // QNN's RmsNorm OpDef requires gamma (and beta) to be rank size(axes), whereas ONNX
+  // RMSNormalization lets `scale` be any shape unidirectionally broadcastable to X.
   const std::optional<std::vector<uint32_t>> squeezed_shape =
-      TrySqueezeLeadingOnesTo(scale_info.shape, axes_rank);
+      utils::TrySqueezeLeadingOnesTo(scale_info.shape, axes_rank);
   RETURN_IF_NOT(squeezed_shape.has_value(),
                 "QNN RMSNorm requires the scale rank to equal the number of normalized axes; this scale has "
                 "non-1 leading dimensions and cannot be squeezed to match.");

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -214,8 +214,14 @@ class QnnQuantParamsWrapper {
     return Ort::Status();
   }
 
-  // Handle "squeeze" of a per-channel or LPBQ quantized tensor. The quantization parameter's
-  // axis may need to be shifted if dimensions before the quantization axis were removed.
+  // Handle "squeeze" of a per-channel or LPBQ quantized tensor's LEADING dimensions.
+  // The quantization parameter's axis is shifted left by the number of leading unit
+  // dimensions removed. Only leading dims may be squeezed by this method: unlike
+  // HandleUnsqueeze (which locates inserted 1s by value, since inserted dims are
+  // always 1 and the rest of the shape is untouched), squeeze cannot be resolved
+  // from shapes by value alone — a squeezed leading dim and the surviving trailing
+  // dims can both legitimately be 1 (e.g. weight [1,1,1,4] squeezed to [1,4]), so
+  // this method anchors on the trailing `new_shape.size()` dims by position instead.
   template <typename IntType>
   Ort::Status HandleSqueeze(gsl::span<const IntType> orig_shape,
                             gsl::span<const IntType> new_shape) {
@@ -240,26 +246,18 @@ class QnnQuantParamsWrapper {
     RETURN_IF_NOT(*quant_axis >= 0 && static_cast<size_t>(*quant_axis) < orig_shape.size(),
                   "Axis value is out of range of the original shape.");
 
-    bool found_axis = false;
-    size_t new_axis = 0;
-    size_t j = 0;
-    for (size_t i = 0; i < orig_shape.size(); ++i) {
-      if (j < new_shape.size() && orig_shape[i] == new_shape[j]) {
-        if (i == static_cast<size_t>(*quant_axis)) {
-          found_axis = true;
-          new_axis = j;
-        }
-        ++j;
-      } else {
-        RETURN_IF_NOT(orig_shape[i] == 1, "Only dimensions of size 1 can be squeezed.");
-        RETURN_IF_NOT(i != static_cast<size_t>(*quant_axis),
-                      "Cannot squeeze a dimension that contains the quantization axis.");
-      }
+    const size_t num_squeezed = orig_shape.size() - new_shape.size();
+    for (size_t i = 0; i < num_squeezed; ++i) {
+      RETURN_IF_NOT(orig_shape[i] == 1, "Only leading dimensions of size 1 can be squeezed.");
+    }
+    for (size_t j = 0; j < new_shape.size(); ++j) {
+      RETURN_IF_NOT(orig_shape[num_squeezed + j] == new_shape[j],
+                    "Squeezed shape does not align with the trailing dimensions of the original shape.");
     }
 
-    RETURN_IF_NOT(j == new_shape.size(), "Squeezed shape does not match the original shape.");
-    RETURN_IF_NOT(found_axis, "Cannot squeeze a dimension that contains the quantization axis.");
-    *quant_axis = static_cast<int32_t>(new_axis);
+    RETURN_IF_NOT(static_cast<size_t>(*quant_axis) >= num_squeezed,
+                  "Cannot squeeze a leading dimension that contains the quantization axis.");
+    *quant_axis = static_cast<int32_t>(static_cast<size_t>(*quant_axis) - num_squeezed);
 
     return Ort::Status();
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -214,6 +214,56 @@ class QnnQuantParamsWrapper {
     return Ort::Status();
   }
 
+  // Handle "squeeze" of a per-channel or LPBQ quantized tensor. The quantization parameter's
+  // axis may need to be shifted if dimensions before the quantization axis were removed.
+  template <typename IntType>
+  Ort::Status HandleSqueeze(gsl::span<const IntType> orig_shape,
+                            gsl::span<const IntType> new_shape) {
+    if (!IsPerChannel() && !IsLPBQ()) {
+      return Ort::Status();
+    }
+
+    RETURN_IF_NOT(orig_shape.size() > new_shape.size(), "Expected squeezed shape to have a smaller rank.");
+
+    int32_t* quant_axis = nullptr;
+    if (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+      quant_axis = &params_.axisScaleOffsetEncoding.axis;
+    } else if (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+      quant_axis = &params_.bwAxisScaleOffsetEncoding.axis;
+    } else if (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION &&
+               params_.blockwiseExpansion != nullptr) {
+      quant_axis = &params_.blockwiseExpansion->axis;
+    } else {
+      return MAKE_EP_FAIL(("Unhandled quantization encoding: " + std::to_string(params_.quantizationEncoding)).c_str());
+    }
+
+    RETURN_IF_NOT(*quant_axis >= 0 && static_cast<size_t>(*quant_axis) < orig_shape.size(),
+                  "Axis value is out of range of the original shape.");
+
+    bool found_axis = false;
+    size_t new_axis = 0;
+    size_t j = 0;
+    for (size_t i = 0; i < orig_shape.size(); ++i) {
+      if (j < new_shape.size() && orig_shape[i] == new_shape[j]) {
+        if (i == static_cast<size_t>(*quant_axis)) {
+          found_axis = true;
+          new_axis = j;
+        }
+        ++j;
+      } else {
+        RETURN_IF_NOT(orig_shape[i] == 1, "Only dimensions of size 1 can be squeezed.");
+        RETURN_IF_NOT(i != static_cast<size_t>(*quant_axis),
+                      "Cannot squeeze a dimension that contains the quantization axis.");
+      }
+    }
+
+    RETURN_IF_NOT(j == new_shape.size(), "Squeezed shape does not match the original shape.");
+    RETURN_IF_NOT(found_axis, "Cannot squeeze a dimension that contains the quantization axis.");
+    *quant_axis = static_cast<int32_t>(new_axis);
+
+    return Ort::Status();
+  }
+
  private:
   Qnn_QuantizeParams_t params_;
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -243,9 +243,6 @@ class QnnQuantParamsWrapper {
       return MAKE_EP_FAIL(("Unhandled quantization encoding: " + std::to_string(params_.quantizationEncoding)).c_str());
     }
 
-    RETURN_IF_NOT(*quant_axis >= 0 && static_cast<size_t>(*quant_axis) < orig_shape.size(),
-                  "Axis value is out of range of the original shape.");
-
     const size_t num_squeezed = orig_shape.size() - new_shape.size();
     for (size_t i = 0; i < num_squeezed; ++i) {
       RETURN_IF_NOT(orig_shape[i] == 1, "Only leading dimensions of size 1 can be squeezed.");
@@ -254,6 +251,9 @@ class QnnQuantParamsWrapper {
       RETURN_IF_NOT(orig_shape[num_squeezed + j] == new_shape[j],
                     "Squeezed shape does not align with the trailing dimensions of the original shape.");
     }
+
+    RETURN_IF_NOT(*quant_axis >= 0 && static_cast<size_t>(*quant_axis) < orig_shape.size(),
+                  "Axis value is out of range of the original shape.");
 
     RETURN_IF_NOT(static_cast<size_t>(*quant_axis) >= num_squeezed,
                   "Cannot squeeze a leading dimension that contains the quantization axis.");

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -509,6 +509,24 @@ inline std::vector<int64_t> GetInitializerShape(const OrtValueInfo* initializer,
 
 // TensorShape GetTensorProtoShape(const ONNX_NAMESPACE::TensorShapeProto& tensor_shape_proto);
 
+// Returns `shape` with leading 1-dims dropped to reach `target_rank`, or std::nullopt if a non-1
+// dim would have to be dropped. A shape already at or below `target_rank` is returned unchanged,
+// so such a shape is always (vacuously) squeezable. Used where ONNX accepts an operand that is
+// unidirectionally broadcastable to a higher rank but the QNN OpDef requires the lower rank, e.g.
+// RMSNorm scale [1, 1, C] against X [1, S, C], or a MatMul weight [1, 1, K, N] against [K, N].
+template <typename T>
+std::optional<std::vector<T>> TrySqueezeLeadingOnesTo(const std::vector<T>& shape, size_t target_rank) {
+  if (shape.size() <= target_rank) {
+    return shape;
+  }
+
+  const size_t num_leading_dims = shape.size() - target_rank;
+  if (std::any_of(shape.begin(), shape.begin() + num_leading_dims, [](T dim) { return dim != 1; })) {
+    return std::nullopt;
+  }
+  return std::vector<T>(shape.begin() + num_leading_dims, shape.end());
+}
+
 template <typename T, typename P>
 Ort::Status PermuteShape(gsl::span<const T> input_shape, gsl::span<const P> perm, gsl::span<T> output_shape) {
   const size_t rank = input_shape.size();

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -658,7 +658,7 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ) {
   RunQDQPerChannelMatMulOpTest<uint16_t, int8_t, uint16_t>({2, 3, 3}, {3}, -1, QDQTolerance(0.0041f));
 }
 
-TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_AIHubRegression_StaticPerChannelInt16Weight) {
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_StaticLeadingUnitDimsPerChannelInt16Weight) {
   RunQDQPerChannelMatMulOpTest<uint16_t, int16_t, uint16_t>(
       {1, 6, 3, 3}, {1, 1, 3, 420}, 3, QDQTolerance(),
       ExpectedEPNodeAssignment::All, 21, false, true);

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -364,6 +364,40 @@ TEST_F(QnnCPUBackendTests, MatMulOp) {
   // RunMatMulOpTest({2, 3, 3, 3}, {3, 2}, true, false);
 }
 
+TEST_F(QnnCPUBackendTests, MatMulOp_QDQ_StaticLeadingUnitDimsPerTensorWeight) {
+  const std::filesystem::path json_qnn_graph_dir = "MatMulOp_QDQ_StaticLeadingUnitDimsPerTensorWeight";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  const std::vector<int64_t> shape_input = {2, 3};
+  const std::vector<int64_t> shape_weight = {1, 1, 3, 4};
+  TestInputDef<float> input_def(
+      shape_input, false,
+      GetFloatDataInRange(-0.1f, 0.1f,
+                          static_cast<size_t>(std::accumulate(shape_input.begin(), shape_input.end(),
+                                                              static_cast<int64_t>(1), std::multiplies<int64_t>()))));
+  TestInputDef<float> weight_def(
+      shape_weight, true,
+      GetFloatDataInRange(-0.1f, 0.1f,
+                          static_cast<size_t>(std::accumulate(shape_weight.begin(), shape_weight.end(),
+                                                              static_cast<int64_t>(1), std::multiplies<int64_t>()))));
+
+  TestQDQModelAccuracy(
+      BuildMatMulOpTestCase(input_def, weight_def),
+      BuildMatMulOpQDQTestCase<uint8_t, uint8_t, uint8_t>(input_def, weight_def, false),
+      provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", /*count=*/1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "MatMul", /*count=*/0);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 //
@@ -659,9 +693,46 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_StaticLeadingUnitDimsPerChannelInt16Weight) {
-  RunQDQPerChannelMatMulOpTest<uint16_t, int16_t, uint16_t>(
-      {1, 6, 3, 3}, {1, 1, 3, 420}, 3, QDQTolerance(),
-      ExpectedEPNodeAssignment::All, 21, false, true);
+  const std::filesystem::path json_qnn_graph_dir = "MatMulOp_QDQ_StaticLeadingUnitDimsPerChannelInt16Weight";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+#if defined(_WIN32)
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#endif
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  const std::vector<int64_t> shape_input = {1, 6, 3, 3};
+  const std::vector<int64_t> shape_weight = {1, 1, 3, 420};
+  TestInputDef<float> input_def(
+      shape_input, false,
+      GetFloatDataInRange(-0.1f, 0.1f,
+                          static_cast<size_t>(std::accumulate(shape_input.begin(), shape_input.end(),
+                                                              static_cast<int64_t>(1), std::multiplies<int64_t>()))));
+  TestInputDef<float> weight_def(
+      shape_weight, true,
+      GetFloatDataInRange(-0.1f, 0.1f,
+                          static_cast<size_t>(std::accumulate(shape_weight.begin(), shape_weight.end(),
+                                                              static_cast<int64_t>(1), std::multiplies<int64_t>()))));
+
+  TestQDQModelAccuracy(BuildMatMulOpTestCase(input_def, weight_def),
+                       BuildQDQPerChannelMatMulTestCase<uint16_t, int16_t, uint16_t>(
+                           input_def, weight_def, /*weight_quant_axis=*/3, /*use_contrib_qdq=*/false),
+                       provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
+
+  if (::testing::Test::IsSkipped()) return;
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "FullyConnected", /*count=*/1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "MatMul", /*count=*/0);
 }
 
 // Tests MatMul with two uint16 (quantized) inputs that are both dynamic.

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -658,6 +658,12 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ) {
   RunQDQPerChannelMatMulOpTest<uint16_t, int8_t, uint16_t>({2, 3, 3}, {3}, -1, QDQTolerance(0.0041f));
 }
 
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_AIHubRegression_StaticPerChannelInt16Weight) {
+  RunQDQPerChannelMatMulOpTest<uint16_t, int16_t, uint16_t>(
+      {1, 6, 3, 3}, {1, 1, 3, 420}, 3, QDQTolerance(),
+      ExpectedEPNodeAssignment::All, 21, false, true);
+}
+
 // Tests MatMul with two uint16 (quantized) inputs that are both dynamic.
 // This exercises a logic in QNN EP that inserts a QNN Convert op before input[1] to convert asymmetric uint16 into
 // symmetric one.

--- a/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_quant_params_wrapper_test.cc
@@ -1143,6 +1143,107 @@ TEST(QnnUnit_QuantParamsWrapperTest, HandleUnsqueeze_NoShiftNeeded_LeavesAxisUnc
   EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 0);
 }
 
+TEST(QnnUnit_QuantParamsWrapperTest, HandleSqueeze_NotPerChannel_NoOp) {
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerTensor(0.5f, 0);
+  std::vector<uint32_t> orig{1, 1, 4, 5};
+  std::vector<uint32_t> nu{4, 5};
+  EXPECT_TRUE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleSqueeze_RankNotDecreased_ReturnsError) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4(/*axis=*/0);
+  std::vector<uint32_t> orig{3, 4};
+  std::vector<uint32_t> nu{3, 4};  // same size — error
+  EXPECT_FALSE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleSqueeze_AxisScaleOffset_ShiftsWhenLeadingOnesRemoved) {
+  // Per-channel along axis 3 (N) of a {1, 1, 3, 4} weight; squeeze to {3, 4}
+  // should move the per-channel axis from 3 to 1.
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f, 0.4f};
+  const std::vector<int32_t> offsets{0, 0, 0, 0};
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/3);
+  std::vector<uint32_t> orig{1, 1, 3, 4};
+  std::vector<uint32_t> nu{3, 4};
+  ASSERT_TRUE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 1);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleSqueeze_BwAxisScaleOffset_ShiftsWhenLeadingOnesRemoved) {
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f};
+  const std::vector<int32_t> offsets{0, 0, 0};
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannelBw(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1, /*bitwidth=*/4);
+  std::vector<uint32_t> orig{1, 3};
+  std::vector<uint32_t> nu{3};
+  ASSERT_TRUE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().bwAxisScaleOffsetEncoding.axis, 0);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleSqueeze_AxisOutOfRange_ReturnsError) {
+  QnnQuantParamsWrapper q = MakePerChannelNonInt4(/*axis=*/5);
+  std::vector<uint32_t> orig{1, 3, 4};
+  std::vector<uint32_t> nu{3, 4};
+  EXPECT_FALSE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleSqueeze_SurvivingContractionDimIsOne_StillShiftsAxisCorrectly) {
+  // Regression test: weight [1, 1, 1, 4] (K=1, N=4) squeezed to [1, 4], axis=3 (N).
+  // A naive by-value alignment can desync at i=0 (orig[0]=1 spuriously matches
+  // new_shape[0]=1, the surviving K dim) even though this squeeze is valid and
+  // the axis is on N, not K. HandleSqueeze must align by position (trailing
+  // new_shape.size() dims), not by value, to get this right.
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f, 0.4f};
+  const std::vector<int32_t> offsets{0, 0, 0, 0};
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/3);
+  std::vector<uint32_t> orig{1, 1, 1, 4};
+  std::vector<uint32_t> nu{1, 4};
+  ASSERT_TRUE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().axisScaleOffsetEncoding.axis, 1);
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleSqueeze_AxisOnSqueezedLeadingDim_ReturnsError) {
+  // axis=1 falls inside the two squeezed leading dims of {1, 1, 3, 4} -> {3, 4}.
+  const std::vector<float> scales{0.1f};
+  const std::vector<int32_t> offsets{0};
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/1);
+  std::vector<uint32_t> orig{1, 1, 3, 4};
+  std::vector<uint32_t> nu{3, 4};
+  EXPECT_FALSE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest,
+     HandleSqueeze_TrailingDimsMismatch_ReturnsError) {
+  // new_shape's trailing dims don't match orig_shape's trailing dims positionally.
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f, 0.4f};
+  const std::vector<int32_t> offsets{0, 0, 0, 0};
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/3);
+  std::vector<uint32_t> orig{1, 1, 3, 4};
+  std::vector<uint32_t> nu{4, 3};  // swapped — does not align positionally with orig's trailing {3, 4}.
+  EXPECT_FALSE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleSqueeze_NonLeadingNonUnitDimSqueezed_ReturnsError) {
+  // Only leading dims may be squeezed; a non-1 leading dim must be rejected.
+  const std::vector<float> scales{0.1f, 0.2f, 0.3f, 0.4f};
+  const std::vector<int32_t> offsets{0, 0, 0, 0};
+  QnnQuantParamsWrapper q = QnnQuantParamsWrapper::PerChannel(gsl::make_span(scales), gsl::make_span(offsets), /*axis=*/3);
+  std::vector<uint32_t> orig{2, 1, 3, 4};  // leading dim is 2, not 1 — cannot be squeezed.
+  std::vector<uint32_t> nu{3, 4};
+  EXPECT_FALSE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+}
+
+TEST(QnnUnit_QuantParamsWrapperTest, HandleSqueeze_LPBQ_ShiftsWhenLeadingOnesRemoved) {
+  QnnQuantParamsWrapper q = MakeLPBQ();  // axis=1, rank assumed 2 in MakeLPBQ's own shape model.
+  std::vector<uint32_t> orig{1, 1, 3};
+  std::vector<uint32_t> nu{1, 3};
+  ASSERT_TRUE(q.HandleSqueeze<uint32_t>(gsl::make_span(orig), gsl::make_span(nu)).IsOK());
+  EXPECT_EQ(q.Get().blockwiseExpansion->axis, 0);
+}
+
 // `Get() const` overload — only reachable from a const-context call site.
 // All other tests use a non-const wrapper and therefore call the non-const
 // overload (line 49 in the header). Without this test the const-Get line


### PR DESCRIPTION
## Summary
Route static MatMul weights that carry only leading unit dimensions (for example `[1,1,K,N]`) to the existing FullyConnected lowering path, since `[1,...,1,K,N]` is exactly equivalent to `[K,N]` under ONNX broadcasting.

## Why
On QAIRT 2.35 / HTP V73, QNN `MatMul` **passes op validation but fails graph finalization** with `QNN_COMMON_ERROR_MEM_ALLOC` (Code 1002) whenever `input[1]` carries a per-axis (`QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET`) encoding **and** the effective batch dim is > 1. A 9-variant factor screen showed this is independent of N (fails at N=42 and N=420), of weight bit-width (int8 and int16), and of whether the leading dims are 1 or a real batch. Per-tensor weights pass at the same shapes, and per-channel passes at batch 1.

The shape itself is supported; the trigger is the per-axis weight combined with a batch. `FullyConnected` flattens the batch into rows, so the failing pattern never reaches the backend.

This is a targeted workaround for the squeezable subset. A genuinely batched per-channel weight such as `[1,6,3,420]` still fails finalize and is not addressed here — squeezing is not semantics-preserving when the leading dims are not 1. See the discussion thread for the full screen.

## Changes
- `matmul_op_builder.cc`: one routing decision (`squeeze_static_weight_to_2d`) computed in `CheckInputs` and consumed downstream; the squeeze is gated on the quantization-axis remap actually succeeding, so a weight it cannot handle stays on the existing QNN MatMul path rather than failing the node.
- `qnn_quant_params_wrapper.h`: new `HandleSqueeze`, alongside the existing `HandleTranspose` / `HandleUnsqueeze`, remapping the quantization axis across the squeeze for `AXIS_SCALE_OFFSET`, `BW_AXIS_SCALE_OFFSET` and `BLOCKWISE_EXPANSION`.
- `qnn_utils.h`: shared `TrySqueezeLeadingOnesTo` helper; the duplicate local copy in `rmsnormalization_op_builder.cc` now uses it.
- Tests: HTP regression test for the AI Hub failure shape `[1,6,3,3] x [1,1,3,420]` (uint16 activation/output, static per-channel int16 weight) asserting `FullyConnected` is emitted and `MatMul` is not; a CPU test covering rank-2 `input_0` with a rank > 2 weight; and unit tests for `HandleSqueeze` including the K=1 axis-collision case.