### PR TITLE
[QNN EP] Fix BatchNorm crash/rejection with mixed input/output quant dtype

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -7,6 +7,7 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/qnn_graph_utils.h"
@@ -447,17 +448,24 @@ class BatchNormalizationOpBuilder : public BaseOpBuilder {
 namespace {
 
 // Helper to check if a BatchNorm param is constant - either direct initializer or through a DQ node.
+//
+// node_unit.GetDQNodes() is only populated for a QDQGroup-type NodeUnit. When the surrounding QDQ
+// selector rejects the group (e.g. BatchNormalizationNodeGroupSelector requires the quantized input
+// and output element types to match; mixed-bitwidth BN like u8-in/u16-out does not), BatchNorm becomes
+// a SingleNode-type NodeUnit with an empty GetDQNodes(). In that case the param's standalone DQ node
+// is visited (and constant-folded via TryFoldConstantQDQ) as its own NodeUnit before BN, in topological
+// order, so IsEffectivelyConstantInput (which also checks IsFoldedConstant) still recognizes it.
 bool IsParamConstant(const QnnModelWrapper& qnn_model_wrapper,
                      const OrtNodeUnit& node_unit,
                      const std::string& name) {
-  if (qnn_model_wrapper.IsConstantInput(name)) {
+  if (qnn_model_wrapper.IsEffectivelyConstantInput(name)) {
     return true;
   }
-  // Check if param comes through a DQ node with constant input
+  // Check if param comes through a DQ node with constant input (QDQGroup NodeUnit case).
   for (const OrtNode* dq_node : node_unit.GetDQNodes()) {
     const Ort::ConstNode const_dq_node(dq_node);
     if (const_dq_node.GetOutputs()[0].GetName() == name) {
-      return qnn_model_wrapper.IsConstantInput(const_dq_node.GetInputs()[0].GetName());
+      return qnn_model_wrapper.IsEffectivelyConstantInput(const_dq_node.GetInputs()[0].GetName());
     }
   }
   return false;
@@ -628,14 +636,17 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
                                (bias_info.qnn_data_type == QNN_DATATYPE_FLOAT_32 ||
                                 bias_info.qnn_data_type == QNN_DATATYPE_FLOAT_16);
 
+    // A param may be a real ONNX initializer (initializer_tensor set) or a standalone DQ-of-constant
+    // already folded to a STATIC tensor by TryFoldConstantQDQ (initializer_tensor is null in that
+    // case; see IsParamConstant above) -- read bytes from whichever the param actually is.
     std::vector<uint8_t> scale_unpacked_tensor;
     std::vector<uint8_t> bias_unpacked_tensor;
     std::vector<uint8_t> mean_unpacked_tensor;
     std::vector<uint8_t> var_unpacked_tensor;
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info.initializer_tensor, scale_unpacked_tensor));
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, bias_unpacked_tensor));
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(mean_info.initializer_tensor, mean_unpacked_tensor));
-    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(var_info.initializer_tensor, var_unpacked_tensor));
+    RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, inputs[1].name, scale_unpacked_tensor));
+    RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, inputs[2].name, bias_unpacked_tensor));
+    RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, inputs[3].name, mean_unpacked_tensor));
+    RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, inputs[4].name, var_unpacked_tensor));
 
     std::vector<double> scale_double_tensor;
     std::vector<double> bias_double_tensor;

