### PR TITLE
Fix GPU test flakiness

### DIFF
--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1816,11 +1816,28 @@ TEST_F(QnnHTPBackendTests, LoadingAndUnloadingOfQnnLibrary_FixSegFault) {
 #endif  // !BUILD_QNN_EP_STATIC_LIB && !defined(__linux__)
 
 #if defined(WIN32) && !BUILD_QNN_EP_STATIC_LIB
+// RAII guard that unconditionally unregisters an execution provider library on scope exit.
+// The AutoEp tests below register the EP library directly (without appending a device to the
+// session options, so RegisterQnnEpLibrary / RegisteredEpDeviceUniquePtr cannot be reused).
+// Without this guard, an early return from an ASSERT_* failure would leave the library
+// registered in the shared Ort::Env, corrupting subsequent tests (the source of the
+// intermittent failures).
+struct ScopedEpLibraryGuard {
+  const char* registration_name;
+  ~ScopedEpLibraryGuard() {
+    OrtStatus* status = Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, registration_name);
+    if (status != nullptr) {
+      Ort::GetApi().ReleaseStatus(status);
+    }
+  }
+};
+
 // Tests autoEP feature to automatically select an EP that supports the NPU.
 // Currently only works on Windows.
 TEST_F(QnnHTPBackendTests, AutoEp_PreferNpu) {
   ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
                                                                      ORT_TSTR("onnxruntime_providers_qnn.dll")));
+  ScopedEpLibraryGuard ep_guard{kQnnExecutionProvider};
 
   Ort::SessionOptions so;
   // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
@@ -1832,13 +1849,12 @@ TEST_F(QnnHTPBackendTests, AutoEp_PreferNpu) {
     Ort::Session session(*ort_env, ort_model_path, so);
     EXPECT_TRUE(SessionHasEp(session, kQnnExecutionProvider));
   }
-
-  ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
 
 TEST_F(QnnGPUBackendTests, AutoEp_PreferGpu) {
   ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
                                                                      ORT_TSTR("onnxruntime_providers_qnn.dll")));
+  ScopedEpLibraryGuard ep_guard{kQnnExecutionProvider};
 
   Ort::SessionOptions so;
   // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
@@ -1850,13 +1866,12 @@ TEST_F(QnnGPUBackendTests, AutoEp_PreferGpu) {
     Ort::Session session(*ort_env, ort_model_path, so);
     EXPECT_TRUE(SessionHasEp(session, kQnnExecutionProvider));
   }
-
-  ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
 
 TEST_F(QnnHTPBackendTests, AutoEp_AllDevices) {
   ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
                                                                      ORT_TSTR("onnxruntime_providers_qnn.dll")));
+  ScopedEpLibraryGuard ep_guard{kQnnExecutionProvider};
 
   Ort::SessionOptions so;
   // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
@@ -1878,13 +1893,12 @@ TEST_F(QnnHTPBackendTests, AutoEp_AllDevices) {
     Ort::Session session(*ort_env, ort_model_path, so);
     EXPECT_TRUE(SessionHasEp(session, kQnnExecutionProvider));
   }
-
-  ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
 
 TEST_F(QnnHTPBackendTests, AutoEp_NpuOnly) {
   ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
                                                                      ORT_TSTR("onnxruntime_providers_qnn.dll")));
+  ScopedEpLibraryGuard ep_guard{kQnnExecutionProvider};
 
   Ort::SessionOptions so;
   // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
@@ -1908,13 +1922,12 @@ TEST_F(QnnHTPBackendTests, AutoEp_NpuOnly) {
     Ort::Session session(*ort_env, ort_model_path, so);
     EXPECT_TRUE(SessionHasEp(session, kQnnExecutionProvider));
   }
-
-  ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
 
 TEST_F(QnnGPUBackendTests, AutoEp_GpuOnly) {
   ASSERT_ORTSTATUS_OK(Ort::GetApi().RegisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider,
                                                                      ORT_TSTR("onnxruntime_providers_qnn.dll")));
+  ScopedEpLibraryGuard ep_guard{kQnnExecutionProvider};
 
   Ort::SessionOptions so;
   // Add this session option for GetEpGraphAssignmentInfo in SessionHasEp
@@ -1938,8 +1951,6 @@ TEST_F(QnnGPUBackendTests, AutoEp_GpuOnly) {
     Ort::Session session(*ort_env, ort_model_path, so);
     EXPECT_TRUE(SessionHasEp(session, kQnnExecutionProvider));
   }
-
-  ASSERT_ORTSTATUS_OK(Ort::GetApi().UnregisterExecutionProviderLibrary(*ort_env, kQnnExecutionProvider));
 }
 
 TEST_F(QnnGPUBackendTests, ElementwiseAbsoluteVerifier) {

--- a/qcom/model_test/model_test.py
+++ b/qcom/model_test/model_test.py
@@ -15,6 +15,7 @@ import jsonc
 import numpy as np
 import onnx
 import onnxruntime_qnn
+import pytest
 
 import onnxruntime
 
@@ -114,36 +115,48 @@ class ModelTestCase:
         ]
 
     def run(self) -> None:
-        inputs = self.load_inputs()
-        expected = self.load_outputs()
+        try:
+            inputs = self.load_inputs()
+            expected = self.load_outputs()
 
-        if len(inputs) == 0:
-            logging.info(f"{self.__model_root.name} has no reference data.")
-            return
+            if len(inputs) == 0:
+                logging.info(f"{self.__model_root.name} has no reference data.")
+                return
 
