### PR TITLE
[BQ] Extend HTP native BQ to MatMulNBits and refine Conv path

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -401,7 +401,7 @@ Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                          std::vector<std::string>& input_names,
                                          bool do_op_validation) const {
   const auto& inputs = node_unit.Inputs();
-  assert(inputs.size() >= 2);
+  RETURN_IF_NOT(inputs.size() >= 2, "Expecting at least two inputs.");
 
   std::vector<uint32_t> input0_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[0].shape, input0_shape),
@@ -426,7 +426,7 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   OnnxConvType conv_type = {};
   RETURN_IF_ERROR(GetOnnxConvType(node_unit.OpType(), conv_type));
 
-  assert(num_inputs >= 2);  // Checked by IsOpSupported.
+  RETURN_IF_NOT(num_inputs >= 2, "Expecting at least two inputs.");  // Checked by IsOpSupported.
 
   //
   // Input 0
@@ -486,8 +486,8 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
                                ? "weight quant params not LPBQ (enable_block_quant_weight_optimization=0, non-INT4, or asymmetric ZP)"
                                : "unknown";
       ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Conv weight encoding: BW_FLOAT_BLOCK for " + input1_name +
-                   " [LPBQ skipped: " + reason + "]")
+                  ("Conv weight encoding: non-LPBQ block-quant path for " + input1_name +
+                   " [LPBQ skipped: " + reason + "] — native BQ (BLOCK) vs BW_FLOAT_BLOCK is decided below")
                       .c_str());
     }
   }
@@ -495,15 +495,10 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
   if (is_bq_weight && !use_lpbq_path) {
     RETURN_IF_NOT(input_info.is_initializer, "QNN EP: BQ Conv weight must be a constant initializer");
 
-    // Activation handling: BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via Dequantize.
-    if (utils::IsQuant16bit(act_dtype)) {
-      // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
-      // stays aligned with the ONNX graph naming.
-      const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
-      RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper, act_name,
-                                                             fp16_act_name, do_op_validation, "Conv"));
-      input_names[0] = fp16_act_name;
-    }
+    // Activation handling: the non-native BQ kernel (BW_FLOAT_BLOCK) requires FP16, so INT16 → FP16 via
+    // Dequantize. The native BQ kernel (ENCODING_BLOCK) consumes INT16 directly and needs no Dequantize.
+    // The insertion is deferred until the offsets are known, since offset symmetry is one of the
+    // native-BQ preconditions checked by bq::IsHTPSupportedNativeBQ below.
 
     // Common: transpose weight data from OIHW→HWIO (or IOHW→HWIO for ConvTranspose).
     // TransposeFromNchwToHwcn unpacks INT4 to INT8 internally (1 byte per element).
