### PR TITLE
Match QNN GQA OpDef for total_sequence_length input shape

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/group_query_attention_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/group_query_attention_op_builder.cc
@@ -131,10 +131,27 @@ Ort::Status GroupQueryAttentionOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mod
       8u,  // sin_cache
       9u   // position_ids
   };
+  constexpr size_t kQnnTotalSeqLenIdx = 2;  // index of total_sequence_length in qnn_idx_to_onnx
 
-  for (const auto onnx_idx : qnn_idx_to_onnx) {
+  for (size_t qnn_idx = 0; qnn_idx < qnn_idx_to_onnx.size(); ++qnn_idx) {
+    const auto onnx_idx = qnn_idx_to_onnx[qnn_idx];
     if (onnx_inputs.size() > onnx_idx && onnx_inputs[onnx_idx].Exists()) {
-      RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, onnx_inputs[onnx_idx], logger, input_names));
+      // QNN requires total_sequence_length as a 0D scalar, but ONNX provides it as shape [1].
+      // Build the tensor wrapper directly with an empty shape to avoid a Reshape.
+      if (qnn_idx == kQnnTotalSeqLenIdx) {
+        const std::string& input_name = onnx_inputs[onnx_idx].name;
+        if (!qnn_model_wrapper.IsQnnTensorWrapperExist(input_name)) {
+          TensorInfo tensor_info = {};
+          RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(onnx_inputs[onnx_idx], tensor_info));
+          tensor_info.shape = {};  // override to 0D scalar
+          QnnTensorWrapper tensor_wrapper;
+          RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(tensor_info, input_name, tensor_wrapper));
+          RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(tensor_wrapper)), "Failed to add tensor.");
+        }
+        input_names.push_back(input_name);
+      } else {
+        RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, onnx_inputs[onnx_idx], logger, input_names));
+      }
     } else {
       std::string null_tensor_name = utils::UniqueNameGenerator().New(node_unit, "_null_tensor");
       input_names.emplace_back(null_tensor_name);

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -146,9 +146,9 @@ size_t GetQnnTensorDataSizeInBytes(size_t num_elements, Qnn_DataType_t element_t
 }
 
 size_t GetQnnTensorDataSizeInBytes(gsl::span<const uint32_t> shape, Qnn_DataType_t element_type) {
-  // TODO can we just treat empty shape as a scalar?
+  // Empty shape means a 0D scalar: exactly 1 element.
   if (shape.empty()) {
-    ORT_CXX_API_THROW("Empty shape not allowed.", ORT_EP_FAIL);
+    return GetQnnTensorDataSizeInBytes(static_cast<size_t>(1), element_type);
   }
   SafeInt<size_t> num_elements = std::accumulate(shape.begin(), shape.end(), SafeInt<size_t>{1}, std::multiplies<>{});
   return GetQnnTensorDataSizeInBytes(num_elements, element_type);

--- a/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
@@ -140,9 +140,10 @@ TEST(QnnUnit_UtilsTest, GetQnnTensorDataSizeInBytes_RegularTypes) {
 }
 
 TEST(QnnUnit_UtilsTest, GetQnnTensorDataSizeInBytes_SpanEmptyThrows) {
-  EXPECT_THROW(
+  // Empty shape represents a 0D scalar: size should equal one element.
+  EXPECT_EQ(
       qnn::utils::GetQnnTensorDataSizeInBytes(gsl::span<const uint32_t>{}, QNN_DATATYPE_FLOAT_32),
-      Ort::Exception);
+      4u);
 }
 
 TEST(QnnUnit_UtilsTest, GetQnnTensorDataSizeInBytes_SpanMultiDim) {


### PR DESCRIPTION
- The QNN GroupQueryAttention op def requires total_sequence_length (input[2]) to be a 0D scalar, but the ONNX com.microsoft.GroupQueryAttention op provides it as a 1D tensor with shape [1]. This mismatch causes op validation failure at runtime

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


