### PR TITLE
[QNN EP] Support quantized ReduceL2

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -181,13 +181,19 @@ Ort::Status ReduceOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, c
               "QNN EP: ReduceLogSumExp operator only supports float input dtypes.");
   }
 
-  if (reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_L2 && node_unit.Inputs()[0].quant_param.has_value()) {
-    // QNN's Dequantize op does not accept per-channel quantized inputs; the float32 decomposition
-    // below assumes the inserted Dequantize can consume the input tensor's quant params as-is.
-    bool is_per_channel = false;
-    int64_t axis = 0;
-    RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_channel, axis));
-    RETURN_IF(is_per_channel, "QNN EP: ReduceL2 operator does not support per-channel quantized input.");
+  if (reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_L2) {
+    // QNN's Dequantize/Quantize ops do not accept per-channel quantized tensors; the float32
+    // decomposition below assumes the inserted Dequantize/Quantize can consume the node unit's
+    // input/output quant params as-is.
+    for (const auto& io_def : {node_unit.Inputs()[0], node_unit.Outputs()[0]}) {
+      if (!io_def.quant_param.has_value()) {
+        continue;
+      }
+      bool is_per_channel = false;
+      int64_t axis = 0;
+      RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(io_def, is_per_channel, axis));
+      RETURN_IF(is_per_channel, "QNN EP: ReduceL2 operator does not support per-channel quantized input/output.");
+    }
   }
 
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
@@ -258,9 +264,9 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape), "Cannot get input shape.");
     std::vector<uint32_t> output_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.shape, output_shape), "Cannot get output shape.");
-    const bool is_quantized_op = input.quant_param.has_value();
+    const bool is_quantized_input = input.quant_param.has_value();
     Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
-    if (!is_quantized_op) {
+    if (!is_quantized_input) {
       RETURN_IF_ERROR(utils::GetQnnDataType(false, output.type, qnn_data_type));
     }
     std::string input_name = input_names[0];
@@ -271,7 +277,7 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
       return qnn_model_wrapper.AddTensorWrapper(std::move(wrapper));
     };
 
-    if (is_quantized_op) {
+    if (is_quantized_input) {
       // Insert Dequantize (quantized -> float32) before the float32 decomposition.
       const std::string dq_output_name = utils::UniqueNameGenerator().New(input_name, "_to_f32");
       RETURN_IF_NOT(add_tensor(dq_output_name, QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
@@ -322,12 +328,12 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     // Step 3: y = Sqrt(y_pow2_sum)
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output.name);
     const std::string sqrt_output_name =
-        is_quantized_op ? utils::UniqueNameGenerator().New(output.name, "_f32") : output.name;
+        is_quantized_input ? utils::UniqueNameGenerator().New(output.name, "_f32") : output.name;
     Qnn_TensorType_t sqrt_tensor_type =
-        (!is_quantized_op && is_graph_output) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+        (!is_quantized_input && is_graph_output) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
     // The quantized branch below still needs output_shape for the final Quantize output tensor.
     RETURN_IF_NOT(add_tensor(sqrt_output_name, sqrt_tensor_type, qnn_data_type, QnnQuantParamsWrapper(),
-                             is_quantized_op ? std::vector<uint32_t>(output_shape) : std::move(output_shape)),
+                             is_quantized_input ? std::vector<uint32_t>(output_shape) : std::move(output_shape)),
                   "AddTensorWrapper failed");
     std::string sqrt_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_UNARY);
     std::vector<std::string> sqrt_param_names;
@@ -343,7 +349,7 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                                   do_op_validation),
                   "CreateQnnNode failed");
 
