### PR TITLE
[QNN-EP] Set the default to unroll LSTM at ORT

### DIFF
--- a/cmake/patches/ort_core/0004-Update-argument-for-monolithic-lstm.patch
+++ b/cmake/patches/ort_core/0004-Update-argument-for-monolithic-lstm.patch
@@ -16,7 +16,7 @@ index f08b974d60..a50d771234 100644
              ORT_THROW("Wrong value for htp_arch. select from: " + str);
            }
 -        } else if (key == "enable_htp_fp16_precision" || key == "offload_graph_io_quantization" || key == "extended_udma") {
-+        } else if (key == "enable_htp_fp16_precision" || key == "offload_graph_io_quantization" || key == "extended_udma" || key == "disable_htp_monolithic_lstm") {
++        } else if (key == "enable_htp_fp16_precision" || key == "offload_graph_io_quantization" || key == "extended_udma" || key == "enable_htp_monolithic_lstm") {
            std::unordered_set<std::string> supported_options = {"0", "1"};
            if (supported_options.find(value) == supported_options.end()) {
              std::ostringstream str_stream;

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -205,10 +205,12 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 |'0'|Default. Disabled. Inference with fp32 precision if it's fp32 model.|
 |'1'|Enable the float32 model to be inferenced with fp16 precision.|
 
-|`"disable_htp_monolithic_lstm"`|Description|
+|`"enable_htp_monolithic_lstm"`|Description|
 |---|---|
-|'0'|Default. HTP uses the monolithic LSTM graph configuration.|
-|'1'|Disable the monolithic LSTM graph configuration on HTP.|
+|'0'|Default. LSTM is expanded into per-timestep cells at the ORT layer.|
+|'1'|Run the monolithic LSTM kernel on HTP (single graph node).|
+
+Warning: Enabling HTP Monolithic LSTM may improve session creation time, but this improvement may come with a regression in inference performance.
 
 |`"enable_htp_spill_fill_buffer"`|Description|
 |---|---|

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/lstm_op_builder.cc
@@ -250,6 +250,12 @@ Ort::Status LSTMOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
                                          const Ort::Logger& logger) const {
   ORT_UNUSED_PARAMETER(logger);
+
+  // Both unrolled/monolithic paths need X's shape to read seq_length/batch_size/input_size at compile time
+  // Reject a dynamic/symbolic X shape here rather than hard-failing later in ComposeGraph.
+  TensorInfo x_tensor_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], x_tensor_info));
+
   if (node_unit.Inputs().size() > 4 && node_unit.Inputs()[4].Exists()) {
     TensorInfo tensor_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[4], tensor_info));
@@ -337,6 +343,20 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
   const uint32_t seq_length = layout == 0 ? input_tensor_infos[0].shape[0] : input_tensor_infos[0].shape[1];
   const int32_t direction_idx = input_tensor_infos[1].shape[0] < 2 || direction == "forward" ? 0 : 1;
 
+  // When false (default), lower LSTM as ORT-QNN-EP side per-timestep unrolled QNN_OP_LSTM cells + Pack.
+  // When true, lower as a single monolithic QNN_OP_LSTM node and rely on HTP's native
+  // monolithic LSTM kernel (enabled via enable_htp_monolithic_lstm provider option, which also
+  // toggles the QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM graph config).
+  //
+  // The monolithic path is only meaningful for the HTP/NPU backend.
+  // The IR backend is also allowed to honor the flag
+  // so that a serialized DLC can faithfully mirror the HTP monolithic graph — otherwise an
+  // IR-produced DLC (always unrolled) could not be compared against the HTP monolithic one.
+  // All other backends (CPU/GPU) have no monolithic kernel and always use the unrolled lowering.
+  const bool enable_htp_monolithic_lstm = (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) ||
+                                           IsIrBackend(qnn_model_wrapper.GetQnnBackendType())) &&
+                                          qnn_model_wrapper.GetModelSettings().enable_htp_monolithic_lstm;
+
   // params
   std::vector<std::string> param_names;
 
@@ -354,8 +374,9 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
                                       QNN_OP_LSTM_PARAM_OUTPUT_CLIP_THRESHOLD, param_names));
 
   // time_major