@@ -557,10 +552,51 @@ Ort::Status ConvOpBuilder::ProcessConv2D3DInputs(QnnModelWrapper& qnn_model_wrap
     RETURN_IF_ERROR(bq::ComputeBQOffsets(qnn_model_wrapper, inputs[1].quant_param->zero_point,
                                          is_unsigned_weight, bitwidth, OC * nb, offsets_qnn));
 
-    QnnQuantParamsWrapper bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
-                                                                                gsl::span<const float>(offsets_qnn),
-                                                                                bitwidth,
-                                                                                gsl::span<const uint32_t>(block_size_arr));
+    // Prefer the HTP native BQ kernel (QNN_QUANTIZATION_ENCODING_BLOCK) when the BQ parameters satisfy its
+    // constraints: it consumes the INT16 activation and produces an INT16 output directly, avoiding the
+    // INT16→FP16 activation Dequantize and FP16→INT16 output Quantize that BW_FLOAT_BLOCK requires.
+    // Restricted to the bias-less case (num_inputs < 3): with a bias present the BW_FLOAT_BLOCK path also
+    // dequantizes the INT32 bias to FP16 (see ProcessConv2D3DBias), which the native kernel does not expect.
+    const bool is_supported_native_bq = num_inputs < 3 &&
+                                        bq::IsHTPSupportedNativeBQ(qnn_model_wrapper.GetHtpArch(),
+                                                                   act_dtype,
+                                                                   bitwidth,
+                                                                   static_cast<uint32_t>(block_size),
+                                                                   static_cast<uint32_t>(OC),
+                                                                   gsl::span<const float>(offsets_qnn));
+
+    QnnQuantParamsWrapper bq_quant_params;
+    if (is_supported_native_bq) {
+      // Native BQ requires symmetric quantization; IsHTPSupportedNativeBQ has verified all offsets are zero.
+      const std::vector<int32_t> offsets_sym(offsets_qnn.size(), 0);
+      bq_quant_params = QnnQuantParamsWrapper::Block(gsl::span<const float>(scales_qnn),
+                                                     gsl::span<const int32_t>(offsets_sym),
+                                                     gsl::span<const uint32_t>(block_size_arr));
+      ORT_CXX_LOG(logger,
+                  ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Conv weight encoding: native BQ (BLOCK) for " + input1_name).c_str());
+    } else {
+      bq_quant_params = QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>(scales_qnn),
+                                                            gsl::span<const float>(offsets_qnn),
+                                                            bitwidth,
+                                                            gsl::span<const uint32_t>(block_size_arr));
+      ORT_CXX_LOG(logger,
+                  ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Conv weight encoding: BW_FLOAT_BLOCK for " + input1_name).c_str());
+
+      // Non-native BQ kernel computes in FP16, so dequantize the INT16 activation first.
+      if (utils::IsQuant16bit(act_dtype)) {
+        // Reuse the original DequantizeLinear output name for the FP16 tensor so the QNN graph
+        // stays aligned with the ONNX graph naming.
+        const std::string fp16_act_name = Ort::ConstNode(&node_unit.GetNode()).GetInputs()[0].GetName();
+        RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper,
+                                                               act_name,
+                                                               fp16_act_name,
+                                                               do_op_validation,
+                                                               "Conv"));
+        input_names[0] = fp16_act_name;
+      }
+    }
 
     // Always use SFIXED_POINT_8: unsigned types are pre-converted by TransformUnsignedToSignedFixedPoint.
     QnnTensorWrapper bq_weight_wrapper(input1_name, tensor_type,
@@ -749,7 +785,7 @@ Ort::Status ConvOpBuilder::ProcessConv1DInputs(QnnModelWrapper& qnn_model_wrappe
   OnnxConvType conv_type = {};
   RETURN_IF_ERROR(GetOnnxConvType(node_unit.OpType(), conv_type));
 
-  assert(num_inputs >= 2);  // Checked by IsOpSupported.
+  RETURN_IF_NOT(num_inputs >= 2, "Expecting at least two inputs.");  // Checked by IsOpSupported.
 
   //
   // Input 0
@@ -1212,12 +1248,17 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
   RETURN_IF_ERROR(utils::GetQnnDataType(is_quantized_tensor, output_type, qnn_data_type));
 
-  // Detect BQ Conv from the weight tensor's quant encoding.
-  // BQ  (BW_FLOAT_BLOCK):       Conv outputs FP16 → need FP16 intermediate + Convert(FP16→INT16).
+  // Detect the non-native BQ Conv from the weight tensor's quant encoding.
+  // native BQ (BLOCK)             : Conv outputs INT16 → standard quantized output path.
+  // non-native BQ (BW_FLOAT_BLOCK): Conv outputs FP16 → need FP16 intermediate + Quantize(FP16→INT16).
+  // LPBQ (BLOCKWISE_EXPANSION)    : Conv outputs INT16 → standard quantized output path.
+  // NOTE: IsBlockQuantized() is true for both BLOCK and BW_FLOAT_BLOCK, so match the encoding directly.
   // input_names[1] is the weight — IsOpSupported guarantees Conv has >= 2 inputs.
-  bool is_bq_conv = false;
+  bool is_bw_float_block = false;
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1])) {
-    is_bq_conv = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized();
+    const auto& quant_params = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().Get();
+    is_bw_float_block = quant_params.encodingDefinition == QNN_DEFINITION_DEFINED &&
+                        quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK;
   }
 
   const auto& output_name = outputs[0].name;
@@ -1256,8 +1297,8 @@ Ort::Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
     Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
 
