### PR TITLE
[CI] Fix nightly workflow ghost runs on push events

### DIFF
--- a/.github/workflows/qualcomm-internal-release-nightly.yml
+++ b/.github/workflows/qualcomm-internal-release-nightly.yml
@@ -41,9 +41,9 @@ jobs:
   coverage:
     name: Per-File Coverage Tracking
     needs: setup
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/qualcomm-internal-coverage.yml
     secrets: inherit
-    continue-on-error: true
     with:
       nightly_coverage: true
       qa_tag: ${{ needs.setup.outputs.qa_tag }}


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the coverage caller job in `qualcomm-internal-release-nightly.yml`
- Replace with `if: ${{ !cancelled() }}` to preserve "run even if setup fails" behavior

## Root Cause
GitHub Actions does not support `continue-on-error` on reusable workflow caller jobs (`uses:`). The unsupported key causes the push-event schema validator to create ghost "workflow file issue" runs (0s duration, immediate failure) for every push to any branch — even though the nightly workflow only has a `schedule` trigger.

This regression was introduced in #527.

## Trade-off
If the coverage job itself fails, the nightly workflow will now show as failed (previously masked by `continue-on-error`). Artifact publishing is unaffected since `coverage` and `publish-artifacts` are parallel jobs.

## Test plan
- [x] Push this branch and verify no ghost run is created for `qualcomm-internal-release-nightly.yml`
- [ ] Verify next scheduled nightly run still succeeds with coverage job

🤖 Generated with [Claude Code](https://claude.com/claude-code)