### PR TITLE
[QNN EP] Recover MaxPool UT on Linux arm64

### DIFF
--- a/onnxruntime/test/providers/qnn/maxpool_test.cc
+++ b/onnxruntime/test/providers/qnn/maxpool_test.cc
@@ -100,10 +100,6 @@ TEST_F(QnnCPUBackendTests, MaxPool_Global) {
 }
 
 TEST_F(QnnCPUBackendTests, MaxPool_Rank3) {
-  QNN_SKIP_TEST_ON_AARCH64("Test not supported on Linux ARM64");
-  // TODO: QNN CPU backend produces incorrect rank-3 MaxPool results on Linux
-  // aarch64 (qcs6490) — verified by running the same DLC with qnn-net-run + CPU backend.
-  // Re-enable once the QNN CPU team fixes the backend bug; ORT QNN EP itself is not at fault.
   RunPoolOpTest("MaxPool",
                 TestInputDef<float>({1, 16, 120}, false, -10.0f, 10.0f),  // Dynamic input with range [-10, 10]
                 {test::MakeAttribute("kernel_shape", std::vector<int64_t>{3}),


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
There's a fix from QNN CPU for MaxPool on Linux arm64. Will merge once qairt uplevel to 2.49.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