-    if (is_bq_conv && is_quantized_tensor) {
-      // BQ Conv outputs FP16; downstream QDQ expects INT16.
+    if (is_bw_float_block && is_quantized_tensor) {
+      // Non-native BQ Conv outputs FP16; downstream QDQ expects INT16.
       // Emit: Conv (FP16 output) → Quantize (FP16 → INT16 quantized output).
       // Reuse the original QuantizeLinear input name for the FP16 tensor so the QNN graph
       // stays aligned with the ONNX graph naming.

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <cassert>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -59,22 +58,32 @@ namespace qnn {
  * 1. Reshape
  *      in   Input     fp16/fp32/uint16/int16   [batch_size, sequence_len, K]
  *      out  Output    fp16/fp32/uint16/int16   [batch_size, 1, sequence_len, K]
- * 2a. Cast
+ * 2a. Cast (only when A is fp32)
  *      in   Input     fp32                     [batch_size, 1, sequence_len, K]
  *      out  Output    fp16                     [batch_size, 1, sequence_len, K]
- * 2b. Dequantize
+ * 2b. Dequantize (only when A is uint16/int16 and the weight is BW_FLOAT_BLOCK)
  *      in   Input     uint16/int16             [batch_size, 1, sequence_len, K]
  *      out  Output    fp16                     [batch_size, 1, sequence_len, K]
  * 3. Conv2d
  *      in   Input     fp16                     [batch_size, 1, sequence_len, K]
- *      in   Weight    qint8 (BwFloatBlock)     [1, 1, K, N]
- *                       scales   fp32          [N * (K / block_size)]
- *                       offsets  fp32          [N * (K / block_size)]
+ *                     uint16/int16               (LPBQ / native BQ)
+ *      in   Weight    qint8, one byte per element, transposed [N,K] -> [1, 1, K, N]
+ *                     (BLOCKWISE_EXPANSION)
+ *                       per-channel scales  fp32   [N]
+ *                       per-block scales    uint8  [N * (K / block_size)]
+ *                       offsets             int32  [N], all 0
+ *                     (BLOCK)
+ *                       scales              fp32   [N * (K / block_size)]
+ *                       offsets             int32  [N * (K / block_size)], all 0
+ *                     (BW_FLOAT_BLOCK)
+ *                       scales              fp32   [N * (K / block_size)]
+ *                       offsets             fp32   [N * (K / block_size)]
  *      out  Output    fp16                     [batch_size, 1, sequence_len, N]
- * 4a. Cast
+ *                     uint16/int16               (LPBQ / native BQ)
+ * 4a. Cast (only when Y is fp32)
  *      in   Input     fp16                     [batch_size, 1, sequence_len, N]
  *      out  Output    fp32                     [batch_size, 1, sequence_len, N]
- * 4b. Quantize
+ * 4b. Quantize (only when Y is uint16/int16 and the weight is BW_FLOAT_BLOCK)
  *      in   Input     fp16                     [batch_size, 1, sequence_len, N]
  *      out  Output    uint16/int16             [batch_size, 1, sequence_len, N]
  * 5. Reshape
@@ -287,7 +296,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
   const int64_t block_size = node_helper.Get("block_size", static_cast<int64_t>(0));
 
   // Should already be guaranteed in IsOpSupported.
-  assert(K > 0 && N > 0 && bits > 0 && block_size > 0);
+  RETURN_IF_NOT(K > 0 && N > 0 && bits > 0 && block_size > 0, "Unexpected MatMulNbits attribute values.");
 
   const int64_t num_elements_per_uint8 = kByteBits / bits;
   const int64_t num_zp_per_uint8 = K / block_size < num_elements_per_uint8 ? K / block_size : num_elements_per_uint8;
@@ -309,7 +318,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
       is_act_16bitquant = utils::IsQuant16bit(input_info.qnn_data_type);
 
       // Input A having 3D shape is guaranteed in IsOpSupported.
-      assert(input_info.shape.size() == 3);
+      RETURN_IF_NOT(input_info.shape.size() == 3, "Unexpected MatMulNBits input rank");
       std::vector<uint32_t> reshape_output_shape = {input_info.shape[0], 1, input_info.shape[1], input_info.shape[2]};
 
       const std::string reshape_output_name = utils::UniqueNameGenerator().New(input_names[0], "_reshape_4d");
@@ -474,12 +483,17 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
         }
 
         if (!used_lpbq) {
-          // BwFloatBlock (float block-quantized) path.
+          // Non-LPBQ block-quant path: native BQ (BLOCK) or BW_FLOAT_BLOCK, decided below.
           const char* reason = !is_act_16bitquant ? "activation not 16-bit quantized"
                                : bits != 4        ? "bits != 4 (LPBQ only supports INT4)"
                                : !zp_is_symmetric ? "zero-points not symmetric"
                                                   : "LPBQ conversion failed (enable_block_quant_weight_optimization=0)";
-          ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("MatMulNBits weight encoding: BW_FLOAT_BLOCK for " + weight_tensor_name + " [LPBQ skipped: " + reason + "]").c_str());
+          ORT_CXX_LOG(logger,
+                      ORT_LOGGING_LEVEL_VERBOSE,
+                      ("MatMulNBits weight encoding: non-LPBQ block-quant path for " + weight_tensor_name +
+                       " [LPBQ skipped: " + reason + "]")
+                          .c_str());
+
           // 2.5 Block-quantized offsets.
           std::vector<float> per_block_float_zp;
           if (inputs.size() > 3 && inputs[3].Exists()) {
@@ -502,19 +516,47 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
 
           // Note that unlike weights requiring transpose, scales/offsets are expected in original ONNX shape.
           const std::vector<uint32_t> block_sizes = {1, 1, gsl::narrow_cast<uint32_t>(block_size), 1};
-          quantize_param = QnnQuantParamsWrapper::BwFloatBlock(per_block_float_scale,
-                                                               per_block_float_zp,
-                                                               gsl::narrow_cast<uint32_t>(bits),
-                                                               block_sizes);
-          if (is_act_16bitquant) {
-            // 2.6 Add Dequantize to UINT16/INT16 → FP16.
-            const std::string fp16_act_name = utils::UniqueNameGenerator().New(input_names[0], "_dq_fp16");
-            RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper,
-                                                                   input_names[0],
-                                                                   fp16_act_name,
-                                                                   do_op_validation,
-                                                                   "MatMulNBits"));
-            input_names[0] = fp16_act_name;
+
+          // Prefer the HTP native BQ kernel (QNN_QUANTIZATION_ENCODING_BLOCK) when the BQ parameters satisfy
+          // its constraints: it consumes the INT16 activation and produces an INT16 output directly, avoiding
+          // the INT16→FP16 activation Dequantize and FP16→INT16 output Quantize that BW_FLOAT_BLOCK requires.
+          RETURN_IF_NOT(qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[0]),
+                        "Expecting MatMulNBits input tensor wrapper should already be constructed.");
+          const Qnn_DataType_t act_dtype = qnn_model_wrapper.GetQnnTensorWrapper(input_names[0]).GetTensorDataType();
+          const bool is_supported_native_bq = bq::IsHTPSupportedNativeBQ(qnn_model_wrapper.GetHtpArch(),
+                                                                         act_dtype,
+                                                                         gsl::narrow_cast<uint32_t>(bits),
+                                                                         gsl::narrow_cast<uint32_t>(block_size),
+                                                                         gsl::narrow_cast<uint32_t>(N),
+                                                                         per_block_float_zp);
+
+          if (is_supported_native_bq) {
+            // Native BQ requires symmetric quantization; IsHTPSupportedNativeBQ verified all offsets are zero.
+            const std::vector<int32_t> per_block_int32_zp(per_block_float_zp.size(), 0);
+            quantize_param = QnnQuantParamsWrapper::Block(per_block_float_scale,
+                                                          per_block_int32_zp,
+                                                          block_sizes);
+            ORT_CXX_LOG(logger,
+                        ORT_LOGGING_LEVEL_VERBOSE,
+                        ("MatMulNBits weight encoding: native BQ (BLOCK) for " + weight_tensor_name).c_str());
+          } else {
+            quantize_param = QnnQuantParamsWrapper::BwFloatBlock(per_block_float_scale,
+                                                                 per_block_float_zp,
+                                                                 gsl::narrow_cast<uint32_t>(bits),
+                                                                 block_sizes);
+            ORT_CXX_LOG(logger,
+                        ORT_LOGGING_LEVEL_VERBOSE,
+                        ("MatMulNBits weight encoding: BW_FLOAT_BLOCK for " + weight_tensor_name).c_str());
+            if (is_act_16bitquant) {
+              // 2.6 Add Dequantize to UINT16/INT16 → FP16 (only the non-native BQ kernel needs FP16 activation).
+              const std::string fp16_act_name = utils::UniqueNameGenerator().New(input_names[0], "_dq_fp16");
+              RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper,
+                                                                     input_names[0],
+                                                                     fp16_act_name,
+                                                                     do_op_validation,
+                                                                     "MatMulNBits"));
+              input_names[0] = fp16_act_name;
+            }
           }
         }
       }