-  // set to true since current builder only support time major lstm(layout=0)
-  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), true,
+  // monolithic QNN_OP_LSTM consumes the whole 3D sequence at once (time_major=true);
+  // the unrolled path feeds one 2D timestep per cell node (time_major=false).
+  RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), enable_htp_monolithic_lstm,
                                      QNN_OP_LSTM_PARAM_TIME_MAJOR, param_names));
 
   // input_gate_qscale
@@ -388,8 +409,10 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
 
   qnn_model_wrapper.AddTensorWrapper(std::move(null_tensor_wrapper));
 
-  std::vector<std::string> qnn_lstm_input_names(25, null_tensor_name);
-  qnn_lstm_input_names[0] = input_names[0];
+  std::vector<std::string> qnn_lstm_input_names(enable_htp_monolithic_lstm ? 25 : 24, null_tensor_name);
+  if (enable_htp_monolithic_lstm) {
+    qnn_lstm_input_names[0] = input_names[0];
+  }
   // input W
   {
     // QNN in[1] = ONNX in[1][direction, 2*hidden_size:3*hidden_size, :]
@@ -663,28 +686,127 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
       {batch_size, hidden_size},
       {batch_size, hidden_size}};
 
-  std::vector<std::string> qnn_lstm_output_names = {
-      utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_all_hidden_state_" + direction),
-      utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_cell_state_" + direction),
-      utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_hidden_state_" + direction)};
+  // reshape_input_names ends up holding, in ONNX output order [Y, Y_h, Y_c], the QNN tensor
+  // name that feeds the final reshape-to-ONNX-shape step below.
+  std::vector<std::string> reshape_input_names(3);
 
   // QNN output order: all_hidden, last_cell, last_hidden
   // ONNX output order: all_hidden, last_hidden, last_cell
-  int output_position_map[] = {0, 2, 1};
-  for (size_t j = 0; j < qnn_lstm_output_names.size(); j++) {
-    QnnTensorWrapper output_tensorwrapper(qnn_lstm_output_names[j],
-                                          QNN_TENSOR_TYPE_NATIVE,
-                                          output_tensor_infos[output_position_map[j]].qnn_data_type,
-                                          output_tensor_infos[output_position_map[j]].quant_param.Copy(),
-                                          std::vector<uint32_t>(qnn_lstm_output_shapes[j]));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
-                  ("QNN EP: Failed to add " + std::to_string(j) + "th output tensor for QNN LSTM.").c_str());
+  // so output_tensor_infos (ONNX order) must be mapped to QNN output position.
+  static constexpr int kOutputPositionMap[] = {0, 2, 1};
+  auto emit_lstm_outputs = [&](const std::vector<std::string>& out_names,
+                               const std::vector<std::vector<uint32_t>>& out_shapes) -> Ort::Status {
+    for (size_t j = 0; j < 3; j++) {
+      QnnTensorWrapper output_tensorwrapper(out_names[j],
+                                            QNN_TENSOR_TYPE_NATIVE,
+                                            output_tensor_infos[kOutputPositionMap[j]].qnn_data_type,
+                                            output_tensor_infos[kOutputPositionMap[j]].quant_param.Copy(),
+                                            std::vector<uint32_t>(out_shapes[j]));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
+                    ("QNN EP: Failed to add " + std::to_string(j) + "th output tensor for QNN LSTM.").c_str());
+    }
+    return Ort::Status();
+  };
+
+  if (!enable_htp_monolithic_lstm) {
+    // Unrolled path: HTP does not have a fast native path for a single 3D QNN_OP_LSTM node,
+    // so emit one QNN_OP_LSTM cell per timestep (2D in/out) and chain hidden/cell state
+    // between cells, then Pack all per-timestep hidden states back into a 3D tensor.
+    std::vector<std::string> qnn_all_hidden_state_names(seq_length);
+    for (uint32_t i = 0; i < seq_length; i++) {
+      uint32_t sequence_idx = direction == "forward" ? i : seq_length - i - 1;
+      std::vector<std::string> qnn_lstm_input_names_i = qnn_lstm_input_names;
+
+      // input X: QNN in[0] = ONNX in[0][sequence_idx, :, :]
+      {
+        uint32_t begin_mask = 0b000U;
+        uint32_t end_mask = 0b000U;
+        uint32_t shrink_axes = 0b001U;
+        uint32_t new_axes_mask = 0b000U;
+        std::vector<std::vector<int32_t>> ranges = {{SafeInt<int32_t>(sequence_idx), SafeInt<int32_t>(sequence_idx + 1), 1},
+                                                    {0, SafeInt<int32_t>(batch_size), 1},
+                                                    {0, SafeInt<int32_t>(input_size), 1}};
+        std::string qnn_lstm_input_name = utils::UniqueNameGenerator().New(input_names[0], "_cell_" + std::to_string(sequence_idx) + "_input");
+        std::vector<uint32_t> output_shape = {batch_size, input_size};
+        RETURN_IF_ERROR(AddStridedSliceOrReshape(/*qnn_model_wrapper=*/qnn_model_wrapper,
+                                                 /*node_unit=*/node_unit,
+                                                 /*input_name=*/input_names[0],
+                                                 /*output_name=*/qnn_lstm_input_name,
+                                                 /*input_shape=*/input_tensor_infos[0].shape,
+                                                 /*output_shape=*/output_shape,
+                                                 /*ranges=*/ranges,
+                                                 /*begin_mask=*/begin_mask,
+                                                 /*end_mask=*/end_mask,
+                                                 /*shrink_axes=*/shrink_axes,
+                                                 /*new_axes_mask=*/new_axes_mask,
+                                                 /*tensor_data_type=*/input_tensor_infos[0].qnn_data_type,
+                                                 /*QnnQuantParamsWrapper=*/input_tensor_infos[0].quant_param,
+                                                 /*do_op_validation=*/do_op_validation,
+                                                 /*is_for_input=*/false,
+                                                 /*is_for_output=*/false));
+        qnn_lstm_input_names_i[0] = qnn_lstm_input_name;
+      }
+
+      std::vector<uint32_t> qnn_lstm_output_shape = {batch_size, hidden_size};
+      std::vector<std::string> qnn_lstm_output_names = {
+          utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_all_hidden_state_" + std::to_string(sequence_idx) + "_" + direction),
+          utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_cell_state_" + std::to_string(sequence_idx) + "_" + direction),
+          utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_hidden_state_" + std::to_string(sequence_idx) + "_" + direction)};
+      qnn_lstm_input_names[10] = qnn_lstm_output_names[2];  // update initial_h for next cell
+      qnn_lstm_input_names[11] = qnn_lstm_output_names[1];  // update initial_c for next cell
+      // Single-timestep cell, so out[0] (all_hidden) == out[2] (final hidden state); reuse out[2].
+      qnn_all_hidden_state_names[sequence_idx] = qnn_lstm_output_names[2];
+
+      RETURN_IF_ERROR(emit_lstm_outputs(qnn_lstm_output_names,
+                                        {qnn_lstm_output_shape, qnn_lstm_output_shape, qnn_lstm_output_shape}));
+      const std::string lstm_node_name = utils::UniqueNameGenerator().New(node_unit, "_cell" + std::to_string(sequence_idx) + "_" + direction);
+      RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(lstm_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_LSTM,
+                                                    std::move(qnn_lstm_input_names_i), std::move(qnn_lstm_output_names),
+                                                    std::vector<std::string>(param_names), do_op_validation),
+                    "QNN EP: Failed to create Qnn LSTM node.");
+    }
+
+    // Pack all per-timestep hidden states together for ONNX output[0] (Y).
+    const std::string qnn_pack_output_name = utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_hidden_state_all_" + direction);
+    std::vector<std::string> pack_param_names;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), qnn_pack_output_name, 0,
+                                           QNN_OP_PACK_PARAM_AXIS, pack_param_names));
+
+    QnnTensorWrapper pack_output_tensorwrapper(qnn_pack_output_name,
+                                               QNN_TENSOR_TYPE_NATIVE,
+                                               output_tensor_infos[0].qnn_data_type,
+                                               output_tensor_infos[0].quant_param.Copy(),
+                                               {seq_length, batch_size, hidden_size});
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pack_output_tensorwrapper)),
+                  "QNN EP: Failed to add output tensor for QNN Pack.");
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(qnn_pack_output_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_PACK,
+                                                  std::move(qnn_all_hidden_state_names), {qnn_pack_output_name},
+                                                  std::move(pack_param_names), do_op_validation),
+                  "QNN EP: Failed to create Qnn Pack node.");
+
+    // qnn_lstm_input_names[10]/[11] now hold the final timestep's hidden/cell state (Y_h, Y_c).
+    reshape_input_names = {qnn_pack_output_name, qnn_lstm_input_names[10], qnn_lstm_input_names[11]};
+  } else {
+    // Monolithic path: a single QNN_OP_LSTM node consumes/produces the whole 3D sequence
+    // at once, relying on HTP's native monolithic LSTM kernel (QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM).
+    std::vector<std::string> qnn_lstm_output_names = {
+        utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_all_hidden_state_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_cell_state_" + direction),
+        utils::UniqueNameGenerator().New(node_unit, "_QNN_LSTM_output_hidden_state_" + direction)};
+
+    // QNN output order: all_hidden, last_cell, last_hidden
+    // ONNX output order: all_hidden, last_hidden, last_cell
+    RETURN_IF_ERROR(emit_lstm_outputs(qnn_lstm_output_names, qnn_lstm_output_shapes));
+    const std::string lstm_node_name = utils::UniqueNameGenerator().New(node_unit, "_" + direction);
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(lstm_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_LSTM,
+                                                  std::move(qnn_lstm_input_names), std::vector<std::string>(qnn_lstm_output_names),
+                                                  std::vector<std::string>(param_names), do_op_validation),
+                  "QNN EP: Failed to create Qnn LSTM node.");
+    for (size_t i = 0; i < 3; i++) {
+      reshape_input_names[i] = qnn_lstm_output_names[kOutputPositionMap[i]];
+    }
   }
