### PR TITLE
[QNN EP] Add cross-compile build path for Linux aarch64 wheels on x86_64 hosts

### DIFF
--- a/qcom/build_and_test.py
+++ b/qcom/build_and_test.py
@@ -43,7 +43,12 @@ from ep_build.tasks.build import (
     QdcTestsTask,
     RunAsanTask,
 )
-from ep_build.tasks.docker import MANYLINUX_2_34_AARCH64_TAG, UBUNTU_22_04_X86_64_TAG, DockerBuildTask
+from ep_build.tasks.docker import (
+    MANYLINUX_2_34_AARCH64_TAG,
+    MANYLINUX_2_34_AARCH64_XCOMPILE_TAG,
+    UBUNTU_22_04_X86_64_TAG,
+    DockerBuildTask,
+)
 from ep_build.tasks.python import (
     CreateOrtVenvTask,
     CreateQdcVenvTask,
@@ -258,6 +263,47 @@ class TaskLibrary:
             env["CCACHE_DIR"] = str(ccache_dir)
         else:
             extra_args.append("--no-use-cache")
+
+        return plan.add_step(
+            BuildEpLinuxTask(
+                None,
+                self.__venv_path,
+                "linux",
+                "aarch64_manylinux_2_34",
+                self.__config,
+                self.__target_py_version,
+                self.__ort_prebuilt_root,
+                self.__qairt_sdk_root,
+                "build",
+                extra_args=extra_args,
+                env=env,
+                build_archive=self.__build_archive,
+            )
+        )
+
+    @implementation_detail
+    @depends(["create_venv"])
+    def _build_ort_linux_aarch64_manylinux_2_34_cross(self, plan: Plan) -> str:
+        """Cross-compile aarch64 from x86_64 container using LLVM toolchain."""
+        extra_args = [
+            "--qnn-arch-abi=aarch64-oe-linux-gcc11.2",
+        ]
+
+        env = os.environ.copy()
+        if self.__docker_ccache_root is not None:
+            ccache_dir = self.__docker_ccache_root / "linux-aarch64-manylinux_2_34"
+            env["CCACHE_DIR"] = str(ccache_dir)
+        else:
+            extra_args.append("--no-use-cache")
+
+        from ep_build.tools import get_tools_dir  # noqa:PLC0415
+
+        tools_dir = get_tools_dir()
+        tc_dirs = sorted(tools_dir.glob("linux_oe_gcc112_toolchain-*"))
+        if tc_dirs:
+            tc_name = tc_dirs[-1].name
+            container_tools = Path(os.environ.get("ORT_BUILD_TOOLS_PATH", str(tools_dir)))
+            env["ORT_BUILD_LINUX_TOOLCHAIN_ROOT"] = str(container_tools / tc_name)
 
         return plan.add_step(
             BuildEpLinuxTask(
@@ -560,8 +606,29 @@ class TaskLibrary:
                 raise NotImplementedError("Building for Android on this host is not supported.")
 
     @task
-    @depends(["docker_build_manylinux_2_34_aarch64"])
+    @depends(
+        [
+            (is_host_x86_64(), "docker_build_manylinux_2_34_cross"),
+            (not is_host_x86_64(), "docker_build_manylinux_2_34_aarch64"),
+        ]
+    )
     def build_ort_linux_aarch64_manylinux_2_34(self, plan: Plan) -> str:
+        if is_host_x86_64():
+            return plan.add_step(
+                BuildEpDockerTask(
+                    "Cross-compiling ONNX Runtime for Linux on AArch64 manylinux_2_34",
+                    "aarch64_manylinux_2_34",
+                    self.__config,
+                    self.__target_py_version,
+                    self.__qairt_sdk_root,
+                    self.__docker_ccache_root,
+                    self.__build_archive,
+                    inner_task="_build_ort_linux_aarch64_manylinux_2_34_cross",
+                    docker_tag=MANYLINUX_2_34_AARCH64_XCOMPILE_TAG,
+                    platform="linux/amd64",
+                    python="python3",
+                ),
+            )
         return plan.add_step(
             BuildEpDockerTask(
                 "Building ONNX Runtime for Linux on AArch64 manylinux_2_34",
@@ -820,6 +887,23 @@ class TaskLibrary:
                     "ORT_NIGHTLY_BUILD": os.environ.get("ORT_NIGHTLY_BUILD", "0"),
                     "ORT_VERSION_SUFFIX": os.environ.get("ORT_VERSION_SUFFIX", ""),
                 },
+            )
+        )
+
+    @task
+    def docker_build_manylinux_2_34_cross(self, plan: Plan) -> str:
+        return plan.add_step(
+            DockerBuildTask(
+                "Building manylinux_2_34 cross-compile Docker image",
+                REPO_ROOT / "qcom" / "scripts" / "linux" / "manylinux_2_34_cross" / "Dockerfile",
+                MANYLINUX_2_34_AARCH64_XCOMPILE_TAG,
+                build_args={
+                    "BUILD_UID": str(os.getuid()),
+                    "BUILD_GID": str(os.getgid()),
+                    "ORT_NIGHTLY_BUILD": os.environ.get("ORT_NIGHTLY_BUILD", "0"),
+                    "ORT_VERSION_SUFFIX": os.environ.get("ORT_VERSION_SUFFIX", ""),
+                },
+                platform="linux/amd64",
             )
         )
 

--- a/qcom/ep_build/tasks/build.py
+++ b/qcom/ep_build/tasks/build.py
@@ -43,15 +43,21 @@ class BuildEpDockerTask(CompositeTask):
         inner_task: str = "_build_ort_linux_aarch64_manylinux_2_34",
         docker_tag: str = MANYLINUX_2_34_AARCH64_TAG,
         platform: str = "linux/aarch64",
+        python: str | None = None,
     ) -> None:
         dist_rel_dir = Path("build") / f"linux-{target_arch}" / config / "dist"
+        if target_py_version:
+            py_tag = f"cp{target_py_version.replace('.', '')}"
+            whl_glob = (REPO_ROOT / dist_rel_dir).glob(f"*-{py_tag}-*.whl")
+        else:
+            whl_glob = (REPO_ROOT / dist_rel_dir).glob("*.whl")
 
         super().__init__(
             group_name,
             [
                 RemovePathsTask(
                     "Deleting wheels to workaround ORT build bug",
-                    (REPO_ROOT / dist_rel_dir).glob("*.whl"),
+                    whl_glob,
                 ),
                 DockerBuildAndTestTask(
                     "Building ONNX Runtime inside a container",
@@ -64,6 +70,7 @@ class BuildEpDockerTask(CompositeTask):
                     ccache_root=ccache_root,
                     build_archive=build_archive,
                     platform=platform,
+                    python=python,
                 ),
             ],
         )

--- a/qcom/ep_build/tasks/docker.py
+++ b/qcom/ep_build/tasks/docker.py
@@ -14,6 +14,7 @@ from ..util import DEFAULT_PYTHON_LINUX
 DOCKER_BUILD_USER = "ortqnnep"
 DOCKER_REPO_ROOT = Path("/ort")
 MANYLINUX_2_34_AARCH64_TAG = "ort-manylinux_2_34_aarch64"
+MANYLINUX_2_34_AARCH64_XCOMPILE_TAG = "ort-manylinux_2_34_aarch64_xcompile"
 UBUNTU_22_04_X86_64_TAG = "ort-ubuntu_22_04_x86_64"
 
 
@@ -93,12 +94,13 @@ class DockerBuildAndTestTask(DockerRunTask):
         ccache_root: Path | None = None,
         build_archive: bool = False,
         platform: str = "linux/aarch64",
+        python: str | None = None,
     ) -> None:
         # deferred to avoid circular import
         from ..tools import get_package_dir, get_tools_dir  # noqa:PLC0415
 
         cmd = [
-            str(DEFAULT_PYTHON_LINUX),
+            python or str(DEFAULT_PYTHON_LINUX),
             str(DOCKER_REPO_ROOT / "qcom" / "build_and_test.py"),
             f"--target-py-version={target_py_version}",
         ]

