### PR TITLE
[QNN EP] Fix OOB read in OrtPadNodeGroupSelector::Check on Pad with 0 dq inputs

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1118,7 +1118,9 @@ bool OrtPadNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_api
   // Pad can have 1 or 2 dq input, the optional input constant_value can be quantized or non-quantized.
   // QNN supports data input quantized with constant_value input non-quantized.
   int num_dq_inputs = static_cast<int>(dq_nodes.size());
-  if (num_dq_inputs > 2) {
+  // Data input (dq_nodes[0] below) must be quantized; reject 0 here since CheckQDQNodes
+  // only checks dq_nodes.size() against num_dq_inputs, which is derived from it.
+  if (num_dq_inputs < 1 || num_dq_inputs > 2) {
     return false;
   }
 

--- a/onnxruntime/test/providers/qnn/pad_test.cc
+++ b/onnxruntime/test/providers/qnn/pad_test.cc
@@ -701,6 +701,28 @@ TEST_F(QnnHTPBackendTests, Pad_Noop_QDQ) {
                            has_constant_value_input);
 }
 
+// Regression test: Pad's data input is float (no preceding DQ), but its output feeds a Q node
+// directly. OrtPadNodeGroupSelector::Check() must reject this zero-DQ node group instead of
+// indexing dq_nodes[0], which previously crashed with SIGSEGV.
+TEST_F(QnnHTPBackendTests, PadFloatInputDirectlyToQ_NoDq) {
+  GetTestModelFn model_fn = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("data", {3, 2}, {1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.6f});
+    builder.MakeInitializer<int64_t>("pads", {4}, {0, 2, 0, 0});
+    builder.AddNode("Pad", "Pad", {"data", "pads"}, {"pad_out"});
+    builder.AddQuantizeLinearNode<uint8_t>("q", "pad_out", 0.05f, 128, "Y");
+    builder.MakeOutput("Y");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(model_fn,
+                  provider_options,
+                  18,  // opset
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some});
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if defined(_M_ARM64)


### PR DESCRIPTION
## Summary
- `OrtPadNodeGroupSelector::Check` only rejected `dq_nodes.size() > 2`, never `== 0`. A Pad node whose `data` input is not DQ-quantized but whose output feeds a `QuantizeLinear` passes `CheckQDQNodes` (0 == 0) and then dereferences `dq_nodes[0]` on an empty vector, crashing with SIGSEGV.
- Fix: also reject `num_dq_inputs < 1`, matching the existing comment ("Pad can have 1 or 2 dq input").

## Root cause
Hit via a real model (Moonshine decoder, w8a8 QDQ) containing float32 `Pad` nodes fed by `Transpose`/`Concat` (not `DequantizeLinear`) whose output feeds `QuantizeLinear` directly — `dq_nodes` empty, `q_nodes` non-empty.