-  const std::string lstm_node_name = utils::UniqueNameGenerator().New(node_unit, "_" + direction);
-  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(lstm_node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_LSTM,
-                                                std::move(qnn_lstm_input_names), std::vector<std::string>(qnn_lstm_output_names),
-                                                std::vector<std::string>(param_names), do_op_validation),
-                "QNN EP: Failed to create Qnn LSTM node.");
+
   // in the output shapes below, the value of 1 indicates unidirectional
   std::vector<std::vector<uint32_t>> onnx_lstm_output_shapes = {
       {seq_length, 1, batch_size, hidden_size},
@@ -693,8 +815,8 @@ Ort::Status LSTMOpBuilder::AddUnidirectionLSTM(QnnModelWrapper& qnn_model_wrappe
   for (size_t i = 0; i < 3; i++) {
     // if bidirection, return output names for concat
     if (onnx_outputs.size() > i && onnx_outputs[i].Exists()) {
-      const std::string reshape_output_name = is_bidirection ? utils::UniqueNameGenerator().New(qnn_lstm_output_names[output_position_map[i]], "_unsqueeze_" + direction) : onnx_outputs[i].name;
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/qnn_lstm_output_names[output_position_map[i]],
+      const std::string reshape_output_name = is_bidirection ? utils::UniqueNameGenerator().New(reshape_input_names[i], "_unsqueeze_" + direction) : onnx_outputs[i].name;
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(/*input_name=*/reshape_input_names[i],
                                                        /*output_name=*/reshape_output_name,
                                                        /*input_shape=*/qnn_lstm_output_shapes[i],
                                                        /*output_shape=*/onnx_lstm_output_shapes[i],

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -122,7 +122,7 @@ typedef struct HtpGraphConfigs {
   int32_t vtcm_size_in_mb = 0;
   HtpGraphFinalizationOptimizationMode htp_graph_finalization_opt_mode = HtpGraphFinalizationOptimizationMode::kDefault;
   bool enable_htp_fp16_precision = false;
-  bool disable_htp_monolithic_lstm = false;
+  bool enable_htp_monolithic_lstm = false;
 } HtpGraphConfigs_t;
 
 enum class QnnBackendType : uint8_t {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -39,6 +39,7 @@ struct ModelSettings {
   bool htp_shared_memory = false;
   bool htp_bf16_enable = false;
   bool enable_block_quant_weight_optimization = false;
+  bool enable_htp_monolithic_lstm = false;
 };
 
 class QnnModelWrapper {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -441,7 +441,7 @@ void QnnEp::ParsePerSocHtpConfigs() {
     qnn::HtpGraphConfigs_t config{vtcm_size_in_mb_per_soc[idx],
                                   htp_graph_configs_.htp_graph_finalization_opt_mode,
                                   htp_graph_configs_.enable_htp_fp16_precision,
-                                  htp_graph_configs_.disable_htp_monolithic_lstm};
+                                  htp_graph_configs_.enable_htp_monolithic_lstm};
     htp_graph_configs_per_soc_.push_back(std::move(config));
   }
 
@@ -895,12 +895,15 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                                  false,
                                                                  logger_);
 
-  // HTP monolithic lstm
-  htp_graph_configs_.disable_htp_monolithic_lstm = ParseBoolOption(ort_api,
-                                                                   session_options_,
-                                                                   FormatEPConfigKey("disable_htp_monolithic_lstm"),
-                                                                   false,
-                                                                   logger_);
+  // HTP monolithic lstm. Default false: lower LSTM as ORT-side per-timestep unrolled cells
+  // (expand at ORT). Set to true to run the monolithic LSTM kernel on HTP.
+  static constexpr const char* kEnableHtpMonolithicLstm = "enable_htp_monolithic_lstm";
+  htp_graph_configs_.enable_htp_monolithic_lstm = ParseBoolOption(ort_api,
+                                                                  session_options_,
+                                                                  FormatEPConfigKey(kEnableHtpMonolithicLstm),
+                                                                  false,
+                                                                  logger_);
+  model_settings_.enable_htp_monolithic_lstm = htp_graph_configs_.enable_htp_monolithic_lstm;
 
   // Try to parse multi-SoC HTP options first. If not multi-SoC htp_arch/soc_model is given, fallback to normal parsing.
   ParsePerSocHtpConfigs();
@@ -1647,7 +1650,7 @@ void QnnEp::InitQnnHtpGraphConfigs(
       graph_precision_config->customConfig = htp_graph_precision_config;
     }
 
-    if (!configs.disable_htp_monolithic_lstm) {
+    if (configs.enable_htp_monolithic_lstm) {
       gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_monolithic_lstm_config = configs_builder.PushCustomConfig();
       htp_graph_monolithic_lstm_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM;
       htp_graph_monolithic_lstm_config->monolithicLstm = true;

--- a/onnxruntime/test/providers/qnn/lstm_test.cc
+++ b/onnxruntime/test/providers/qnn/lstm_test.cc
@@ -248,13 +248,13 @@ static void RunHtpQDQLSTMOpTest(const TestInputDef<float>& X_def,
                                 const int64_t hidden_size,
                                 const int64_t layout,
                                 ExpectedEPNodeAssignment expected_ep_assignment,
-                                bool disable_htp_monolithic_lstm = true,
+                                bool enable_htp_monolithic_lstm = false,
                                 QDQTolerance tolerance = QDQTolerance(),
                                 int opset = 22) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
-  provider_options["disable_htp_monolithic_lstm"] = disable_htp_monolithic_lstm ? "1" : "0";
+  provider_options["enable_htp_monolithic_lstm"] = enable_htp_monolithic_lstm ? "1" : "0";
 
   TestQDQModelAccuracy(BuildLSTMTestCase<float>(X_def, W_def, R_def, B_def, H_def, C_def, P_def, has_Y, has_Y_h, has_Y_c, direction, hidden_size, layout),
                        BuildQDQLSTMTestCase<QuantType>(X_def, W_def, R_def, B_def, H_def, C_def, P_def, has_Y, has_Y_h, has_Y_c, direction, hidden_size, layout),
@@ -278,12 +278,12 @@ static void RunHtpFp16LSTMOpTest(const TestInputDef<float>& X_def,
                                  const int64_t hidden_size,
                                  const int64_t layout,
                                  ExpectedEPNodeAssignment expected_ep_assignment,
-                                 bool disable_htp_monolithic_lstm = true,
+                                 bool enable_htp_monolithic_lstm = false,
                                  float tolerance = 0.004f,
                                  int opset = 22) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
-  provider_options["disable_htp_monolithic_lstm"] = disable_htp_monolithic_lstm ? "1" : "0";
+  provider_options["enable_htp_monolithic_lstm"] = enable_htp_monolithic_lstm ? "1" : "0";
 
   TestFp16ModelAccuracy(BuildLSTMTestCase<float>(X_def, W_def, R_def, B_def, H_def, C_def, P_def, has_Y, has_Y_h, has_Y_c, direction, hidden_size, layout),
                         BuildLSTMTestCase<Ort::Float16_t>(X_def, W_def, R_def, B_def, H_def, C_def, P_def, has_Y, has_Y_h, has_Y_c, direction, hidden_size, layout),
@@ -500,10 +500,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_all_initializer) {
                                QDQTolerance(0.008f));
 }
 
-// disable since there is a bug in optional output
-// see https://github.com/microsoft/onnxruntime/pull/27301
-// TODO: enable once above PR merged, ort-core released and we uplevel ort-core
-TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_only) {
+TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_Y_only) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
   uint32_t batch_size = 3;
@@ -529,10 +526,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_only) {
                                ExpectedEPNodeAssignment::All);
 }
 
-// disable since there is a bug in optional output
-// see https://github.com/microsoft/onnxruntime/pull/27301
-// TODO: enable once above PR merged, ort-core released and we uplevel ort-core
-TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_h_only) {
+TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_Y_h_only) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
   uint32_t batch_size = 3;
@@ -558,10 +552,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_h_only) {
                                ExpectedEPNodeAssignment::All);
 }
 
-// disable since there is a bug in optional output
-// see https://github.com/microsoft/onnxruntime/pull/27301
-// TODO: enable once above PR merged, ort-core released and we uplevel ort-core
-TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_c_only) {
+TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_Y_c_only) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
   uint32_t batch_size = 3;
