### PR TITLE
[QNN EP] Fix RMSNorm accuracy on QNN GPU by adding missing dummy tensor

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -88,12 +88,11 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
 
 #if !defined(QNN_SDK_VERSION_MINOR) || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR < 49)
-  // QNN SDK < 2.49 requires an explicit beta/bias input for QNN_OP_RMS_NORM on NPU.
+  // QNN SDK < 2.49 requires an explicit beta/bias input for QNN_OP_RMS_NORM on NPU and GPU.
   // SDK 2.49+ accepts beta as optional, so the dummy tensor is only needed for older SDKs.
   // Note: SDK 2.47 and 2.48 share the same QNN API version (2.36), so QNN_SDK_VERSION_MINOR
   // derived from CMake is used here instead of QNN_API_VERSION_MINOR.
-  bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
-  if (is_npu_backend) {
+  {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
                 ("RMSNorm node " + node_unit.Name() + ": adding dummy beta tensor (SDK < 2.49).").c_str());
     TensorInfo scale_info = {};
@@ -131,10 +130,8 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
     input_names.push_back(beta_tensor_name);
   }
 #else
-  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
-    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                ("RMSNorm node " + node_unit.Name() + ": skipping dummy beta tensor (SDK >= 2.49).").c_str());
-  }
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("RMSNorm node " + node_unit.Name() + ": skipping dummy beta tensor (SDK >= 2.49).").c_str());
 #endif  // !defined(QNN_SDK_VERSION_MINOR) || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR < 49)
 
   return Ort::Status();


### PR DESCRIPTION

### Description
- QNN_OP_RMS_NORM requires an explicit beta/bias input on SDK < 2.49, but RMSNormalizationOpBuilder only added the dummy zero-beta tensor when the backend was NPU, leaving GPU RmsNorm nodes without a beta input and producing incorrect/uninitialized output on GPU.




### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


