### PR TITLE
[CI] Fix corrupt QAIRT SDK cache poisoning CI builds

### DIFF
--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -207,6 +207,7 @@ python_314_windows_arm64:
 qairt:
   version: 2.47.0.260601
   url: https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/{version}/v{version}.zip
+  sha256: d3497e110eae82c35a9152a93c0a18bbede402aaf9faa7a97c8079eb0f522b01
   content_root: qairt/{version}
   bindir: bin
 qualcomm_device_cloud_sdk:

--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -155,18 +155,22 @@ onnx_models:
 ort_prebuilt_windows_x64: &ort_prebuilt_common
   version: 1.26.0
   url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-x64-{version}.zip
+  sha256: 6ebe99b5564bf4d029b6e93eac9ff423682b6212eade769e9ca3f685eaf500b4
   content_root: onnxruntime-win-x64-{version}
 ort_prebuilt_windows_arm64:
   <<: *ort_prebuilt_common
   url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-arm64-{version}.zip
+  sha256: 852e89621fb752b261821dda131042ed7c7fa18d8bb06768bd4eb7fa7086d87f
   content_root: onnxruntime-win-arm64-{version}
 ort_prebuilt_linux_x64:
   <<: *ort_prebuilt_common
   url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-linux-x64-{version}.tgz
+  sha256: 1254da24fb389cf39dc0ff3451ab48301740ffbfcbaf646849df92f80ee92c57
   content_root: onnxruntime-linux-x64-{version}
 ort_prebuilt_linux_aarch64:
   <<: *ort_prebuilt_common
   url: https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-linux-aarch64-{version}.tgz
+  sha256: 34ff1c2d0f12e2cf3d33a0c5f82e39792e1d581fbd6968fd7c30d173654be01a
   content_root: onnxruntime-linux-aarch64-{version}
 python_311_windows_x86_64: &py_x86_64_common
   version: 3.11.9
@@ -213,3 +217,4 @@ qairt:
 qualcomm_device_cloud_sdk:
   version: 0.3.0
   url: https://softwarecenter.qualcomm.com/api/download/software/tools/Qualcomm_Device_Cloud_SDK/Windows/{version}/qualcomm_device_cloud_sdk-{version}.zip
+  sha256: 80e690591a576b8bcbe0357e3a2d364a03768cc801acd15358b4b740e43a9a1b