@@ -611,7 +602,9 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_forward) {
                        direction,                                                                               // direction
                        hidden_size,                                                                             // hidden_size
                        0,                                                                                       // layout
-                       ExpectedEPNodeAssignment::All);
+                       ExpectedEPNodeAssignment::All,
+                       false,  // enable_htp_monolithic_lstm: use QNN-EP-side unrolled path
+                       0.51);  // near-zero output elem: fp16 rel err is large; matches monolithic sibling tol
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_reverse) {
@@ -668,7 +661,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional) {
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
       false,
-      0.25);
+      0.50);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_B) {
@@ -696,7 +689,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_B) {
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
       false,
-      0.07);
+      0.15);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_H) {
@@ -781,7 +774,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_all_initializer) {
       0,                                                                                      // layout
       ExpectedEPNodeAssignment::All,
       false,
-      0.14);
+      0.50);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_Y_only) {
@@ -810,7 +803,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_Y_only) {
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
       false,
-      0.25);
+      0.50);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_Y_h_only) {
@@ -899,7 +892,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_forward_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_reverse_monolithic_lstm) {
@@ -929,7 +922,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_reverse_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_monolithic_lstm) {
@@ -959,7 +952,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_B_monolithic_lstm) {
@@ -988,7 +981,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_B_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_H_monolithic_lstm) {
@@ -1017,7 +1010,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_H_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_C_monolithic_lstm) {
@@ -1046,7 +1039,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_C_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_P_monolithic_lstm) {
@@ -1073,7 +1066,7 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_wo_P_monolithic_lstm) {
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_all_initializer_monolithic_lstm) {
@@ -1103,14 +1096,11 @@ TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_all_initializer_monolit
                                hidden_size,                                                                            // hidden_size
                                0,                                                                                      // layout
                                ExpectedEPNodeAssignment::All,
-                               false,
+                               true,
                                QDQTolerance(0.008f));
 }
 