@@ -637,21 +679,28 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                            param_tensor_names));
 
     // Input originally having 3D shape is guaranteed in IsOpSupported.
-    assert(output_info.shape.size() == 3);
+    RETURN_IF_NOT(output_info.shape.size() == 3, "Unexpected MatMulNBits output rank.");
     std::vector<uint32_t> conv2d_output_shape = {output_info.shape[0], 1, output_info.shape[1], output_info.shape[2]};
 
-    // Detect LPBQ from the registered weight tensor's quant encoding.
-    // For LPBQ, the Conv2D output uses the actual output data type (e.g., uint16/int16 for QDQ models).
-    // For BwFloatBlock, the Conv2D kernel always outputs FP16.
-    const bool is_lpbq = qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1]) &&
-                         qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsLPBQ();
-    const Qnn_DataType_t conv2d_output_dtype = is_lpbq ? output_info.qnn_data_type : QNN_DATATYPE_FLOAT_16;
+    // Determine the Conv2D output data type from the registered weight tensor's quant encoding.
+    // Only BW_FLOAT_BLOCK forces the kernel to compute in FP16; LPBQ (BLOCKWISE_EXPANSION) and native BQ
+    // (BLOCK) both produce the actual output data type (e.g. uint16/int16 for QDQ models) directly.
+    // NOTE: IsBlockQuantized() is true for both BLOCK and BW_FLOAT_BLOCK, so match the encoding directly.
+    bool is_bw_float_block = false;
+    if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1])) {
+      const auto& weight_quant_params = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().Get();
+      is_bw_float_block = weight_quant_params.encodingDefinition == QNN_DEFINITION_DEFINED &&
+                          weight_quant_params.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK;
+    }
+    const Qnn_DataType_t conv2d_output_dtype = is_bw_float_block ? QNN_DATATYPE_FLOAT_16 : output_info.qnn_data_type;
+    QnnQuantParamsWrapper conv2d_output_qparam = is_bw_float_block ? QnnQuantParamsWrapper()
+                                                                   : output_info.quant_param.Copy();
 
     const std::string conv2d_output_name = utils::UniqueNameGenerator().New(output_tensor.name, "_conv2d");
     QnnTensorWrapper conv2d_output_tensor_wrapper(conv2d_output_name,
                                                   QNN_TENSOR_TYPE_NATIVE,
                                                   conv2d_output_dtype,
-                                                  output_info.quant_param.Copy(),
+                                                  std::move(conv2d_output_qparam),
                                                   std::vector<uint32_t>(conv2d_output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(conv2d_output_tensor_wrapper)),
                   "Failed to add Conv2d output tensor.");
@@ -680,8 +729,8 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                     do_op_validation));
 
       reshape_input_name = cast_output_name;
