### PR TITLE
[QNN EP] Extract Quantize/Dequantize into a standalone op builder

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -81,7 +81,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateSimpleOpBuilder("Atan", *this);
   CreateSimpleOpBuilder("Ceil", *this);
   CreateSimpleOpBuilder("Cos", *this);
-  CreateSimpleOpBuilder("DequantizeLinear", *this);
+  CreateQuantizeOpBuilder("DequantizeLinear", *this);
   CreateSimpleOpBuilder("DepthToSpace", *this);
   CreateSimpleOpBuilder("Div", *this);
   CreateSimpleOpBuilder("Elu", *this);
@@ -107,7 +107,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateSimpleOpBuilder("Or", *this);
   CreateSimpleOpBuilder("Pow", *this);
   CreateSimpleOpBuilder("PRelu", *this);
-  CreateSimpleOpBuilder("QuantizeLinear", *this);
+  CreateQuantizeOpBuilder("QuantizeLinear", *this);
   CreateSimpleOpBuilder("Relu", *this);
   CreateSimpleOpBuilder("Round", *this);
   CreateScatterElementsOpBuilder("ScatterElements", *this);

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.h
@@ -95,6 +95,7 @@ void CreateOneHotOpBuilder(const std::string& op_type, OpBuilderRegistrations& o
 void CreatePadOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreatePoolOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateQLinearMatMulOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
+void CreateQuantizeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateQuickGeluOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateRandomNormalLikeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);
 void CreateRandomUniformLikeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/quantize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/quantize_op_builder.cc
@@ -1,0 +1,123 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Handles ONNX QuantizeLinear and DequantizeLinear. Q/DQ have no QNN params, so
+// only inputs & outputs are processed (plus a compile-time constant-fold short-circuit).
+class QuantizeOpBuilder : public BaseOpBuilder {
+ public:
+  QuantizeOpBuilder() : BaseOpBuilder("QuantizeOpBuilder") {}
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QuantizeOpBuilder);
+
+ protected:
+  Ort::Status ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                          const OrtNodeUnit& node_unit,
+                                          std::vector<std::string>&& input_names,
+                                          const Ort::Logger& logger,
+                                          bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+ private:
+  Ort::Status ValidateQdqNode(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const;
+};
+
+Ort::Status QuantizeOpBuilder::ValidateQdqNode(QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& node_unit) const {
+  const std::string& op_type = node_unit.OpType();
+
+  if (op_type == "DequantizeLinear") {
+    bool is_per_chan_quant = false;
+    int64_t quant_axis = 0;
+    RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_chan_quant, quant_axis));
+    // Per-channel standalone DQ is allowed only if the input is a compile-time constant;
+    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
+    RETURN_IF(is_per_chan_quant && !is_input_const,
+              "QNN EP does not support a standalone DQ op with per-channel quantization");
+
+    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
+        qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name)) {
+      // Only register the override for the first DQ node that consumes this graph output.
+      // If another DQ node already maps to the same external name, skip registration so
+      // that the second output becomes a separate APP_READ tensor instead of creating
+      // two APP_READ tensors with the same external name (which reduces the composed
+      // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
+      if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Outputs()[0].name)) {
+        // The tensor name override is used to align the output name of DLC produced by IRBackend
+        // with the output name of original onnx graph for better consistency.
+        qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
+                                                /*external=*/node_unit.Outputs()[0].name);
+      }
+      return MAKE_EP_FAIL("QNN EP is configured to not take DQ nodes that generate a graph output.");
+    }
+  }
+
+  if (op_type == "QuantizeLinear") {
+    bool is_per_chan_quant = false;
+    int64_t quant_axis = 0;
+    RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Outputs()[0], is_per_chan_quant, quant_axis));
+    // Per-channel standalone Q is allowed only if the input is a compile-time constant;
+    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
+    RETURN_IF(is_per_chan_quant && !is_input_const,
+              "QNN EP does not support a standalone Q op with per-channel quantization");
+
+    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
+        qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
+      // Only register the override for the first Q node that consumes this graph input.
+      // If another Q node already maps to the same external name, skip registration so
+      // that the second input becomes a separate APP_WRITE tensor instead of creating
+      // two APP_WRITE tensors with the same external name (which reduces the composed
+      // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
+      if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Inputs()[0].name)) {
+        // The tensor name override is used to align the input name of DLC produced by IRBackend
+        // with the input name of original onnx graph for better consistency.
+        qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
+                                                /*external=*/node_unit.Inputs()[0].name);
+      }
+      return MAKE_EP_FAIL("QNN EP is configured to not take Q nodes that consume a graph input.");
+    }
+  }
+
+  return Ort::Status();
+}
+
+Ort::Status QuantizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
+                                                           const OrtNodeUnit& node_unit,
+                                                           std::vector<std::string>&& input_names,
+                                                           const Ort::Logger& logger,
+                                                           bool do_op_validation) const {
+  if (input_names.empty()) {
+    return Ort::Status();
+  }
+
+  const std::string& op_type = node_unit.OpType();
+
+  if (do_op_validation) {
+    RETURN_IF_ERROR(ValidateQdqNode(qnn_model_wrapper, node_unit));
+  }
+
+  // Emit a STATIC tensor instead of an APP_WRITE input for standalone Q/DQ on constant inputs.
+  if (CanFoldConstantQdq(qnn_model_wrapper, node_unit)) {
+    Ort::Status fold_status = TryFoldConstantQDQ(qnn_model_wrapper, node_unit);
+    if (fold_status.IsOK()) {
+      return Ort::Status();
+    }
+  }
+
+  return ProcessOutputs(qnn_model_wrapper, node_unit,
+                        std::move(input_names),
+                        /*param_tensor_names=*/{},
+                        logger, do_op_validation, GetQnnOpType(op_type));
+}
+
+void CreateQuantizeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {
+  op_registrations.AddOpBuilder(op_type, std::make_unique<QuantizeOpBuilder>());
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/quantize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/quantize_op_builder.cc
@@ -95,8 +95,6 @@ Ort::Status QuantizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
     return Ort::Status();
   }
 
