### PR TITLE
[QNN EP] Promote BatchNorm to F32 when any ONNX param is per-channel

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -492,8 +492,12 @@ void OverrideParamTypeForRequantize(Qnn_DataType_t x_dtype,
 // Single source of truth for float execution, shared by ProcessInputs (stores params) and
 // ProcessAttributesAndOutputs (emits the op).
 //   - has_float_output: quantized input, no output Q -> float island; BN emits float directly.
-//   - use_float_params: also covers u8/u16 input with per-channel scale, whose fused weight
-//     gamma/sqrt(var+eps) can overflow a single per-tensor requant scale.
+//   - use_float_params: also covers u8/u16 input where any ONNX BN param (scale/bias/mean/var)
+//     is per-channel. QNN BN takes only per-tensor fused_scale/fused_bias, so folding a
+//     per-channel input into the fused weight (gamma/sqrt(var+eps)) or fused bias
+//     (beta - mean*fused_scale) and then squeezing it back to one scale is lossy — the
+//     per-channel divergence baked in cannot be recovered. The float-promotion path
+//     (Dequantize -> BN in F32 -> Quantize) preserves that divergence.
 struct BatchNormFloatExecution {
   bool has_float_output;
   bool use_float_params;
@@ -501,15 +505,22 @@ struct BatchNormFloatExecution {
 
 BatchNormFloatExecution GetBatchNormFloatExecution(const TensorInfo& input_info,
                                                    const TensorInfo& scale_info,
+                                                   const TensorInfo& bias_info,
+                                                   const TensorInfo& mean_info,
+                                                   const TensorInfo& var_info,
                                                    const TensorInfo& output_info) {
   const bool is_quantized_op = input_info.quant_param.IsQuantized();
   const bool has_float_output = is_quantized_op && !output_info.quant_param.IsQuantized();
+  const bool any_param_per_channel = scale_info.quant_param.IsPerChannel() ||
+                                     bias_info.quant_param.IsPerChannel() ||
+                                     mean_info.quant_param.IsPerChannel() ||
+                                     var_info.quant_param.IsPerChannel();
   const bool use_float_params =
       has_float_output ||
       (is_quantized_op &&
        (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
         input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
-       scale_info.quant_param.IsPerChannel());
+       any_param_per_channel);
   return {has_float_output, use_float_params};
 }
 
@@ -621,7 +632,9 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
     // When BN runs in float, params below are stored as f32 (see GetBatchNormFloatExecution).
     TensorInfo output_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
-    const bool use_float_params = GetBatchNormFloatExecution(input_info, scale_info, output_info).use_float_params;
+    const bool use_float_params =
+        GetBatchNormFloatExecution(input_info, scale_info, bias_info, mean_info, var_info, output_info)
+            .use_float_params;
 
     // Check if bias needs conversion (will be done after preprocessing)
     const bool bias_is_float = !bias_info.quant_param.IsQuantized() &&
@@ -750,12 +763,19 @@ Ort::Status BatchNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWra
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));
   TensorInfo scale_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[1], scale_info));
+  TensorInfo bias_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[2], bias_info));
+  TensorInfo mean_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[3], mean_info));
+  TensorInfo var_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[4], var_info));
 
   TensorInfo output_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Outputs()[0], output_info));
 
   // has_float_output emits BN's float result with no trailing Quantize, feeding downstream float ops.
-  const BatchNormFloatExecution float_exec = GetBatchNormFloatExecution(input_info, scale_info, output_info);
+  const BatchNormFloatExecution float_exec =
+      GetBatchNormFloatExecution(input_info, scale_info, bias_info, mean_info, var_info, output_info);
   const bool has_float_output = float_exec.has_float_output;
   const bool use_float_params = float_exec.use_float_params;
 

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -785,6 +785,95 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U8) {
                        qdq_model_fn, provider_options, 21, ExpectedEPNodeAssignment::All);
 }
 