--- a/qcom/ep_build/util.py
+++ b/qcom/ep_build/util.py
@@ -244,7 +244,7 @@ else:
     BASH_EXECUTABLE = run_and_get_output(["which", "bash"], quiet=True)
 
 
-DEFAULT_PYTHON_LINUX = Path("python3.10")
+DEFAULT_PYTHON_LINUX = Path(os.environ.get("ORT_BUILD_PYTHON", "python3.10"))
 
 DEFAULT_PYTHON_WINDOWS = Path("python.exe")
 

--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -220,6 +220,14 @@ case "${target_platform}" in
           platform_args+=(--cmake_extra_defines
                           CMAKE_TOOLCHAIN_FILE:FILEPATH="${toolchain_cmake}"
                           ARM64:BOOL=TRUE)
+        elif [ -n "${ORT_BUILD_LINUX_TOOLCHAIN_ROOT:-}" ]; then
+          if [ ! -d "${ORT_BUILD_LINUX_TOOLCHAIN_ROOT}" ]; then
+            export ORT_BUILD_LINUX_TOOLCHAIN_ROOT="$(get_linux_oe_gcc112_toolchain_root)"
+          fi
+          toolchain_cmake="${REPO_ROOT}/qcom/scripts/linux/linux-aarch64-gcc11.toolchain.cmake"
+          platform_args+=(--cmake_extra_defines
+                          CMAKE_TOOLCHAIN_FILE:FILEPATH="${toolchain_cmake}"
+                          ARM64:BOOL=TRUE)
         fi
         ;;
       test)