-  const std::string& op_type = node_unit.OpType();
-
   if (do_op_validation) {
     RETURN_IF_ERROR(ValidateQdqNode(qnn_model_wrapper, node_unit));
   }
@@ -112,7 +110,7 @@ Ort::Status QuantizeOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_
   return ProcessOutputs(qnn_model_wrapper, node_unit,
                         std::move(input_names),
                         /*param_tensor_names=*/{},
-                        logger, do_op_validation, GetQnnOpType(op_type));
+                        logger, do_op_validation, GetQnnOpType(node_unit.OpType()));
 }
 
 void CreateQuantizeOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -3,7 +3,6 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
-#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/qnn_graph_utils.h"
@@ -79,58 +78,6 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
                    "Got ONNX's Sum operator with " +
                    std::to_string(inputs_num) + " inputs.")
                       .c_str());
-  }
-
-  if (op_type == "DequantizeLinear") {
-    bool is_per_chan_quant = false;
-    int64_t quant_axis = 0;
-    RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_chan_quant, quant_axis));
-    // Per-channel standalone DQ is allowed only if the input is a compile-time constant;
-    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
-    RETURN_IF(is_per_chan_quant && !is_input_const,
-              "QNN EP does not support a standalone DQ op with per-channel quantization");
-
-    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
-        qnn_model_wrapper.IsGraphOutput(node_unit.Outputs()[0].name)) {
-      // Only register the override for the first DQ node that consumes this graph output.
-      // If another DQ node already maps to the same external name, skip registration so
-      // that the second output becomes a separate APP_READ tensor instead of creating
-      // two APP_READ tensors with the same external name (which reduces the composed
-      // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
-      if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Outputs()[0].name)) {
-        // The tensor name override is used to align the output name of DLC produced by IRBackend
-        // with the output name of original onnx graph for better consistency.
-        qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Inputs()[0].name,
-                                                /*external=*/node_unit.Outputs()[0].name);
-      }
-      return MAKE_EP_FAIL("QNN EP is configured to not take DQ nodes that generate a graph output.");
-    }
-  }
-
-  if (op_type == "QuantizeLinear") {
-    bool is_per_chan_quant = false;
-    int64_t quant_axis = 0;
-    RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Outputs()[0], is_per_chan_quant, quant_axis));
-    // Per-channel standalone Q is allowed only if the input is a compile-time constant;
-    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
-    RETURN_IF(is_per_chan_quant && !is_input_const,
-              "QNN EP does not support a standalone Q op with per-channel quantization");
-
-    if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
-        qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
-      // Only register the override for the first Q node that consumes this graph input.
-      // If another Q node already maps to the same external name, skip registration so
-      // that the second input becomes a separate APP_WRITE tensor instead of creating
-      // two APP_WRITE tensors with the same external name (which reduces the composed
-      // QNN graph's input count and causes a null slot in qnn_tensor_infos at runtime).
-      if (!qnn_model_wrapper.IsExternalOverrideTarget(node_unit.Inputs()[0].name)) {
-        // The tensor name override is used to align the input name of DLC produced by IRBackend
-        // with the input name of original onnx graph for better consistency.
-        qnn_model_wrapper.SetTensorNameOverride(/*internal=*/node_unit.Outputs()[0].name,
-                                                /*external=*/node_unit.Inputs()[0].name);
-      }
-      return MAKE_EP_FAIL("QNN EP is configured to not take Q nodes that consume a graph input.");
-    }
   }
 
   if (op_type == "Softplus" && qnn_backend_type != QnnBackendType::CPU) {
@@ -314,14 +261,6 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
       }
     }
 #endif