-    if (is_quantized_op) {
+    if (is_quantized_input) {
       // Insert Quantize (float32 -> quantized) after the float32 decomposition, using the
       // QDQ node unit's output quant params.
       Qnn_DataType_t final_qnn_data_type = QNN_DATATYPE_FLOAT_32;

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -171,11 +171,6 @@ Ort::Status ReduceOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, c
   RETURN_IF(reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_PROD && is_npu_backend,
             "QNN EP: ReduceProd operator not supported by HTP backend.");
 
-  // ReduceL2 is composed by Mul->ReduceSum->Sqrt, it's not easy to set the quantization parameters for the activation
-  // tensors between, so we don't support ReduceL2 with quantized input for now.
-  RETURN_IF(reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_L2 && node_unit.Inputs()[0].quant_param.has_value(),
-            "QNN EP: ReduceL2 operator does not support quantized input for now.");
-
   if (reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_LOG_SUM_EXP) {
     RETURN_IF(node_unit.Inputs()[0].quant_param.has_value(),
               "QNN EP: ReduceLogSumExp operator does not support quantized input.");
@@ -242,23 +237,44 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   if (node_unit.OpType() == "ReduceL2") {
     // If ReduceL2, QNN doesn't have a single Op for it, we need to add a
     // ElementWiseMultiply->ReduceSum->ElementWiseSquareRoot node sequence.
+    //
+    // The intermediate Multiply/ReduceSum activations don't have well-defined quantization
+    // parameters (squaring a quantized value doesn't map to a simple rescale), so when the
+    // node unit is quantized we Dequantize the input to float32, run the decomposition in
+    // float32, then Quantize the final result back using the QDQ node unit's output quant
+    // params -- mirroring how BatchNormalizationOpBuilder handles the same problem.
     const auto& input = node_unit.Inputs()[0];
     const auto& output = node_unit.Outputs()[0];
     std::vector<uint32_t> input_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape), "Cannot get input shape.");
     std::vector<uint32_t> output_shape;
     RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(output.shape, output_shape), "Cannot get output shape.");
-    RETURN_IF(input.quant_param.has_value(), "Input tensor must not be quantized.");
-    ONNXTensorElementDataType output_type = output.type;
+    const bool is_quantized_op = input.quant_param.has_value();
     Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
-    RETURN_IF_ERROR(utils::GetQnnDataType(false, output_type, qnn_data_type));
-    const std::string input_name = input_names[0];
+    if (!is_quantized_op) {
+      RETURN_IF_ERROR(utils::GetQnnDataType(false, output.type, qnn_data_type));
+    }
+    std::string input_name = input_names[0];
+
+    if (is_quantized_op) {
+      // Insert Dequantize (quantized -> float32) before the float32 decomposition.
+      const std::string dq_output_name = utils::UniqueNameGenerator().New(input_name, "_to_f32");
+      QnnTensorWrapper dq_tensorwrapper(dq_output_name, QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
+                                        QnnQuantParamsWrapper(), std::vector<uint32_t>(input_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(dq_tensorwrapper)), "AddTensorWrapper failed");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_dequant_in"),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
+                                                    {input_name}, {dq_output_name}, {},
+                                                    do_op_validation),
+                    "Failed to add dequantize node");
+      input_name = dq_output_name;
+    }
 
     // Step 1: y_pow2 = x * x, using ElementWiseMultiply instead of ElementWisePower so we don't need to add a new
     // initializer tensor for the power value. The performance difference is negligible.
     const std::string pow2_output_name = utils::UniqueNameGenerator().New(input_name, "_pow2");
     QnnTensorWrapper pow2_tensorwrapper(pow2_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
-                                        std::move(input_shape));
+                                        std::vector<uint32_t>(input_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pow2_tensorwrapper)), "AddTensorWrapper failed");
     std::string pow2_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
     std::vector<std::string> pow2_param_names;
@@ -289,10 +305,13 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                   "CreateQnnNode failed");
 
     // Step 3: y = Sqrt(y_pow2_sum)