-// disable since there is a bug in optional output
-// see https://github.com/microsoft/onnxruntime/pull/27301
-// TODO: enable once above PR merged, ort-core released and we uplevel ort-core
-TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_only_monolithic_lstm) {
+TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_Y_only_monolithic_lstm) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
   uint32_t batch_size = 3;
@@ -1137,13 +1127,10 @@ TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_only_monolit
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
-// disable since there is a bug in optional output
-// see https://github.com/microsoft/onnxruntime/pull/27301
-// TODO: enable once above PR merged, ort-core released and we uplevel ort-core
-TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_h_only_monolithic_lstm) {
+TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_Y_h_only_monolithic_lstm) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
   uint32_t batch_size = 3;
@@ -1170,13 +1157,10 @@ TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_h_only_monol
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
-// disable since there is a bug in optional output
-// see https://github.com/microsoft/onnxruntime/pull/27301
-// TODO: enable once above PR merged, ort-core released and we uplevel ort-core
-TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_c_only_monolithic_lstm) {
+TEST_F(QnnHTPBackendTests, LSTM_QDQ_sanity_bidirectional_Y_c_only_monolithic_lstm) {
   std::string direction = "bidirectional";
   uint32_t num_direction = 2;
   uint32_t batch_size = 3;
@@ -1203,7 +1187,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_LSTM_QDQ_sanity_bidirectional_Y_c_only_monol
                                hidden_size,                                                                             // hidden_size
                                0,                                                                                       // layout
                                ExpectedEPNodeAssignment::All,
-                               false);
+                               true);
 }
 
 // HTP Fp16 monolithic lstm
