### PR TITLE
[QNN EP] Fix LSTM null tensor dtype for QnnIr backend

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
@@ -386,7 +386,7 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
 
   // Common LSTM cell inputs
   const std::string null_tensor_name = "null_tensor";
-  QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_UNDEFINED,
+  QnnTensorWrapper null_tensor_wrapper(null_tensor_name, QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_FLOAT_32,
                                        QnnQuantParamsWrapper(), std::vector<uint32_t>{0});
 
   qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));


### PR DESCRIPTION
### Description

Fix LSTM null tensor dtype from `QNN_DATATYPE_UNDEFINED` to `QNN_DATATYPE_FLOAT_32` for optional input placeholders.


### Motivation and Context

LSTM models with unused optional inputs fail graph composition on the IR backend.

This PR is a small hotfix for a PR revert we are doing on 2.4.0 release branch but merged in mainline.
https://github.com/onnxruntime/onnxruntime-qnn/pull/323