-    } else if (utils::IsQuant16bit(output_info.qnn_data_type) && !is_lpbq) {
-      // 2. Add Quantize to FP16 → UINT16/INT16.
+    } else if (utils::IsQuant16bit(output_info.qnn_data_type) && is_bw_float_block) {
+      // 2. Add Quantize to FP16 → UINT16/INT16 (only needed when the kernel computed in FP16).
       const std::string q_suffix = output_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16 ? "_q_int16" : "_q_uint16";
       const std::string q_output_name = utils::UniqueNameGenerator().New(output_tensor.name, q_suffix);
       RETURN_IF_ERROR(bq::AddFp16ToInt16QuantizeOutput(qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -7,6 +7,12 @@
 #include <string_view>
 #include <vector>
 
+#include <gsl/gsl>
+
+#include "HTP/QnnHtpDeviceConfigShared.h"
+#include "QnnTypes.h"
+
+#include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/common/inlined_containers.h"
 
@@ -19,6 +25,12 @@ namespace {
 // the MatMulNBits HTP constraints).
 const InlinedHashMap<uint32_t, int64_t> kHtpBQBitsAndBlockSizeMultipliers{
     {2, 16}, {4, 8}, {8, 4}};
+
+// HTP native BQ constraints.
+const QnnHtpDevice_Arch_t kHtpNativeBQMinArch = QNN_HTP_DEVICE_ARCH_V81;
+const InlinedHashSet<uint32_t> kHtpNativeBQBits{4};
+const InlinedHashSet<uint32_t> kHtpNativeBQBlockSize{32, 64, 128};
+const uint32_t kHtpNativeBQChannelMultiplier = 32;
 }  // namespace
 
 namespace bq {
@@ -148,6 +160,59 @@ Ort::Status AddFp16ToInt16QuantizeOutput(QnnModelWrapper& qnn_model_wrapper,
                                            int16_tensor_type, int16_qnn_data_type,
                                            std::move(int16_quant_param),
                                            std::move(output_shape), do_op_validation);
+}
+
+bool IsHTPSupportedNativeBQ(QnnHtpDevice_Arch_t htp_arch,
+                            Qnn_DataType_t act_data_type,
+                            uint32_t bitwidth,
+                            uint32_t block_size,
+                            uint32_t output_channel,
+                            gsl::span<const float> offsets) {
+  // HTP native BQ constraints (subject to change):
+  // - min HTP arch: 81
+  // - activation data type: QNN_DATATYPE_UFIXED_POINT_16
+  // - weight bitwidth: 4 bit
+  // - symmetric quantization: offset=0
+  // - block size: 32, 64, 128
+  // - output channel: multiplier of 32
+
+  // HTP arch.
+  if (htp_arch < kHtpNativeBQMinArch) {
+    return false;
+  }
+
+  // Activation data type.
+  if (act_data_type != QNN_DATATYPE_UFIXED_POINT_16) {
+    return false;
+  }
+
+  // Weight bitwidth.
+  if (kHtpNativeBQBits.find(bitwidth) == kHtpNativeBQBits.end()) {
+    return false;
+  }
+
+  // Symmetric quantization.
+  for (float offset : offsets) {
+    if (offset != 0.0f) {
+      return false;
+    }
+  }
+
+  // Block size.
+  if (kHtpNativeBQBlockSize.find(block_size) == kHtpNativeBQBlockSize.end()) {
+    return false;
+  }
+
+  // Output channel.
+  if (output_channel % kHtpNativeBQChannelMultiplier != 0) {
+    return false;
+  }
+
+#ifdef QNN_HTP_NATIVE_BQ_AVAILABLE
+  return true;
+#else
+  return false;
+#endif
 }
 
 }  // namespace bq

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
@@ -10,6 +10,7 @@
 
 #include <gsl/gsl>
 
+#include "HTP/QnnHtpDeviceConfigShared.h"
 #include "QnnTypes.h"
 
 #include "core/providers/qnn/builder/qnn_quant_params_wrapper.h"
@@ -91,6 +92,16 @@ Ort::Status AddFp16ToInt16QuantizeOutput(QnnModelWrapper& qnn_model_wrapper,
                                          QnnQuantParamsWrapper int16_quant_param,
                                          std::vector<uint32_t> output_shape,
                                          bool do_op_validation);
+
+// Determine whether given BQ parameters are natively supported by HTP. If true, activation data type can be kept in
+// fixed point; otherwise, insert Dequantize and Quantize nodes around to make activation in FP16.
+// Note: HTP native BQ requires HTP arch >= 81.
+bool IsHTPSupportedNativeBQ(QnnHtpDevice_Arch_t htp_arch,
+                            Qnn_DataType_t act_data_type,
+                            uint32_t bitwidth,
+                            uint32_t block_size,
+                            uint32_t output_channel,
+                            gsl::span<const float> offsets);
 
 }  // namespace bq
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -64,6 +64,11 @@ namespace qnn {
 #endif
 #endif
 
+// HTP native BQ support starts from QAIRT 2.51 (QNN API 2.40).
+#if QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 40)
+#define QNN_HTP_NATIVE_BQ_AVAILABLE
+#endif  // QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 40)
+
 // QNN only support subset of POSIX of dlopen/dlsym/dladdr/dlerror/dlclose
 // except the following flags for dlopen, others should be done only
 // when we really need them

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -627,20 +627,20 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
   } else if (is_block_quant) {
     if (!qnn_model_wrapper.GetModelSettings().enable_block_quant_weight_optimization) {
       ORT_CXX_LOG(qnn_model_wrapper.GetLogger(), ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Block quant weight optimization disabled, falling back to float BQ path"));
+                  ("Block quant weight optimization disabled, BQ path is adopted as-is"));
       return Ort::Status();
     }
     // ONNX block quantization -> QNN LPBQ (BLOCKWISE_EXPANSION) conversion only supported for 4-bit.
     if (io_def.type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4) {
       ORT_CXX_LOG(qnn_model_wrapper.GetLogger(), ORT_LOGGING_LEVEL_VERBOSE,
-                  ("BQ to LPBQ conversion only supported for int4 weights, falling back to float BQ path"));
+                  ("BQ to LPBQ conversion only supported for int4 weights, falling back to BQ path"));
       return Ort::Status();
     }
     // LPBQ requires symmetric quantization (all zero-points must be zero).
     for (const int32_t zp : zero_points) {
       if (zp != 0) {
         ORT_CXX_LOG(qnn_model_wrapper.GetLogger(), ORT_LOGGING_LEVEL_VERBOSE,
-                    ("BQ to LPBQ conversion requires symmetric quantization, falling back to float BQ path"));
+                    ("BQ to LPBQ conversion requires symmetric quantization, falling back to BQ path"));
         return Ort::Status();
       }
     }
