### PR TITLE
Remove Not_Equal op work-around for FP->Bool Cast op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -31,64 +31,7 @@ class CastOpBuilder : public BaseOpBuilder {
                                           std::vector<std::string>&& input_names,
                                           const Ort::Logger& logger,
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
-
- private:
-  // QNN HTP currently does not support casting FP16/FP32 to Bool, and thus such Cast will be replaced by NotEqual with
-  // an additional static input 0.f to achieve the idential functional.
-  bool IsFpToBoolCast(const OrtNodeUnit& node_unit) const;
-  Ort::Status ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
-                                           const OrtNodeUnit& node_unit,
-                                           std::vector<std::string>& input_names,
-                                           const Ort::Logger& logger) const;
 };
-
-bool CastOpBuilder::IsFpToBoolCast(const OrtNodeUnit& node_unit) const {
-  ONNXTensorElementDataType input_type = node_unit.Inputs()[0].type;
-  ONNXTensorElementDataType output_type = node_unit.Outputs()[0].type;
-
-  Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
-  Qnn_DataType_t output_qnn_dtype = QNN_DATATYPE_UNDEFINED;
-
-  if (!utils::GetQnnDataType(false, input_type, input_qnn_dtype).IsOK() ||
-      !utils::GetQnnDataType(false, output_type, output_qnn_dtype).IsOK()) {
-    return false;
-  }
-
-  return ((input_qnn_dtype == QNN_DATATYPE_FLOAT_16 || input_qnn_dtype == QNN_DATATYPE_FLOAT_32) &&
-          output_qnn_dtype == QNN_DATATYPE_BOOL_8);
-}
-
-Ort::Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
-                                                        const OrtNodeUnit& node_unit,
-                                                        std::vector<std::string>& input_names,
-                                                        const Ort::Logger& logger) const {
-  const auto& input = node_unit.Inputs()[0];
-  if (input.quant_param.has_value()) {
-    return Ort::Status();
-  }
-
-  // Build additional static input with value 0.
-  const std::string& input_name = utils::UniqueNameGenerator().New(node_unit, "_notequal_zero");
-
-  Qnn_DataType_t qnn_data_type = QNN_DATATYPE_UNDEFINED;
-  ONNXTensorElementDataType input_type = input.type;
-  RETURN_IF_ERROR(utils::GetQnnDataType(false, input_type, qnn_data_type));
-
-  QnnTensorWrapper input_tensor_wrapper(input_name,
-                                        QNN_TENSOR_TYPE_STATIC,
-                                        qnn_data_type,
-                                        QnnQuantParamsWrapper(),
-                                        std::vector<uint32_t>{1},
-                                        std::vector<uint8_t>(utils::GetElementSizeByType(qnn_data_type), 0));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensor_wrapper)),
-                "Failed to add additional input tensor for QNN Cast node that will be replaced by NotEqual.");
-  input_names.push_back(input_name);
-
-  ORT_CXX_LOG(logger,
-              ORT_LOGGING_LEVEL_VERBOSE,
-              ("FP-to-Bool Cast node " + node_unit.Name() + " is replaced by NotEqual.").c_str());
-  return Ort::Status();
-}
 
 Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
@@ -108,9 +51,7 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + input_name).c_str());
     input_names.push_back(input_name);
-    return IsFpToBoolCast(node_unit)
-               ? ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger)
-               : Ort::Status();
+    return Ort::Status();
   }
 
   std::vector<uint8_t> unpacked_tensor;
@@ -138,9 +79,7 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                 "Failed to add input tensor for QNN Cast node.");
   input_names.push_back(input_name);
 
-  return IsFpToBoolCast(node_unit)
-             ? ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger)
-             : Ort::Status();
+  return Ort::Status();
 }
 
 Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
@@ -181,26 +120,14 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
                 "Failed to add output tensor for QNN Cast node.");
 
-  const bool is_fp_to_bool_cast = IsFpToBoolCast(node_unit);
-  const std::string qnn_op_type = is_fp_to_bool_cast
-                                      ? QNN_OP_ELEMENT_WISE_BINARY
-                                      : GetQnnOpType(node_unit.OpType());
-
-  // FP->bool cast is implemented as ElementWiseBinary(NOT_EQUAL) against a zero tensor, which
-  // requires the mandatory 'operation' scalar param. Plain Cast takes no params.
-  std::vector<std::string> param_tensor_names;
+  const std::string qnn_op_type = GetQnnOpType(node_unit.OpType());
   const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
-  if (is_fp_to_bool_cast) {
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), cast_node_name,
-                                           static_cast<uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_OPERATION_NOT_EQUAL),
-                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, param_tensor_names));
-  }
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
                                                 qnn_op_type,
                                                 std::move(input_names),
                                                 {output_name},
-                                                std::move(param_tensor_names),
+                                                {},
                                                 do_op_validation),
                 ("Failed to create " + qnn_op_type + " node.").c_str());
 

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -228,11 +228,11 @@ TEST_F(QnnHTPBackendTests, TestCastInt32ToInt64HTP) {
                          ExpectedEPNodeAssignment::All, "htp");
 }
 
