### PR TITLE
[QNN EP] Fix Windows MSVC 14.51 build: suppress C4875 and uplevel numpy

### DIFF
--- a/cmake/external/onnxruntime_external_deps.cmake
+++ b/cmake/external/onnxruntime_external_deps.cmake
@@ -487,7 +487,8 @@ onnxruntime_fetchcontent_declare(
     ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0001-cpp-model-test-runner-uses-plugin-EP.patch &&
     ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0002-Add-Roialign-Op-to-HTP.patch &&
     ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0003-Allow-users-to-specify-arm64ReproDir-by-cmake-flag.patch &&
-    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0004-Update-argument-for-monolithic-lstm.patch
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0004-Update-argument-for-monolithic-lstm.patch &&
+    ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/ort_core/0005-Suppress-C4875-for-MSVC-14.51.patch
   EXCLUDE_FROM_ALL)
 FetchContent_Populate(ort_core)
 

--- a/cmake/patches/ort_core/0005-Suppress-C4875-for-MSVC-14.51.patch
+++ b/cmake/patches/ort_core/0005-Suppress-C4875-for-MSVC-14.51.patch
@@ -1,0 +1,21 @@
+MSVC 14.51+ (cl 19.51) emits C4875 ("a non-string literal argument to
+[[gsl::suppress]] is deprecated") for the bundled Microsoft.GSL v4.0.0
+GSL_SUPPRESS macro, which expands to [[gsl::suppress(bounds.2)]] with a bare
+token. ORT builds with /WX, so this turns into C2220 and fails compilation of
+sources that include ort_core first-party headers using GSL_SUPPRESS (e.g.
+capture.cc via capture.h). Older toolsets (14.44) did not emit C4875. Suppress
+just this warning via ORT_WARNING_FLAGS, alongside the other per-warning
+suppressions already present here.
+
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -603,6 +603,8 @@ set(ORT_WARNING_FLAGS)
+     list(APPEND ORT_WARNING_FLAGS "/wd5054")
+     # Enable warning: data member 'member' will be initialized after data member 'member2' / base class 'base_class'
+     list(APPEND ORT_WARNING_FLAGS "/w15038")
++    # MSVC 14.51+ deprecates non-string-literal [[gsl::suppress]] args (C4875); GSL v4.0.0 still emits the bare-token form.
++    list(APPEND ORT_WARNING_FLAGS "/wd4875")
+
+     # set linker flags to minimize the binary size.
+     if (MSVC)

--- a/tools/ci_build/github/windows/python/requirements.txt
+++ b/tools/ci_build/github/windows/python/requirements.txt
@@ -1,4 +1,4 @@
-numpy==2.2.6; python_version < "3.14"
+numpy==2.3.0; python_version < "3.14"
 numpy==2.3.2; python_version >= "3.14"
 mypy
 pytest


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- C4875 -> C2220 (warning-as-error). Microsoft.GSL v4.0.0's GSL_SUPPRESS macro expands to [[gsl::suppress(bounds.2)]] with a bare token argument. MSVC 14.51 newly deprecates non-string-literal [[gsl::suppress]] args (C4875), and ORT builds with /WX, so ort_core sources that include first-party headers using GSL_SUPPRESS (e.g. capture.cc via capture.h) fail to compile. Add /wd4875 to ORT_WARNING_FLAGS in ort_core's cmake/CMakeLists.txt via a new patch (cmake/patches/ort_core/0005-Suppress-C4875-for-MSVC-14.51.patch), alongside the existing per-warning suppressions (/wd4251, /wd5054 etc.) that are applied to all ort_core first-party targets. This is the correct layer: /w15038 and the other flags in ORT_WARNING_FLAGS reach capture.cc through the same target_compile_options loop (CMakeLists.txt:1192).

- numpy 2.2.6 has no prebuilt win_arm64 wheel on PyPI, so a native ARM64 build compiles it from source and hits an MSVC 14.51 internal compiler error (C1001). Uplevel numpy to 2.3.0 (which ships a cp311 win_arm64 wheel) for python_version < 3.14 in the Windows build requirements, so uv installs a binary wheel instead of building from source.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Two build breakages surface with the newer MSVC 14.51 (cl 19.51) ARM64 toolset that did not occur with 14.44