@@ -708,7 +708,7 @@ Ort::Status QnnQuantParamsWrapper::Init(const QnnModelWrapper& qnn_model_wrapper
                                                               per_block_int_scales, lpbq_offsets);
     if (!status.IsOK()) {
       ORT_CXX_LOG(qnn_model_wrapper.GetLogger(), ORT_LOGGING_LEVEL_VERBOSE,
-                  ("BQ to LPBQ conversion failed, falling back to float BQ path: " + std::string(status.GetErrorMessage())).c_str());
+                  ("BQ to LPBQ conversion failed, falling back to BQ path: " + std::string(status.GetErrorMessage())).c_str());
       return Ort::Status();
     }
 

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3,12 +3,15 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
 #include <optional>
 #include <string>
 
-#include "test/providers/qnn/qnn_test_utils.h"
-
+#include <gsl/gsl_util>
 #include "gtest/gtest.h"
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
 
 namespace onnxruntime {
 namespace test {
@@ -3430,6 +3433,45 @@ ProviderOptions GetLPBQConvProviderOptions() {
   return opts;
 }
 
+// Runs a BQ Conv model on the QNN HTP backend and verifies which BQ encoding path QNN EP selected by inspecting the
+// dumped QNN graph JSON.
+//   - Native BQ  (QNN_QUANTIZATION_ENCODING_BLOCK): no INT16→FP16 activation Dequantize and no
+//     FP16→INT16 output Quantize are inserted → Quantize=1, Dequantize=1.
+//   - Fallback   (QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK): activation Dequantize and output
+//     Quantize are inserted → Quantize=2, Dequantize=2.
+void RunNativeBQConvTest(GetQDQTestCaseFn build_fn,
+                         bool expect_native_bq,
+                         float fp32_abs_err = 1e-2f) {
+  ProviderOptions provider_options = GetBQConvProviderOptions();
+
+  // Dump JSON graph for verifying native BQ working as expected.
+  const std::filesystem::path json_qnn_graph_dir = "ConvNativeBQ";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(build_fn,
+                  provider_options,
+                  /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(fp32_abs_err)});
+
+#ifndef QNN_HTP_NATIVE_BQ_AVAILABLE
+  // HTP native BQ support starts from QAIRT 2.51 (QNN API 2.40).
+  // Disable here to avoid guarding everywhere.
+  expect_native_bq = false;
+#endif
+
+  if (expect_native_bq) {
+    AssertOpInQnnGraph(json_qnn_graph_dir, "Quantize", 1);
+    AssertOpInQnnGraph(json_qnn_graph_dir, "Dequantize", 1);
+  } else {
+    AssertOpInQnnGraph(json_qnn_graph_dir, "Quantize", 2);
+    AssertOpInQnnGraph(json_qnn_graph_dir, "Dequantize", 2);
+  }
+}
+
 }  // namespace
 
 // 1x1 Conv, INT4 weight, block_size=8, uint16 activation, no bias.
@@ -3751,6 +3793,123 @@ TEST_F(QnnHTPBackendTests, ConvLPBQ_U16Int4_1x1_WithFloatBias_BS32) {
                   GetLPBQConvProviderOptions(),
                   /*opset=*/21,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// ── HTP native BQ path ────────────────────────────────────────────────────────
+// HTP native BQ kernel adopts QNN_QUANTIZATION_ENCODING_BLOCK encoding type.
+// Compared to non-native BQ kernel adopting QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK, no INT16→FP16 activation dequant
+// and no FP16→INT16 output quantize are inserted.
+
+// Native path: INT4, block_size=32, IC=32, OC=32.
+TEST_F(QnnHTPBackendTests, ConvBQ_Native_U16Int4_BlockSize32) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
+
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{32, 32, 1, 1},
+                                          /*block_size=*/32,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
+}
+
+// Native path: INT4, block_size=64, IC=64, OC=32.
+TEST_F(QnnHTPBackendTests, ConvBQ_Native_U16Int4_BlockSize64) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
+
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
+                                          /*weight=*/{32, 64, 1, 1},
+                                          /*block_size=*/64,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
+}
+
+// Native path: INT4, block_size=128, IC=128, OC=32.
+TEST_F(QnnHTPBackendTests, ConvBQ_Native_U16Int4_BlockSize128) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
+
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 128, 4, 4},
+                                          /*weight=*/{32, 128, 1, 1},
+                                          /*block_size=*/128,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
+}
+
+// Native path: INT4, block_size=32, IC=64, OC=64.
+TEST_F(QnnHTPBackendTests, ConvBQ_Native_U16Int4_MultiBlock) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
+
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 64, 4, 4},
+                                          /*weight=*/{64, 64, 1, 1},
+                                          /*block_size=*/32,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
+}
+
+// Fallback edge: Unsupported bitwidth 8.
+TEST_F(QnnHTPBackendTests, ConvBQ_NativeFallback_Int8BlockSize32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{32, 32, 1, 1},
+                                          /*block_size=*/32,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/8),
+                      /*expect_native_bq=*/false);
+}
+
+// Fallback edge: Unsupported block size 16.
+TEST_F(QnnHTPBackendTests, ConvBQ_NativeFallback_BlockSize16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{32, 32, 1, 1},
+                                          /*block_size=*/16,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/false);
+}
+
+// Fallback edge: Unsupported asymmetric offsets.
+TEST_F(QnnHTPBackendTests, ConvBQ_NativeFallback_UInt4Asymmetric) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{32, 32, 1, 1},
+                                          /*block_size=*/32,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4,
+                                          /*weight_is_unsigned=*/true),
+                      /*expect_native_bq=*/false);
+}
+
+// Fallback edge: Unsupported non-32 multiplier OC.
+TEST_F(QnnHTPBackendTests, ConvBQ_NativeFallback_OcNotMultipleOf32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{16, 32, 1, 1},
+                                          /*block_size=*/32,
+                                          /*bias=*/false,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/false);
+}
+
+// Fallback edge: Unsupported Conv with bias.
+TEST_F(QnnHTPBackendTests, ConvBQ_NativeFallback_ConvWithBias) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  RunNativeBQConvTest(BuildBQConvTestCase(/*input=*/{1, 32, 4, 4},
+                                          /*weight=*/{32, 32, 1, 1},
+                                          /*block_size=*/32,
+                                          /*bias=*/true,
+                                          /*weight_bits=*/4),
+                      /*expect_native_bq=*/false);
 }
 
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).

