### PR TITLE
[QNN EP] Fix backend lib loaded check

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -302,7 +302,7 @@ void QnnBackendManager::SetQnnBackendType(uint32_t backend_id) {
 }
 
 Ort::Status QnnBackendManager::LoadBackend() {
-  if (backend_lib_handle_) {
+  if (backend_lib_loaded_) {
     // Backend already loaded
     return Ort::Status();
   }
@@ -357,6 +357,7 @@ Ort::Status QnnBackendManager::LoadBackend() {
       << " backend id: " << backend_id_;
   ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_INFO, oss.str().c_str());
 
+  backend_lib_loaded_ = true;
   return Ort::Status();
 }
 
@@ -2470,6 +2471,7 @@ void QnnBackendManager::ReleaseResources() {
     validator_backend_lib_handle_ = nullptr;
   }
 
+  backend_lib_loaded_ = false;
   backend_partial_setup_completed_ = false;
   backend_setup_completed_ = false;
 }

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -742,6 +742,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   ProfilingLevel profiling_level_;
   ProfilingLevel profiling_level_merge_;
   const std::string profiling_file_path_;
+  bool backend_lib_loaded_ = false;
   bool system_lib_loaded_ = false;
 
   // ----------------------------------------------------------------------


### PR DESCRIPTION
### Description
* `LoadBackend` checks if `backend_lib_handle_` is null to determine if the backend has already been loaded. But `GetQnnInterfaceProvider` can fail after successfully loading the lib, if e.g. it fails in the API version check. This means that if a) a backend lib with a incomptabile version is used, and b) `LoadBackend` is called twice (as can happen in the `IsDx12SharedMemoryAllocatorSupported` path), then, the second call to `LoadBackend` will 'succeed', the fields in `qnn_interface_` will be null, and a crash will follow, instead of getting the expected graceful API version check error.
* To fix this, use a separate flag (`backend_lib_loaded_`) that is only set if `GetQnnInterfaceProvider` succeeded, similar to `system_lib_loaded_`.