-        logging.info(f"Evaluating {self.__model_root.name} with {len(inputs)} reference datasets.")
-        assert len(inputs) == len(expected)
+            logging.info(f"Evaluating {self.__model_root.name} with {len(inputs)} reference datasets.")
+            assert len(inputs) == len(expected)
 
-        for ds_idx in range(len(inputs)):
-            logging.debug(f"Inputs: { {n: t.shape for n, t in inputs[ds_idx].items()} }")
-            logging.debug(f"Expected outputs: { {n: t.shape for n, t in expected[ds_idx].items()} }")
-            actual = dict(
-                zip(self.output_names, cast(Sequence[np.ndarray], self.__session.run([], inputs[ds_idx])), strict=False)
-            )
-            for name in expected[ds_idx]:
-                if name not in actual:
-                    logging.debug(f"Actual outputs: { {n: t.shape for n, t in actual.items()} }")
-                    raise ValueError(f"Output {name} not found in actual.")
-                atol = self.__atol[name]
-                rtol = self.__rtol[name]
-                cosine_similarity = self.__cosine_similarity.get(name, None)
-                logging.info(f"Comparing actual outputs for {name} to reference.")
-                if cosine_similarity is not None:
-                    am.assert_cosine_similar(actual[name], expected[ds_idx][name], cosine_similarity)
-                    logging.info(f"{name} is cosine-similar enough (threshold: {cosine_similarity})")
-                else:
-                    np.testing.assert_allclose(actual[name], expected[ds_idx][name], atol=atol, rtol=rtol)
-                    logging.info(f"{name} is close enough (rtol: {rtol}; atol: {atol})")
+            for ds_idx in range(len(inputs)):
+                logging.debug(f"Inputs: { {n: t.shape for n, t in inputs[ds_idx].items()} }")
+                logging.debug(f"Expected outputs: { {n: t.shape for n, t in expected[ds_idx].items()} }")
+                actual = dict(
+                    zip(
+                        self.output_names,
+                        cast(Sequence[np.ndarray], self.__session.run([], inputs[ds_idx])),
+                        strict=False,
+                    )
+                )
+                for name in expected[ds_idx]:
+                    if name not in actual:
+                        logging.debug(f"Actual outputs: { {n: t.shape for n, t in actual.items()} }")
+                        raise ValueError(f"Output {name} not found in actual.")
+                    atol = self.__atol[name]
+                    rtol = self.__rtol[name]
+                    cosine_similarity = self.__cosine_similarity.get(name, None)
+                    logging.info(f"Comparing actual outputs for {name} to reference.")
+                    if cosine_similarity is not None:
+                        am.assert_cosine_similar(actual[name], expected[ds_idx][name], cosine_similarity)
+                        logging.info(f"{name} is cosine-similar enough (threshold: {cosine_similarity})")
+                    else:
+                        np.testing.assert_allclose(actual[name], expected[ds_idx][name], atol=atol, rtol=rtol)
+                        logging.info(f"{name} is close enough (rtol: {rtol}; atol: {atol})")
+        finally:
+            # Explicitly release the InferenceSession so GPU resources in the QNN
+            # context memory are freed before the next test begins rather
+            # than waiting for the garbage collector. Without this, accumulated sessions
+            # across a test suite run can exhaust GPU memory and cause non-deterministic
+            # failures in later tests.
+            del self.__session
 
 
 class ModelTestSuite:
@@ -281,6 +294,10 @@ def get_qnn_ep_device(backend_type: BackendT) -> tuple[onnxruntime.OrtEpDevice, 
     qnn_ep_devices = [ed for ed in onnxruntime.get_ep_devices() if ed.ep_name == ep_names[0]]
 
     eps_and_devices = {get_backend_type(ed.device.type): ed for ed in qnn_ep_devices}
+
+    if backend_type not in eps_and_devices:
+        pytest.skip(f"QNN {backend_type.upper()} backend device not available on this machine")
+
     ep_device = eps_and_devices[backend_type]
 
     return ep_device, get_qnn_backend_path(backend_type)


### PR DESCRIPTION
### Summary

Fix GPU test flakiness in CI.

#### Missing teardown on test failure

The five AutoEp tests all call `RegisterExecutionProviderLibrary` directly on the process-global `ort_env` and rely on a matching `UnregisterExecutionProviderLibrary` call at the end of the test body. That final call is written as an `ASSERT_*` statement — meaning if any earlier assertion in the same test fires, `ASSERT_*` expands to `return` and the unregister is silently skipped. The EP library stays registered in `ort_env` for the lifetime of the process, so the next test that tries to register the same name gets a duplicate-registration error.

The fix replaces the trailing unregister call with a `ScopedEpLibraryGuard` RAII struct whose destructor calls `UnregisterExecutionProviderLibrary` unconditionally. The EP library is now always released on scope exit regardless of how the test body terminates.

#### Python model tests: InferenceSession not released between tests

`ModelTestCase` creates an `InferenceSession` in `__init__` and holds it until the object is garbage collected. With many parametrized test cases, CPython's GC does not collect sessions promptly — they accumulate and can exhaust GPU memory or DX12 command queue capacity, causing non-deterministic failures in later tests. Fixed by wrapping `run()` in `try/finally` and explicitly deleting the session before the method returns.
