### PR TITLE
Add L2Norm Fusion pass

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/l2_norm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/l2_norm_fusion.cc
@@ -1,0 +1,241 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_node_group/l2_norm_fusion.h"
+
+#include <array>
+#include <gsl/gsl>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+constexpr char kOpReduceL2[] = "ReduceL2";
+constexpr char kOpAdd[] = "Add";
+constexpr char kOpDiv[] = "Div";
+
+// Reads a constant float scalar initializer by name, if present. Returns nullopt otherwise.
+std::optional<float> GetConstantFloatScalar(const QnnModelWrapper& qmw, const std::string& input_name) {
+  if (!qmw.IsConstantInput(input_name)) {
+    return std::nullopt;
+  }
+  const OrtValueInfo* value_info = qmw.GetConstantTensor(input_name);
+  if (!value_info) {
+    return std::nullopt;
+  }
+  Ort::ConstValueInfo ort_value_info(value_info);
+  Ort::ConstValue ort_value;
+  if (!ort_value_info.GetInitializer(ort_value).IsOK()) {
+    return std::nullopt;
+  }
+  auto type_info = ort_value_info.TypeInfo();
+  auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+  if (tensor_info.GetElementType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    return std::nullopt;
+  }
+  if (tensor_info.GetElementCount() != 1) {
+    return std::nullopt;
+  }
+  const float* data = ort_value.GetTensorData<float>();
+  if (!data) {
+    return std::nullopt;
+  }
+  return *data;
+}
+
+#define ValidateOnQnn(qmw, node_units, root_input, final_output, epsilon, axes) \
+  CreateOrValidateOnQnn((qmw), (node_units), (root_input), (final_output), (epsilon), (axes), true)
+#define CreateOnQnn(qmw, node_units, root_input, final_output, epsilon, axes) \
+  CreateOrValidateOnQnn((qmw), (node_units), (root_input), (final_output), (epsilon), (axes), false)
+
+// Emits (or validates) a single QNN L2Norm op for the fused ReduceL2 -> Add(eps) -> Div pattern.
+static Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qmw,
+                                         gsl::span<const OrtNodeUnit* const> node_units,
+                                         const OrtNodeUnitIODef& root_input,
+                                         const OrtNodeUnitIODef& final_output,
+                                         float epsilon,
+                                         gsl::span<const uint32_t> axes,
+                                         bool validate) {
+  const std::string node_name = utils::UniqueNameGenerator().New(*node_units[0]);
+
+  QnnTensorWrapper input_tensor;
+  QnnTensorWrapper output_tensor;
+  RETURN_IF_ERROR(qmw.MakeTensorWrapper(root_input, input_tensor));
+  RETURN_IF_ERROR(qmw.MakeTensorWrapper(final_output, output_tensor));
+
+  Qnn_Scalar_t epsilon_scalar = QNN_SCALAR_INIT;
+  epsilon_scalar.dataType = QNN_DATATYPE_FLOAT_32;
+  epsilon_scalar.floatValue = epsilon;
+  QnnParamWrapper epsilon_param(node_units[0]->Index(), node_units[0]->Name(),
+                                QNN_OP_L2_NORM_PARAM_EPSILON, epsilon_scalar);
+
+  std::vector<uint32_t> axes_vec(axes.begin(), axes.end());
+  std::vector<uint32_t> axes_shape{static_cast<uint32_t>(axes_vec.size())};
+  QnnParamWrapper axes_param(node_units[0]->Index(), node_units[0]->Name(),
+                             QNN_OP_L2_NORM_PARAM_AXES,
+                             std::move(axes_shape), std::move(axes_vec));
+
+  if (validate) {
+    return qmw.ValidateQnnNode(node_name,
+                               QNN_OP_PACKAGE_NAME_QTI_AISW,
+                               QNN_OP_L2_NORM,
+                               {input_tensor.GetQnnTensor()},
+                               {output_tensor.GetQnnTensor()},
+                               {epsilon_param.GetQnnParam(), axes_param.GetQnnParam()});
+  }
+
+  const std::string epsilon_param_name = epsilon_param.GetParamTensorName();
+  RETURN_IF_NOT(qmw.AddParamWrapper(std::move(epsilon_param)), "Failed to add epsilon param.");
+  const std::string axes_param_name = axes_param.GetParamTensorName();
+  RETURN_IF_NOT(qmw.AddParamWrapper(std::move(axes_param)), "Failed to add axes param.");
+
+  if (!qmw.IsQnnTensorWrapperExist(root_input.name)) {
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(input_tensor)), "Failed to add input tensor.");
+  }
+  if (!qmw.IsQnnTensorWrapperExist(final_output.name)) {
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(output_tensor)), "Failed to add output tensor.");
+  }
+
+  RETURN_IF_NOT(qmw.CreateQnnNode(node_name,
+                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                  QNN_OP_L2_NORM,
+                                  {root_input.name},
+                                  {final_output.name},
+                                  {epsilon_param_name, axes_param_name},
+                                  validate),
+                "Failed to create fused L2Norm node.");
+
+  return Ort::Status();
+}
+
+}  // namespace
+
+std::unique_ptr<IQnnNodeGroup> L2NormFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& reducel2_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    [[maybe_unused]] const Ort::Logger& logger) {
+  // Must start with a ReduceL2 SingleNode with keepdims=1 (so the norm broadcasts against x in Div).
+  if (reducel2_node_unit.OpType() != kOpReduceL2 ||
+      reducel2_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return nullptr;
+  }
+
+  OrtNodeAttrHelper reducel2_helper(reducel2_node_unit);
+  if (reducel2_helper.Get("keepdims", static_cast<int64_t>(1)) != 1) {
+    return nullptr;
+  }
+
+  // ReduceL2 -> Add (the +epsilon).
+  const std::array<std::string_view, 1> add_types{kOpAdd};
+  const OrtNodeUnit* add_node_unit = GetOnlyChildOfType(qnn_model_wrapper, reducel2_node_unit, add_types,
+                                                        node_to_node_unit, node_unit_to_qnn_node_group);
+  if (add_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  // The Add's other input must be a constant float scalar (the epsilon).
+  std::optional<float> epsilon;
+  for (const auto& add_in : add_node_unit->Inputs()) {
+    if (add_in.name == reducel2_node_unit.Outputs()[0].name) {
+      continue;
+    }
+    epsilon = GetConstantFloatScalar(qnn_model_wrapper, add_in.name);
+  }
+  if (!epsilon.has_value()) {
+    return nullptr;
+  }
+
+  // Add -> Div. Div numerator must be the ReduceL2's input; denominator is Add's output.
+  const std::array<std::string_view, 1> div_types{kOpDiv};
+  const OrtNodeUnit* div_node_unit = GetOnlyChildOfType(qnn_model_wrapper, *add_node_unit, div_types,
+                                                        node_to_node_unit, node_unit_to_qnn_node_group);
+  if (div_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  const std::string& reducel2_input_name = reducel2_node_unit.Inputs()[0].name;
+  const std::string& add_output_name = add_node_unit->Outputs()[0].name;
+  const auto& div_inputs = div_node_unit->Inputs();
+  if (div_inputs.size() != 2 ||
+      div_inputs[0].name != reducel2_input_name ||
+      div_inputs[1].name != add_output_name) {
+    return nullptr;
+  }
+
+  // Axes from the ReduceL2 (handles opset<18 attr and opset>=18 input forms).
+  std::optional<std::vector<uint32_t>> axes = GetReduceAxes(qnn_model_wrapper, reducel2_node_unit);
+  if (!axes.has_value() || axes->empty()) {
+    return nullptr;
+  }
+
+  std::array<const OrtNodeUnit*, 3> fused_units{&reducel2_node_unit, add_node_unit, div_node_unit};
+  if (Ort::Status status = CreateOrValidateOnQnn(qnn_model_wrapper, fused_units,
+                                                 reducel2_node_unit.Inputs()[0], div_node_unit->Outputs()[0],
+                                                 epsilon.value(), axes.value(), /*validate=*/true);
+      !status.IsOK()) {
+    return nullptr;
+  }
+
+  return std::make_unique<L2NormFusion>(reducel2_node_unit, *add_node_unit, *div_node_unit);
+}
+
+gsl::span<const OrtNodeUnit* const> L2NormFusion::GetNodeUnits() const {
+  return node_units_;
+}
+
+Ort::Status L2NormFusion::IsSupported(QnnModelWrapper& qnn_model_wrapper,
+                                      [[maybe_unused]] const Ort::Logger& logger) const {
+  std::optional<std::vector<uint32_t>> axes = GetReduceAxes(qnn_model_wrapper, *node_units_[0]);
+  RETURN_IF_NOT(axes.has_value() && !axes->empty(), "L2NormFusion: failed to get ReduceL2 axes.");
+
+  const OrtNodeUnit& add_node_unit = *node_units_[1];
+  std::optional<float> epsilon;
+  for (const auto& add_in : add_node_unit.Inputs()) {
+    if (add_in.name == node_units_[0]->Outputs()[0].name) {
+      continue;
+    }
+    epsilon = GetConstantFloatScalar(qnn_model_wrapper, add_in.name);
+  }
+  RETURN_IF_NOT(epsilon.has_value(), "L2NormFusion: failed to get epsilon.");
+
+  return ValidateOnQnn(qnn_model_wrapper, node_units_, node_units_[0]->Inputs()[0],
+                       node_units_[2]->Outputs()[0], epsilon.value(), axes.value());
+}
+
+Ort::Status L2NormFusion::AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper,
+                                            [[maybe_unused]] const Ort::Logger& logger) const {
+  std::optional<std::vector<uint32_t>> axes = GetReduceAxes(qnn_model_wrapper, *node_units_[0]);
+  RETURN_IF_NOT(axes.has_value() && !axes->empty(), "L2NormFusion: failed to get ReduceL2 axes.");
+
+  const OrtNodeUnit& add_node_unit = *node_units_[1];
+  std::optional<float> epsilon;
+  for (const auto& add_in : add_node_unit.Inputs()) {
+    if (add_in.name == node_units_[0]->Outputs()[0].name) {
+      continue;
+    }
+    epsilon = GetConstantFloatScalar(qnn_model_wrapper, add_in.name);
+  }
+  RETURN_IF_NOT(epsilon.has_value(), "L2NormFusion: failed to get epsilon.");
+
+  return CreateOnQnn(qnn_model_wrapper, node_units_, node_units_[0]->Inputs()[0],
+                     node_units_[2]->Outputs()[0], epsilon.value(), axes.value());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/l2_norm_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/l2_norm_fusion.h
@@ -1,0 +1,62 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+/// <summary>
+/// Fuses the L2-normalize pattern  Div(x, Add(ReduceL2(x), eps))  =>  QNN_OP_L2_NORM(x, axis, epsilon).
+///
+/// QNN has no single ReduceL2 op, so the ReduceL2 op builder lowers it to a
+/// ElementWiseMultiply(x*x) -> ReduceSum -> Sqrt sequence. In fp16 the ReduceSum of squares
+/// overflows once the L2 norm exceeds the fp16 max -- e.g. reducing many channels of moderately
+/// large activations -- producing inf/NaN and corrupting the normalize. HTP's native
+/// L2Norm op computes the same normalize without this overflow. This fusion detects the
+/// ReduceL2 -> Add(eps) -> Div subgraph and emits QNN_OP_L2_NORM so the normalize runs on that
+/// fp16-safe kernel instead of the overflow-prone decomposition
+/// </summary>
+class L2NormFusion : public IQnnNodeGroup {
+ public:
+  L2NormFusion(const OrtNodeUnit& reducel2_node_unit,
+               const OrtNodeUnit& add_node_unit,
+               const OrtNodeUnit& div_node_unit)
+      : node_units_{&reducel2_node_unit, &add_node_unit, &div_node_unit} {
+  }
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(L2NormFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return node_units_[2]; }
+  std::string_view Type() const override { return "L2NormFusion"; }
+
+  /// <summary>
+  /// Traverses the graph from a starting ReduceL2 NodeUnit to check for a valid
+  /// ReduceL2 -> Add(eps) -> Div(x, .) normalize sequence. Returns a IQnnNodeGroup if matched.
+  /// </summary>
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& reducel2_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::array<const OrtNodeUnit*, 3> node_units_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -20,6 +20,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/gather_transpose_reshape_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/gelu_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/hardsigmoid_mul_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/l2_norm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/layer_norm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.h"
@@ -101,6 +102,7 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"Erf", {GeluFusion::TryFusion}},
     {"Tanh", {TanhGeluFusion::TryFusion}},
     {"ReduceMean", {LayerNormFusion::TryFusion}},
+    {"ReduceL2", {L2NormFusion::TryFusion}},
     {"Einsum", {ReshapeEinsumReshapeNodeGroup::TryFusion}},
     {"Reshape", {SpaceToDepthFusion::TryFusion, Rank6ToRank5Fusion::TryFusion}},
     {"Transpose", {ChannelShuffleFusion::TryFusion, TransposeReshapeTransposeFusion::TryFusion}}};

--- a/onnxruntime/test/providers/qnn/qnn_node_group/l2_norm_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/l2_norm_fusion_test.cc
@@ -1,0 +1,145 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <vector>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Builds the L2-normalize subgraph:  Div(x, Add(ReduceL2(x, axis), eps)).
+// This is x / (||x||_2 + eps) along `axis`. The QNN EP should fuse it into a single QNN L2Norm op.
+// Without the fusion, the EP decomposes ReduceL2 into Mul(x*x) -> ReduceSum -> Sqrt; in fp16 the
+// ReduceSum of squares overflows once the norm exceeds the fp16 max, corrupting the result.
+GetTestModelFn BuildL2NormalizeTestCase(const TestInputDef<float>& input_def,
+                                        int64_t axis,
+                                        float eps = 1e-7f) {
+  return [=, &input_def](ModelTestBuilder& builder) -> void {
+    MakeTestInput<float>(builder, "input", input_def);
+    builder.MakeInitializer<int64_t>("axes", {1}, {axis});
+    builder.MakeScalarInitializer<float>("eps", eps);
+
+    builder.AddNode("reducel2", "ReduceL2", {"input", "axes"}, {"l2_out"}, "",
+                    {builder.MakeScalarAttribute("keepdims", int64_t{1})});
+    builder.AddNode("add_eps", "Add", {"l2_out", "eps"}, {"denom"});
+    builder.AddNode("div", "Div", {"input", "denom"}, {"output"});
+    builder.MakeOutput("output");
+  };
+}
+
+// ReduceL2 whose output does NOT feed the Add(eps)->Div normalize pattern (here it feeds the Div as
+// the numerator instead). The fusion must NOT fire.
+GetTestModelFn BuildReduceL2NoFusionTestCase(const TestInputDef<float>& input_def, int64_t axis) {
+  return [=, &input_def](ModelTestBuilder& builder) -> void {
+    MakeTestInput<float>(builder, "input", input_def);
+    builder.MakeInitializer<int64_t>("axes", {1}, {axis});
+    builder.AddNode("reducel2", "ReduceL2", {"input", "axes"}, {"l2_out"}, "",
+                    {builder.MakeScalarAttribute("keepdims", int64_t{1})});
+    // l2_out used directly as a numerator (not the eps/normalize shape) -> not the fused pattern.
+    builder.AddNode("add_self", "Add", {"l2_out", "l2_out"}, {"output"});
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetHtpFp16ProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_htp_fp16_precision"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  return provider_options;
+}
+
+}  // namespace
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// Fusion fires on the standard L2-normalize pattern: graph has a single L2Norm and none of the
+// decomposed ReduceL2 ops (Mul/ReduceSum/Sqrt) nor the Add/Div elementwise ops remain.
+TEST_F(QnnHTPBackendTests, L2NormFusion_Basic) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "L2NormFusion_Basic";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetHtpFp16ProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  // Normalize along the channel axis (axis=1) of an NCHW-style input.
+  auto input_def = TestInputDef<float>({1, 8, 4, 4}, false, GetFloatDataInRange(-3.0f, 3.0f, 128));
+  RunQnnModelTest(BuildL2NormalizeTestCase(input_def, /*axis=*/1),
+                  provider_options,
+                  /*opset_version=*/18,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "L2Norm", 1);
+  // Fused: no leftover ReduceSum / elementwise (Mul, Add, Div, Sqrt) ops from the decomposition.
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ReduceSum", 0);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseBinary", 0);
+}
+
+// Regression for fp16 overflow in the decomposed L2 norm: with large activations the sum of squares
+// exceeds the fp16 max (|x| ~ 180 -> x^2 ~ 32k, summed over many channels >> 65504 -> inf). The fused
+// L2Norm must compute the norm on the fp16-safe kernel and match the CPU reference.
+TEST_F(QnnHTPBackendTests, L2NormFusion_LargeValues_NoFp16Overflow) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "L2NormFusion_LargeValues";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetHtpFp16ProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  // 128 channels of values up to ~180: per-element square ~32k, channel-sum overflows fp16 if the
+  // square is materialized (the un-fused decomposition). The fused L2Norm avoids the overflow.
+  auto input_def = TestInputDef<float>({1, 128, 5, 5}, false, GetFloatDataInRange(-180.0f, 180.0f, 128 * 25));
+  RunQnnModelTest(BuildL2NormalizeTestCase(input_def, /*axis=*/1),
+                  provider_options,
+                  /*opset_version=*/18,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "L2Norm", 1);
+}
+
+// Negative: a ReduceL2 not in the normalize pattern must NOT be fused (no L2Norm emitted).
+TEST_F(QnnHTPBackendTests, L2NormFusion_NoFusionWhenNotNormalize) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "L2NormFusion_NoFusion";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetHtpFp16ProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({1, 8, 4, 4}, false, GetFloatDataInRange(-3.0f, 3.0f, 128));
+  RunQnnModelTest(BuildReduceL2NoFusionTestCase(input_def, /*axis=*/1),
+                  provider_options,
+                  /*opset_version=*/18,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "L2Norm", 0);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
This PR implements L2Norm fusion pass. L2Norm op implements the following math (with slight change): output = x / sqrt(max(sum(x**2), epsilon))

### Motivation and Context

This fixes CVT model issue for FP precision. Native path shows an accuracy of 0.376 but EP shows an accuracy of 0.319. Expected is 0.377.

This op involves the following sub operations: ReduceL2->Add->Div. ReduceL2 sums the squares of input activation at the given axis. In FP16 precision this operation overflows for sufficiently large input activations. But, HTP has a fused op QNN_OP_L2_NORM which maintains the intermediate tensor at high precision which avoids overflow issues. This PR generates this fused op which solves the accuracy issue now. EP now shows 0.3759 which is inline with what's expected. 