+// Regression for AISW-192600: gamma is per-tensor but var is per-channel. The fused weight
+// gamma/sqrt(var+eps) has per-channel divergence driven entirely by var; folding it back to a
+// single per-tensor scale used to lose precision. Verifies the float-promotion path is now
+// selected in this case (previously only triggered when gamma itself was per-channel).
+TEST_F(QnnHTPBackendTests, BatchNorm2D_PerTensorGamma_PerChannelVar_U16) {
+#if defined(__linux__) && !defined(__aarch64__)
+  GTEST_SKIP() << "Skipped on x86_64 simulator due to flaky behavior";
+#endif
+  constexpr int64_t batch = 1;
+  constexpr int64_t channels = 4;
+  constexpr int64_t H = 2;
+  constexpr int64_t W = 2;
+  // Wide inter-channel variance spread stresses the per-tensor fused-scale requant path.
+  std::vector<float> input_data = {
+      -4.0f, -2.0f, 2.0f, 4.0f,   // ch0: var ~= 10
+      -3.0f, -1.0f, 1.0f, 3.0f,   // ch1: var ~= 5
+      5.0f, 5.1f, 4.9f, 5.0f,     // ch2: var ~= 0.005
+      -2.0f, -1.9f, -2.1f, -2.0f  // ch3: var ~= 0.005
+  };
+  std::vector<float> scale_data = {1.0f, 1.5f, 2.0f, 3.0f};
+  std::vector<float> bias_data = {0.0f, 0.5f, 1.0f, -1.0f};
+
+  TestInputDef<float> input_def({batch, channels, H, W}, false, input_data);
+  TestInputDef<float> scale_def({channels}, true, scale_data);
+  TestInputDef<float> bias_def({channels}, true, bias_data);
+
+  GetTestQDQModelFn<uint16_t> qdq_model_fn = [input_def, scale_def, bias_def](
+                                                 ModelTestBuilder& builder,
+                                                 std::vector<QuantParams<uint16_t>>& output_qparams) {
+    const auto& input_shape = input_def.GetShape();
+    const auto& input_data_ref = input_def.GetRawData();
+    const int64_t num_channels = input_shape[1];
+
+    // Input: symmetric U16 Q/DQ per-tensor.
+    MakeTestInput<float>(builder, "input", input_def);
+    QuantParams<uint16_t> input_qparams = GetTestInputQuantParams<uint16_t>(input_def, /*symmetric*/ true);
+    std::string input_qdq = AddQDQNodePair<uint16_t>(builder, "input_qdq", "input",
+                                                      input_qparams.scale, input_qparams.zero_point);
+
+    // scale (gamma): PER-TENSOR U8 Q/DQ.
+    const auto& scale_data_ref = scale_def.GetRawData();
+    float scale_abs_max = 0.0f;
+    for (float v : scale_data_ref) scale_abs_max = std::max(scale_abs_max, std::abs(v));
+    if (scale_abs_max == 0.0f) scale_abs_max = 1.0f;
+    const float scale_qscale = scale_abs_max / static_cast<float>(std::numeric_limits<uint8_t>::max());
+    builder.MakeInitializer<float>("scale_init", {num_channels}, scale_data_ref);
+    std::string scale_qdq = AddQDQNodePair<uint8_t>(builder, "scale_qdq", "scale_init",
+                                                     scale_qscale, static_cast<uint8_t>(0));
+
+    // bias: raw float initializer (converted internally to S32 by OverrideParamTypeForRequantize).
+    builder.MakeInitializer<float>("bias", bias_def.GetShape(), bias_def.GetRawData());
+
+    std::vector<float> mean_vals(num_channels);
+    std::vector<float> var_vals(num_channels);
+    ComputeChannelMeanAndVar(input_data_ref, input_shape, mean_vals, var_vals);
+
+    // mean: raw float initializer.
+    builder.MakeInitializer<float>("mean", {num_channels}, mean_vals);
+
+    // var: PER-CHANNEL U8 Q/DQ (axis=0). This is the AISW-192600 scenario.
+    std::vector<float> var_scales(num_channels);
+    std::vector<uint8_t> var_zps(num_channels, 0);
+    for (int64_t c = 0; c < num_channels; ++c) {
+      float abs_max = std::abs(var_vals[c]);
+      if (abs_max == 0.0f) abs_max = 1.0f;
+      var_scales[c] = abs_max / static_cast<float>(std::numeric_limits<uint8_t>::max());
+    }
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attr = {
+        builder.MakeScalarAttribute("axis", static_cast<int64_t>(0))};
+    builder.MakeInitializer<float>("var_init", {num_channels}, var_vals);
+    std::string var_qdq = AddQDQNodePair<uint8_t>(builder, "var_qdq", "var_init",
+                                                    var_scales, var_zps, axis_attr, axis_attr);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> bn_attrs;
+    builder.AddNode("batchnorm", "BatchNormalization",
+                    {input_qdq, scale_qdq, "bias", "mean", var_qdq},
+                    {"batchnorm_output"}, "", bn_attrs);
+    AddQDQNodePairWithOutputAsGraphOutput<uint16_t>(builder, "output_qdq", "batchnorm_output",
+                                                     output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
+                       qdq_model_fn, provider_options, 21, ExpectedEPNodeAssignment::All,
+                       QDQTolerance(0.008f));
+}
+
 // Builds the float (reference) form of the NASNet reduction-cell pattern:
 //   X -> BatchNormalization -> Relu -> Conv -> Y
 template <typename FLOAT_TYPE>


### PR DESCRIPTION
### Description

QNN BN takes only 3 inputs (X, fused_scale, fused_bias) while ONNX BN has 5, so the op builder folds gamma/beta/mean/var into fused_scale = gamma / sqrt(var + eps) and fused_bias = beta - mean * fused_scale. Postprocess then emits fused_scale/fused_bias with a single per-tensor QNN quant scale.

If any ONNX BN param is per-channel, the fused tensors are inherently per-channel in real values (their divergence is driven by the per-channel input). Squeezing that divergence into a single per-tensor scale loses precision. 

The op builder already has a float-promotion path (Dequantize -> BN_F32 -> Quantize) triggered by GetBatchNormFloatExecution when scale_info.quant_param.IsPerChannel(). Extend that predicate to also trigger when bias/mean/var are per-channel -- same root cause.