-    Qnn_TensorType_t output_tensor_type =
-        qnn_model_wrapper.IsGraphOutput(output.name) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-    QnnTensorWrapper sqrt_tensorwrapper(output.name, output_tensor_type, qnn_data_type,
-                                        QnnQuantParamsWrapper(), std::move(output_shape));
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output.name);
+    const std::string sqrt_output_name =
+        is_quantized_op ? utils::UniqueNameGenerator().New(output.name, "_f32") : output.name;
+    Qnn_TensorType_t sqrt_tensor_type =
+        (!is_quantized_op && is_graph_output) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+    QnnTensorWrapper sqrt_tensorwrapper(sqrt_output_name, sqrt_tensor_type, qnn_data_type,
+                                        QnnQuantParamsWrapper(), std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sqrt_tensorwrapper)), "AddTensorWrapper failed");
     std::string sqrt_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_UNARY);
     std::vector<std::string> sqrt_param_names;
@@ -303,10 +322,26 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_ELEMENT_WISE_UNARY,
                                                   {reduce_output_name},
-                                                  {output.name},
+                                                  {sqrt_output_name},
                                                   std::move(sqrt_param_names),
                                                   do_op_validation),
                   "CreateQnnNode failed");
+
+    if (is_quantized_op) {
+      // Insert Quantize (float32 -> quantized) after the float32 decomposition, using the
+      // QDQ node unit's output quant params.
+      TensorInfo output_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output, output_info));
+      Qnn_TensorType_t final_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+      QnnTensorWrapper final_tensorwrapper(output.name, final_tensor_type, output_info.qnn_data_type,
+                                           std::move(output_info.quant_param), std::move(output_shape));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_tensorwrapper)), "AddTensorWrapper failed");
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_quant_out"),
+                                                    QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
+                                                    {sqrt_output_name}, {output.name}, {},
+                                                    do_op_validation),
+                    "Failed to add quantize node");
+    }
   } else if (node_unit.OpType() == "ReduceLogSumExp") {
     // Decompose ReduceLogSumExp(x, axes, keepdims) numerically-stably as:
     //   m       = ReduceMax(x, axes, keepdims=True)

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reduce_op_builder.cc
@@ -181,6 +181,15 @@ Ort::Status ReduceOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper, c
               "QNN EP: ReduceLogSumExp operator only supports float input dtypes.");
   }
 
+  if (reduce_op_type == ReduceOpType::REDUCE_OP_TYPE_L2 && node_unit.Inputs()[0].quant_param.has_value()) {
+    // QNN's Dequantize op does not accept per-channel quantized inputs; the float32 decomposition
+    // below assumes the inserted Dequantize can consume the input tensor's quant params as-is.
+    bool is_per_channel = false;
+    int64_t axis = 0;
+    RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_channel, axis));
+    RETURN_IF(is_per_channel, "QNN EP: ReduceL2 operator does not support per-channel quantized input.");
+  }
+
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
 }
 
@@ -256,12 +265,18 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     }
     std::string input_name = input_names[0];
 
+    auto add_tensor = [&qnn_model_wrapper](std::string name, Qnn_TensorType_t type, Qnn_DataType_t dtype,
+                                           QnnQuantParamsWrapper quant_param, std::vector<uint32_t> shape) {
+      QnnTensorWrapper wrapper(std::move(name), type, dtype, std::move(quant_param), std::move(shape));
+      return qnn_model_wrapper.AddTensorWrapper(std::move(wrapper));
+    };
+
     if (is_quantized_op) {
       // Insert Dequantize (quantized -> float32) before the float32 decomposition.
       const std::string dq_output_name = utils::UniqueNameGenerator().New(input_name, "_to_f32");
-      QnnTensorWrapper dq_tensorwrapper(dq_output_name, QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
-                                        QnnQuantParamsWrapper(), std::vector<uint32_t>(input_shape));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(dq_tensorwrapper)), "AddTensorWrapper failed");
+      RETURN_IF_NOT(add_tensor(dq_output_name, QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
+                               QnnQuantParamsWrapper(), std::vector<uint32_t>(input_shape)),
+                    "AddTensorWrapper failed");
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_dequant_in"),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEQUANTIZE,
                                                     {input_name}, {dq_output_name}, {},
