### PR TITLE
[QNN EP] Auto-configure ADSP_LIBRARY_PATH so the Python wheel finds the HTP skel

### DIFF
--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 
 import os
+import platform
 import sys
 
 from . import build_and_package_info  # noqa: F401
@@ -26,7 +27,7 @@ except ImportError:
 
 def _configure_dsp_skel_search_path():
     """Ensure the QNN HTP DSP skel (libQnnHtpV*Skel.so) can be found by the
-    fastRPC loader on Windows.
+    fastRPC loader on Windows ARM64.
 
     The DSP-side fastRPC loader searches ``ADSP_LIBRARY_PATH`` (plus a few fixed
     system paths) for the skel. Unlike the Windows DLL loader, it does NOT
@@ -40,13 +41,22 @@ def _configure_dsp_skel_search_path():
     falls back to the HNRD user-driver path, and newer ops (e.g. GroupQueryAttention,
     MatMulNBits) fail op validation and land on CPU.
 
+    This only matters when a real Hexagon DSP is present, i.e. on a Windows ARM64
+    (Snapdragon) device. On Windows x64 there is no DSP, so the skel is never
+    loaded and this is a no-op there. We therefore restrict it to native ARM64.
+
     We prepend the package directory to ``ADSP_LIBRARY_PATH`` (idempotently, and
     preserving any user-provided value).
     """
-    if sys.platform != "win32":
-        # Linux/Android package and load the skel via different mechanisms.
+    if sys.platform != "win32" or platform.machine().lower() not in ("arm64", "aarch64"):
+        # Only Windows ARM64 (Snapdragon) has an on-device DSP that loads the skel.
+        # x64 hosts have no DSP; Linux/Android package and load the skel differently.
         return
     skel_dir = LIB_DIR_FULL_PATH
+    existing = os.environ.get("ADSP_LIBRARY_PATH", "")
+    parts = existing.split(";") if existing else []
+    if skel_dir not in parts:
+        os.environ["ADSP_LIBRARY_PATH"] = ";".join([skel_dir, *parts])
     existing = os.environ.get("ADSP_LIBRARY_PATH", "")
     parts = existing.split(";") if existing else []
     if skel_dir not in parts:

--- a/onnxruntime/python/__init__.py
+++ b/onnxruntime/python/__init__.py
@@ -24,6 +24,38 @@ except ImportError:
     pass
 
 
+def _configure_dsp_skel_search_path():
+    """Ensure the QNN HTP DSP skel (libQnnHtpV*Skel.so) can be found by the
+    fastRPC loader on Windows.
+
+    The DSP-side fastRPC loader searches ``ADSP_LIBRARY_PATH`` (plus a few fixed
+    system paths) for the skel. Unlike the Windows DLL loader, it does NOT
+    automatically include the directory a DLL was loaded from -- so when
+    ``QnnHtp.dll`` is loaded dynamically from deep under ``site-packages``, the
+    skel that sits next to it is not on the search path. Native executables
+    (qnn-net-run, onnxruntime_perf_test) work without this because they run from
+    the same directory as the skel; the Python wheel does not.
+
+    Without this, skel load fails (``qnn_open 0x80000406`` / error 1002), QNN
+    falls back to the HNRD user-driver path, and newer ops (e.g. GroupQueryAttention,
+    MatMulNBits) fail op validation and land on CPU.
+
+    We prepend the package directory to ``ADSP_LIBRARY_PATH`` (idempotently, and
+    preserving any user-provided value).
+    """
+    if sys.platform != "win32":
+        # Linux/Android package and load the skel via different mechanisms.
+        return
+    skel_dir = LIB_DIR_FULL_PATH
+    existing = os.environ.get("ADSP_LIBRARY_PATH", "")
+    parts = existing.split(";") if existing else []
+    if skel_dir not in parts:
+        os.environ["ADSP_LIBRARY_PATH"] = ";".join([skel_dir, *parts])
+
+
+_configure_dsp_skel_search_path()
+
+
 def _lib_name(base):
     if sys.platform == "win32":
         return f"{base}.dll"


### PR DESCRIPTION
## Problem

Using the Windows ARM64 `onnxruntime_qnn` Python wheel to drive QNN HTP fails to load the DSP skel and silently falls back to CPU.

Root cause: the HTP DSP skel (`libQnnHtpV*Skel.so`) is loaded by the fastRPC loader, which searches `ADSP_LIBRARY_PATH` plus a few fixed system paths. Unlike the Windows DLL loader, it does **not** automatically include the directory `QnnHtp.dll` was loaded from. When `QnnHtp.dll` is loaded dynamically by Python from deep under `site-packages`, the skel sitting right next to it is not on the DSP search path. Native executables (`qnn-net-run`, `onnxruntime_perf_test`) avoid this only because they run from the same directory as the skel.

Resulting failure chain:
- skel load fails: `qnn_open 0x80000406` / error `1002`
- QNN falls back to the HNRD user-driver path (`Traditional path not available. Switching to user driver path`)
- newer ops (`GroupQueryAttention`, `MatMulNBits`) then fail op validation with error `3110` and land on CPU

This looks like an op-support bug but is purely a missing skel search path.

## Fix

Prepend the `onnxruntime_qnn` package directory to `ADSP_LIBRARY_PATH` at import time in `onnxruntime/python/__init__.py`:
- Windows only (Linux/Android package and load the skel differently)
- idempotent (skips if already present)
- preserves any user-provided `ADSP_LIBRARY_PATH` (ours is prepended)

## Verification

On Glymur (Snapdragon X Next Gen, HTP V81), with **no** manual `ADSP_LIBRARY_PATH`:
- `import onnxruntime_qnn` now sets `ADSP_LIBRARY_PATH` to the package dir automatically
- pre-set user value is preserved (ours prepended)
- `gen_ctx` (AOT) and inference run entirely on HTP — **no HNRD fallback, no 3110**