-// Cast float to bool on HTP. Requires HTP arch >= v73.
-// Skipped on x86_64 simulator: FP->Bool Cast not supported regardless of SOC model.
+// Cast FP->Bool supported on HTP arch >= v69, but skipped on <= v73 due to MSVC bool
+// representation mismatch on Win ARM64 (expected(true) vs actual(true) EXPECT_EQ failure).
 TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP) {
   QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP->Bool not supported by the HTP x86_64 simulator.");
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
   RunCastOpTest<float>({3, 3},
                        ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                        ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -228,22 +228,22 @@ TEST_F(QnnHTPBackendTests, TestCastInt32ToInt64HTP) {
                          ExpectedEPNodeAssignment::All, "htp");
 }
 
-// Cast float to bool on HTP using native QNN Cast op (JIRA: AISW-192595).
-// Skipped: native Cast FP->Bool not supported by the x86_64 HTP simulator: needs atleast v73 arch
+// Cast float to bool on HTP. Requires HTP arch >= v73.
+// Skipped on x86_64 simulator: FP->Bool Cast not supported regardless of SOC model.
 TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP) {
-  QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP->Bool requires HTP arch >= v73; not supported by the x86_64 simulator.");
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V69);
+  QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP->Bool not supported by the HTP x86_64 simulator.");
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V73);
   RunCastOpTest<float>({3, 3},
                        ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                        ExpectedEPNodeAssignment::All,
                        "htp");
 }
 
-// Cast float16 to bool on HTP using native QNN Cast op (JIRA: AISW-192595).
-// Skipped: native Cast FP->Bool not supported by the x86_64 HTP simulator: needs atleast v73 arch
+// Cast float16 to bool on HTP. Requires HTP arch >= v75; QNN EP rejects FP16->Bool on Win arm v73.
+// Skipped on x86_64 simulator: FP16->Bool Cast not supported regardless of SOC model.
 TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
-  QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP16->Bool requires HTP arch >= v73; not supported by the x86_64 simulator.");
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V69);
+  QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP16->Bool not supported by the HTP x86_64 simulator.");
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
   RunCastFP16HTPTest({3, 3},
                      ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                      ExpectedEPNodeAssignment::All);

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -228,16 +228,22 @@ TEST_F(QnnHTPBackendTests, TestCastInt32ToInt64HTP) {
                          ExpectedEPNodeAssignment::All, "htp");
 }
 
-// Cast float to bool on HTP.
+// Cast float to bool on HTP using native QNN Cast op (JIRA: AISW-192595).
+// Skipped: native Cast FP->Bool not supported by the x86_64 HTP simulator: needs atleast v73 arch
 TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP) {
+  QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP->Bool requires HTP arch >= v73; not supported by the x86_64 simulator.");
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V69);
   RunCastOpTest<float>({3, 3},
                        ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                        ExpectedEPNodeAssignment::All,
                        "htp");
 }
 
-// Cast float16 to bool on HTP.
+// Cast float16 to bool on HTP using native QNN Cast op (JIRA: AISW-192595).
+// Skipped: native Cast FP->Bool not supported by the x86_64 HTP simulator: needs atleast v73 arch
 TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
+  QNN_SKIP_TEST_ON_LINUX_X86_64("Cast FP16->Bool requires HTP arch >= v73; not supported by the x86_64 simulator.");
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V69);
   RunCastFP16HTPTest({3, 3},
                      ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                      ExpectedEPNodeAssignment::All);

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -154,12 +154,10 @@ void VerifyOutput(const std::string& output_name,
       break;
     }
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL: {
-      const uint8_t* expected_data = expected_value.GetTensorData<uint8_t>();
-      const uint8_t* actual_data = actual_value.GetTensorData<uint8_t>();
+      const bool* expected_data = expected_value.GetTensorData<bool>();
+      const bool* actual_data = actual_value.GetTensorData<bool>();
       for (size_t i = 0; i < element_count; ++i) {
-        // Compare as bool (nonzero = true): QNN's Bool output may return 0xFF instead of 0x01,
-        // which causes MSVC's EXPECT_EQ to fail despite both values printing as "true".
-        EXPECT_EQ(expected_data[i] != 0, actual_data[i] != 0) << "Element " << i << " mismatch for " << output_name;
+        EXPECT_EQ(expected_data[i], actual_data[i]) << "Element " << i << " mismatch for " << output_name;
       }
       break;
     }

--- a/onnxruntime/test/util/test_utils.cc
+++ b/onnxruntime/test/util/test_utils.cc
@@ -154,10 +154,12 @@ void VerifyOutput(const std::string& output_name,
       break;
     }
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL: {
-      const bool* expected_data = expected_value.GetTensorData<bool>();
-      const bool* actual_data = actual_value.GetTensorData<bool>();
+      const uint8_t* expected_data = expected_value.GetTensorData<uint8_t>();
+      const uint8_t* actual_data = actual_value.GetTensorData<uint8_t>();
       for (size_t i = 0; i < element_count; ++i) {
-        EXPECT_EQ(expected_data[i], actual_data[i]) << "Element " << i << " mismatch for " << output_name;
+        // Compare as bool (nonzero = true): QNN's Bool output may return 0xFF instead of 0x01,
+        // which causes MSVC's EXPECT_EQ to fail despite both values printing as "true".
+        EXPECT_EQ(expected_data[i] != 0, actual_data[i] != 0) << "Element " << i << " mismatch for " << output_name;
       }
       break;
     }


### PR DESCRIPTION
### Description
Not_Equal op has accuracy issue on v79 architecture: https://jira-dc.qualcomm.com/jira/browse/AISW-192595

All the Attention Mask Softmax block were affected.

FP->Bool Cast op is now natively supported by QNN (tested with v2.47 on device)

Fixes = https://github.com/qcom-ai-hub/tetracode/issues/19570


