### PR TITLE
Fix the path check order on Windows

### DIFF
--- a/qcom/scripts/all/archive_tests.py
+++ b/qcom/scripts/all/archive_tests.py
@@ -115,7 +115,7 @@ class PerArchAcceptRules:
 
 def _iter_release_files(release_dir: Path):
     for p in release_dir.glob("**/*"):
-        if not p.is_file() or (platform.system() == "Windows" and p.is_symlink()):
+        if (platform.system() == "Windows" and p.is_symlink()) or not p.is_file():
             continue
         if _ALWAYS_REJECT_RE.search(p.as_posix()):
             continue


### PR DESCRIPTION
### Description
Fix the path check order on Windows.

### Motivation and Context
Fix nightly workflow failure (https://github.com/onnxruntime/onnxruntime-qnn/actions/runs/29819741778/job/88599719513). When `p.is_file()` is placed first, Windows device will check `is_file()` and cause a symlink access denied error.