@@ -273,9 +288,9 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     // Step 1: y_pow2 = x * x, using ElementWiseMultiply instead of ElementWisePower so we don't need to add a new
     // initializer tensor for the power value. The performance difference is negligible.
     const std::string pow2_output_name = utils::UniqueNameGenerator().New(input_name, "_pow2");
-    QnnTensorWrapper pow2_tensorwrapper(pow2_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
-                                        std::vector<uint32_t>(input_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pow2_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(add_tensor(pow2_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
+                             std::move(input_shape)),
+                  "AddTensorWrapper failed");
     std::string pow2_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
     std::vector<std::string> pow2_param_names;
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), pow2_node_name,
@@ -292,9 +307,9 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
     // Step 2: y_pow2_sum = ReduceSum(y_pow2)
     const std::string reduce_output_name = utils::UniqueNameGenerator().New(input_name, "_sum");
-    QnnTensorWrapper reduce_tensorwrapper(reduce_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
-                                          std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(reduce_tensorwrapper)), "AddTensorWrapper failed");
+    RETURN_IF_NOT(add_tensor(reduce_output_name, QNN_TENSOR_TYPE_NATIVE, qnn_data_type, QnnQuantParamsWrapper(),
+                             std::vector<uint32_t>(output_shape)),
+                  "AddTensorWrapper failed");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, QNN_OP_REDUCE_SUM),
                                                   QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                   QNN_OP_REDUCE_SUM,
@@ -310,9 +325,10 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
         is_quantized_op ? utils::UniqueNameGenerator().New(output.name, "_f32") : output.name;
     Qnn_TensorType_t sqrt_tensor_type =
         (!is_quantized_op && is_graph_output) ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-    QnnTensorWrapper sqrt_tensorwrapper(sqrt_output_name, sqrt_tensor_type, qnn_data_type,
-                                        QnnQuantParamsWrapper(), std::vector<uint32_t>(output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sqrt_tensorwrapper)), "AddTensorWrapper failed");
+    // The quantized branch below still needs output_shape for the final Quantize output tensor.
+    RETURN_IF_NOT(add_tensor(sqrt_output_name, sqrt_tensor_type, qnn_data_type, QnnQuantParamsWrapper(),
+                             is_quantized_op ? std::vector<uint32_t>(output_shape) : std::move(output_shape)),
+                  "AddTensorWrapper failed");
     std::string sqrt_node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_UNARY);
     std::vector<std::string> sqrt_param_names;
     RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), sqrt_node_name,
@@ -330,12 +346,15 @@ Ort::Status ReduceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     if (is_quantized_op) {
       // Insert Quantize (float32 -> quantized) after the float32 decomposition, using the
       // QDQ node unit's output quant params.
-      TensorInfo output_info = {};
-      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output, output_info));
+      Qnn_DataType_t final_qnn_data_type = QNN_DATATYPE_FLOAT_32;
+      RETURN_IF_ERROR(utils::GetQnnDataType(output.quant_param.has_value(), output.type, final_qnn_data_type,
+                                            qnn_model_wrapper.GetQnnBackendType()));
+      QnnQuantParamsWrapper final_quant_param;
+      RETURN_IF_ERROR(final_quant_param.Init(qnn_model_wrapper, output));
       Qnn_TensorType_t final_tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
