### PR TITLE
cmake: Rename pkg-config output to libonnxruntime_providers_qnn.pc

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.28)
 # Don't let cmake set a default value for CMAKE_CUDA_ARCHITECTURES
 cmake_policy(SET CMP0104 OLD)
 # Project
-project(onnxruntime_qnn C CXX ASM)
+project(onnxruntime_providers_qnn C CXX ASM)
 
 # Disable fast-math for Intel oneAPI compiler
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -871,9 +871,9 @@ else()
   option(BUILD_PKGCONFIG_FILES "Build and install pkg-config files" OFF)
 endif()
 if (BUILD_PKGCONFIG_FILES)
-   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libonnxruntime.pc.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/libonnxruntime.pc @ONLY)
-  install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libonnxruntime.pc DESTINATION
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libonnxruntime_providers_qnn.pc.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libonnxruntime_providers_qnn.pc @ONLY)
+  install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libonnxruntime_providers_qnn.pc DESTINATION
     ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 endif()
 

--- a/cmake/libonnxruntime_providers_qnn.pc.cmake.in
+++ b/cmake/libonnxruntime_providers_qnn.pc.cmake.in
@@ -5,9 +5,9 @@ docdir=${prefix}/@CMAKE_INSTALL_DOCDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@CMAKE_PROJECT_NAME@
 
-Name: onnxruntime_providers_qnn
+Name: @CMAKE_PROJECT_NAME@
 Description: ONNX runtime QNN execution provider
 URL: https://github.com/onnxruntime/onnxruntime-qnn
 Version: @ORT_VERSION@
-Libs: -L${libdir} -lonnxruntime_providers_qnn
+Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
 Cflags: -I${includedir}

--- a/cmake/libonnxruntime_providers_qnn.pc.cmake.in
+++ b/cmake/libonnxruntime_providers_qnn.pc.cmake.in
@@ -5,9 +5,9 @@ docdir=${prefix}/@CMAKE_INSTALL_DOCDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@CMAKE_PROJECT_NAME@
 
-Name: @CMAKE_PROJECT_NAME@
-Description: ONNX runtime
-URL: https://github.com/microsoft/@CMAKE_PROJECT_NAME@
+Name: onnxruntime_providers_qnn
+Description: ONNX runtime QNN execution provider
+URL: https://github.com/onnxruntime/onnxruntime-qnn
 Version: @ORT_VERSION@
-Libs: -L${libdir} -l@CMAKE_PROJECT_NAME@
+Libs: -L${libdir} -lonnxruntime_providers_qnn
 Cflags: -I${includedir}


### PR DESCRIPTION
### Description

  Renames the generated pkg-config file from `libonnxruntime.pc` to `libonnxruntime_providers_qnn.pc`, and renames the top-level CMake project from `onnxruntime_qnn` to `onnxruntime_providers_qnn`.

  - Renamed `cmake/libonnxruntime.pc.cmake.in` → `cmake/libonnxruntime_providers_qnn.pc.cmake.in`.
  - Updated `cmake/CMakeLists.txt` to `configure_file()`/`install()` the new template name and output filename.
  - Changed `project(onnxruntime_qnn ...)` to `project(onnxruntime_providers_qnn ...)`.
  - Updated the template's `Name`, `Libs`, and `includedir` to derive from `@CMAKE_PROJECT_NAME@`, `Description` to `ONNX runtime QNN execution provider`, and `URL` to `https://github.com/onnxruntime/onnxruntime-qnn`.

  ### Motivation and Context

  This tree builds only the QNN execution provider, not the full generic ONNX Runtime distribution. Installing a pkg-config file named `libonnxruntime.pc` with `Name: onnxruntime` and `Description: ONNX runtime` is misleading — it implies a complete/generic onnxruntime install and can
  collide with a real upstream `libonnxruntime.pc` on the same system (e.g. two packages both installing to `${libdir}/pkgconfig/libonnxruntime.pc`). Renaming the file and its metadata to `libonnxruntime_providers_qnn` makes `pkg-config --list-all`, `pkg-config --cflags`, and
  `pkg-config --libs` correctly identify this as the QNN-specific package and avoids the naming collision.

  The CMake project name `onnxruntime_qnn` no longer matched the intended package identity either, so it's renamed to `onnxruntime_providers_qnn`, and the pkg-config template now derives its `Name`/`Libs`/`includedir` fields from `@CMAKE_PROJECT_NAME@` instead of hardcoding the string,
  so the project name and package metadata stay in sync going forward.