--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -225,6 +225,58 @@ TEST_F(QnnCPUBackendTests, BatchNorm2D_int8) {
 
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
+// Same shape as BuildQDQBatchNormTestCase, but the output Q/DQ pair can use a different quantized
+// type than the input, so that dq_nodes[0]'s element type differs from q_nodes[0]'s. That mismatch
+// is exactly what BatchNormalizationNodeGroupSelector::Check (ORT core) rejects when forming the
+// BatchNorm QDQ NodeUnit, which degrades BatchNorm to a SingleNode NodeUnit with no DQ nodes attached.
+template <typename InputQType, typename OutputQType, typename ScaleQType>
+GetTestQDQModelFn<OutputQType> BuildQDQBatchNormMixedDtypeTestCase(const TestInputDef<float>& input_def,
+                                                                   const TestInputDef<float>& scale_def,
+                                                                   const TestInputDef<float>& bias_def) {
+  QNN_ASSERT(input_def.IsRawData());  // Need raw data to compute mean and variance inputs.
+
+  return [input_def, scale_def, bias_def](ModelTestBuilder& builder,
+                                          std::vector<QuantParams<OutputQType>>& output_qparams) {
+    const auto& input_shape = input_def.GetShape();
+    const auto& input_data = input_def.GetRawData();
+    const int64_t num_channels = input_shape[1];
+    bool input_symmetric = sizeof(InputQType) == sizeof(uint16_t);
+    MakeTestInput(builder, "X", input_def);
+    QuantParams<InputQType> input_qparams = GetTestInputQuantParams<InputQType>(input_def, input_symmetric);
+    std::string x_dq_name = AddQDQNodePair<InputQType>(builder, "qdq1", "X", input_qparams.scale, input_qparams.zero_point);
+
+    MakeTestInput(builder, "scale", scale_def);
+    QuantParams<ScaleQType> scale_qparams = GetTestInputQuantParams<ScaleQType>(scale_def);
+    std::string scale_dq_name = AddQDQNodePair<ScaleQType>(builder, "qdq2", "scale", scale_qparams.scale, scale_qparams.zero_point);
+
+    // bias (as int32) => DQ =>
+    std::string bias_dq_name = MakeTestQDQBiasInput(builder, "bias", bias_def, input_qparams.scale * scale_qparams.scale, true);
+
+    std::vector<float> mean_vals(num_channels);
+    std::vector<float> var_vals(num_channels);
+    ComputeChannelMeanAndVar(input_data, input_shape, mean_vals, var_vals);
+
+    builder.MakeInitializer<float>("mean", {num_channels}, mean_vals);
+    builder.MakeInitializer<float>("var", {num_channels}, var_vals);
+
+    // Create attributes
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("epsilon", 1e-5f));
+    attributes.push_back(builder.MakeScalarAttribute("momentum", 0.9f));
+    builder.AddNode(
+        "bn",
+        "BatchNormalization",
+        {x_dq_name.c_str(), scale_dq_name.c_str(), bias_dq_name.c_str(), "mean", "var"},
+        {"Y"},
+        "",
+        attributes);
+
+    AddQDQNodePairWithOutputAsGraphOutput<OutputQType>(
+        builder, "qdq_out", "Y",
+        output_qparams[0].scale, output_qparams[0].zero_point);
+  };
+}
+
 /**
  * Runs an BatchNormalization model on the QNN HTP backend. Checks the graph node assignment, and that inference
  * outputs for QNN and CPU match.
@@ -415,6 +467,52 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_U16S16S32) {
 #else
                                          "");
 #endif
+}
+
+// Input quantized u8, output quantized u16: BatchNormalizationNodeGroupSelector::Check (ORT core)
+// requires the quantized input and output element types to match to fuse BatchNorm into a QDQGroup
+// NodeUnit. With mismatched types, BatchNorm degrades to a SingleNode NodeUnit whose GetDQNodes() is
+// empty, so IsParamConstant's DQ-node fallback couldn't recognize the (still individually
+// EP-supported) DQ-wrapped scale/bias/mean/var as constant, rejecting BatchNorm as "dynamic scale".
+// Reproduces tetracode #20348.
+TEST_F(QnnHTPBackendTests, BatchNorm2D_U8In_U16Out_MixedDtype) {
+  constexpr int64_t num_channels = 2;
+  std::vector<float> input_data = {-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 1.1f, 3.3f, 8.0f,
+                                   -7.0f, -5.0f, -3.0f, -1.0f, 0.0f, 2.1f, 4.3f, 7.0f};
+  TestInputDef<float> input_def({2, num_channels, 2, 2}, false, input_data);
+  TestInputDef<float> scale_def({num_channels}, true, {1.0f, 2.0f});
+  TestInputDef<float> bias_def({num_channels}, true, {1.1f, 2.1f});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
+                       BuildQDQBatchNormMixedDtypeTestCase<uint8_t, uint16_t, uint8_t>(input_def, scale_def, bias_def),
+                       provider_options,
+                       21,
+                       ExpectedEPNodeAssignment::All);
+}
+
+// Same mismatch in the other direction: input quantized u16, output quantized u8.
+// Reproduces tetracode #20348.
+TEST_F(QnnHTPBackendTests, BatchNorm2D_U16In_U8Out_MixedDtype) {
+  constexpr int64_t num_channels = 2;
+  std::vector<float> input_data = {-8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 1.1f, 3.3f, 8.0f,
+                                   -7.0f, -5.0f, -3.0f, -1.0f, 0.0f, 2.1f, 4.3f, 7.0f};
+  TestInputDef<float> input_def({2, num_channels, 2, 2}, false, input_data);
+  TestInputDef<float> scale_def({num_channels}, true, {1.0f, 2.0f});
+  TestInputDef<float> bias_def({num_channels}, true, {1.1f, 2.1f});
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
+                       BuildQDQBatchNormMixedDtypeTestCase<uint16_t, uint8_t, uint8_t>(input_def, scale_def, bias_def),
+                       provider_options,
+                       21,
+                       ExpectedEPNodeAssignment::All);
 }
 
 // Test FP16 BatchNormalization on the HTP backend.


### PR DESCRIPTION
## Summary
- `BatchNormalizationNodeGroupSelector` (ORT core) requires the quantized input and output element types to match to fuse `BatchNorm` into a `QDQGroup` NodeUnit. When they don't (e.g. u8 input / u16 output — a legitimate AIMET-quantized pattern), BatchNorm degrades to a `SingleNode` NodeUnit whose `GetDQNodes()` is empty, even though scale/bias/mean/var are each still produced by a standalone (individually EP-supported) DQ node.
- This broke two call sites in `batchnormalization_op_builder.cc`:
  - `IsParamConstant`'s DQ-node fallback only checked `GetDQNodes()`, so it rejected the node with `"QNN doesn't support dynamic scale/bias/mean/var"` — all 48 BN nodes in the reporting model fell back to CPU.
  - `ProcessInputs` unconditionally called `UnpackInitializerData` on `initializer_tensor`, which is null for a non-initializer param — once `IsParamConstant` no longer blocked the node, this crashed with a null-pointer SEH exception instead.
- Fixes both to use `IsEffectivelyConstantInput` / `GetEffectivelyConstantTensorBytes`, which also recognize a standalone DQ-of-constant already folded to a STATIC tensor by `TryFoldConstantQDQ` — the same helpers `clip_op_builder.cc` uses for the analogous Clip case (`Support Clip with DequantizeLinear-wrapped constant min/max`, #586).
- Adds two regression tests (`BatchNorm2D_U8In_U16Out_MixedDtype`, `BatchNorm2D_U16In_U8Out_MixedDtype`) exercising the exact input/output dtype mismatch.