@@ -1234,7 +1218,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_forward_monolithic_lstm) {
                        hidden_size,                                                                             // hidden_size
                        0,                                                                                       // layout
                        ExpectedEPNodeAssignment::All,
-                       false,
+                       true,
                        0.51);
 }
 
@@ -1265,7 +1249,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_reverse_monolithic_lstm) {
                        hidden_size,                                                                             // hidden_size
                        0,                                                                                       // layout
                        ExpectedEPNodeAssignment::All,
-                       false,
+                       true,
                        0.013);
 }
 
@@ -1297,7 +1281,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_monolithic_lstm) {
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.05);
 }
 
@@ -1328,7 +1312,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_B_monolithic_lstm) 
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.7);
 }
 
@@ -1359,7 +1343,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_H_monolithic_lstm) 
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.12);
 }
 
@@ -1390,7 +1374,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_C_monolithic_lstm) 
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.03);
 }
 
@@ -1419,8 +1403,8 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_wo_P_monolithic_lstm) 
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
-      0.22);
+      true,
+      0.55);
 }
 
 TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_all_initializer_monolithic_lstm) {
@@ -1451,7 +1435,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_all_initializer_monoli
       hidden_size,                                                                            // hidden_size
       0,                                                                                      // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.05);
 }
 
@@ -1483,7 +1467,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_Y_only_monolithic_lstm
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.06);
 }
 