-      QnnTensorWrapper final_tensorwrapper(output.name, final_tensor_type, output_info.qnn_data_type,
-                                           std::move(output_info.quant_param), std::move(output_shape));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(final_tensorwrapper)), "AddTensorWrapper failed");
+      RETURN_IF_NOT(add_tensor(output.name, final_tensor_type, final_qnn_data_type, std::move(final_quant_param),
+                               std::move(output_shape)),
+                    "AddTensorWrapper failed");
       RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit, "_quant_out"),
                                                     QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_QUANTIZE,
                                                     {sqrt_output_name}, {output.name}, {},

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1617,6 +1617,7 @@ void OrtSelectorManager::CreateSelectors() {
       {"LogSoftmax", {}},
       {"LpNormalization", {}},
       {"Neg", {}},
+      {"ReduceL2", {}},
       {"ReduceLogSumExp", {}},
       {"ReduceMax", {}},
       {"ReduceMean", {}},

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -438,15 +438,16 @@ template <typename QuantType>
 GetTestQDQModelFn<QuantType> BuildQDQReduceOpTestCase(const std::string& reduce_op_type,
                                                       const TestInputDef<float>& input_def,
                                                       bool axes_as_input, const std::vector<int64_t>& axes, bool keepdims,
-                                                      bool noop_with_empty_axes) {
+                                                      bool noop_with_empty_axes, bool use_ms_domain_qdq = false) {
   return [reduce_op_type, input_def, axes_as_input, axes, keepdims,
-          noop_with_empty_axes](ModelTestBuilder& builder,
-                                std::vector<QuantParams<QuantType>>& output_qparams) {
+          noop_with_empty_axes, use_ms_domain_qdq](ModelTestBuilder& builder,
+                                                   std::vector<QuantParams<QuantType>>& output_qparams) {
     // input -> Q -> DQ ->
     MakeTestInput<float>(builder, "input", input_def);
     const QuantParams<QuantType> input_qparams = GetTestInputQuantParams<QuantType>(input_def);
     const std::string input_qdq =
-        AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point);
+        AddQDQNodePair<QuantType>(builder, "qdq_in", "input", input_qparams.scale, input_qparams.zero_point,
+                                  use_ms_domain_qdq);
 
     // -> ReduceOp (e.g., ReduceSum) ->
     std::vector<std::string> input_names;
@@ -473,7 +474,7 @@ GetTestQDQModelFn<QuantType> BuildQDQReduceOpTestCase(const std::string& reduce_
 
     // -> Q -> DQ -> final output
     AddQDQNodePairWithOutputAsGraphOutput<QuantType>(
-        builder, "qdq_out", reduce_out, output_qparams[0].scale, output_qparams[0].zero_point);
+        builder, "qdq_out", reduce_out, output_qparams[0].scale, output_qparams[0].zero_point, use_ms_domain_qdq);
   };
 }
 
@@ -495,7 +496,8 @@ static void RunReduceOpQDQTest(const std::string& op_type,
                                const std::vector<int64_t>& axes,
                                bool keepdims,
                                int opset,
-                               ExpectedEPNodeAssignment expected_ep_assignment) {
+                               ExpectedEPNodeAssignment expected_ep_assignment,
+                               bool use_ms_domain_qdq = false) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -506,7 +508,7 @@ static void RunReduceOpQDQTest(const std::string& op_type,
   TestQDQModelAccuracy(BuildReduceOpTestCase<float>(op_type, input_def, axes_as_input, axes, keepdims,
                                                     noop_with_empty_axes),
                        BuildQDQReduceOpTestCase<QuantType>(op_type, input_def, axes_as_input, axes, keepdims,
-                                                           noop_with_empty_axes),
+                                                           noop_with_empty_axes, use_ms_domain_qdq),
                        provider_options,
                        opset,
                        expected_ep_assignment);
@@ -844,7 +846,8 @@ TEST_F(QnnHTPBackendTests, ReduceL2U8Opset13_NoKeepDims) {
                               ExpectedEPNodeAssignment::All);
 }
 
