### PR TITLE
[QNN EP][Affinity] Phase 1 - Add op_affinity provider option with backend scope

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -59,7 +59,7 @@ For build instructions, please see the [BUILD page](./build.md).
     - Python 3.11.x
     - Numpy 1.25.2 or >= 1.26.4
   - Install: `pip install onnxruntime-qnn`
-- [NuGet package - `Qualcomm.ML.OnnxRuntime.QNN`](https://www.nuget.org/packages/Qualcomm.ML.OnnxRuntime.QNN) 
+- [NuGet package - `Qualcomm.ML.OnnxRuntime.QNN`](https://www.nuget.org/packages/Qualcomm.ML.OnnxRuntime.QNN)
   - A single package covering Windows ARM64 (ARM64X), ARM64EC, and x64 (`win-arm64`, `win-arm64ec`, `win-arm64x`, `win-x64` RuntimeIdentifiers) with appropriate fallbacks.
 - Archives (`.zip` and `.tgz`)
   - **Note**: Ships the QNN EP shared library and headers for use outside of Python on Windows and Linux hosts and targets.
@@ -247,6 +247,10 @@ Warning: Enabling HTP Monolithic LSTM may improve session creation time, but thi
 |`"op_packages"`|Description|
 |---|---|
 |Op package config (string)|Register custom op packages. Format: `<OpType>:<PackagePath>:<InterfaceSymbolName>[:<Target>]`. Multiple packages can be separated by commas.|
+
+|`"op_affinity"`|Description|
+|---|---|
+|Filter spec (string) — inline `"[backend:][mode:]<op types>"` or `"@<path to json file>"`|Controls which ONNX op types the QNN EP claims. **Two modes:** `exclude` (default) keeps every op on QNN *except* the listed op types, which fall back to another EP (typically the CPU EP); `include` claims *only* the listed op types and forces every other op type to fall back.<br><br>**Inline form:** `"exclude:Softmax,LayerNormalization"` or `"include:Conv,MatMul"`. `mode:` is optional and defaults to `exclude`, so `"Softmax"` ≡ `"exclude:Softmax"`. Op types are comma-separated, matched **case-sensitively**, and must not contain spaces.<br><br>**Backend scope (optional):** prefix with a backend name to scope the filter to one backend, e.g. `"htp:exclude:Softmax"`. Accepts the same QNN backend names as `backend_type`: `cpu`/`gpu`/`htp`/`dsp`/`ir` (`htp` also matches `htp_fp16` sessions). Without this prefix, the filter applies no matter what backend the session is actually running (via `backend_type`/`backend_path`).<br><br>**Config-file form:** `"@C:\path\to\filter.json"` — a path (prefixed with `@`) to a JSON file, for long lists. Schema: `{ "backend": "htp", "mode": "exclude" \| "include", "op_types": ["Softmax", "Conv"] }` (`"backend"` optional; JSONC comments allowed).<br><br>See [OP Affinity - Details](#op-affinity---details) for matching granularity, defaults, and the `disable_cpu_ep_fallback` interaction.|
 
 |`"dump_json_qnn_graph"`|Description|
 |---|---|
@@ -1667,3 +1671,24 @@ Currently, only pre-compiled models with EPContext nodes are supported. The  exa
 ```
 <graph name>;<adapter binary section path>
 ```
+
+
+## OP Affinity - Details
+
+#### Matching examples
+1. For a graph `Conv → Softmax` (two separate node groups), `"exclude:Softmax"` keeps `Conv` on QNN and falls `Softmax` back to
+another EP (typically CPU).
+2. For a fused QDQ group `DequantizeLinear → Conv → QuantizeLinear`, filter on the group's target op type: `"exclude:Conv"` removes
+  the whole group from QNN; `"exclude:DequantizeLinear"` has no effect.
+
+#### Backend scope mismatch
+On a session running a backend other than the one the filter is scoped to, the filter is skipped entirely (logged at INFO) rather
+than applied.
+
+#### Empty list and default
+- Default (option unset) is `exclude` with an empty list — all ops go to QNN.
+- `include` with an empty list forces **all** ops off QNN (logged at WARNING).
+- An op type in the list that matches no node is ignored with a WARNING (typically a typo).
+
+#### Interaction with `session.disable_cpu_ep_fallback`
+Setting both is logged at WARNING; if a filtered-off op has no other EP to run on, session creation fails.

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -37,6 +37,21 @@ class QnnQuantParamsWrapper;
 
 namespace utils {
 /**
+ * Trims surrounding ASCII whitespace (space, tab, CR, LF) and returns a copy.
+ * Returns an empty string if the input is empty or all-whitespace.
+ * @param s The string to trim.
+ * @return The trimmed copy.
+ */
+inline std::string TrimWhitespace(std::string_view s) {
+  const auto begin = s.find_first_not_of(" \t\r\n");
+  if (begin == std::string_view::npos) {
+    return std::string();
+  }
+  const auto end = s.find_last_not_of(" \t\r\n");
+  return std::string(s.substr(begin, end - begin + 1));
+}
+
+/**
  * Returns a lowercase version of the input string.
  * /param str The string to lowercase.
  * /return The lowercased string.

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -889,6 +889,19 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                               logger_);
   }
 
+  // Op affinity: keep certain ONNX op types/op names on/off QNN, optionally scoped to a backend.
+  std::string op_affinity_str;
+  GetSessionConfigEntryOrDefault(ort_api, session_options_,
+                                 FormatEPConfigKey("op_affinity"), "", op_affinity_str);
+  op_affinity_ = qnn::OnnxOpAffinity::FromOptionValue(op_affinity_str, logger_);
+
+  if (op_affinity_.IsActive() && disable_cpu_ep_fallback_) {
+    ORT_CXX_LOG(logger_,
+                ORT_LOGGING_LEVEL_WARNING,
+                "op_affinity is configured and fallback to the CPU EP is disabled (disable_cpu_ep_fallback). "
+                "If op_affinity keeps a node off QNN and no other EP can run it, session creation will fail.");
+  }
+
   // HTP FP16 precision mode
   htp_graph_configs_.enable_htp_fp16_precision = ParseBoolOption(ort_api,
                                                                  session_options_,
@@ -1528,7 +1541,20 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
   }
 
   for (const std::unique_ptr<qnn::IQnnNodeGroup>& qnn_node_group : qnn_node_groups) {
-    Ort::Status support_status = qnn_node_group->IsSupported(qnn_model_wrapper, logger_);
+    // Apply the user's op affinity. Inactive affinity always returns false, so this is a no-op when
+    // the option is unset.
+    Ort::Status support_status;
+
+    if (op_affinity_.ShouldFilterOff(*qnn_node_group->GetTargetNodeUnit(),
+                                     qnn_backend_manager_->GetQnnBackendType())) {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE,
+                  ("op_affinity: keeping op type '" + qnn_node_group->GetTargetNodeUnit()->OpType() +
+                   "' off QNN; it will fall back to another EP.")
+                      .c_str());
+      support_status = MAKE_EP_FAIL("Filtered off QNN by op_affinity provider option");
+    } else {
+      support_status = qnn_node_group->IsSupported(qnn_model_wrapper, logger_);
+    }
     const bool supported = support_status.IsOK();
 
     LogNodeSupport(logger_, *qnn_node_group, support_status);
@@ -1558,6 +1584,8 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
       }
     }
   }
+
+  op_affinity_.WarnUnmatchedEntries(qnn_backend_manager_->GetQnnBackendType(), logger_);
   return nullptr;
 }
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -24,6 +24,7 @@
 #include "core/providers/qnn/builder/onnx_ctx_model_helper.h"
 #include "core/providers/qnn/cache_compatibility/qnn_cache_compatibility_info.h"
 #include "core/providers/qnn/cache_compatibility/qnn_cache_compatibility_manager.h"
+#include "core/providers/qnn/qnn_onnx_op_affinity.h"
 #include "core/providers/qnn/qnn_telemetry.h"
 #include "core/providers/qnn/rpcmem_library.h"
 #include "core/providers/qnn/qnn_node_compute_info_base.h"
@@ -246,6 +247,10 @@ class QnnEp : public OrtEp, public ApiPtrs {
   uint32_t default_rpc_polling_time_ = 0;
   qnn::ModelSettings model_settings_ = {};
   qnn::HtpGraphConfigs_t htp_graph_configs_;
+
+  // Op Affinity controlling which ONNX op types the QNN EP claims in GetCapability, configured via
+  // the "op_affinity" provider option.
+  qnn::OnnxOpAffinity op_affinity_;
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";

--- a/onnxruntime/core/providers/qnn/qnn_onnx_op_affinity.cc
+++ b/onnxruntime/core/providers/qnn/qnn_onnx_op_affinity.cc
@@ -1,0 +1,261 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/qnn_onnx_op_affinity.h"
+
+#include <exception>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "nlohmann/json.hpp"
+
+#include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+// Only the exact "include" spelling selects include mode; anything else (the default, or a typo)
+// resolves to the safer exclude mode.
+OnnxOpAffinity::Mode ParseMode(const std::string& mode_str) {
+  return (mode_str == "include") ? OnnxOpAffinity::Mode::kInclude : OnnxOpAffinity::Mode::kExclude;
+}
+
+// Recognized backend scope names, derived from QnnBackendTypeToString() (the single source of truth)
+// rather than a hand-maintained list, so the two can't drift. "htp" also covers HTP_FP16 -- see
+// AppliesToBackend().
+bool IsKnownBackendName(std::string_view name) {
+  for (uint8_t i = 0; i <= static_cast<uint8_t>(QnnBackendType::SERIALIZER); ++i) {
+    if (name == QnnBackendTypeToString(static_cast<QnnBackendType>(i))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Phase-2 syntax guard. '[' is reserved for a future op-name qualifier, "OpType[name=...]". Phase 1
+// doesn't implement name matching, so reject any token carrying it (rather than treat it as a literal
+// op type that would silently never match) -- this keeps a phase-1 spec a strict subset of the future
+// grammar. Colons are NOT reserved (UDO op types use them). Throws so FromOptionValue() degrades the
+// whole filter to inactive.
+void RejectReservedOpTypeChars(const std::string& op_type) {
+  if (op_type.find('[') != std::string::npos) {
+    throw std::runtime_error("op_affinity op type '" + op_type +
+                             "' uses the reserved '[' character (op-name qualifier); "
+                             "op-name filtering is not supported in this version.");
+  }
+}
+
+}  // namespace
+
+OnnxOpAffinity::OnnxOpAffinity(const std::string& inline_spec) {
+  // Inline spec: "[backend:][mode:]<comma-separated op types>". Only exact reserved words are treated
+  // as prefixes -- an op type may itself contain a colon (e.g. UDO "custom:MyOp"), so an unrecognized
+  // prefix stays part of the literal op-type list.
+  std::string remainder = inline_spec;
+
+  // Optional backend scope prefix (checked before mode: it is the outermost segment).
+  if (const auto colon = remainder.find(':'); colon != std::string::npos) {
+    const std::string maybe_backend = remainder.substr(0, colon);
+    if (IsKnownBackendName(maybe_backend)) {
+      backend_scope_ = maybe_backend;
+      remainder = remainder.substr(colon + 1);
+    }
+  }
+
+  // Optional mode prefix.
+  std::string mode_str = "exclude";
+  if (const auto colon = remainder.find(':'); colon != std::string::npos) {
+    const std::string maybe_mode = remainder.substr(0, colon);
+    if (maybe_mode == "exclude" || maybe_mode == "include") {
+      mode_str = maybe_mode;
+      remainder = remainder.substr(colon + 1);
+    }
+  }
+
+  mode_ = ParseMode(mode_str);
+  for (const auto& token : utils::SplitString(remainder, ",", /*keep_empty*/ false)) {
+    if (!token.empty()) {
+      std::string op_type(token);
+      RejectReservedOpTypeChars(op_type);  // phase-2 "[name=...]" syntax -> degrade to inactive
+      selected_op_types_.emplace(std::move(op_type));
+    }
+  }
+}
+
+OnnxOpAffinity::OnnxOpAffinity(const std::filesystem::path& config_file) {
+  // JSON config file: { "backend": "htp", "mode": "exclude"|"include", "op_types": [...] }
+  // ("backend" optional). Anything malformed -- unopenable file, bad JSON, or a field of the wrong
+  // type/value -- throws; FromOptionValue() catches and degrades to an inactive filter + WARNING. The
+  // per-field type/value checks below keep this path as loud as the inline path rather than silently
+  // coercing a typo'd config to a surprising default.
+  std::ifstream ifs(config_file);
+  if (!ifs) {
+    throw std::runtime_error("op_affinity config file could not be opened: " +
+                             config_file.string());
+  }
+
+  const nlohmann::json j = nlohmann::json::parse(ifs, /*cb*/ nullptr, /*allow_exceptions*/ true,
+                                                 /*ignore_comments*/ true);
+
+  if (j.contains("backend")) {
+    if (!j.at("backend").is_string()) {
+      throw std::runtime_error("op_affinity config: \"backend\" must be a string.");
+    }
+    std::string backend = utils::TrimWhitespace(j.at("backend").get<std::string>());
+    if (!backend.empty()) {
+      backend_scope_ = std::move(backend);
+    }
+  }
+
+  std::string mode_str = "exclude";  // default mode when not specified
+  if (j.contains("mode")) {
+    if (!j.at("mode").is_string()) {
+      throw std::runtime_error("op_affinity config: \"mode\" must be a string.");
+    }
+    mode_str = j.at("mode").get<std::string>();
+    // Unlike the inline path (where an unrecognized token falls into the op-type list), a config file
+    // names the mode explicitly, so a value that is neither "exclude" nor "include" is a typo -- reject
+    // it loudly rather than let ParseMode coerce it to exclude.
+    if (mode_str != "exclude" && mode_str != "include") {
+      throw std::runtime_error("op_affinity config: \"mode\" must be \"exclude\" or \"include\", got \"" +
+                               mode_str + "\".");
+    }
+  }
+  mode_ = ParseMode(mode_str);
+
+  if (j.contains("op_types")) {
+    if (!j.at("op_types").is_array()) {
+      throw std::runtime_error("op_affinity config: \"op_types\" must be an array of strings.");
+    }
+    for (const auto& item : j.at("op_types")) {
+      if (!item.is_string()) {
+        throw std::runtime_error("op_affinity config: every entry in \"op_types\" must be a string.");
+      }
+      // File values may be whitespace-padded; trim so entries match node op types.
+      std::string op_type = utils::TrimWhitespace(item.get<std::string>());
+      if (!op_type.empty()) {
+        RejectReservedOpTypeChars(op_type);  // phase-2 "[name=...]" syntax -> degrade to inactive
+        selected_op_types_.emplace(std::move(op_type));
+      }
+    }
+  }
+}
+
+OnnxOpAffinity OnnxOpAffinity::FromOptionValue(const std::string& option_value, const Ort::Logger& logger) {
+  const std::string trimmed = utils::TrimWhitespace(option_value);
+  if (trimmed.empty()) {
+    return OnnxOpAffinity{};  // No filter configured; keep default (exclude + empty list).
+  }
+
+  OnnxOpAffinity filter;
+  try {
+    if (trimmed[0] == '@') {
+      // Value is a path to a JSON config file.
+      const std::string path = utils::TrimWhitespace(std::string_view(trimmed).substr(1));
+      filter = OnnxOpAffinity(std::filesystem::path(path));
+    } else {
+      filter = OnnxOpAffinity(trimmed);
+    }
+  } catch (const std::exception& ex) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                (std::string("Failed to parse op_affinity value '") + trimmed +
+                 "': " + ex.what() + ". Falling back to no filtering.")
+                    .c_str());
+    return OnnxOpAffinity{};  // Bad value degrades to "no filtering" rather than failing the session.
+  }
+
+  if (filter.mode_ == Mode::kInclude && filter.selected_op_types_.empty()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                "op_affinity mode is 'include' but the op-type list is empty; "
+                "ALL op types will fall back off QNN.");
+  }
+
+  // A backend scope that is not a recognized backend name can never match a real session; warn so a
+  // typo (e.g. "hpt:exclude:...") is visible rather than a silent no-op.
+  if (filter.backend_scope_.has_value() && !IsKnownBackendName(*filter.backend_scope_)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                ("op_affinity backend scope '" + *filter.backend_scope_ +
+                 "' is not a recognized backend name; the filter will not apply to any session.")
+                    .c_str());
+  }
+
+  if (filter.IsActive()) {
+    std::string joined;
+    for (const auto& op_type : filter.selected_op_types_) {
+      joined += (joined.empty() ? "" : ", ") + op_type;
+    }
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("op_affinity backend=" +
+                 (filter.backend_scope_.has_value() ? *filter.backend_scope_ : std::string("<any>")) +
+                 " mode=" +
+                 std::string(filter.mode_ == Mode::kInclude ? "include" : "exclude") +
+                 " op_types=[" + joined + "]")
+                    .c_str());
+  }
+
+  return filter;
+}
+
+bool OnnxOpAffinity::AppliesToBackend(QnnBackendType backend_type) const {
+  if (!backend_scope_.has_value()) {
+    return true;  // Unscoped filter applies to any backend.
+  }
+  // "htp" and "htp_fp16" are the same physical backend at different precision settings, so a scope
+  // written as either name matches a session running the other.
+  if (backend_type == QnnBackendType::HTP || backend_type == QnnBackendType::HTP_FP16) {
+    return *backend_scope_ == "htp" || *backend_scope_ == "htp_fp16";
+  }
+  return *backend_scope_ == QnnBackendTypeToString(backend_type);
+}
+
+bool OnnxOpAffinity::ShouldFilterOff(const OrtNodeUnit& target_node_unit, QnnBackendType backend_type) const {
+  if (!IsActive() || !AppliesToBackend(backend_type)) {
+    return false;  // Inactive, or scoped to a different backend: never keeps anything off QNN.
+  }
+  const std::string target_op_type = target_node_unit.OpType();
+  const bool in_list = selected_op_types_.count(target_op_type) != 0;
+  if (in_list) {
+    matched_op_types_.emplace(target_op_type);
+  }
+  //   exclude mode: filter off the op types in the list.
+  //   include mode: filter off every op type NOT in the list.
+  return (mode_ == Mode::kExclude) ? in_list : !in_list;
+}
+
+void OnnxOpAffinity::WarnUnmatchedEntries(QnnBackendType backend_type, const Ort::Logger& logger) const {
+  // GetSupportedNodes runs multiple times per session (see header), so matched_op_types_ must not
+  // survive past this call -- otherwise an op matched only in a later pass would be wrongly flagged
+  // as unmatched here. Cleared unconditionally on every exit path below.
+
+  // A filter scoped to a backend this session isn't running can never match by design, so the
+  // per-entry "did you make a typo?" warnings would be misleading. Suppress them and log one INFO.
+  if (IsActive() && !AppliesToBackend(backend_type)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO,
+                ("op_affinity is scoped to backend '" + *backend_scope_ +
+                 "' but this session runs '" + QnnBackendTypeToString(backend_type) +
+                 "' -- filter skipped.")
+                    .c_str());
+    matched_op_types_.clear();
+    return;
+  }
+
+  for (const auto& op_type : selected_op_types_) {
+    if (matched_op_types_.count(op_type) == 0) {
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("op_affinity entry '" + op_type +
+                   "' did not match any node in the graph; check for a typo in the op type name.")
+                      .c_str());
+    }
+  }
+  matched_op_types_.clear();
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_onnx_op_affinity.h
+++ b/onnxruntime/core/providers/qnn/qnn_onnx_op_affinity.h
@@ -1,0 +1,110 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Encapsulates the "op_affinity" provider option: which ONNX op types the QNN EP claims in
+// GetSupportedNodes. It filters on the ONNX op type (e.g. "Softmax"), NOT on QNN op names -- the
+// "Onnx" in the class name is a deliberate reminder of that. Parsing (inline spec or "@<path>" JSON
+// config file), the exclude/include policy, the optional backend scope, and the diagnostic logging
+// all live here so qnn_execution_provider.cc only needs to construct one via FromOptionValue() and
+// call ShouldFilterOff() per node group.
+//
+// Two modes:
+//   kExclude (default): every op goes to QNN EXCEPT the listed op types, which fall back to another
+//                       EP (typically CPU). Empty list = no filtering (the default).
+//   kInclude:           ONLY the listed op types are claimed by QNN; everything else falls back. An
+//                       empty list forces ALL ops off QNN.
+//
+// Optional backend scope: a filter may be scoped to a single backend (e.g. "htp") using the same
+// backend-name strings as the "backend_type" option. A session runs one backend, so scope is a
+// single filter-wide constant. A filter scoped to a backend the session isn't running is inert
+// (ShouldFilterOff() returns false) -- see AppliesToBackend().
+//
+// ShouldFilterOff() takes the whole OrtNodeUnit (not just the op-type string) so a future node-name
+// filter can be added here without touching call sites.
+class OnnxOpAffinity {
+ public:
+  enum class Mode : uint8_t { kExclude,
+                              kInclude };
+
+  // An inactive filter (kExclude + empty list) -- the default when the option is unset.
+  OnnxOpAffinity() = default;
+
+  // Build a filter from an inline spec "[backend:][mode:]<comma-separated op types>" (backend
+  // optional, mode defaults to "exclude"). Parsing is pure string work and does not throw.
+  explicit OnnxOpAffinity(const std::string& inline_spec);
+
+  // const char* overload delegating to the std::string constructor. Without it, a string literal
+  // (e.g. OnnxOpAffinity("exclude:Softmax")) is an ambiguous conversion between std::string and
+  // std::filesystem::path (the config-file constructor below); this exact-match overload resolves it.
+  explicit OnnxOpAffinity(const char* inline_spec) : OnnxOpAffinity(std::string(inline_spec)) {}
+
+  // Build a filter from a JSON config file
+  // { "backend": "htp", "mode": "exclude"|"include", "op_types": [...] } ("backend" optional).
+  // Throws std::runtime_error if the file cannot be opened, and lets nlohmann::json parse errors
+  // propagate. FromOptionValue() is the caller that catches these and degrades to an inactive
+  // filter, so construction itself is free to throw on bad input.
+  explicit OnnxOpAffinity(const std::filesystem::path& config_file);
+
+  // Parse a provider-option value into a filter -- either an inline spec "[backend:][mode:]<op types>"
+  // (mode defaults to "exclude") or "@<path>" to a JSON config file. On any parse failure this logs a
+  // WARNING and returns an inactive filter, so a bad value degrades to "no filtering" rather than
+  // failing session creation. Also logs the include-with-empty-list warning and a VERBOSE summary.
+  static OnnxOpAffinity FromOptionValue(const std::string& option_value, const Ort::Logger& logger);
+
+  // True if the filter would keep at least one op off QNN. An empty exclude list is inactive; include
+  // mode is always active. Backend scope is not considered here -- that's AppliesToBackend()'s job.
+  bool IsActive() const {
+    return !selected_op_types_.empty() || mode_ == Mode::kInclude;
+  }
+
+  // True if this filter applies to the session's backend. An unscoped filter applies to any backend;
+  // a scoped filter applies only when its scope matches the running backend's name -- except "htp"
+  // and "htp_fp16" are aliases for the same physical backend. When false, ShouldFilterOff() returns
+  // false unconditionally.
+  bool AppliesToBackend(QnnBackendType backend_type) const;
+
+  // Decide whether the given node group's target op should be kept off QNN. An inactive filter, or one
+  // scoped to a different backend, always returns false. Records a match for WarnUnmatchedEntries().
+  // const: only mutates the mutable diagnostic bookkeeping, so it's callable from the const
+  // GetSupportedNodes().
+  bool ShouldFilterOff(const OrtNodeUnit& target_node_unit, QnnBackendType backend_type) const;
+
+  // Warn about list entries that never matched any node group since the last call -- almost always a
+  // misspelled op type, which would otherwise be a silent no-op. Clears the match bookkeeping on every
+  // exit path, so repeated calls (GetSupportedNodes runs multiple times per session) each start clean.
+  // If the filter is scoped to a backend the session isn't running, no entry can match by design, so
+  // the per-entry warnings are suppressed in favor of a single INFO line. Takes the session backend to
+  // tell the two cases apart.
+  void WarnUnmatchedEntries(QnnBackendType backend_type, const Ort::Logger& logger) const;
+
+ private:
+  Mode mode_ = Mode::kExclude;
+  // The op types listed in the filter spec. In exclude mode these are kept off QNN; in include mode
+  // these are the only op types claimed by QNN. Empty in the default (inactive) exclude filter.
+  std::unordered_set<std::string> selected_op_types_;
+  // Optional backend scope. nullopt = applies to any backend. Stored as the backend-name string
+  // ("htp"/"gpu"/...) rather than the QnnBackendType enum so it compares directly against
+  // QnnBackendTypeToString() and stays decoupled from the enum's internal ordering.
+  std::optional<std::string> backend_scope_;
+  // Entries matched by ShouldFilterOff() since the last WarnUnmatchedEntries() call (which clears this
+  // on every exit path). Mutable diagnostic bookkeeping only -- does not affect filtering. Scoped to
+  // "since the last call" because GetSupportedNodes can run multiple times per session.
+  mutable std::unordered_set<std::string> matched_op_types_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -1527,6 +1527,435 @@ TEST_F(QnnHTPBackendTests, EPRejectsDynamicShapesF32) {
                   /*verify_output*/ true);
 }
 