--- a/onnxruntime/test/providers/qnn/matmulnbits_test.cc
+++ b/onnxruntime/test/providers/qnn/matmulnbits_test.cc
@@ -3,10 +3,15 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
+#include <optional>
+#include <string>
 #include <type_traits>
 
+#include <gsl/gsl_util>
 #include "gtest/gtest.h"
 
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
@@ -183,6 +188,7 @@ static void RunMatMulNBitsTest(const TestParams params,
 //   - output Y    : MatMulNBits → Q(ActQType) → DQ → graph output
 template <int bits, typename ActQType>
 static void RunHtpQDQMatMulNBitsTest(const TestParams params,
+                                     std::optional<bool> expect_native_bq = std::nullopt,
                                      ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
                                      QDQTolerance tolerance = QDQTolerance()) {
   static_assert(std::is_same_v<ActQType, uint16_t> || std::is_same_v<ActQType, int16_t>,
@@ -193,10 +199,39 @@ static void RunHtpQDQMatMulNBitsTest(const TestParams params,
   provider_options["offload_graph_io_quantization"] = "0";
   if (params.enable_lpbq) {
     provider_options["enable_block_quant_weight_optimization"] = "1";
+  } else {
+    // Explicit: keep the BQ→LPBQ conversion off so the BQ (native BLOCK / BW_FLOAT_BLOCK) path is exercised.
+    provider_options["enable_block_quant_weight_optimization"] = "0";
   }
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif
+
+#ifndef QNN_HTP_NATIVE_BQ_AVAILABLE
+  // HTP native BQ support starts from QAIRT 2.51 (QNN API 2.40).
+  // Disable here to avoid guarding everywhere.
+  if (expect_native_bq.has_value()) {
+    *expect_native_bq = false;
+  }
+#endif
+
+  // When expect_native_bq is set, dump the QNN graph JSON so the selected BQ encoding can be verified:
+  //   - Native BQ (QNN_QUANTIZATION_ENCODING_BLOCK): consumes/produces INT16 directly, so only the
+  //     activation Quantize and output Dequantize of the QDQ model remain → Quantize=1, Dequantize=1.
+  //   - Fallback (QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK): computes in FP16, so an extra INT16→FP16
+  //     activation Dequantize and FP16→INT16 output Quantize are inserted → Quantize=2, Dequantize=2.
+  const std::filesystem::path json_qnn_graph_dir = "MatMulNBitsNativeBQ";
+  auto cleanup = gsl::finally([&expect_native_bq, &json_qnn_graph_dir]() {
+    if (expect_native_bq.has_value()) {
+      std::filesystem::remove_all(json_qnn_graph_dir);
+    }
+  });
+  if (expect_native_bq.has_value()) {
+    std::filesystem::remove_all(json_qnn_graph_dir);
+    ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+    provider_options["dump_json_qnn_graph"] = "1";
+    provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+  }
 
   // Generate the raw float data once so that the float and QDQ models use identical inputs and weights.
   RandomValueGenerator random{1234};
@@ -258,6 +293,12 @@ static void RunHtpQDQMatMulNBitsTest(const TestParams params,
                                  21,  // opset 21 for 16-bit Q/DQ
                                  expected_ep_assignment,
                                  tolerance);
+
+  if (expect_native_bq.has_value()) {
+    const size_t expected_count = *expect_native_bq ? 1 : 2;
+    AssertOpInQnnGraph(json_qnn_graph_dir, "Quantize", expected_count);
+    AssertOpInQnnGraph(json_qnn_graph_dir, "Dequantize", expected_count);
+  }
 }
 
 #if defined(_M_ARM64)
@@ -531,7 +572,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B2_BS32) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B2_BS32_ZP) {
@@ -543,7 +584,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B2_BS32_ZP) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B2_BS64) {
@@ -555,7 +596,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B2_BS64) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B2_BS64_ZP) {
@@ -567,7 +608,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B2_BS64_ZP) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B2_BS128) {
@@ -579,7 +620,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B2_BS128) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B2_BS128_ZP) {
@@ -591,11 +632,13 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B2_BS128_ZP) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS32) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
 
   TestParams params;
   params.M = 1;
@@ -603,7 +646,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS32) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS32_ZP) {
@@ -615,11 +658,37 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS32_ZP) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/false);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/false);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N16_K64_B4_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 16;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B4_BS64) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
 
   TestParams params;
   params.M = 1;