-// - Uses uint16 as the quantization type.
+// - Uses uint16 as the quantization type. Requires the MS domain QDQ ops since standard
+//   QuantizeLinear/DequantizeLinear don't support a uint16 zero-point.
 // - Uses opset 18, which has "axes" as an input.
 TEST_F(QnnHTPBackendTests, ReduceL2U16Opset18) {
   RunReduceOpQDQTest<uint16_t>("ReduceL2",
@@ -852,7 +855,8 @@ TEST_F(QnnHTPBackendTests, ReduceL2U16Opset18) {
                                {0, 1},  // axes
                                true,    // keepdims
                                18,      // opset
-                               ExpectedEPNodeAssignment::All);
+                               ExpectedEPNodeAssignment::All,
+                               true);  // use_ms_domain_qdq
 }
 
 //

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -844,6 +844,17 @@ TEST_F(QnnHTPBackendTests, ReduceL2U8Opset13_NoKeepDims) {
                               ExpectedEPNodeAssignment::All);
 }
 
+// - Uses uint16 as the quantization type.
+// - Uses opset 18, which has "axes" as an input.
+TEST_F(QnnHTPBackendTests, ReduceL2U16Opset18) {
+  RunReduceOpQDQTest<uint16_t>("ReduceL2",
+                               TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                               {0, 1},  // axes
+                               true,    // keepdims
+                               18,      // opset
+                               ExpectedEPNodeAssignment::All);
+}
+
 //
 // ReduceLogSumExp on HTP
 //

--- a/onnxruntime/test/providers/qnn/reduce_test.cc
+++ b/onnxruntime/test/providers/qnn/reduce_test.cc
@@ -802,6 +802,49 @@ TEST_F(QnnHTPBackendTests, ReduceMeanS8Opset18) {
 }
 
 //
+// ReduceL2 on HTP
+//
+
+// Test creates a Q -> DQ -> ReduceL2 -> Q -> DQ graph, and checks that all
+// nodes are supported by the QNN EP, and that the inference results match the CPU EP results.
+//
+// - Uses uint8 as the quantization type.
+// - Uses opset 18, which has "axes" as an input.
+TEST_F(QnnHTPBackendTests, ReduceL2U8Opset18) {
+  RunReduceOpQDQTest<uint8_t>("ReduceL2",
+                              TestInputDef<float>({2, 2}, false, -10.0f, 10.0f),
+                              {0, 1},  // axes
+                              true,    // keepdims
+                              18,      // opset
+                              ExpectedEPNodeAssignment::All);
+}
+
+// - Uses int8 as the quantization type.
+// - Uses opset 13, which has "axes" as an input.
+TEST_F(QnnHTPBackendTests, ReduceL2S8Opset13) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 20.0f, 9);
+
+  RunReduceOpQDQTest<int8_t>("ReduceL2",
+                             TestInputDef<float>({3, 3}, false, input_data),
+                             {0, 1},  // axes
+                             true,    // keepdims
+                             13,      // opset
+                             ExpectedEPNodeAssignment::All);
+}
+
+// Tests that keepdims = false generates expected results.
+TEST_F(QnnHTPBackendTests, ReduceL2U8Opset13_NoKeepDims) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 9);
+
+  RunReduceOpQDQTest<uint8_t>("ReduceL2",
+                              TestInputDef<float>({3, 3}, false, input_data),
+                              {1},    // axes
+                              false,  // keepdims
+                              13,     // opset
+                              ExpectedEPNodeAssignment::All);
+}
+
+//
 // ReduceLogSumExp on HTP
 //
 


### PR DESCRIPTION
## Summary
- `ReduceL2` was missing from the QDQ node-unit selector map in `qnn_ep_utils.cc`, so ORT never fused the surrounding DQ/Q pair into a quantized node unit for this op.
- `reduce_op_builder.cc` also explicitly rejected quantized `ReduceL2` input and fell back to running the Mul->ReduceSum->Sqrt decomposition entirely in float32, leaving a stray float32 activation tensor in an otherwise fully-quantized QDQ graph. That silently breaks HTP targets without fp16 support (surfaces later as a confusing device-compatibility failure rather than a clear EP error).
- Register `ReduceL2` in the selector map, and rewrite the decomposition to Dequantize -> compute in float32 -> Quantize using the node unit's real output quant params, mirroring the existing pattern in `BatchNormalizationOpBuilder` for the same "intermediate activations have no well-defined quant params" problem.