### PR TITLE
[QNN EP] Add Softplus to QDQ-fusion unary_ops selector allowlist

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1630,6 +1630,7 @@ void OrtSelectorManager::CreateSelectors() {
       {"Sin", {}},
       {"Slice", {}},
       {"Softmax", {}},
+      {"Softplus", {}},
       {"SpaceToDepth", {}},
       {"Sqrt", {}},
       {"Tanh", {}}};

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -568,9 +568,8 @@ TEST_F(QnnHTPBackendTests, UnaryOp_Softplus_U16) {
 // Dequantize pair. With offload_graph_io_quantization=0, the graph's Q/DQ input and output
 // boundary nodes are always present (1 Quantize + 1 Dequantize) even when fused; an extra
 // pair beyond that indicates Softplus itself failed to fuse.
-// Regression test for https://github.com/qcom-ai-hub/tetracode/issues/20283, where Softplus
-// was missing from the QDQ-fusion selector's unary_ops allowlist even though the op-builder
-// fully supports quantized Softplus.
+// Regression test for Softplus being missing from the QDQ-fusion selector's unary_ops
+// allowlist even though the op-builder fully supports quantized Softplus.
 TEST_F(QnnHTPBackendTests, NeuronOpType_Softplus) {
   const std::filesystem::path json_qnn_graph_dir = "NeuronOpType_Softplus";
   std::filesystem::remove_all(json_qnn_graph_dir);

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -563,6 +563,44 @@ TEST_F(QnnHTPBackendTests, UnaryOp_Softplus_U16) {
                          true);
 }
 
+// Check that QNN fuses DQ -> Softplus -> Q into a single quantized ElementWiseNeuron op,
+// instead of leaving Softplus running as unfused float32 bracketed by its own Quantize/
+// Dequantize pair. With offload_graph_io_quantization=0, the graph's Q/DQ input and output
+// boundary nodes are always present (1 Quantize + 1 Dequantize) even when fused; an extra
+// pair beyond that indicates Softplus itself failed to fuse.
+// Regression test for https://github.com/qcom-ai-hub/tetracode/issues/20283, where Softplus
+// was missing from the QDQ-fusion selector's unary_ops allowlist even though the op-builder
+// fully supports quantized Softplus.
+TEST_F(QnnHTPBackendTests, NeuronOpType_Softplus) {
+  const std::filesystem::path json_qnn_graph_dir = "NeuronOpType_Softplus";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup =
+      gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  std::vector<TestInputDef<float>> input_defs = {
+      TestInputDef<float>({1, 2, 2, 2}, /*is_initializer=*/false, -1.0f, 1.0f)};
+  TestQDQModelAccuracy(BuildOpTestCase<float>("Softplus_node", "Softplus", input_defs, {}, {}),
+                       BuildQDQOpTestCase<uint8_t>("Softplus_node", "Softplus", input_defs, {}, {}),
+                       provider_options,
+                       /*opset_version=*/14,
+                       /*expected_ep_assignment=*/ExpectedEPNodeAssignment::All);
+
+  if (!HasQnnJsonGraph(json_qnn_graph_dir)) {
+    return;
+  }
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseNeuron", /*count=*/1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Quantize", /*count=*/1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Dequantize", /*count=*/1);
+}
+
 // Check that QNN compiles DQ -> HardSwish -> Q as a single unit.
 // Use an input of rank 3.
 TEST_F(QnnHTPBackendTests, UnaryOp_HardSwish) {


### PR DESCRIPTION
## Summary
- Softplus's op-builder (`simple_op_builder.cc`) already fully supports quantized Softplus via `QNN_OP_ELEMENT_WISE_NEURON` — the same dispatch path used by `Sigmoid`/`Tanh` — but `Softplus` was missing from `OrtSelectorManager::CreateSelectors()`'s `unary_ops` QDQ-fusion allowlist in `qnn_ep_utils.cc`.
- Without a matching selector, ORT never recognizes the `DequantizeLinear -> Softplus -> QuantizeLinear` node group as fusable, so Softplus runs as unfused float32 bracketed by its own Quantize/Dequantize pair instead of collapsing into a single fused HTP op.
- Adds `"Softplus"` to the allowlist (one line), matching how `Sigmoid`/`Tanh`/`Softmax`/etc. are already registered.