+// Shared model + checker helpers for the "op_affinity" provider-option tests below. Every
+// one of these tests uses the same tiny Conv -> Softmax graph (both ops are static-shape and
+// QNN-supported, so without any filter both land on QNN) and only differs in the filter value and
+// the expected per-op EP assignment. Factoring these out keeps each test to just its option value
+// and expectation.
+
+// Builds a Conv -> Softmax graph. Only the graph name varies between tests.
+static std::function<void(ModelTestBuilder&)> MakeConvSoftmaxBuilder(const std::string& graph_name) {
+  return [graph_name](ModelTestBuilder& builder) {
+    builder.graph_->set_name(graph_name);
+
+    builder.MakeInput<float>("input1",
+                             std::vector<int64_t>{1, 2, 8, 8},
+                             GetFloatDataInRange(0.0f, 1.0f, 128));
+    builder.MakeInitializer<float>("weight",
+                                   std::vector<int64_t>{2, 2, 2, 2},
+                                   GetFloatDataInRange(-0.3f, 0.3f, 16));
+    builder.MakeInitializer<float>("bias",
+                                   std::vector<int64_t>{2},
+                                   {0.0f, 1.0f});
+
+    builder.AddNode("Conv", "Conv", {"input1", "weight", "bias"}, {"conv_output"}, kOnnxDomain);
+    builder.AddNode("Softmax", "Softmax", {"conv_output"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Builds an EP-assignment checker that asserts each named op type is assigned to the expected EP.
+// `expected` maps ONNX op type -> EP name (e.g. {{"Softmax", kCpuExecutionProvider},
+// {"Conv", kQnnExecutionProvider}}). Every listed op must be seen exactly on its expected EP.
+static std::function<void(const Ort::Session&)> MakeOpAssignmentChecker(
+    std::unordered_map<std::string, std::string> expected) {
+  return [expected](const Ort::Session& session) {
+    std::unordered_map<std::string, bool> seen;
+    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
+      std::string ep_name = subgraph.GetEpName();
+      for (const auto& node : subgraph.GetNodes()) {
+        std::string op_type = node.GetOperatorType();
+        auto it = expected.find(op_type);
+        if (it != expected.end()) {
+          EXPECT_EQ(ep_name, it->second) << op_type << " assigned to unexpected EP";
+          seen[op_type] = (ep_name == it->second);
+        }
+      }
+    }
+    for (const auto& [op_type, ep_name] : expected) {
+      EXPECT_TRUE(seen[op_type]) << op_type << " node not found on expected EP " << ep_name;
+    }
+  };
+}
+
+// Test the "op_affinity" provider option in the default (exclude) mode: a fully-static,
+// QNN-supported op listed in the filter must be kept off QNN and fall back to the CPU EP, while
+// the rest of the graph stays on QNN. Without the option both ops would be assigned to QNN.
+TEST_F(QnnHTPBackendTests, EPFilterExcludesOpType) {
+  // Conv -> Softmax, both static-shape and both QNN-supported.
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_exclude_graph");
+
+  // Softmax was filtered off via op_affinity (exclude) -> must be on CPU EP; Conv stays on QNN.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  // "exclude:" prefix omitted on purpose -> exercises the default-mode path.
+  provider_options["op_affinity"] = "Softmax";  // keep Softmax off QNN
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Test the "op_affinity" backend scope (phase 1) on a matching backend: "htp:exclude:Softmax" on an
+// HTP session behaves exactly like the unscoped exclude test -- Softmax falls back to CPU, Conv
+// stays on QNN. Confirms the "htp:" prefix is parsed and matches the running backend.
+TEST_F(QnnHTPBackendTests, EPFilterBackendScopeMatches) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_backend_scope_match_graph");
+
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "htp:exclude:Softmax";  // scoped to htp -> applies this session
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Test the "op_affinity" backend scope (phase 1) on a non-matching backend: "gpu:exclude:Softmax" on
+// an HTP session is inert -- the filter is skipped, so Softmax stays on QNN just as if no option
+// were set. Both ops must be assigned to QNN. This is the guarantee that a config scoped to a
+// different backend does not affect the session it isn't for.
+TEST_F(QnnHTPBackendTests, EPFilterBackendScopeMismatchIsInert) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_backend_scope_mismatch_graph");
+
+  // gpu-scoped filter on an htp session -> no effect: both ops stay on QNN.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kQnnExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "gpu:exclude:Softmax";  // scoped to gpu -> inert on this htp session
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Test the "op_affinity" provider option in include mode: ONLY the listed op types are
+// claimed by QNN; every other op type is forced to fall back. Here "include:Conv" keeps Conv on
+// QNN and pushes Softmax to the CPU EP (the mirror image of the exclude-mode test above).
+TEST_F(QnnHTPBackendTests, EPFilterIncludesOpType) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_include_graph");
+
+  // include:Conv -> Conv stays on QNN; Softmax (not in the list) is forced to CPU EP.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "include:Conv";  // only Conv on QNN, rest fall back
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// C1: op_affinity supplied via a JSON config file ("@<path>") in exclude mode. The file
+// { "mode": "exclude", "op_types": ["Softmax"] } must have the same effect as the inline
+// "Softmax" spec in EPFilterExcludesOpType: Softmax falls back to CPU, Conv stays on QNN.
+TEST_F(QnnHTPBackendTests, EPFilterExcludesOpTypeFromConfigFile) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_exclude_configfile_graph");
+
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  // Write the JSON config file to a temp path and pass it as "@<path>".
+  const std::filesystem::path cfg_path =
+      std::filesystem::temp_directory_path() / "ort_qnn_op_affinity_exclude.json";
+  {
+    nlohmann::json j;
+    j["mode"] = "exclude";
+    j["op_types"] = {"Softmax"};
+    std::ofstream(cfg_path) << j.dump();
+  }
+  ASSERT_TRUE(std::filesystem::exists(cfg_path));
+  auto cleanup = gsl::finally([&cfg_path]() { std::filesystem::remove(cfg_path); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "@" + cfg_path.string();  // config-file path
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// C2: op_affinity supplied via a JSON config file ("@<path>") in include mode. The file
+// { "mode": "include", "op_types": ["Conv"] } must mirror the inline "include:Conv" spec in
+// EPFilterIncludesOpType: only Conv stays on QNN, Softmax is forced to the CPU EP.
+TEST_F(QnnHTPBackendTests, EPFilterIncludesOpTypeFromConfigFile) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_include_configfile_graph");
+
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  const std::filesystem::path cfg_path =
+      std::filesystem::temp_directory_path() / "ort_qnn_op_affinity_include.json";
+  {
+    nlohmann::json j;
+    j["mode"] = "include";
+    j["op_types"] = {"Conv"};
+    std::ofstream(cfg_path) << j.dump();
+  }
+  ASSERT_TRUE(std::filesystem::exists(cfg_path));
+  auto cleanup = gsl::finally([&cfg_path]() { std::filesystem::remove(cfg_path); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "@" + cfg_path.string();  // config-file path
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Edge case: an op type in the filter list that matches no node in the graph (e.g. a typo
+// "Softmaxx") must be a quiet no-op -- every op stays on QNN -- plus a WARNING in GetSupportedNodes
+// ("did not match any node ... check for a typo"). Here neither op is filtered off, so both Conv
+// and Softmax remain on QNN.
+TEST_F(QnnHTPBackendTests, EPFilterUnknownOpTypeIsIgnored) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_unknown_optype_graph");
+
+  // Nothing is filtered -> both ops stay on QNN.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kQnnExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "Softmaxx";  // typo: matches no node -> no-op + WARNING
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Edge case: op type matching is case-sensitive (documented behavior). "softmax" (lowercase) must
+// NOT match the "Softmax" node, so the filter is a no-op and both ops stay on QNN.
+TEST_F(QnnHTPBackendTests, EPFilterOpTypeMatchIsCaseSensitive) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_case_sensitive_graph");
+
+  // "softmax" != "Softmax" -> nothing filtered -> both ops stay on QNN.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kQnnExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "softmax";  // lowercase -> case-sensitive miss -> no-op
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Edge case: a config file path that does not exist. The parser logs a WARNING and leaves the
+// filter disabled (default exclude + empty list), so the option is a no-op and every op stays on
+// QNN. Uses a path under the temp dir that we assert does not exist.
+TEST_F(QnnHTPBackendTests, EPFilterConfigFileNotFoundFallsBackToDefault) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_configfile_missing_graph");
+
+  // Parse fails -> filter disabled -> both ops stay on QNN.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kQnnExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  const std::filesystem::path missing_path =
+      std::filesystem::temp_directory_path() / "ort_qnn_op_affinity_does_not_exist.json";
+  std::filesystem::remove(missing_path);  // ensure it is absent
+  ASSERT_FALSE(std::filesystem::exists(missing_path));
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "@" + missing_path.string();  // nonexistent -> WARNING + no-op
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// Edge case: include mode with an empty op-type list ("include:"). Since ONLY listed op types may
+// stay on QNN and the list is empty, EVERY op is forced to fall back to the CPU EP (logged at
+// WARNING in OnnxOpAffinity). Both Conv and Softmax must land on CPU.
+TEST_F(QnnHTPBackendTests, EPFilterIncludeEmptyForcesAllOff) {
+  auto model_build_fn = MakeConvSoftmaxBuilder("ep_filter_include_empty_graph");
+
+  // include + empty list -> everything falls back to CPU.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kCpuExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["op_affinity"] = "include:";  // empty list -> all ops off QNN + WARNING
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  provider_options["enable_htp_fp16_precision"] = "1";
+
+  // Everything falls back to CPU -> no node lands on QNN.
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::None, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
+}
+
+// N-2: op_affinity combined with session.disable_cpu_ep_fallback. When a filtered-off op
+// has no other EP to run on and CPU fallback is disabled, session creation must fail. The conflict
+// itself is enforced by the ORT framework (not the QNN EP): once the filter keeps Softmax off QNN,
+// it is assigned to the default CPU EP, which the framework then rejects because fallback is off.
+TEST_F(QnnHTPBackendTests, TestDisableCPUFallback_OpTypeToFilterForcesFallback) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  // Conv -> Softmax, both QNN(HTP)-supported. Filtering Softmax off QNN leaves it on the default
+  // CPU EP; with fallback disabled the session must throw.
+  auto model_func = [](ModelTestBuilder& builder) {
+    builder.graph_->set_name("op_affinity_fallback_conflict");
+    builder.MakeInput<float>("input1", std::vector<int64_t>{1, 2, 8, 8},
+                             GetFloatDataInRange(0.0f, 1.0f, 128));
+    builder.MakeInitializer<float>("weight", std::vector<int64_t>{2, 2, 2, 2},
+                                   GetFloatDataInRange(-0.3f, 0.3f, 16));
+    builder.MakeInitializer<float>("bias", std::vector<int64_t>{2}, {0.0f, 1.0f});
+    builder.AddNode("Conv", "Conv", {"input1", "weight", "bias"}, {"conv_output"}, kOnnxDomain);
+    builder.AddNode("Softmax", "Softmax", {"conv_output"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 19}, {kMSDomain, 1}};
+  ModelTestBuilder helper;
+  model_func(helper);
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+
+  Ort::SessionOptions so;
+  so.AddConfigEntry(kOrtSessionOptionsDisableCPUEPFallback, "1");  // Disable fallback to the CPU EP.
+
+  ProviderOptions options;
+  options["backend_type"] = "htp";
+#if defined(__linux__) && !defined(__aarch64__)
+  options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+  options["offload_graph_io_quantization"] = "0";
+  options["enable_htp_fp16_precision"] = "1";
+  options["op_affinity"] = "Softmax";  // force Softmax off QNN -> lands on CPU EP
+
+  RegisteredEpDeviceUniquePtr registered_ep_device;
+  RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, options);
+
+  try {
+    Ort::Session session(*ort_env, model_data.data(), model_data.size(), so);
+    FAIL();  // Should not get here!
+  } catch (const Ort::Exception& excpt) {
+    ASSERT_EQ(excpt.GetOrtErrorCode(), ORT_FAIL);
+    ASSERT_THAT(excpt.what(), testing::HasSubstr("This session contains graph nodes that are assigned to the default "
+                                                 "CPU EP, but fallback to CPU EP has been explicitly disabled by "
+                                                 "the user."));
+  }
+}
+
 TEST_F(QnnHTPBackendTests, DumpJsonQNNGraph) {
   const ORTCHAR_T* ort_model_path = ORT_MODEL_FOLDER "nhwc_resize_sizes_opset18.quant.onnx";
   ProviderOptions options;
@@ -1977,6 +2406,31 @@ TEST_F(QnnGPUBackendTests, CosineSimilarityVerifier) {
                   options,
                   13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, CosineSimilarityVerifier(0.99f)});
+}
+
+// op_affinity is documented as EP-wide (works with any backend_type), but its integration tests
+// otherwise all live under QnnHTPBackendTests. Exercise the GPU backend directly so a backend-name
+// drift bug (e.g. the known-backend-name check falling out of sync with the runtime's backend-type
+// strings) would fail CI on GPU, not just be caught by synthetic backend-scope unit tests.
+TEST_F(QnnGPUBackendTests, EPFilterExcludesOpType) {
+  // Conv -> Softmax, both float32 (unquantized) and both QNN(GPU)-supported.
+  auto model_build_fn = MakeConvSoftmaxBuilder("gpu_ep_filter_exclude_graph");
+
+  // Softmax was filtered off via op_affinity (exclude) -> must be on CPU EP; Conv stays on QNN.
+  std::function<void(const Ort::Session&)> ep_graph_checker =
+      MakeOpAssignmentChecker({{"Softmax", kCpuExecutionProvider}, {"Conv", kQnnExecutionProvider}});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "gpu";
+  provider_options["op_affinity"] = "gpu:exclude:Softmax";  // scoped to gpu -> applies this session
+
+  RunQnnModelTest(model_build_fn,
+                  provider_options,
+                  /*opset*/ 19,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(1e-3f),
+                                       &ep_graph_checker},
+                  OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                  /*verify_output*/ true);
 }
 
 // Returns true if QNN EP was created and QNN HTP shared memory allocator is available, false otherwise.

--- a/onnxruntime/test/providers/qnn/unit/qnn_onnx_op_affinity_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_onnx_op_affinity_test.cc
@@ -1,0 +1,525 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Function-level unit tests for OnnxOpAffinity (qnn_onnx_op_affinity.cc) and the
+// utils::TrimWhitespace helper it relies on (builder/qnn_utils.h).
+//
+// OnnxOpAffinity is pure policy logic: it parses the op_affinity provider
+// option (inline spec or "@<path>" JSON config file) and decides whether a node
+// group's target op is kept off QNN. It touches no QNN API, so it is exercised
+// entirely on the host with fake OrtNode pointers -- no device, no session.
+//
+// ShouldFilterOff() takes an OrtNodeUnit and a QnnBackendType (the session's
+// backend). It reads only OpType(), which routes through the global Ort::GetApi().
+// Tests therefore build a single-node OrtNodeUnit via stub OrtApi function
+// pointers and install OrtGlobalApiOverride so OpType() resolves through the same
+// stub (see qnn_unit_test_utils.h); the backend is passed in directly.
+
+#include "gtest/gtest.h"
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/qnn_onnx_op_affinity.h"
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+using qnn::OnnxOpAffinity;
+using qnn::QnnBackendType;
+
+// Default session backend used by ShouldFilterOff tests that are not about backend scoping.
+constexpr QnnBackendType kHtp = QnnBackendType::HTP;
+
+// ============================================================
+// OnnxOpAffinity::IsActive  (no OrtNodeUnit needed)
+// ============================================================
+
+TEST(QnnUnit_OnnxOpAffinityTest, IsActive_Default_False) {
+  OnnxOpAffinity filter;  // exclude + empty -> no filtering
+  EXPECT_FALSE(filter.IsActive());
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, IsActive_ExcludeEmptyList_False) {
+  OnnxOpAffinity filter("exclude:");  // exclude with no op types
+  EXPECT_FALSE(filter.IsActive());
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, IsActive_IncludeEmptyList_True) {
+  // include with an empty list is still active: it forces ALL ops off QNN.
+  OnnxOpAffinity filter("include:");
+  EXPECT_TRUE(filter.IsActive());
+}
+
+// ============================================================
+// OnnxOpAffinity config-file constructor
+// ============================================================
+
+namespace {
+
+// Writes `contents` to a uniquely-named temp file and returns the path. The file
+// is removed by RemoveTempFile() at the end of the test.
+std::filesystem::path WriteTempConfig(const std::string& stem, const std::string& contents) {
+  std::filesystem::path path = std::filesystem::temp_directory_path() / stem;
+  std::ofstream ofs(path);
+  ofs << contents;
+  ofs.close();
+  return path;
+}
+
+void RemoveTempFile(const std::filesystem::path& path) {
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+}
+
+}  // namespace
+
+TEST(QnnUnit_OnnxOpAffinityTest, ConfigFileCtor_MissingFile_Throws) {
+  const std::filesystem::path missing =
+      std::filesystem::temp_directory_path() / "qnn_onnx_op_affinity_does_not_exist.json";
+  RemoveTempFile(missing);  // ensure absent
+  EXPECT_THROW(OnnxOpAffinity{missing}, std::runtime_error);
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, ConfigFileCtor_MalformedJson_Throws) {
+  const std::filesystem::path path =
+      WriteTempConfig("qnn_onnx_op_affinity_malformed.json", "{ this is not json ");
+  EXPECT_ANY_THROW(OnnxOpAffinity{path});
+  RemoveTempFile(path);
+}
+
+// The config-file ctor validates every field's type/value loudly (D-1), matching the inline path's
+// error strategy instead of silently coercing a typo to a surprising default. FromOptionValue()
+// catches these throws and degrades the whole filter to inactive + WARNING.
+
+TEST(QnnUnit_OnnxOpAffinityTest, ConfigFileCtor_UnrecognizedMode_Throws) {
+  // "Include" (wrong case) / "excludes" (extra s) would silently become exclude without validation.
+  for (const char* bad_mode : {"Include", "excludes", "filter"}) {
+    const std::filesystem::path path = WriteTempConfig(
+        "qnn_onnx_op_affinity_bad_mode.json",
+        std::string(R"({ "mode": ")") + bad_mode + R"(", "op_types": ["Conv"] })");
+    EXPECT_THROW(OnnxOpAffinity{path}, std::runtime_error) << "mode=" << bad_mode;
+    RemoveTempFile(path);
+  }
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, ConfigFileCtor_NonStringBackend_Throws) {
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_bad_backend.json",
+      R"({ "backend": 123, "op_types": ["Conv"] })");
+  EXPECT_THROW(OnnxOpAffinity{path}, std::runtime_error);
+  RemoveTempFile(path);
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, ConfigFileCtor_NonArrayOpTypes_Throws) {
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_bad_optypes.json",
+      R"({ "mode": "exclude", "op_types": "Conv" })");
+  EXPECT_THROW(OnnxOpAffinity{path}, std::runtime_error);
+  RemoveTempFile(path);
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, ConfigFileCtor_NonStringOpTypeElement_Throws) {
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_bad_optype_elem.json",
+      R"({ "op_types": ["Conv", 123] })");
+  EXPECT_THROW(OnnxOpAffinity{path}, std::runtime_error);
+  RemoveTempFile(path);
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_UnrecognizedMode_DegradesToInactive) {
+  Ort::Logger logger = MakeNullLogger();
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_from_option_bad_mode.json",
+      R"({ "mode": "Include", "op_types": ["Conv"] })");
+  // The ctor throws on the bad mode; FromOptionValue catches and degrades to no filtering.
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("@" + path.string(), logger);
+  EXPECT_FALSE(filter.IsActive());
+  RemoveTempFile(path);
+}
+
+// ============================================================
+// OnnxOpAffinity::ShouldFilterOff -- fixture builds a single-node OrtNodeUnit
+// whose OpType() is configurable via g_fake_op_type.
+// ============================================================
+
+namespace {
+
+// Read by both InitForSingleNode (via the parameter OrtApi) and OrtNodeUnit::
+// OpType() (via the global OrtApi). gtest runs tests sequentially, so a single
+// process-wide string is safe.
+std::string g_fake_op_type = "Softmax";
+
+const OrtValueInfo* const kFakeIO =
+    reinterpret_cast<const OrtValueInfo*>(uintptr_t{0x1000});
+const OrtTypeInfo* const kFakeTypeInfo =
+    reinterpret_cast<const OrtTypeInfo*>(uintptr_t{0x2000});
+const OrtTensorTypeAndShapeInfo* const kFakeTensorShape =
+    reinterpret_cast<const OrtTensorTypeAndShapeInfo*>(uintptr_t{0x3000});
+const OrtNode* const kFakeNode =
+    reinterpret_cast<const OrtNode*>(uintptr_t{0x100});
+
+OrtStatus* StubOpType(const OrtNode*, const char** op) noexcept {
+  *op = g_fake_op_type.c_str();
+  return nullptr;
+}
+OrtStatus* StubNumInputs(const OrtNode*, size_t* n) noexcept {
+  *n = 1;
+  return nullptr;
+}
+OrtStatus* StubNumOutputs(const OrtNode*, size_t* n) noexcept {
+  *n = 1;
+  return nullptr;
+}
+OrtStatus* StubGetInputs(const OrtNode*, const OrtValueInfo** io, size_t) noexcept {
+  io[0] = kFakeIO;
+  return nullptr;
+}
+OrtStatus* StubGetOutputs(const OrtNode*, const OrtValueInfo** io, size_t) noexcept {
+  io[0] = kFakeIO;
+  return nullptr;
+}
+OrtStatus* StubValueInfoName(const OrtValueInfo*, const char** name) noexcept {
+  static const char n[] = "x";
+  *name = n;
+  return nullptr;
+}
+OrtStatus* StubValueInfoTypeInfo(const OrtValueInfo*, const OrtTypeInfo** ti) noexcept {
+  *ti = kFakeTypeInfo;
+  return nullptr;
+}
+OrtStatus* StubCastTensorInfo(const OrtTypeInfo*, const OrtTensorTypeAndShapeInfo** ts) noexcept {
+  *ts = kFakeTensorShape;
+  return nullptr;
+}
+OrtStatus* StubElemType(const OrtTensorTypeAndShapeInfo*, ONNXTensorElementDataType* t) noexcept {
+  *t = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  return nullptr;
+}
+bool StubHasShape(const OrtTensorTypeAndShapeInfo*) noexcept { return true; }
+OrtStatus* StubDimsCount(const OrtTensorTypeAndShapeInfo*, size_t* n) noexcept {
+  *n = 2;
+  return nullptr;
+}
+OrtStatus* StubDims(const OrtTensorTypeAndShapeInfo*, int64_t* dims, size_t) noexcept {
+  dims[0] = 3;
+  dims[1] = 4;
+  return nullptr;
+}
+
+// Builds an OrtApi sufficient to construct a single-node OrtNodeUnit for a plain
+// (non-QDQ) op and to answer OpType().
+OrtApi MakeSingleNodeApi() {
+  OrtApi api{};
+  api.Node_GetOperatorType = StubOpType;
+  api.Node_GetNumInputs = StubNumInputs;
+  api.Node_GetNumOutputs = StubNumOutputs;
+  api.Node_GetInputs = StubGetInputs;
+  api.Node_GetOutputs = StubGetOutputs;
+  api.GetValueInfoName = StubValueInfoName;
+  api.GetValueInfoTypeInfo = StubValueInfoTypeInfo;
+  api.CastTypeInfoToTensorInfo = StubCastTensorInfo;
+  api.GetTensorElementType = StubElemType;
+  api.TensorTypeAndShape_HasShape = StubHasShape;
+  api.GetDimensionsCount = StubDimsCount;
+  api.GetDimensions = StubDims;
+  return api;
+}
+
+}  // namespace
+
+class QnnUnit_OnnxOpAffinityShouldFilterOffTest : public ::testing::Test {
+ protected:
+  // Returns a single-node OrtNodeUnit whose OpType() == op_type. The global API
+  // override stays active for the whole test, so OpType() resolves through the
+  // stub during ShouldFilterOff().
+  OrtNodeUnit MakeNodeUnit(const std::string& op_type) {
+    g_fake_op_type = op_type;
+    return OrtNodeUnit(kFakeNode, api_);
+  }
+
+  OrtApi api_ = MakeSingleNodeApi();
+  OrtGlobalApiOverride override_{&api_};
+};
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Inactive_NeverFiltersOff) {
+  OnnxOpAffinity filter;  // default inactive
+  OrtNodeUnit unit = MakeNodeUnit("Softmax");
+  EXPECT_FALSE(filter.ShouldFilterOff(unit, kHtp));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Exclude_ListedOp_FilteredOff) {
+  OnnxOpAffinity filter("Softmax");  // exclude:Softmax
+  OrtNodeUnit unit = MakeNodeUnit("Softmax");
+  EXPECT_TRUE(filter.ShouldFilterOff(unit, kHtp));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Exclude_UnlistedOp_Kept) {
+  OnnxOpAffinity filter("Softmax");
+  OrtNodeUnit unit = MakeNodeUnit("Conv");  // not in the exclude list
+  EXPECT_FALSE(filter.ShouldFilterOff(unit, kHtp));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Include_ListedOp_Kept) {
+  OnnxOpAffinity filter("include:Conv");
+  OrtNodeUnit unit = MakeNodeUnit("Conv");  // in the include list -> stays on QNN
+  EXPECT_FALSE(filter.ShouldFilterOff(unit, kHtp));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Include_UnlistedOp_FilteredOff) {
+  OnnxOpAffinity filter("include:Conv");
+  OrtNodeUnit unit = MakeNodeUnit("Softmax");  // not in include list -> forced off
+  EXPECT_TRUE(filter.ShouldFilterOff(unit, kHtp));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Exclude_MatchIsCaseSensitive) {
+  OnnxOpAffinity filter("Softmax");
+  OrtNodeUnit unit = MakeNodeUnit("softmax");  // lowercase -> no match -> kept
+  EXPECT_FALSE(filter.ShouldFilterOff(unit, kHtp));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, IncludeEmpty_ForcesAllOff) {
+  OnnxOpAffinity filter("include:");  // empty include list -> every op filtered off
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Conv"), kHtp));
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), kHtp));
+}
+
+// A colon inside an op type (e.g. a UDO "custom:MyOp") must be preserved -- only
+// the exact "exclude"/"include" prefixes (and known backend names) are treated as
+// prefixes.
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, Exclude_UdoOpTypeWithColon_Preserved) {
+  OnnxOpAffinity filter("custom:MyOp");  // no mode/backend prefix -> literal op type
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("custom:MyOp"), kHtp));
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("MyOp"), kHtp));
+}
+
+// ============================================================
+// Backend scope (phase 1): a filter scoped to a backend applies only to that
+// backend's session; scoped to another backend it is inert.
+// ============================================================
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendScope_Inline_MatchingBackend_FiltersOff) {
+  OnnxOpAffinity filter("htp:exclude:Softmax");
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::HTP));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendScope_Inline_OtherBackend_Inert) {
+  OnnxOpAffinity filter("htp:exclude:Softmax");
+  // Same op, but the session runs GPU: the htp-scoped filter must not apply.
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::GPU));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendScope_Inline_DefaultsToExcludeMode) {
+  OnnxOpAffinity filter("htp:Softmax");  // backend prefix, no explicit mode -> exclude
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::HTP));
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("Conv"), QnnBackendType::HTP));
+}
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendScope_Unscoped_AppliesToAnyBackend) {
+  OnnxOpAffinity filter("exclude:Softmax");  // no backend scope
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::HTP));
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::GPU));
+}
+
+// AppliesToBackend is the single source of truth for "does this filter apply".
+TEST(QnnUnit_OnnxOpAffinityTest, AppliesToBackend_ScopedMatchesOnlyItsBackend) {
+  OnnxOpAffinity filter("htp:exclude:Softmax");
+  EXPECT_TRUE(filter.AppliesToBackend(QnnBackendType::HTP));
+  EXPECT_FALSE(filter.AppliesToBackend(QnnBackendType::GPU));
+  EXPECT_FALSE(filter.AppliesToBackend(QnnBackendType::CPU));
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, AppliesToBackend_UnscopedMatchesAll) {
+  OnnxOpAffinity filter("exclude:Softmax");
+  EXPECT_TRUE(filter.AppliesToBackend(QnnBackendType::HTP));
+  EXPECT_TRUE(filter.AppliesToBackend(QnnBackendType::GPU));
+  EXPECT_TRUE(filter.AppliesToBackend(QnnBackendType::CPU));
+}
+
+// Device-independent drift protection (D-2): iterate EVERY QnnBackendType enumerator and assert that a
+// filter scoped to that backend's own name (QnnBackendTypeToString) applies to it. This is the
+// counterpart to the backend-scope parsing SSOT -- IsKnownBackendName derives the accepted names from
+// QnnBackendTypeToString, and this test guarantees each of those names round-trips back to its own
+// enumerator through AppliesToBackend. Unlike the per-backend E2E tests it needs no device/driver, so
+// name drift in cpu/dsp/ir/htp_fp16 (the enumerators the E2E tests don't cover, or skip when hardware
+// is absent) can never slip through unnoticed. "ir" (== SERIALIZER, where the enum name and the string
+// differ most) is the case this most directly guards.
+TEST(QnnUnit_OnnxOpAffinityTest, AppliesToBackend_EveryBackendMatchesItsOwnName) {
+  for (uint8_t i = 0; i <= static_cast<uint8_t>(QnnBackendType::SERIALIZER); ++i) {
+    const auto backend = static_cast<QnnBackendType>(i);
+    const std::string name = qnn::QnnBackendTypeToString(backend);
+    OnnxOpAffinity filter(name + ":exclude:Softmax");
+    EXPECT_TRUE(filter.AppliesToBackend(backend))
+        << "filter scoped to '" << name << "' did not apply to its own backend (enum " << int{i}
+        << ") -- backend-name drift between QnnBackendTypeToString and the op_affinity scope parser.";
+  }
+}
+
+// Backend scope combined with include mode. On the matching backend, include semantics apply as
+// usual (listed ops stay on QNN, everything else is forced off).
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendScope_IncludeMode_MatchingBackend_Parsed) {
+  OnnxOpAffinity filter("htp:include:Conv");                                          // two prefixes: backend then mode
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("Conv"), QnnBackendType::HTP));    // in list -> kept
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::HTP));  // not in list -> off
+}
+
+// Backend gate must win over include's aggressive "force everything not-listed off" behavior: on a
+// non-matching backend the whole filter is inert, so it must NOT push any op off QNN. This guards
+// the early-return-before-include-logic ordering in ShouldFilterOff().
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendScope_IncludeMode_OtherBackend_Inert) {
+  OnnxOpAffinity filter("htp:include:Conv");
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::GPU));  // NOT forced off
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("Conv"), QnnBackendType::GPU));
+}
+
+// Backend prefixes are matched case-sensitively (like mode prefixes). "HTP:" is not a recognized
+// backend name, so it is not treated as a scope; the whole value becomes a single literal op type
+// "HTP:exclude:Softmax" (colons inside a token are legal, per the UDO rule). The filter therefore
+// has no backend scope (applies to any backend) but only matches that exact odd op-type string.
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, BackendPrefix_IsCaseSensitive) {
+  OnnxOpAffinity filter("HTP:exclude:Softmax");
+  EXPECT_TRUE(filter.AppliesToBackend(QnnBackendType::HTP));                                      // no scope parsed
+  EXPECT_FALSE(filter.ShouldFilterOff(MakeNodeUnit("Softmax"), QnnBackendType::HTP));             // plain Softmax not matched
+  EXPECT_TRUE(filter.ShouldFilterOff(MakeNodeUnit("HTP:exclude:Softmax"), QnnBackendType::HTP));  // literal token
+}
+
+// ============================================================
+// OnnxOpAffinity::FromOptionValue -- degrade-not-throw on bad input (needs logger)
+// ============================================================
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_Empty_ReturnsInactive) {
+  Ort::Logger logger = MakeNullLogger();
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("", logger);
+  EXPECT_FALSE(filter.IsActive());
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_Inline_ParsesActive) {
+  Ort::Logger logger = MakeNullLogger();
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("Softmax", logger);
+  EXPECT_TRUE(filter.IsActive());
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_MissingConfigFile_DegradesToInactive) {
+  Ort::Logger logger = MakeNullLogger();
+  const std::filesystem::path missing =
+      std::filesystem::temp_directory_path() / "qnn_onnx_op_affinity_from_option_missing.json";
+  RemoveTempFile(missing);
+  // "@<missing>" makes the config-file ctor throw; FromOptionValue catches and
+  // returns an inactive filter rather than propagating.
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("@" + missing.string(), logger);
+  EXPECT_FALSE(filter.IsActive());
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_ValidConfigFile_ParsesActive) {
+  Ort::Logger logger = MakeNullLogger();
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_from_option_valid.json",
+      R"({ "mode": "include", "op_types": ["Conv"] })");
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("@" + path.string(), logger);
+  EXPECT_TRUE(filter.IsActive());
+  RemoveTempFile(path);
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_ConfigFileBackendScope_AppliesToScopedBackend) {
+  Ort::Logger logger = MakeNullLogger();
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_backend_scope.json",
+      R"({ "backend": "htp", "mode": "exclude", "op_types": ["Softmax"] })");
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("@" + path.string(), logger);
+  EXPECT_TRUE(filter.IsActive());
+  EXPECT_TRUE(filter.AppliesToBackend(QnnBackendType::HTP));
+  EXPECT_FALSE(filter.AppliesToBackend(QnnBackendType::GPU));
+  RemoveTempFile(path);
+}
+
+// Phase-2 syntax ("OpType[name=...]") is reserved but not implemented in phase 1: it must degrade
+// the whole filter to inactive (a loud rejection via WARNING), not silently strip the qualifier.
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_Inline_PhaseTwoNameSyntax_DegradesToInactive) {
+  Ort::Logger logger = MakeNullLogger();
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("htp:exclude:GroupQueryAttention[name=gqa_12]", logger);
+  EXPECT_FALSE(filter.IsActive());
+}
+
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_ConfigFile_PhaseTwoNameSyntax_DegradesToInactive) {
+  Ort::Logger logger = MakeNullLogger();
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_phase2_name.json",
+      R"({ "mode": "exclude", "op_types": ["GroupQueryAttention[name=gqa_12]"] })");
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("@" + path.string(), logger);
+  EXPECT_FALSE(filter.IsActive());
+  RemoveTempFile(path);
+}
+
+// An unknown backend name in a config "backend" key is kept as a scope, so the filter is
+// configured but applies to no real backend -- FromOptionValue warns (suppressed here) and does not
+// crash. (Inline, an unrecognized "word:" prefix is instead absorbed into the op-type list, same as
+// a UDO colon, so this typo path is only reachable via the explicit config "backend" key.)
+TEST(QnnUnit_OnnxOpAffinityTest, FromOptionValue_UnknownBackendScope_AppliesToNothing) {
+  Ort::Logger logger = MakeNullLogger();
+  const std::filesystem::path path = WriteTempConfig(
+      "qnn_onnx_op_affinity_unknown_backend.json",
+      R"({ "backend": "hpt", "mode": "exclude", "op_types": ["Softmax"] })");  // "hpt" typo
+  OnnxOpAffinity filter = OnnxOpAffinity::FromOptionValue("@" + path.string(), logger);
+  EXPECT_FALSE(filter.AppliesToBackend(QnnBackendType::HTP));
+  EXPECT_FALSE(filter.AppliesToBackend(QnnBackendType::GPU));
+  RemoveTempFile(path);
+}
+
+// ============================================================
+// OnnxOpAffinity::WarnUnmatchedEntries -- must not crash with the null logger;
+// exercises both the matched (no warning) and unmatched (warning) branches.
+// ============================================================
+
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, WarnUnmatchedEntries_RunsAfterMatching) {
+  Ort::Logger logger = MakeNullLogger();
+  OnnxOpAffinity filter("exclude:Softmax,Typoo");
+  // "Softmax" matches a node; "Typoo" never does.
+  filter.ShouldFilterOff(MakeNodeUnit("Softmax"), kHtp);
+  filter.WarnUnmatchedEntries(kHtp, logger);  // "Typoo" -> WARNING (suppressed by null logger)
+  SUCCEED();
+}
+
+// A backend-scoped filter used on a different-backend session logs a single INFO and does not
+// emit per-entry typo warnings (nothing matched because of the backend, not a typo). Just exercise
+// the path with the null logger to confirm it does not crash and takes the early-return branch.
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, WarnUnmatchedEntries_BackendMismatch_NoCrash) {
+  Ort::Logger logger = MakeNullLogger();
+  OnnxOpAffinity filter("htp:exclude:Softmax");
+  // Session runs GPU; nothing was ever matched. Must not warn about "Softmax" as a typo.
+  filter.WarnUnmatchedEntries(QnnBackendType::GPU, logger);
+  SUCCEED();
+}
+
+// GetSupportedNodes (and thus WarnUnmatchedEntries) runs multiple times per session in practice --
+// ORT's partitioner calls GetCapabilityImpl twice per graph, and once per SoC in a multi-SoC session.
+// WarnUnmatchedEntries() must clear matched_op_types_ so a match recorded in one call does not leak
+// into the next call's typo check, and conversely an entry that only matches in a later call must not
+// be penalized for having gone unmatched in an earlier one. Exercised here as a no-crash smoke test
+// (this test file has no log-capturing infra to assert on which specific entries warn); the class
+// invariant itself is documented on WarnUnmatchedEntries() in qnn_onnx_op_affinity.h.
+TEST_F(QnnUnit_OnnxOpAffinityShouldFilterOffTest, WarnUnmatchedEntries_AcrossMultipleGetSupportedNodesCalls) {
+  Ort::Logger logger = MakeNullLogger();
+  OnnxOpAffinity filter("exclude:Softmax,Conv");
+
+  // First "GetSupportedNodes" pass: only Softmax appears in this subgraph/SoC.
+  filter.ShouldFilterOff(MakeNodeUnit("Softmax"), kHtp);
+  filter.WarnUnmatchedEntries(kHtp, logger);  // "Conv" unmatched here -> WARNING (suppressed)
+
+  // Second pass: only Conv appears. Must not still think Softmax is unmatched (it isn't checked
+  // again since it already logged), and must correctly find Conv now matched -> no WARNING for it.
+  filter.ShouldFilterOff(MakeNodeUnit("Conv"), kHtp);
+  filter.WarnUnmatchedEntries(kHtp, logger);
+  SUCCEED();
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
@@ -1401,6 +1401,29 @@ TEST(QnnUnit_UtilsTest, ConvertBlockQuantScalesToLpbq_UnsupportedBitwdithReturns
   EXPECT_FALSE(st.IsOK());
 }
 
+// =============================================================================
+// qnn::utils::TrimWhitespace(std::string_view)
+// =============================================================================
+
+TEST(QnnUnit_UtilsTest, TrimWhitespace_NoWhitespace_Unchanged) {
+  EXPECT_EQ(qnn::utils::TrimWhitespace("Softmax"), "Softmax");
+}
+
+TEST(QnnUnit_UtilsTest, TrimWhitespace_LeadingAndTrailing_Stripped) {
+  EXPECT_EQ(qnn::utils::TrimWhitespace("  Softmax  "), "Softmax");
+  EXPECT_EQ(qnn::utils::TrimWhitespace("\t\r\nSoftmax\n\r\t"), "Softmax");
+}
+
+TEST(QnnUnit_UtilsTest, TrimWhitespace_InnerWhitespace_Preserved) {
+  // Only the ends are trimmed; interior spacing is left intact.
+  EXPECT_EQ(qnn::utils::TrimWhitespace("  a b  "), "a b");
+}
+
+TEST(QnnUnit_UtilsTest, TrimWhitespace_EmptyOrAllWhitespace_ReturnsEmpty) {
+  EXPECT_EQ(qnn::utils::TrimWhitespace(""), "");
+  EXPECT_EQ(qnn::utils::TrimWhitespace("   \t\r\n  "), "");
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
## Summary

Adds an `op_affinity` QNN provider option controlling which ONNX op types the QNN EP claims in `GetSupportedNodes`. Filtered-off ops fall back to another EP (typically the CPU EP).

**Modes:**
- `exclude` (default): all ops go to QNN *except* the listed types.
- `include`: *only* the listed types are claimed; every other op type falls back.

**Backend scope (optional):** prefix with a backend name (`cpu`/`gpu`/`htp`/`dsp`/`ir`, same strings as `backend_type`) to scope the whole filter to one backend, e.g. `"htp:exclude:GroupQueryAttention"`. A QNN EP session runs one backend, so scope is a single filter-wide constant. On a session running a different backend the filter is inert (logged once at INFO). `htp` and `htp_fp16` are aliases for the same physical backend, so either scope name matches a session running the other.

## Option format

- **Inline**: `"[backend:][mode:]<comma-separated op types>"`, e.g. `"htp:exclude:Softmax"`, `"include:Conv,MatMul"`, `"Softmax"` (≡ `"exclude:Softmax"`). No spaces; exact, case-sensitive match. Only exact `backend:`/`exclude:`/`include:` words are treated as prefixes, so a UDO op type may itself contain a colon (`custom:MyOp`).
- **Config file**: `"@<path>"` to JSON `{ "backend": "htp", "mode": "exclude"|"include", "op_types": [...] }` (`backend` optional, JSONC comments allowed).

## Error handling

Errors are handled uniformly and loudly, then degrade to "no filtering" (a WARNING) rather than failing session creation:

- Unopenable / malformed config file.
- Config file with a wrong-typed or invalid field: non-string `backend`, `mode` that is neither `"exclude"` nor `"include"` (e.g. `"Include"`, `"excludes"`), non-array `op_types`, or a non-string element inside `op_types`.
- Unknown backend scope name (the filter can never match a real session).
- The reserved `OpType[name=...]` per-node qualifier (see follow-ups) — supplying it now degrades the whole filter to inactive.

An op type in the list that matches no node in the graph is reported per-graph with a WARNING (typically a typo). If the filter is scoped to a backend the session isn't running, those per-entry warnings are suppressed in favor of one INFO line explaining the filter was skipped.

If `op_affinity` is active and `session.disable_cpu_ep_fallback` is set, a WARNING is logged at construction (session creation will fail later if a filtered-off op has no other EP to run on).

## Changes

- **`qnn_onnx_op_affinity.{h,cc}`** (new): `qnn::OnnxOpAffinity` encapsulates parsing, the exclude/include policy, the optional backend scope, and diagnostics. `FromOptionValue()` is the single entry point (degrade-not-throw); `AppliesToBackend()` gates the whole filter for the session backend; `ShouldFilterOff(OrtNodeUnit, QnnBackendType)` applies the decision per node group; `WarnUnmatchedEntries()` is the typo guard. Backend scope is stored as the backend-name string and compared against `QnnBackendTypeToString` (the single source of truth for recognized names, so parsing and matching can't drift).
- **`qnn_execution_provider.{cc,h}`**: build one `OnnxOpAffinity` from the option and call `ShouldFilterOff` per node group in `GetSupportedNodes`, passing the session backend. Filtered-off nodes are tagged in the framework op trace as intentional (via a shared `AppendUnsupportedNodesForGroup` helper). Adds the `disable_cpu_ep_fallback` warning above.
- **Tests**:
  - `unit/qnn_onnx_op_affinity_test.cc` — host-side function tests (no device): `IsActive`, config-file constructor validation (missing/malformed/bad-field), `ShouldFilterOff` across exclude/include × backend match/mismatch, case-sensitive op and prefix matching, UDO colon preservation, `FromOptionValue` degrade paths, phase-2 syntax rejection, unknown backend, `WarnUnmatchedEntries` across multiple `GetSupportedNodes` calls, and a **device-independent tripwire** (`AppliesToBackend_EveryBackendMatchesItsOwnName`) that iterates every `QnnBackendType` enumerator to catch backend-name drift.
  - `qnn_basic_test.cc` — `QnnHTPBackendTests` end-to-end EP-assignment over `Conv → Softmax`: exclude/include, backend-scope match/mismatch, config-file exclude/include, unknown-op-type ignored, case-sensitive, config-not-found fallback, include-empty-forces-all-off, and `disable_cpu_ep_fallback` interaction. One `QnnGPUBackendTests` exclude test guards the non-HTP path.
- **`QNN-ExecutionProvider.md`**: documents the option in the provider-option table and an `OP Affinity - Details` section (matching examples, backend-scope mismatch, empty-list/default, `disable_cpu_ep_fallback` interaction, reserved syntax).

## Notes / follow-ups
- Phase 2 (`OpType[name=...]` per-node filtering) and an EP-built-in default filter are separate, later PRs. The `[` syntax is frozen now so phase-1 specs stay forward-compatible; users will be able to dump the EP-side graph to discover the post-transform node names to target.