@@ -627,7 +696,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B4_BS64) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B4_BS64_ZP) {
@@ -639,11 +708,13 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B4_BS64_ZP) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B4_BS128) {
+  QNN_SKIP_TEST_IF_NO_PLATFORM_ATTRS();
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  auto htp_arch = GetPlatformAttributes().htp_arch;
 
   TestParams params;
   params.M = 1;
@@ -651,7 +722,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B4_BS128) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/htp_arch >= QNN_HTP_DEVICE_ARCH_V81);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B4_BS128_ZP) {
@@ -663,7 +734,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B4_BS128_ZP) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B8_BS32) {
@@ -675,7 +746,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B8_BS32) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B8_BS32_ZP) {
@@ -687,7 +758,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B8_BS32_ZP) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B8_BS64) {
@@ -699,7 +770,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B8_BS64) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B8_BS64_ZP) {
@@ -711,7 +782,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B8_BS64_ZP) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B8_BS128) {
@@ -723,7 +794,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B8_BS128) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B8_BS128_ZP) {
@@ -735,7 +806,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B8_BS128_ZP) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params, /*expect_native_bq=*/false);
 }
 
 // QDQ MatMulNBits with INT16 (SFIXED_POINT_16) activations/output.
@@ -749,7 +820,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B2_BS32) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B2_BS32_ZP) {
@@ -761,7 +832,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B2_BS32_ZP) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B2_BS64) {
@@ -773,7 +844,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B2_BS64) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B2_BS64_ZP) {
@@ -785,7 +856,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B2_BS64_ZP) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B2_BS128) {
@@ -797,7 +868,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B2_BS128) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B2_BS128_ZP) {
@@ -809,7 +880,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B2_BS128_ZP) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B4_BS32) {
@@ -821,7 +892,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B4_BS32) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B4_BS32_ZP) {
@@ -833,7 +904,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B4_BS32_ZP) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B4_BS64) {
@@ -845,7 +916,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B4_BS64) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B4_BS64_ZP) {
@@ -857,7 +928,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B4_BS64_ZP) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B4_BS128) {
@@ -869,7 +940,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B4_BS128) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B4_BS128_ZP) {
@@ -881,7 +952,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B4_BS128_ZP) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B8_BS32) {
@@ -893,7 +964,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B8_BS32) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B8_BS32_ZP) {
@@ -905,7 +976,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B8_BS32_ZP) {
   params.K = 64;
   params.block_size = 32;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B8_BS64) {
@@ -917,7 +988,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B8_BS64) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B8_BS64_ZP) {
@@ -929,7 +1000,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B8_BS64_ZP) {
   params.K = 128;
   params.block_size = 64;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B8_BS128) {
@@ -941,7 +1012,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B8_BS128) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B8_BS128_ZP) {
@@ -953,7 +1024,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B8_BS128_ZP) {
   params.K = 256;
   params.block_size = 128;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params, /*expect_native_bq=*/false);
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K64_B4_BS16) {
@@ -966,7 +1037,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K64_B4_BS16) {
   params.block_size = 16;
   params.has_zero_point = false;
   params.enable_lpbq = true;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K128_B4_BS32) {
@@ -979,7 +1050,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K128_B4_BS32) {
   params.block_size = 32;
   params.has_zero_point = false;
   params.enable_lpbq = true;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.01f));
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.01f));
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N2_K128_B4_BS64) {
@@ -992,7 +1063,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N2_K128_B4_BS64) {
   params.block_size = 64;
   params.has_zero_point = false;
   params.enable_lpbq = true;
-  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.01f));
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.01f));
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N8_K64_B4_BS32_ZP) {
@@ -1006,7 +1077,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N8_K64_B4_BS32_ZP) {
   params.has_zero_point = true;
   params.is_zp_symmetric = true;
   params.enable_lpbq = true;
-  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
 
 // Should fallback to BW_FLOAT_BLOCK (bits=8)

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -2176,6 +2176,11 @@ inline HRESULT CreateD3D12Buffer(
 
 #endif  // _WIN32 && ...
 
+// HTP native BQ support starts from QAIRT 2.51 (QNN API 2.40).
+#if QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 40)
+#define QNN_HTP_NATIVE_BQ_AVAILABLE
+#endif  // QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 40)
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Route block-quantized weights to the HTP native BQ kernel (QNN_QUANTIZATION_ENCODING_BLOCK) when supported, avoiding the extra INT16->FP16 activation dequant and FP16->INT16 output quantize that the non-native BW_FLOAT_BLOCK kernel requires.

- conv_op_builder: select native BLOCK vs BW_FLOAT_BLOCK via bq::IsHTPSupportedNativeBQ; only insert activation dequant / output quantize on the non-native fallback path.
- matmulnbits_op_builder: accept uint16/int16 activation on HTP, apply the same native-vs-fallback selection.
- qnn_quant_params_wrapper: clarify BQ fallback log wording.
- tests: add native BQ Conv and MatMulNBits QDQ coverage plus fallback edges.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Support HTP native BQ for Conv2d and MatMulNBits (which essentially built into Conv2d).

**\*\*Note\*\*** Current implementation is guarded to adopt native BQ path only if QAIRT >= 2.51 to avoid breaking any test until QAIRT is upleveled, and so do the testcases.