-  }
-
-  // Emit a STATIC tensor instead of an APP_WRITE input for standalone Q/DQ on constant inputs.
-  if (CanFoldConstantQdq(qnn_model_wrapper, node_unit)) {
-    Ort::Status fold_status = TryFoldConstantQDQ(qnn_model_wrapper, node_unit);
-    if (fold_status.IsOK()) {
-      return Ort::Status();
-    }
   }
 
   std::vector<std::string> param_tensor_names;

--- a/onnxruntime/test/providers/qnn/quantize_op_test.cc
+++ b/onnxruntime/test/providers/qnn/quantize_op_test.cc
@@ -1,0 +1,213 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <string>
+#include <vector>
+
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// Verifies that Q and DQ nodes round-trip correctly when used as standalone ops in a
+// Q -> Transpose -> DQ graph. QNN optimizes away Q -> DQ on constant graph I/O, so
+// the output should be perfectly accurate relative to the float32 values.
+TEST_F(QnnHTPBackendTests, QuantAccuracyTest) {
+  ProviderOptions provider_options;
+
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // Note: a graph input -> Q -> DQ -> is optimized by Qnn to have a perfectly accurate output.
+  // ORT's CPU EP, on the otherhand, actually quantizes and dequantizes the input, which leads to different outputs.
+  auto builder_func = [](ModelTestBuilder& builder) {
+    const TestInputDef<float> input0_def({1, 2, 3}, false, {1.0f, 2.0f, 10.0f, 20.0f, 100.0f, 200.0f});
+
+    // input -> Q -> Transpose -> DQ -> output
+    MakeTestInput<float>(builder, "input0", input0_def);
+    const QuantParams<uint8_t> qparams = GetTestInputQuantParams<uint8_t>(input0_def);
+
+    builder.AddQuantizeLinearNode<uint8_t>("q_in", "input0", qparams.scale, qparams.zero_point, "quant_input");
+
+    builder.AddNode("Transpose",
+                    "Transpose",
+                    {"quant_input"},
+                    {"op_output"});
+
+    builder.MakeOutput("Y");
+    builder.AddDequantizeLinearNode<uint8_t>("dq_out", "op_output", qparams.scale, qparams.zero_point, "Y");
+  };
+
+  // Runs model with DQ-> Atan-> Q and compares the outputs of the CPU and QNN EPs.
+  // 1st run will generate the Qnn context cache binary file
+  RunQnnModelTest(builder_func,
+                  provider_options,
+                  13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
+// Builds a graph where a (DQ -> Q) sequence at the graph's output is fuse into a QNN Convert operator.
+// ONNX Graph: DQ -> Add -> Q -> DQ -> Q -> graph_output
+// QNN Graph:  DQ -> Add -> Q -> Convert -> graph_output
+template <typename InQuantType, typename OutQuantType>
+static GetTestModelFn BuildDQQConvertAtOutputTestCase(const TestInputDef<float>& input0_def,
+                                                      const TestInputDef<float>& input1_def,
+                                                      const QuantParams<OutQuantType>& output_qparams) {
+  return [input0_def, input1_def, output_qparams](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input0", input0_def);
+    MakeTestInput<float>(builder, "input1", input1_def);
+
+    // Input0 -> Quantize(InQuantType) -> Dequantize(InQuantType to float) -> input0_after_qdq
+    const QuantParams<InQuantType> input0_qparams = GetTestInputQuantParams<InQuantType>(input0_def);
+    const std::string input0_after_qdq =
+        AddQDQNodePair<InQuantType>(builder, "qdq0", "input0", input0_qparams.scale, input0_qparams.zero_point);
+
+    // Input1 -> Quantize(InQuantType) -> Dequantize(InQuantType to float) -> input1_after_qdq
+    const QuantParams<InQuantType> input1_qparams = GetTestInputQuantParams<InQuantType>(input1_def);
+    const std::string input1_after_qdq =
+        AddQDQNodePair<InQuantType>(builder, "qdq1", "input1", input1_qparams.scale, input1_qparams.zero_point);
+
+    // Add op -> add_out
+    builder.AddNode("Add",
+                    "Add",
+                    {input0_after_qdq, input1_after_qdq},
+                    {"add_out"});
+
+    // op_output -> Quantize(InQuantType) -> add_out_q
+    QuantParams<InQuantType> add_out_qparams = ConvertQuantParams<OutQuantType, InQuantType>(output_qparams);
+    add_out_qparams.scale *= 1.01f;  // Make qparams slightly different so DQ->Q are not optimized out.
+
+    auto add_qdq_name = AddQDQNodePair(builder, "add_qdq", "add_out", add_out_qparams.scale, add_out_qparams.zero_point);
+
+    // Add a Q to quantize to OutQuantType.
+    // The previous DQ and this Q will be fused into a QNN Convert.
+    builder.MakeOutput("Y");
+    builder.AddQuantizeLinearNode<OutQuantType>("final_q", add_qdq_name, output_qparams.scale, output_qparams.zero_point, "Y");
+  };
+}
+
+// Test fusion of (DQ -> Q) into QNN's Convert op using the same quant type.
+TEST_F(QnnHTPBackendTests, DQ_Q_ConvertFusion_SameType) {
+  std::vector<float> input0_data = {-8.0f, -6.0, -2.0f, 0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+  std::vector<float> input1_data = {-8.0f, -6.0, -2.0f, 0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+  TestInputDef<float> input0_def({1, 2, 2, 2}, false, input0_data);
+  TestInputDef<float> input1_def({1, 2, 2, 2}, false, input1_data);
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  QuantParams<uint8_t> out_qparams_u8 = {1.0f, 128};
+  QuantParams<uint16_t> out_qparams_u16 = {1.0f, 32768};
+
+  // QNN Convert op converts uint8 to uint8 at the graph output. Slightly different scale values.
+  RunQnnModelTest(BuildDQQConvertAtOutputTestCase<uint8_t, uint8_t>(input0_def, input1_def, out_qparams_u8),
+                  provider_options,
+                  21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+
+  // QNN Convert op converts uint16 to uint16 at the graph output. Slightly different scale values.
+  RunQnnModelTest(BuildDQQConvertAtOutputTestCase<uint16_t, uint16_t>(input0_def, input1_def, out_qparams_u16),
+                  provider_options,
+                  21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
+// Standalone per-channel Quantize/Dequantize support on the HTP backend.
+//
+// QnnQuantizeOpBuilder::ValidateQdqNode rejects a standalone per-channel Q/DQ node when its
+// data input is NOT a compile-time constant (graph input / activation), because QNN has no
+// per-channel encoding for such a tensor. When the data input IS constant, the node is instead
+// constant-folded into a STATIC tensor and stays on QNN EP. The tests below cover both branches
+// for Q and DQ.
+
+// Per-channel DQ on a NON-constant (graph) input must be rejected -> whole graph falls back to CPU.
+TEST_F(QnnHTPBackendTests, StandalonePerChannelDequantizeLinear_NonConstInput_Unsupported) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    // Quantized activation as a graph input (non-constant) with shape [2, 3].
+    auto* input = builder.MakeInput<uint8_t>("input", {2, 3}, static_cast<uint8_t>(0), static_cast<uint8_t>(255));
+
+    // Per-channel scales/zero-points along axis 0 (3 columns per row -> 2 channels).
+    const std::vector<float> scales = {0.1f, 0.2f};
+    const std::vector<uint8_t> zero_points = {0, 0};
+
+    builder.AddDequantizeLinearNode<uint8_t>("dq", input->name(), scales, zero_points, "output",
+                                             {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+    builder.MakeOutput("output");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  // Per-channel standalone DQ on a non-constant input is unsupported: expect no nodes on QNN EP.
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::None});
+}
+
+// Per-channel Q on a NON-constant (graph) input must be rejected -> whole graph falls back to CPU.
+TEST_F(QnnHTPBackendTests, StandalonePerChannelQuantizeLinear_NonConstInput_Unsupported) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    // Float activation as a graph input (non-constant) with shape [2, 3].
+    auto* input = builder.MakeInput<float>("input", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+
+    // Per-channel scales/zero-points along axis 0 (2 channels).
+    const std::vector<float> scales = {0.1f, 0.2f};
+    const std::vector<uint8_t> zero_points = {0, 0};
+
+    builder.AddQuantizeLinearNode<uint8_t>("q", input->name(), scales, zero_points, "output",
+                                           {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+    builder.MakeOutput("output");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  // Per-channel standalone Q on a non-constant input is unsupported: expect no nodes on QNN EP.
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::None});
+}
+
+// Per-channel DQ on a CONSTANT input is constant-folded into a STATIC tensor and stays on QNN EP.
+TEST_F(QnnHTPBackendTests, StandalonePerChannelDequantizeLinear_ConstInput_Folded) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    // Quantized weights as a constant initializer with shape [2, 3].
+    const std::vector<uint8_t> weights = {10, 20, 30, 40, 50, 60};
+    auto* weights_init = builder.MakeInitializer<uint8_t>("weights", {2, 3}, weights);
+
+    // Per-channel scales/zero-points along axis 0 (2 channels).
+    const std::vector<float> scales = {0.1f, 0.2f};
+    const std::vector<uint8_t> zero_points = {0, 0};
+
+    // DQ(const) -> Mul(graph input) so the DQ output feeds a supported op rather than a graph output.
+    builder.MakeInput<float>("activation", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+    builder.AddDequantizeLinearNode<uint8_t>("dq", weights_init->name(), scales, zero_points, "dq_out",
+                                             {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+    builder.AddNode("Mul", "Mul", {"dq_out", "activation"}, {"output"});
+    builder.MakeOutput("output");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  // Constant per-channel DQ is folded to a STATIC tensor; the whole graph stays on QNN EP.
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif

--- a/onnxruntime/test/providers/qnn/quantize_op_test.cc
+++ b/onnxruntime/test/providers/qnn/quantize_op_test.cc
@@ -15,17 +15,17 @@ namespace onnxruntime {
 namespace test {
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
-// Verifies that Q and DQ nodes round-trip correctly when used as standalone ops in a
-// Q -> Transpose -> DQ graph. QNN optimizes away Q -> DQ on constant graph I/O, so
-// the output should be perfectly accurate relative to the float32 values.
+// Verifies that standalone Q and DQ nodes used around a Transpose produce bit-exact output
+// on QNN EP. QNN keeps the data in quantized form through the Transpose, so no precision is
+// lost. ORT CPU EP actually dequantizes, transposes in float, then re-quantizes, which can
+// introduce rounding differences — hence the test uses RunQnnModelTest (QNN vs CPU) rather
+// than TestQDQModelAccuracy.
 TEST_F(QnnHTPBackendTests, QuantAccuracyTest) {
   ProviderOptions provider_options;
 
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  // Note: a graph input -> Q -> DQ -> is optimized by Qnn to have a perfectly accurate output.
-  // ORT's CPU EP, on the otherhand, actually quantizes and dequantizes the input, which leads to different outputs.
   auto builder_func = [](ModelTestBuilder& builder) {
     const TestInputDef<float> input0_def({1, 2, 3}, false, {1.0f, 2.0f, 10.0f, 20.0f, 100.0f, 200.0f});
 
@@ -44,8 +44,6 @@ TEST_F(QnnHTPBackendTests, QuantAccuracyTest) {
     builder.AddDequantizeLinearNode<uint8_t>("dq_out", "op_output", qparams.scale, qparams.zero_point, "Y");
   };
 
-  // Runs model with DQ-> Atan-> Q and compares the outputs of the CPU and QNN EPs.
-  // 1st run will generate the Qnn context cache binary file
   RunQnnModelTest(builder_func,
                   provider_options,
                   13,
@@ -200,6 +198,38 @@ TEST_F(QnnHTPBackendTests, StandalonePerChannelDequantizeLinear_ConstInput_Folde
   provider_options["backend_type"] = "htp";
 
   // Constant per-channel DQ is folded to a STATIC tensor; the whole graph stays on QNN EP.
+  RunQnnModelTest(build_test_case,
+                  provider_options,
+                  21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
+// Per-channel Q on a CONSTANT input is constant-folded into a STATIC tensor and stays on QNN EP.
+TEST_F(QnnHTPBackendTests, StandalonePerChannelQuantizeLinear_ConstInput_Folded) {
+  auto build_test_case = [](ModelTestBuilder& builder) {
+    // Float weights as a constant initializer with shape [2, 3].
+    const std::vector<float> weights = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    auto* weights_init = builder.MakeInitializer<float>("weights", {2, 3}, weights);
+
+    // Per-channel scales/zero-points along axis 0 (2 channels).
+    const std::vector<float> scales = {0.1f, 0.2f};
+    const std::vector<uint8_t> zero_points = {0, 0};
+
+    // Q(const) -> DQ -> Mul(graph input) so the quantized output feeds a supported op
+    // and the graph output remains float (comparable between QNN EP and CPU EP).
+    builder.MakeInput<float>("activation", {2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+    builder.AddQuantizeLinearNode<uint8_t>("q", weights_init->name(), scales, zero_points, "q_out",
+                                           {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+    builder.AddDequantizeLinearNode<uint8_t>("dq", "q_out", scales, zero_points, "dq_out",
+                                             {builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))});
+    builder.AddNode("Mul", "Mul", {"dq_out", "activation"}, {"output"});
+    builder.MakeOutput("output");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+
+  // Constant per-channel Q is folded to a STATIC tensor; the whole graph stays on QNN EP.
   RunQnnModelTest(build_test_case,
                   provider_options,
                   21,

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -914,40 +914,6 @@ TEST_F(QnnHTPBackendTests, SpaceToDepthOp_U16) {
                          true);        // Use com.microsoft domain for Q/DQ ops
 }
 
-TEST_F(QnnHTPBackendTests, QuantAccuracyTest) {
-  ProviderOptions provider_options;
-
-  provider_options["backend_type"] = "htp";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  // Note: a graph input -> Q -> DQ -> is optimized by Qnn to have a perfectly accurate output.
-  // ORT's CPU EP, on the otherhand, actually quantizes and dequantizes the input, which leads to different outputs.
-  auto builder_func = [](ModelTestBuilder& builder) {
-    const TestInputDef<float> input0_def({1, 2, 3}, false, {1.0f, 2.0f, 10.0f, 20.0f, 100.0f, 200.0f});
-
-    // input -> Q -> Transpose -> DQ -> output
-    MakeTestInput<float>(builder, "input0", input0_def);
-    const QuantParams<uint8_t> qparams = GetTestInputQuantParams<uint8_t>(input0_def);
-
-    builder.AddQuantizeLinearNode<uint8_t>("q_in", "input0", qparams.scale, qparams.zero_point, "quant_input");
-
-    builder.AddNode("Transpose",
-                    "Transpose",
-                    {"quant_input"},
-                    {"op_output"});
-
-    builder.MakeOutput("Y");
-    builder.AddDequantizeLinearNode<uint8_t>("dq_out", "op_output", qparams.scale, qparams.zero_point, "Y");
-  };
-
-  // Runs model with DQ-> Atan-> Q and compares the outputs of the CPU and QNN EPs.
-  // 1st run will generate the Qnn context cache binary file
-  RunQnnModelTest(builder_func,
-                  provider_options,
-                  13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All});
-}
-
 // Test 8-bit QDQ Add
 TEST_F(QnnHTPBackendTests, BinaryOp_Add4D) {
   RunQDQOpTest<uint8_t>("Add",
@@ -1821,73 +1787,6 @@ TEST_F(QnnHTPBackendTests, Add_U8_U16_Convert) {
                        provider_options,
                        18,
                        ExpectedEPNodeAssignment::All);
-}
-
-// Builds a graph where a (DQ -> Q) sequence at the graph's output is fuse into a QNN Convert operator.
-// ONNX Graph: DQ -> Add -> Q -> DQ -> Q -> graph_output
-// QNN Graph:  DQ -> Add -> Q -> Convert -> graph_output
-template <typename InQuantType, typename OutQuantType>
-static GetTestModelFn BuildDQQConvertAtOutputTestCase(const TestInputDef<float>& input0_def,
-                                                      const TestInputDef<float>& input1_def,
-                                                      const QuantParams<OutQuantType>& output_qparams) {
-  return [input0_def, input1_def, output_qparams](ModelTestBuilder& builder) {
-    MakeTestInput<float>(builder, "input0", input0_def);
-    MakeTestInput<float>(builder, "input1", input1_def);
-
-    // Input0 -> Quantize(InQuantType) -> Dequantize(InQuantType to float) -> input0_after_qdq
-    const QuantParams<InQuantType> input0_qparams = GetTestInputQuantParams<InQuantType>(input0_def);
-    const std::string input0_after_qdq =
-        AddQDQNodePair<InQuantType>(builder, "qdq0", "input0", input0_qparams.scale, input0_qparams.zero_point);
-
-    // Input1 -> Quantize(InQuantType) -> Dequantize(InQuantType to float) -> input1_after_qdq
-    const QuantParams<InQuantType> input1_qparams = GetTestInputQuantParams<InQuantType>(input1_def);
-    const std::string input1_after_qdq =
-        AddQDQNodePair<InQuantType>(builder, "qdq1", "input1", input1_qparams.scale, input1_qparams.zero_point);
-
-    // Add op -> add_out
-    builder.AddNode("Add",
-                    "Add",
-                    {input0_after_qdq, input1_after_qdq},
-                    {"add_out"});
-
-    // op_output -> Quantize(InQuantType) -> add_out_q
-    QuantParams<InQuantType> add_out_qparams = ConvertQuantParams<OutQuantType, InQuantType>(output_qparams);
-    add_out_qparams.scale *= 1.01f;  // Make qparams slightly different so DQ->Q are not optimized out.
-
-    auto add_qdq_name = AddQDQNodePair(builder, "add_qdq", "add_out", add_out_qparams.scale, add_out_qparams.zero_point);
-
-    // Add a Q to quantize to OutQuantType.
-    // The previous DQ and this Q will be fused into a QNN Convert.
-    builder.MakeOutput("Y");
-    builder.AddQuantizeLinearNode<OutQuantType>("final_q", add_qdq_name, output_qparams.scale, output_qparams.zero_point, "Y");
-  };
-}
-
-// Test fusion of (DQ -> Q) into QNN's Convert op using the same quant type.
-TEST_F(QnnHTPBackendTests, DQ_Q_ConvertFusion_SameType) {
-  std::vector<float> input0_data = {-8.0f, -6.0, -2.0f, 0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
-  std::vector<float> input1_data = {-8.0f, -6.0, -2.0f, 0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
-  TestInputDef<float> input0_def({1, 2, 2, 2}, false, input0_data);
-  TestInputDef<float> input1_def({1, 2, 2, 2}, false, input1_data);
-
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "htp";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  QuantParams<uint8_t> out_qparams_u8 = {1.0f, 128};
-  QuantParams<uint16_t> out_qparams_u16 = {1.0f, 32768};
-
-  // QNN Convert op converts uint8 to uint8 at the graph output. Slightly different scale values.
-  RunQnnModelTest(BuildDQQConvertAtOutputTestCase<uint8_t, uint8_t>(input0_def, input1_def, out_qparams_u8),
-                  provider_options,
-                  21,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All});
-
-  // QNN Convert op converts uint16 to uint16 at the graph output. Slightly different scale values.
-  RunQnnModelTest(BuildDQQConvertAtOutputTestCase<uint16_t, uint16_t>(input0_def, input1_def, out_qparams_u16),
-                  provider_options,
-                  21,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 
 TEST_F(QnnHTPBackendTests, UnaryOp_HardSigmoid_QU8) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- New quantize_op_builder.cc with QuantizeOpBuilder for both Q and DQ.
- Removed the DQ/Q blocks from SimpleOpBuilder::ExplicitOpCheck and the constant-fold short-circuit from ProcessAttributesAndOutputs.
- Dropped the now-dead qdq_constant_folding.h include from simple_op_builder.cc (kept qnn_graph_utils.h for kMSInternalNHWCDomain).
- Registered both ops via CreateQuantizeOpBuilder in the factory.




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- SimpleOpBuilder had accreted large Q/DQ-specific logic (per-channel-on- non-const rejection, offload_graph_io_quantization external tensor-name overrides, and constant folding), contradicting its "no attributes / no special handling" contract. Move QuantizeLinear and DequantizeLinear into a new QuantizeOpBuilder, matching the existing standalone-builder pattern (selu, quickgelu, etc.).