@@ -1515,7 +1499,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_Y_h_only_monolithic_ls
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.04);
 }
 
@@ -1547,7 +1531,7 @@ TEST_F(QnnHTPBackendTests, LSTM_Fp16_sanity_bidirectional_Y_c_only_monolithic_ls
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All,
-      false,
+      true,
       0.04);
 }
 
@@ -1877,6 +1861,39 @@ TEST_F(QnnCPUBackendTests, LSTM_FP32_sanity_bidirectional_Y_c_only) {
       hidden_size,                                                                             // hidden_size
       0,                                                                                       // layout
       ExpectedEPNodeAssignment::All);
+}
+
+// layout=1 tripwire. IsOpSupported rejects layout != 0, so the LSTM must not be assigned to
+// QNN EP. ORT CPU EP does not support the batchwise (layout=1) LSTM either, so session
+// initialization throws. Verify the throw so a future change that drops/reorders the layout
+// guard (and lets a layout=1 LSTM reach ComposeGraph) is caught here rather than silently.
+TEST_F(QnnCPUBackendTests, LSTM_FP32_layout1_forward) {
+  std::string direction = "forward";
+  uint32_t num_direction = 1;
+  uint32_t batch_size = 6;
+  uint32_t hidden_size = 4;
+  uint32_t input_size = 5;
+  uint32_t seq_len = 6;
+  // layout=1: X [batch, seq, input], initial_h/initial_c [batch, num_directions, hidden]
+  auto B_def = TestInputDef<float>({num_direction, 8 * hidden_size}, false, -1.0f, 1.0f);
+  auto H_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+  auto C_def = TestInputDef<float>({batch_size, num_direction, hidden_size}, false, -1.0f, 1.0f);
+  EXPECT_THROW(
+      RunCpuFP32LSTMOpTest(TestInputDef<float>({batch_size, seq_len, input_size}, false, -1.0f, 1.0f),              // X
+                           TestInputDef<float>({num_direction, 4 * hidden_size, input_size}, false, -1.0f, 1.0f),   // W
+                           TestInputDef<float>({num_direction, 4 * hidden_size, hidden_size}, false, -1.0f, 1.0f),  // R
+                           std::ref(B_def),                                                                         // B
+                           std::ref(H_def),                                                                         // initial_h
+                           std::ref(C_def),                                                                         // initial_c
+                           std::nullopt,                                                                            // P
+                           true,                                                                                    // has_Y
+                           true,                                                                                    // has_Y_h
+                           true,                                                                                    // has_Y_c
+                           direction,                                                                               // direction
+                           hidden_size,                                                                             // hidden_size
+                           1,                                                                                       // layout
+                           ExpectedEPNodeAssignment::None),
+      std::exception);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Set the default to unroll LSTM  at ORT

### Changes
- Rename session option `disable_htp_monolithic_lstm` → `enable_htp_monolithic_lstm` and invert its default so LSTM defaults to unrolling per-timestep `QNN_OP_LSTM` cells (+ `Pack`) at the QNN EP layer, with the HTP-native monolithic LSTM kernel now opt-in.
- Update `lstm_op_builder.cc` to branch the lowering (unrolled vs. monolithic) on the new option, including backend gating (HTP/IR use the flag; CPU/GPU always unroll) and the `QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM` graph-config toggle.
- Update `cmake/patches/ort_core/0004-Update-argument-for-monolithic-lstm.patch` with new option name
- Re-enable 6 previously `DISABLED_` optional-output LSTM tests. They were disabled pending a fix for [microsoft/onnxruntime#27301](https://github.com/microsoft/onnxruntime/pull/27301) (illegal memory access in `GetOutputIndex` with optional outputs). That PR itself wasn't merged, but the same issue was fixed by [microsoft/onnxruntime#27644](https://github.com/microsoft/onnxruntime/pull/27644) (merged 2026-03-16), which is included in the `ort_core` version this repo currently pins (`v1.26.0`). The fix is present, so these tests can be safely re-enabled.
- Restore unrolled-path coverage in `lstm_test.cc`: the non-suffixed FP16 sanity tests (reverse/bidirectional/optional-input cases) had been left exercising the monolithic path and now default back to the unrolled path (matching their name and the new default), removing a duplicate `_monolithic_lstm`-equivalent test in the process. Also add a `layout==1` CPU tripwire test (`LSTM_FP32_layout1_forward`) asserting the LSTM correctly falls back off QNN EP.
- Update `QNN-ExecutionProvider.md` to document the renamed option, including a note for the trade off between monolithic  lstm on/off.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
There are 3 kinds of LSTM use cases:
1. Unroll LSTM at ORT (enable_htp_monolithic_lstm == false)
2. Unroll LSTM at HTP (enable_htp_monolithic_lstm == false)
3. Run Monolithic LSTM on HTP (enable_htp_monolithic_lstm == true)

When `enable_htp_monolithic_lstm == false`. since there is an inference time regression with "Unroll LSTM at HTP" compared to "Unroll LSTM at ORT", set the default to "Unroll LSTM at ORT".