--- a/qcom/scripts/linux/linux-aarch64-gcc11.toolchain.cmake
+++ b/qcom/scripts/linux/linux-aarch64-gcc11.toolchain.cmake
@@ -30,7 +30,9 @@ set(LINUX_TOOLCHAIN_PLATFORM "armv8a-oe-linux")
 
 set(LINUX_TOOLCHAIN_SYSROOT "${LINUX_TOOLCHAIN_ROOT}/sysroots/${LINUX_TOOLCHAIN_PLATFORM}")
 
-if(APPLE)
+if(DEFINED ENV{ORT_LLVM_ROOT})
+  set(LLVM_ROOT "$ENV{ORT_LLVM_ROOT}")
+elseif(APPLE)
   set(LLVM_ROOT "/opt/homebrew/Cellar/llvm@16/16.0.6_1/bin")
 else()
   set(LLVM_ROOT "/usr/lib/llvm-16/bin")

--- a/qcom/scripts/linux/manylinux_2_34_cross/Dockerfile
+++ b/qcom/scripts/linux/manylinux_2_34_cross/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM docker-registry.qualcomm.com/library/ubuntu:26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/qcom/scripts/linux/manylinux_2_34_cross/Dockerfile
+++ b/qcom/scripts/linux/manylinux_2_34_cross/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG BUILD_USER
+ARG BUILD_UID
+ARG BUILD_GID
+
+RUN apt-get update && apt-get install -y \
+    build-essential ninja-build git wget curl patchelf \
+    python3 python3-dev python3-venv python3-pip \
+    lsb-release software-properties-common gnupg ca-certificates \
+    lld-20 clang-20 llvm-20 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV ORT_LLVM_ROOT=/usr/lib/llvm-20/bin
+ENV ORT_BUILD_PYTHON=python3
+
+RUN groupadd -g $BUILD_GID $BUILD_USER && useradd -m -u $BUILD_UID -g $BUILD_USER $BUILD_USER
+
+ARG ORT_NIGHTLY_BUILD=0
+ENV ORT_NIGHTLY_BUILD=$ORT_NIGHTLY_BUILD
+
+ARG ORT_VERSION_SUFFIX=
+ENV ORT_VERSION_SUFFIX=$ORT_VERSION_SUFFIX

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -694,6 +694,9 @@ def build_python_wheel(
 
         args = [sys.executable, os.path.join(source_dir, "setup.py"), "bdist_wheel"]
 
+        if "aarch64" in str(build_dir) and platform.machine() != "aarch64":
+            args.append("--plat-name=manylinux_2_34_aarch64")
+
         # Any combination of the following arguments can be applied
         if nightly_build:
             args.append("--nightly_build")


### PR DESCRIPTION
### Description
Adds a Docker-based cross-compilation build path for producing pip-installable `manylinux_2_34_aarch64` wheels on x86_64 hosts. `build_ort_linux_aarch64_manylinux_2_34` now conditionally dispatches its Docker image: native arm64 image on arm64 hosts, and a new x86_64 image with an aarch64 cross-toolchain on x86_64 hosts. Both paths produce the same wheel artifact, correctly tagged.

Also includes:
  - Configurable toolchain paths via new env vars (`ORT_LLVM_ROOT`, `ORT_BUILD_PYTHON`) with defaults matching current behavior
  - Correct `manylinux_2_34_aarch64` platform tag on cross-compiled wheels (previously would emit `linux_x86_64` or `linux_aarch64` depending on build host)
  - Fix for multi-Python builds so wheels for all requested Python versions are retained (previously only the last version's wheel survived)
  - Auto-download of the OE toolchain in `build.sh` when the toolchain env var points to a missing path

### Motivation and Context
The existing manylinux Docker path uses an aarch64 base image which requires QEMU user-space emulation on x86_64 build hosts. QEMU is unreliable for cmake + ninja builds and subprocess-heavy commands (e.g. `cmake -E echo_append`) fail with `exec format error`, breaking the build.

This PR Decouples the build host architecture from the target architecture in the manylinux Docker path, so aarch64 wheels can be produced on x86_64 hosts without QEMU.