--- a/qcom/scripts/all/package_manager.py
+++ b/qcom/scripts/all/package_manager.py
@@ -13,6 +13,7 @@ import subprocess
 import tarfile
 import tempfile
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
@@ -43,6 +44,26 @@ DEFAULT_MAX_CACHE_SIZE_BYTES = int(
 DEFAULT_TOOLS_DIR = Path(os.environ.get("ORT_BUILD_TOOLS_PATH", REPO_ROOT / "build" / "tools"))
 
 CAFILE = os.environ.get("REQUESTS_CA_BUNDLE", certifi.where())
+
+# How many times to (re)download an archive before giving up, and the base backoff (seconds)
+# between attempts. A download is retried on network errors, checksum mismatches, or bytes that
+# don't look like a valid archive -- all of which indicate a bad/partial body worth re-fetching.
+DOWNLOAD_ATTEMPTS = int(os.environ.get("ORT_BUILD_DOWNLOAD_ATTEMPTS", "3"))
+DOWNLOAD_BACKOFF_BASE_SECONDS = float(os.environ.get("ORT_BUILD_DOWNLOAD_BACKOFF_SECONDS", "2"))
+
+
+def _looks_like_archive(path: Path) -> bool:
+    """Return True if the file is a readable tar or zip archive."""
+    return tarfile.is_tarfile(path) or zipfile.is_zipfile(path)
+
+
+def _peek_bytes(path: Path, count: int = 64) -> bytes:
+    """Read up to `count` bytes from the start of a file for diagnostics (best-effort)."""
+    try:
+        with path.open("rb") as f:
+            return f.read(count)
+    except OSError:
+        return b""
 
 
 def is_host_windows():
@@ -78,53 +99,128 @@ class FileCache:
         url_path = PurePosixPath(url_parts.path)
         cache_dir = self.__cache_dir / cache_key
         cache_file_path = cache_dir / url_path.name
-        if not cache_file_path.exists():
-            logging.info(f"Downloading {url} to {cache_file_path}")
 
-            # Defer writing the final file so we don't leave partial downloads if we get killed.
-            with tempfile.SpooledTemporaryFile(mode="wr+b") as tmp_file:
-                with urllib.request.urlopen(url, context=ssl.create_default_context(cafile=CAFILE)) as response:
-                    content_length = response.getheader("content-length")
-                    length = (
-                        int(response.getheader("content-length")) / 1024 / 1024 if content_length is not None else 0
-                    )
-                    with tqdm.tqdm(
-                        total=length,
-                        unit="MiB",
-                        bar_format="{l_bar}{bar}| {n:.2f}/{total:.2f} [{remaining}, {rate_fmt}{postfix}]",
-                    ) as pbar:
-                        while True:
-                            chunk = response.read(64 * 1024)
-                            if not chunk:
-                                break
-                            tmp_file.write(chunk)
-                            pbar.update(len(chunk) / 1024 / 1024)
+        checksums = [
+            (expected_sha1, "SHA1", hashlib.sha1),
+            (expected_sha256, "SHA256", hashlib.sha256),
+            (expected_md5, "MD5", hashlib.md5),
+        ]
+        has_checksum = any(expected is not None for expected, _, _ in checksums)
+        # Installers and bare binaries (.exe or no suffix) aren't archives, so don't archive-check them.
+        expects_archive = cache_file_path.suffix not in ("", ".exe")
 
-                # Make sure the download's hash matches
-                for expected_sha, sha_name, sha_fn in [
-                    (expected_sha1, "SHA1", hashlib.sha1),
-                    (expected_sha256, "SHA256", hashlib.sha256),
-                    (expected_md5, "MD5", hashlib.md5),
-                ]:
-                    if expected_sha is not None:
-                        tmp_file.seek(0)
-                        actual_sha = sha_fn()
-                        for bytes in iter(lambda: tmp_file.read(32768), b""):
-                            actual_sha.update(bytes)
-                        logging.debug(f"{sha_name} hash for {cache_file_path.name}: {actual_sha.hexdigest()}")
-                        if expected_sha != actual_sha.hexdigest():
-                            raise ValueError(f"{sha_name} mismatch for {cache_file_path.name}")
+        # The package cache is persistent and shared across CI runs, so a single corrupt/partial
+        # download would otherwise poison every future build. Validate before trusting a cache hit
+        # and self-heal by discarding and re-downloading anything that doesn't check out.
+        if cache_file_path.exists():
+            problem = self.__validate_file(cache_file_path, checksums, has_checksum, expects_archive)
+            if problem is None:
+                logging.debug(f"{url} already exists at {cache_file_path}")
+                return cache_file_path
+            logging.warning(f"Discarding cached {cache_file_path} and re-downloading: {problem}")
+            cache_file_path.unlink(missing_ok=True)
 
-                # Write the final file. Note that SpooledTemporaryFile doesn't necessarily create a file
-                # so there's a good chance we're writing to disk for the first time.
-                cache_dir.mkdir(exist_ok=True)
-                tmp_file.seek(0)
-                with cache_file_path.open(mode="wb") as cache_file_stream:
-                    shutil.copyfileobj(tmp_file, cache_file_stream)
-
-        else:
-            logging.debug(f"{url} already exists at {cache_file_path}")
+        self.__download_with_retries(url, cache_dir, cache_file_path, checksums, has_checksum, expects_archive)
         return cache_file_path
+
+    def __download_with_retries(
+        self,
+        url: str,
+        cache_dir: Path,
+        cache_file_path: Path,
+        checksums: list[tuple[str | None, str, Any]],
+        has_checksum: bool,
+        expects_archive: bool,
+    ) -> None:
+        """Download `url` into the cache, retrying on transient failures and bad/partial bodies."""
+        last_error: Exception | None = None
+        for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+            try:
+                self.__download_once(url, cache_dir, cache_file_path, checksums, has_checksum, expects_archive)
+                return
+            except (OSError, ValueError) as e:
+                # OSError covers urllib.error.URLError/HTTPError and socket timeouts; ValueError is
+                # raised by our own checksum/archive validation on a corrupt body. Both are worth a retry.
+                last_error = e
+                if attempt < DOWNLOAD_ATTEMPTS:
+                    delay = DOWNLOAD_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+                    logging.warning(
+                        f"Download attempt {attempt}/{DOWNLOAD_ATTEMPTS} for {url} failed: {e}. "
+                        f"Retrying in {delay:.0f}s."
+                    )
+                    time.sleep(delay)
+        raise RuntimeError(f"Failed to download {url} after {DOWNLOAD_ATTEMPTS} attempt(s).") from last_error
+
+    def __download_once(
+        self,
+        url: str,
+        cache_dir: Path,
+        cache_file_path: Path,
+        checksums: list[tuple[str | None, str, Any]],
+        has_checksum: bool,
+        expects_archive: bool,
+    ) -> None:
+        logging.info(f"Downloading {url} to {cache_file_path}")
+
+        # Defer writing the final file so we don't leave partial downloads if we get killed.
+        with tempfile.SpooledTemporaryFile(mode="wr+b") as tmp_file:
+            with urllib.request.urlopen(url, context=ssl.create_default_context(cafile=CAFILE)) as response:
+                getheader = getattr(response, "getheader", lambda _name, _default=None: None)
+                content_length = getheader("content-length")
+                length = int(content_length) / 1024 / 1024 if content_length is not None else 0
+                with tqdm.tqdm(
+                    total=length,
+                    unit="MiB",
+                    bar_format="{l_bar}{bar}| {n:.2f}/{total:.2f} [{remaining}, {rate_fmt}{postfix}]",
+                ) as pbar:
+                    while True:
+                        chunk = response.read(64 * 1024)
+                        if not chunk:
+                            break
+                        tmp_file.write(chunk)
+                        pbar.update(len(chunk) / 1024 / 1024)
+
+            # Write the final file. Note that SpooledTemporaryFile doesn't necessarily create a file
+            # so there's a good chance we're writing to disk for the first time.
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            tmp_file.seek(0)
+            with cache_file_path.open(mode="wb") as cache_file_stream:
+                shutil.copyfileobj(tmp_file, cache_file_stream)
+
+        # Validate the freshly written file before leaving it in the cache. If it's a checksum
+        # mismatch or not a valid archive, we got a bad/partial/error-page response: purge it and
+        # raise so __download_with_retries can try again rather than caching garbage.
+        problem = self.__validate_file(cache_file_path, checksums, has_checksum, expects_archive)
+        if problem is not None:
+            cache_file_path.unlink(missing_ok=True)
+            raise ValueError(f"Downloaded {cache_file_path.name} failed validation: {problem}")
+
+    @staticmethod
+    def __validate_file(
+        path: Path,
+        checksums: list[tuple[str | None, str, Any]],
+        has_checksum: bool,
+        expects_archive: bool,
+    ) -> str | None:
+        """Return None if the file is trustworthy, otherwise a human-readable reason it isn't."""
+        for expected_sha, sha_name, sha_fn in checksums:
+            if expected_sha is not None:
+                actual = FileCache.__hash_file(path, sha_fn)
+                logging.debug(f"{sha_name} hash for {path.name}: {actual}")
+                if expected_sha != actual:
+                    return f"{sha_name} mismatch (expected {expected_sha}, got {actual})"
+        # With no checksum to rely on (e.g. the qairt SDK), at least confirm we have a real archive.
+        if not has_checksum and expects_archive and not _looks_like_archive(path):
+            return f"not a valid archive (size {path.stat().st_size} bytes, starts with {_peek_bytes(path, 16)!r})"
+        return None
+
+    @staticmethod
+    def __hash_file(path: Path, sha_fn: Any) -> str:
+        hasher = sha_fn()
+        with path.open("rb") as f:
+            for block in iter(lambda: f.read(32768), b""):
+                hasher.update(block)
+        return hasher.hexdigest()
 
     def prune(self) -> None:
         """Prune old entries from the cache until it's below our maximum size."""
@@ -258,7 +354,15 @@ class PackageManager:
                 elif zipfile.is_zipfile(package_path):
                     self.__install_zip(package_path, tmp_rootdir)
                 else:
-                    raise ValueError(f"{package_path.name} has unknown archive format.")
+                    # Backstop: a corrupt archive slipped past FileCache validation. Purge it so the
+                    # next run re-downloads instead of failing forever on the same poisoned cache file.
+                    size = package_path.stat().st_size if package_path.exists() else 0
+                    head = _peek_bytes(package_path, 16)
+                    package_path.unlink(missing_ok=True)
+                    raise ValueError(
+                        f"{package_path.name} has unknown archive format "
+                        f"(size {size} bytes, starts with {head!r}); purged {package_path} from cache."
+                    )
 
                 # Move fully extracted package to final location
                 logging.info(f"Moving {tmp_rootdir} to {self.__package_root}")

--- a/qcom/scripts/all/package_manager.py
+++ b/qcom/scripts/all/package_manager.py
@@ -440,7 +440,19 @@ class PackageManager:
     @staticmethod
     def __parse_config(config_path: Path) -> dict[str, dict[str, Any]]:
         with config_path.open() as config_file:
-            return yaml.safe_load(config_file)
+            config = yaml.safe_load(config_file)
+
+        # Every package must pin a checksum. Without one we cannot detect a corrupt/partial/wrong
+        # download, which is what lets a poisoned entry get stuck in the persistent CI cache.
+        without_checksum = [
+            name for name, atts in config.items() if not any(k in atts for k in ("sha256", "sha1", "md5"))
+        ]
+        if without_checksum:
+            raise ValueError(
+                f"The following packages in {config_path} are missing a required checksum "
+                f"(sha256, sha1, or md5): {', '.join(sorted(without_checksum))}."
+            )
+        return config
 
     @classmethod
     def __uninstall(cls, subdir: Path) -> None:


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Refactor FileCache.fetch into a retry loop (3 attempts, exponential backoff) that re-fetches on network errors, checksum mismatches, or non-archive bodies.
- Validate both on cache-hit and after each download; self-heal by purging and re-downloading anything that fails checksum or isn't a valid tar/zip.
- Add an install() backstop that purges the cache file and raises a clear, actionable error if an unrecognized archive still slips through.
- Pin sha256 for the qairt package in packages.yml (computed from a verified fresh download) so a bad body never gets committed to cache.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- CI builds fail with "v2.47.0.260601.zip has unknown archive format" because a corrupt/partial QAIRT SDK download got written into the persistent runner cache and is reused on every run. Two gaps in package_manager.py allowed this: the qairt package had no checksum (so FileCache.fetch wrote whatever bytes came back), and cache hits were returned without any validation, so a once-poisoned cache stayed poisoned forever.
