### PR TITLE
[CI] Fix nightly failure: drop unused pull-requests:write from coverage workflow

### DIFF
--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -112,6 +112,13 @@ jobs:
       - name: Set up JFrog CLI
         if: inputs.nightly_coverage && steps.gate.outputs.run == 'true' && !cancelled()
         uses: jfrog/setup-jfrog-cli@v5
+        with:
+          # We only use `jf rt upload` for the coverage Excel; we never collect build-info.
+          # The token lacks build-info publish rights, so the action's default post-job
+          # build-publish (and its build-info-based job summary) fail with harmless warnings.
+          # Disable both since we don't produce build-info in the first place.
+          disable-auto-build-publish: true
+          disable-job-summary: true
         env:
           JF_URL: ${{ secrets.BUILD_ARTIFACTORY_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.BUILD_ARTIFACTORY_TOKEN }}

--- a/.github/workflows/qualcomm-internal-coverage.yml
+++ b/.github/workflows/qualcomm-internal-coverage.yml
@@ -6,7 +6,9 @@ name: Qualcomm Internal Coverage
 permissions:
   contents: read
   checks: write
-  pull-requests: write
+  # pull-requests: write is only needed by the "Post Diff Coverage to PR" step, which is
+  # currently disabled (if: false). Requesting it here breaks callers that don't grant it
+  # (e.g. the nightly release workflow). Re-add it when that step is re-enabled.
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary
- Remove `pull-requests: write` from `qualcomm-internal-coverage.yml`'s workflow-level permissions
- Add a comment explaining when to re-add it

## Root Cause
The scheduled nightly (`qualcomm-internal-release-nightly.yml`) fails validation:

```
Error calling workflow 'qualcomm-internal-coverage.yml': The workflow is
requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```

A reusable workflow cannot be granted more permissions than its caller. The nightly workflow does not grant `pull-requests`, but the coverage workflow declared `pull-requests: write`.

That permission's only consumer is the **"Post Diff Coverage to PR"** step, which is currently hard-disabled (`if: false`, pending pipeline stabilization). So the permission was declared but unused.

This failure surfaced only after #600 fixed the earlier ghost-run (invalid-file) issue — the invalid file previously short-circuited validation before it reached the permission check.

## Why this is safe
- The only step needing `pull-requests: write` is disabled (`if: false`)
- CI caller (`qualcomm-internal-ci.yml`) grants `pull-requests: write` at its own level; removing it from the callee just leaves that grant unused — no behavior change for PR CI
- Nightly caller now validates because the callee no longer requests a permission the caller doesn't have

## Follow-up
When re-enabling the "Post Diff Coverage to PR" step, re-add `pull-requests: write` — and note that nightly has no PR context, so the permission should be scoped to the PR/CI path.

## Test plan
- [ ] Verify next scheduled nightly passes workflow validation (no "Invalid workflow file" error)
- [ ] Verify PR CI coverage job still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)