### PR TITLE
[QNN EP] Add Reshape Transpose fusion node group

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -27,6 +27,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_rank5.h"
 #include "core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.h"
@@ -104,7 +105,7 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"ReduceMean", {LayerNormFusion::TryFusion}},
     {"ReduceL2", {L2NormFusion::TryFusion}},
     {"Einsum", {ReshapeEinsumReshapeNodeGroup::TryFusion}},
-    {"Reshape", {SpaceToDepthFusion::TryFusion, Rank6ToRank5Fusion::TryFusion}},
+    {"Reshape", {SpaceToDepthFusion::TryFusion, Rank6ToRank5Fusion::TryFusion, ReshapeTransposeFusion::TryFusion}},
     {"Transpose", {ChannelShuffleFusion::TryFusion, TransposeReshapeTransposeFusion::TryFusion}}};
 
 void registerUDO(const std::string& node_type, const std::string& op_package) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h"
 
@@ -24,41 +24,39 @@ namespace {
 using MapNodeToNodeUnit = std::unordered_map<const OrtNode*, const OrtNodeUnit*>;
 using MapNodeUnitToGroup = std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>;
 
-// Derive the permutation a Reshape performs on its input when the Reshape is
-// structurally equivalent to a Transpose. Non-1 dims must appear in the same relative
-// order in the output; size-1 dims may move freely. Fills `perm` on success so that
-// reshape_output_shape[i] == reshape_input_shape[perm[i]].
-bool DeriveReshapeAsPerm(const std::vector<int64_t>& input_shape,
-                         const std::vector<int64_t>& output_shape,
-                         std::vector<int64_t>& perm) {
-  if (input_shape.size() != output_shape.size()) {
+// The fusion drops the intermediate tensor between Reshape and Transpose. In a QDQ group
+// (Reshape -> Q_r -> DQ -> Transpose -> Q_t), that tensor carries Q_r's scale/offset — if
+// those differ from Q_t's, the original graph rescales between the two ops, and collapsing
+// them would silently discard that rescale and produce a wrong DLC. Rare but real.
+bool HaveMatchingIntermediateEncoding(QnnModelWrapper& qnn_model_wrapper,
+                                      const OrtNodeUnit& reshape_node_unit,
+                                      const OrtNodeUnit& transpose_node_unit) {
+  const OrtNodeUnitIODef& reshape_output = reshape_node_unit.Outputs()[0];
+  const OrtNodeUnitIODef& transpose_output = transpose_node_unit.Outputs()[0];
+
+  const bool reshape_quantized = reshape_output.quant_param.has_value();
+  const bool transpose_quantized = transpose_output.quant_param.has_value();
+  if (reshape_quantized != transpose_quantized) {
     return false;
   }
-  const size_t rank = input_shape.size();
-  for (size_t i = 0; i < rank; ++i) {
-    if (input_shape[i] < 0 || output_shape[i] < 0) {
-      return false;
-    }
+  if (!reshape_quantized) {
+    return true;
   }
 
-  perm.assign(rank, -1);
-  std::vector<int64_t> input_dims = input_shape;
-  for (size_t i = 0; i < rank; ++i) {
-    const int64_t target = output_shape[i];
-    size_t cur = 0;
-    while (cur < rank && input_dims[cur] != target) {
-      if (input_dims[cur] != -1 && input_dims[cur] != 1 && target != 1) {
-        return false;
-      }
-      ++cur;
-    }
-    if (cur == rank) {
-      return false;
-    }
-    perm[i] = static_cast<int64_t>(cur);
-    input_dims[cur] = -1;
+  QnnQuantParamsWrapper reshape_qp;
+  QnnQuantParamsWrapper transpose_qp;
+  if (!reshape_qp.Init(qnn_model_wrapper, reshape_output).IsOK() ||
+      !transpose_qp.Init(qnn_model_wrapper, transpose_output).IsOK()) {
+    return false;
   }
-  return true;
+
+  float scale_diff = 0.0f;
+  int32_t offset_diff = 0;
+  if (!CompareQnnQuantParams(reshape_qp.Get(), transpose_qp.Get(), scale_diff, offset_diff).IsOK()) {
+    // Encoding types differ (or an unsupported encoding) — treat as non-matching.
+    return false;
+  }
+  return scale_diff == 0.0f && offset_diff == 0;
 }
 
 // Try to compose the Reshape-as-perm with the Transpose's perm. Returns true on success
@@ -73,10 +71,11 @@ bool ComputeFusedPerm(const OrtNodeUnit& reshape_node_unit,
     return false;
   }
 
-  std::vector<int64_t> reshape_perm;
-  if (!DeriveReshapeAsPerm(*reshape_input.shape, *reshape_output.shape, reshape_perm)) {
+  if (!IsReshapePermutable(*reshape_input.shape, *reshape_output.shape)) {
     return false;
   }
+  std::vector<int64_t> reshape_perm;
+  ComputeReshapePerm(*reshape_input.shape, *reshape_output.shape, reshape_perm);
   const size_t rank = reshape_perm.size();
 
   OrtNodeAttrHelper transpose_helper(transpose_node_unit);
@@ -201,6 +200,17 @@ std::unique_ptr<IQnnNodeGroup> ReshapeTransposeFusion::TryFusion(
 
   std::vector<int64_t> fused_perm;
   if (!ComputeFusedPerm(reshape_node_unit, *transpose_node_unit, fused_perm)) {
+    return nullptr;
+  }
+
+  // Skip when the Reshape's output encoding differs from the Transpose's — the intermediate
+  // tensor's scale/offset would be silently dropped by the collapse, producing a wrong DLC.
+  if (!HaveMatchingIntermediateEncoding(qnn_model_wrapper, reshape_node_unit, *transpose_node_unit)) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("[ReshapeTransposeFusion] Skipping fusion of Reshape (" + reshape_node_unit.Name() +
+                 ") -> Transpose (" + transpose_node_unit->Name() +
+                 "): intermediate encoding differs from Transpose output encoding")
+                    .c_str());
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.cc
@@ -56,7 +56,10 @@ bool HaveMatchingIntermediateEncoding(QnnModelWrapper& qnn_model_wrapper,
     // Encoding types differ (or an unsupported encoding) — treat as non-matching.
     return false;
   }
-  return scale_diff == 0.0f && offset_diff == 0;
+  // Match base_op_builder.cc's NEARLY_EQUAL_THRESHOLD: scales that differ only by float
+  // round-off should still be considered equal for fusion purposes.
+  constexpr float kNearlyEqualThreshold = 1e-9f;
+  return scale_diff <= kNearlyEqualThreshold && offset_diff == 0;
 }
 
 // Try to compose the Reshape-as-perm with the Transpose's perm. Returns true on success

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.cc
@@ -1,0 +1,240 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h"
+
+#include <gsl/gsl>
+#include <array>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace {
+
+using MapNodeToNodeUnit = std::unordered_map<const OrtNode*, const OrtNodeUnit*>;
+using MapNodeUnitToGroup = std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>;
+
+// Derive the permutation a Reshape performs on its input when the Reshape is
+// structurally equivalent to a Transpose. Non-1 dims must appear in the same relative
+// order in the output; size-1 dims may move freely. Fills `perm` on success so that
+// reshape_output_shape[i] == reshape_input_shape[perm[i]].
+bool DeriveReshapeAsPerm(const std::vector<int64_t>& input_shape,
+                         const std::vector<int64_t>& output_shape,
+                         std::vector<int64_t>& perm) {
+  if (input_shape.size() != output_shape.size()) {
+    return false;
+  }
+  const size_t rank = input_shape.size();
+  for (size_t i = 0; i < rank; ++i) {
+    if (input_shape[i] < 0 || output_shape[i] < 0) {
+      return false;
+    }
+  }
+
+  perm.assign(rank, -1);
+  std::vector<int64_t> input_dims = input_shape;
+  for (size_t i = 0; i < rank; ++i) {
+    const int64_t target = output_shape[i];
+    size_t cur = 0;
+    while (cur < rank && input_dims[cur] != target) {
+      if (input_dims[cur] != -1 && input_dims[cur] != 1 && target != 1) {
+        return false;
+      }
+      ++cur;
+    }
+    if (cur == rank) {
+      return false;
+    }
+    perm[i] = static_cast<int64_t>(cur);
+    input_dims[cur] = -1;
+  }
+  return true;
+}
+
+// Try to compose the Reshape-as-perm with the Transpose's perm. Returns true on success
+// and fills `fused_perm` with reshape_perm[transpose_perm[i]]. Returns false if the
+// Reshape is not Transpose-equivalent or shapes/perms are invalid.
+bool ComputeFusedPerm(const OrtNodeUnit& reshape_node_unit,
+                      const OrtNodeUnit& transpose_node_unit,
+                      std::vector<int64_t>& fused_perm) {
+  const OrtNodeUnitIODef& reshape_input = reshape_node_unit.Inputs()[0];
+  const OrtNodeUnitIODef& reshape_output = reshape_node_unit.Outputs()[0];
+  if (!reshape_input.shape.has_value() || !reshape_output.shape.has_value()) {
+    return false;
+  }
+
+  std::vector<int64_t> reshape_perm;
+  if (!DeriveReshapeAsPerm(*reshape_input.shape, *reshape_output.shape, reshape_perm)) {
+    return false;
+  }
+  const size_t rank = reshape_perm.size();
+
+  OrtNodeAttrHelper transpose_helper(transpose_node_unit);
+  std::vector<int64_t> transpose_perm = transpose_helper.Get("perm", std::vector<int64_t>{});
+  if (transpose_perm.empty()) {
+    // ONNX default for a missing perm is reverse-of-input-rank.
+    transpose_perm.resize(rank);
+    for (size_t i = 0; i < rank; ++i) {
+      transpose_perm[i] = static_cast<int64_t>(rank - 1 - i);
+    }
+  }
+  if (transpose_perm.size() != rank) {
+    return false;
+  }
+
+  fused_perm.assign(rank, 0);
+  for (size_t i = 0; i < rank; ++i) {
+    const int64_t t = transpose_perm[i];
+    if (t < 0 || static_cast<size_t>(t) >= rank) {
+      return false;
+    }
+    fused_perm[i] = reshape_perm[static_cast<size_t>(t)];
+  }
+  return true;
+}
+
+bool IsIdentityPerm(const std::vector<int64_t>& perm) {
+  for (size_t i = 0; i < perm.size(); ++i) {
+    if (perm[i] != static_cast<int64_t>(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
+                                  const OrtNodeUnit& reshape_node_unit,
+                                  const OrtNodeUnit& transpose_node_unit,
+                                  const std::vector<int64_t>& fused_perm,
+                                  bool validate,
+                                  const Ort::Logger& logger) {
+  const OrtNodeUnitIODef& reshape_input = reshape_node_unit.Inputs()[0];
+  const OrtNodeUnitIODef& transpose_output = transpose_node_unit.Outputs()[0];
+
+  if (!qnn_model_wrapper.IsQnnTensorWrapperExist(reshape_input.name)) {
+    QnnTensorWrapper input_wrapper;
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(reshape_input, input_wrapper));
+    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_wrapper)),
+                  "[ReshapeTransposeFusion] Failed to add input tensor wrapper");
+  }
+
+  if (IsIdentityPerm(fused_perm)) {
+    // Identity composed perm => Reshape input and Transpose output shapes coincide.
+    // Emit a noop Reshape so downstream consumers see the expected tensor name.
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("[ReshapeTransposeFusion] Emitting noop Reshape " + reshape_input.name +
+                 " -> " + transpose_output.name)
+                    .c_str());
+    return qnn_model_wrapper.AddNoopReshapeNode(reshape_node_unit.Name(),
+                                                reshape_input.name,
+                                                transpose_output,
+                                                validate);
+  }
+
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(reshape_input.shape, input_shape),
+                ("[ReshapeTransposeFusion] Failed to get input shape for " + reshape_input.name).c_str());
+  std::vector<uint32_t> output_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(transpose_output.shape, output_shape),
+                ("[ReshapeTransposeFusion] Failed to get output shape for " + transpose_output.name).c_str());
+
+  std::vector<uint32_t> perm_u32;
+  perm_u32.reserve(fused_perm.size());
+  for (int64_t p : fused_perm) {
+    perm_u32.push_back(static_cast<uint32_t>(p));
+  }
+
+  Qnn_DataType_t data_type = QNN_DATATYPE_FLOAT_32;
+  RETURN_IF_ERROR(utils::GetQnnDataType(transpose_output.quant_param.has_value(),
+                                        transpose_output.type, data_type));
+
+  QnnTensorWrapper output_wrapper;
+  RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(transpose_output, output_wrapper));
+  QnnQuantParamsWrapper quant_param = output_wrapper.GetQnnQuantParams();
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("[ReshapeTransposeFusion] Emitting single Transpose " + reshape_input.name +
+               " -> " + transpose_output.name)
+                  .c_str());
+
+  return qnn_model_wrapper.AddTransposeNode(transpose_node_unit.Index(),
+                                            reshape_input.name,
+                                            transpose_output.name,
+                                            input_shape,
+                                            perm_u32,
+                                            output_shape,
+                                            data_type,
+                                            quant_param,
+                                            validate,
+                                            qnn_model_wrapper.IsGraphInput(reshape_input.name),
+                                            qnn_model_wrapper.IsGraphOutput(transpose_output.name));
+}
+
+}  // namespace
+
+std::unique_ptr<IQnnNodeGroup> ReshapeTransposeFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& reshape_node_unit,
+    const MapNodeToNodeUnit& node_to_node_unit,
+    const MapNodeUnitToGroup& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  if (reshape_node_unit.OpType() != "Reshape") {
+    return nullptr;
+  }
+
+  const OrtNodeUnit* transpose_node_unit = GetChildNodeUnitAllowQdq(
+      qnn_model_wrapper, reshape_node_unit, "Transpose",
+      node_to_node_unit, node_unit_to_qnn_node_group);
+  if (transpose_node_unit == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<int64_t> fused_perm;
+  if (!ComputeFusedPerm(reshape_node_unit, *transpose_node_unit, fused_perm)) {
+    return nullptr;
+  }
+
+  // Commit only if QNN can build the collapsed op.
+  if (!CreateOrValidateOnQnn(qnn_model_wrapper, reshape_node_unit, *transpose_node_unit,
+                             fused_perm, /*validate=*/true, logger)
+           .IsOK()) {
+    return nullptr;
+  }
+
+  const char* kind = IsIdentityPerm(fused_perm) ? "noop Reshape" : "single Transpose";
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_INFO,
+              ("[ReshapeTransposeFusion] Collapsing Reshape (" + reshape_node_unit.Name() +
+               ") -> Transpose (" + transpose_node_unit->Name() + ") to " + kind)
+                  .c_str());
+  return std::make_unique<ReshapeTransposeFusion>(reshape_node_unit, *transpose_node_unit,
+                                                  std::move(fused_perm));
+}
+
+gsl::span<const OrtNodeUnit* const> ReshapeTransposeFusion::GetNodeUnits() const {
+  return gsl::span<const OrtNodeUnit* const>{node_units_.data(), node_units_.size()};
+}
+
+Ort::Status ReshapeTransposeFusion::IsSupported(QnnModelWrapper& qnn_model_wrapper,
+                                                const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn(qnn_model_wrapper, *node_units_[0], *node_units_[1],
+                               fused_perm_, /*validate=*/true, logger);
+}
+
+Ort::Status ReshapeTransposeFusion::AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper,
+                                                      const Ort::Logger& logger) const {
+  return CreateOrValidateOnQnn(qnn_model_wrapper, *node_units_[0], *node_units_[1],
+                               fused_perm_, /*validate=*/false, logger);
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <gsl/gsl>
+#include <array>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// Fuses Reshape -> [Q -> DQ]? -> Transpose when the Reshape is structurally equivalent
+// to a Transpose (input and output have the same rank; non-1 dims appear in the same
+// relative order; size-1 dims may move freely). Composes the derived Reshape-perm with
+// the Transpose's perm, then emits ONE QNN node:
+//
+//   * composed perm is identity -> single noop Reshape (input/output shapes coincide)
+//   * otherwise                 -> single Transpose(perm = fused) from the Reshape's
+//                                  outer input tensor to the Transpose's outer output
+//                                  tensor
+//
+// The upstream ORT ReshapeTransposeFusion pass in core/optimizer/ handles the same
+// pattern on the pre-partition graph, but for QNN EP models the offending pairs are
+// commonly introduced INSIDE the QNN partition by the layout transformer (Conv
+// NCHW->NHWC) during partitioning. Level-2 fusion can no longer see them, so we handle
+// the same rewrite here inside qnn_node_group, where visibility is restricted to what
+// QNN EP will actually compile.
+class ReshapeTransposeFusion : public IQnnNodeGroup {
+ public:
+  ReshapeTransposeFusion(const OrtNodeUnit& reshape_node_unit,
+                         const OrtNodeUnit& transpose_node_unit,
+                         std::vector<int64_t> fused_perm)
+      : node_units_{&reshape_node_unit, &transpose_node_unit},
+        fused_perm_(std::move(fused_perm)) {}
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeTransposeFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return node_units_[0]; }
+  std::string_view Type() const override { return "ReshapeTransposeFusion"; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& reshape_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::array<const OrtNodeUnit*, 2> node_units_;  // {Reshape, Transpose}
+  std::vector<int64_t> fused_perm_;               // reshape_perm[transpose_perm[i]] for each i
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <gsl/gsl>
+#include <algorithm>
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -102,6 +104,60 @@ bool IsScalarConstantApprox(const QnnModelWrapper& qnn_model_wrapper,
                             const std::string& input_name,
                             float expected,
                             float tol = 1e-3f);
+
+/// <summary>
+/// Returns true when a Reshape from `input_shape` to `output_shape` is structurally
+/// equivalent to a Transpose: both shapes have the same rank, all dims are static and
+/// non-negative, and the sequence of non-1 dims is identical (same values in the same
+/// order). Size-1 dims are free to appear anywhere.
+///
+/// Defined inline so consumers (including out-of-EP unit tests) do not need to link
+/// against the QNN EP module to use it.
+/// </summary>
+inline bool IsReshapePermutable(const std::vector<int64_t>& input_shape,
+                                const std::vector<int64_t>& output_shape) {
+  if (input_shape.size() != output_shape.size()) {
+    return false;
+  }
+  const auto is_negative = [](int64_t d) { return d < 0; };
+  if (std::any_of(input_shape.begin(), input_shape.end(), is_negative) ||
+      std::any_of(output_shape.begin(), output_shape.end(), is_negative)) {
+    return false;
+  }
+
+  const auto is_non_one = [](int64_t d) { return d != 1; };
+  std::vector<int64_t> input_non_one;
+  std::vector<int64_t> output_non_one;
+  std::copy_if(input_shape.begin(), input_shape.end(), std::back_inserter(input_non_one), is_non_one);
+  std::copy_if(output_shape.begin(), output_shape.end(), std::back_inserter(output_non_one), is_non_one);
+  return input_non_one == output_non_one;
+}
+
+/// <summary>
+/// Precondition: IsReshapePermutable(input_shape, output_shape) is true. Fills `perm` so
+/// that output_shape[i] == input_shape[perm[i]]. Non-1 dims are matched left-to-right
+/// (preserving their relative order); size-1 dims greedily take the next unused slot.
+///
+/// Defined inline so consumers (including out-of-EP unit tests) do not need to link
+/// against the QNN EP module to use it.
+/// </summary>
+inline void ComputeReshapePerm(const std::vector<int64_t>& input_shape,
+                               const std::vector<int64_t>& output_shape,
+                               std::vector<int64_t>& perm) {
+  const size_t rank = input_shape.size();
+  perm.assign(rank, -1);
+  std::vector<bool> used(rank, false);
+  for (size_t i = 0; i < rank; ++i) {
+    const int64_t target = output_shape[i];
+    for (size_t j = 0; j < rank; ++j) {
+      if (!used[j] && input_shape[j] == target) {
+        perm[i] = static_cast<int64_t>(j);
+        used[j] = true;
+        break;
+      }
+    }
+  }
+}
 
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <gsl/util>
+#include "gtest/gtest.h"
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+namespace {
+
+// Add -> Reshape -> Transpose -> Add. Wraps the Reshape/Transpose in Adds so both
+// nodes end up strictly inside a QNN partition (graph inputs/outputs go through the
+// Adds, so the fusion pattern is never a graph boundary).
+GetTestModelFn BuildReshapeTransposeFloatCase(const std::vector<int64_t>& input_shape,
+                                              const std::vector<int64_t>& reshape_shape,
+                                              const std::vector<int64_t>& transpose_perm) {
+  return [input_shape, reshape_shape, transpose_perm](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_transpose_fusion_graph");
+
+    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "input", input_def);
+
+    builder.MakeScalarInitializer<float>("add_const1", 0.0f);
+    builder.AddNode("pre_add", "Add", {"input", "add_const1"}, {"pre_add_out"}, kOnnxDomain);
+
+    builder.Make1DInitializer<int64_t>("reshape_shape", reshape_shape);
+    builder.AddNode("reshape", "Reshape", {"pre_add_out", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    builder.AddNode("transpose", "Transpose", {"reshape_out"}, {"transpose_out"},
+                    kOnnxDomain, {builder.MakeIntsAttribute("perm", transpose_perm)});
+
+    builder.MakeScalarInitializer<float>("add_const2", 0.0f);
+    builder.AddNode("post_add", "Add", {"transpose_out", "add_const2"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  return provider_options;
+}
+
+// RAII wrapper: create a fresh dump dir, ask QNN EP to write its JSON graph into it,
+// and remove it at scope exit. Returns the dir path.
+std::filesystem::path MakeDumpDir(ProviderOptions& provider_options, const std::string& name) {
+  const std::filesystem::path dir = name;
+  std::filesystem::remove_all(dir);
+  EXPECT_TRUE(std::filesystem::create_directory(dir));
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = dir.string();
+  return dir;
+}
+
+}  // namespace
+
+// Composed perm is identity: fusion collapses to a single noop Reshape and drops the
+// Transpose. Reshape [3,4,1,1] -> [3,1,4,1] is Transpose-equivalent with derived
+// perm=[0,2,1,3]; a following Transpose(perm=[0,2,1,3]) gives fused=[0,1,2,3]. The
+// noop Reshape passes QNN op validation (both endpoints have identical shape
+// [3,4,1,1]).
+TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_IdentityComposedPerm_NoopReshape) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ProviderOptions provider_options = GetProviderOptions();
+  const auto dir = MakeDumpDir(provider_options, "ReshapeTransposeFusion_Identity");
+  auto cleanup = gsl::finally([&dir]() { std::filesystem::remove_all(dir); });
+
+  RunQnnModelTest(BuildReshapeTransposeFloatCase(/*input_shape=*/{3, 4, 1, 1},
+                                                 /*reshape_shape=*/{3, 1, 4, 1},
+                                                 /*transpose_perm=*/{0, 2, 1, 3}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-2f)});
+
+  // Fusion produced a single noop Reshape and zero Transposes.
+  AssertOpInQnnGraph(dir, "Transpose", 0);
+  AssertOpInQnnGraph(dir, "Reshape", 1);
+}
+
+// Composed perm is non-identity but the Reshape is Transpose-equivalent: fusion
+// collapses to a single Transpose(fused_perm) and drops the Reshape entirely.
+// Reshape-perm=[0,3,1,2], Transpose perm=[0,1,3,2], fused=[0,3,2,1].
+TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_NonIdentityComposedPerm_SingleTranspose) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ProviderOptions provider_options = GetProviderOptions();
+  const auto dir = MakeDumpDir(provider_options, "ReshapeTransposeFusion_NonIdentity");
+  auto cleanup = gsl::finally([&dir]() { std::filesystem::remove_all(dir); });
+
+  RunQnnModelTest(BuildReshapeTransposeFloatCase(/*input_shape=*/{1, 4, 4, 1},
+                                                 /*reshape_shape=*/{1, 1, 4, 4},
+                                                 /*transpose_perm=*/{0, 1, 3, 2}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-2f)});
+
+  // Fusion produced exactly one Transpose (with the fused perm) and zero Reshapes.
+  AssertOpInQnnGraph(dir, "Transpose", 1);
+  AssertOpInQnnGraph(dir, "Reshape", 0);
+}
+
+// Reshape is NOT structurally a Transpose (ranks differ). Fusion must decline and both
+// original nodes must remain in the compiled QNN graph.
+TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_NonTransposeEquivalentReshape_NotFused) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ProviderOptions provider_options = GetProviderOptions();
+  const auto dir = MakeDumpDir(provider_options, "ReshapeTransposeFusion_NotFused");
+  auto cleanup = gsl::finally([&dir]() { std::filesystem::remove_all(dir); });
+
+  // Rank changes from 3 to 2 -- DeriveReshapeAsPerm returns false.
+  RunQnnModelTest(BuildReshapeTransposeFloatCase(/*input_shape=*/{1, 4, 4},
+                                                 /*reshape_shape=*/{1, 16},
+                                                 /*transpose_perm=*/{1, 0}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-2f)});
+
+  AssertOpInQnnGraph(dir, "Reshape", 1);
+  AssertOpInQnnGraph(dir, "Transpose", 1);
+}
+
+// Two non-1 dims have equal size and sit at non-adjacent positions in the input.
+// DeriveReshapeAsPerm walks the output left-to-right and picks the first still-unclaimed
+// input dim that matches, so [2,1,2,1] -> [2,2,1,1] resolves to reshape_perm=[0,2,1,3]
+// (first output '2' -> input dim 0, second output '2' -> input dim 2). Composed with
+// Transpose perm=[0,2,1,3] this gives identity, so fusion must fire and emit a single
+// noop Reshape.
+//
+// If the greedy instead picked the second input '2' for the first output '2', the
+// derived perm would be [2,0,1,3] and the composed perm [2,1,0,3] (non-identity) --
+// same tensor shapes but a genuinely different data mapping. This test locks in the
+// greedy invariant: reordering equal non-1 dims across size-1 dims is legal only if the
+// pick preserves the relative order of the non-1 dims.
+TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_EqualNonUnitDims_Identity) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ProviderOptions provider_options = GetProviderOptions();
+  const auto dir = MakeDumpDir(provider_options, "ReshapeTransposeFusion_EqualDims");
+  auto cleanup = gsl::finally([&dir]() { std::filesystem::remove_all(dir); });
+
+  RunQnnModelTest(BuildReshapeTransposeFloatCase(/*input_shape=*/{2, 1, 2, 1},
+                                                 /*reshape_shape=*/{2, 2, 1, 1},
+                                                 /*transpose_perm=*/{0, 2, 1, 3}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-2f)});
+
+  AssertOpInQnnGraph(dir, "Transpose", 0);
+  AssertOpInQnnGraph(dir, "Reshape", 1);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
@@ -12,6 +12,7 @@
 
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
 
 namespace onnxruntime {
 namespace test {
@@ -42,6 +43,49 @@ GetTestModelFn BuildReshapeTransposeFloatCase(const std::vector<int64_t>& input_
 
     builder.MakeScalarInitializer<float>("add_const2", 0.0f);
     builder.AddNode("post_add", "Add", {"transpose_out", "add_const2"}, {"output"}, kOnnxDomain);
+
+    builder.MakeOutput("output");
+  };
+}
+
+// Wraps Reshape and Transpose in a QDQ node unit each: Add -> Q -> DQ -> Reshape -> Q_r -> DQ ->
+// Transpose -> Q_t -> DQ -> Add. All Q/DQ pairs share the same scale/zero-point so the QNN
+// Reshape/Transpose builders (which require aligned input/output quant params) can lower the
+// graph, and the fusion's HaveMatchingIntermediateEncoding check passes.
+GetTestModelFn BuildReshapeTransposeQdqCase(const std::vector<int64_t>& input_shape,
+                                            const std::vector<int64_t>& reshape_shape,
+                                            const std::vector<int64_t>& transpose_perm) {
+  return [input_shape, reshape_shape, transpose_perm](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("reshape_transpose_fusion_qdq_graph");
+
+    constexpr float kScale = 1.0f / 128.0f;
+    constexpr uint8_t kZeroPoint = 128;
+
+    MakeTestInput<float>(builder, "input", TestInputDef<float>(input_shape, false, -1.0f, 1.0f));
+
+    builder.MakeScalarInitializer<float>("add_const1", 0.0f);
+    builder.AddNode("pre_add", "Add", {"input", "add_const1"}, {"pre_add_out"}, kOnnxDomain);
+
+    // pre_add_out -> Q -> DQ -> reshape_in
+    const std::string reshape_in =
+        AddQDQNodePair<uint8_t>(builder, "qdq_reshape_in", "pre_add_out", kScale, kZeroPoint);
+
+    builder.Make1DInitializer<int64_t>("reshape_shape", reshape_shape);
+    builder.AddNode("reshape", "Reshape", {reshape_in, "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    // reshape_out -> Q_r -> DQ -> transpose_in
+    const std::string transpose_in =
+        AddQDQNodePair<uint8_t>(builder, "qdq_reshape_out", "reshape_out", kScale, kZeroPoint);
+
+    builder.AddNode("transpose", "Transpose", {transpose_in}, {"transpose_out"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("perm", transpose_perm)});
+
+    // transpose_out -> Q_t -> DQ -> post_add_in
+    const std::string post_add_in =
+        AddQDQNodePair<uint8_t>(builder, "qdq_transpose_out", "transpose_out", kScale, kZeroPoint);
+
+    builder.MakeScalarInitializer<float>("add_const2", 0.0f);
+    builder.AddNode("post_add", "Add", {post_add_in, "add_const2"}, {"output"}, kOnnxDomain);
 
     builder.MakeOutput("output");
   };
@@ -161,6 +205,29 @@ TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_EqualNonUnitDims_Identity) {
 
   AssertOpInQnnGraph(dir, "Transpose", 0);
   AssertOpInQnnGraph(dir, "Reshape", 1);
+}
+
+// QDQ Reshape -> QDQ Transpose with matching intermediate encoding.
+// Exercises HaveMatchingIntermediateEncoding on the quantized path: fusion should collapse
+// the pair to a single Transpose in the QNN graph, same as the float case.
+TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_Qdq_MatchingEncoding_SingleTranspose) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["offload_graph_io_quantization"] = "0";
+  const auto dir = MakeDumpDir(provider_options, "ReshapeTransposeFusion_Qdq_Match");
+  auto cleanup = gsl::finally([&dir]() { std::filesystem::remove_all(dir); });
+
+  RunQnnModelTest(BuildReshapeTransposeQdqCase(/*input_shape=*/{1, 4, 4, 1},
+                                               /*reshape_shape=*/{1, 1, 4, 4},
+                                               /*transpose_perm=*/{0, 1, 3, 2}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-2f)});
+
+  // Fusion fired: exactly one Transpose and zero Reshapes remain in the QNN graph.
+  AssertOpInQnnGraph(dir, "Transpose", 1);
+  AssertOpInQnnGraph(dir, "Reshape", 0);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
 
 #if !defined(ORT_MINIMAL_BUILD)
 
@@ -120,7 +120,7 @@ TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_NonTransposeEquivalentReshape_
   const auto dir = MakeDumpDir(provider_options, "ReshapeTransposeFusion_NotFused");
   auto cleanup = gsl::finally([&dir]() { std::filesystem::remove_all(dir); });
 
-  // Rank changes from 3 to 2 -- DeriveReshapeAsPerm returns false.
+  // Rank changes from 3 to 2 -- IsReshapePermutable returns false.
   RunQnnModelTest(BuildReshapeTransposeFloatCase(/*input_shape=*/{1, 4, 4},
                                                  /*reshape_shape=*/{1, 16},
                                                  /*transpose_perm=*/{1, 0}),
@@ -134,7 +134,7 @@ TEST_F(QnnHTPBackendTests, ReshapeTransposeFusion_NonTransposeEquivalentReshape_
 }
 
 // Two non-1 dims have equal size and sit at non-adjacent positions in the input.
-// DeriveReshapeAsPerm walks the output left-to-right and picks the first still-unclaimed
+// ComputeReshapePerm walks the output left-to-right and picks the first still-unclaimed
 // input dim that matches, so [2,1,2,1] -> [2,2,1,1] resolves to reshape_perm=[0,2,1,3]
 // (first output '2' -> input dim 0, second output '2' -> input dim 2). Composed with
 // Transpose perm=[0,2,1,3] this gives identity, so fusion must fire and emit a single

--- a/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/reshape_transpose_fusion_test.cc
@@ -29,8 +29,7 @@ GetTestModelFn BuildReshapeTransposeFloatCase(const std::vector<int64_t>& input_
   return [input_shape, reshape_shape, transpose_perm](ModelTestBuilder& builder) -> void {
     builder.graph_->set_name("reshape_transpose_fusion_graph");
 
-    auto input_def = TestInputDef<float>(input_shape, false, -1.0f, 1.0f);
-    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "input", TestInputDef<float>(input_shape, false, -1.0f, 1.0f));
 
     builder.MakeScalarInitializer<float>("add_const1", 0.0f);
     builder.AddNode("pre_add", "Add", {"input", "add_const1"}, {"pre_add_out"}, kOnnxDomain);

--- a/onnxruntime/test/providers/qnn/unit/qnn_node_group_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_node_group_utils_test.cc
@@ -1,0 +1,212 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Function-level unit tests for the shape/permutation helpers in
+// qnn_node_group/utils.h. Both helpers are defined inline in the header, so
+// these tests run in every build (no QNN_EP_INTERNAL_SYMBOL_ACCESS guard).
+
+#include "gtest/gtest.h"
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <cstdint>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+// =============================================================================
+// qnn::IsReshapePermutable
+// =============================================================================
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_SameShapeIsPermutable) {
+  EXPECT_TRUE(qnn::IsReshapePermutable({2, 3, 4}, {2, 3, 4}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_ScalarSameRank) {
+  EXPECT_TRUE(qnn::IsReshapePermutable({}, {}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_RankMismatchRejected) {
+  EXPECT_FALSE(qnn::IsReshapePermutable({1, 4, 4}, {1, 16}));
+  EXPECT_FALSE(qnn::IsReshapePermutable({1, 16}, {1, 4, 4}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_NegativeDimRejected) {
+  EXPECT_FALSE(qnn::IsReshapePermutable({-1, 4}, {4, -1}));
+  EXPECT_FALSE(qnn::IsReshapePermutable({2, 4}, {-1, 4}));
+  EXPECT_FALSE(qnn::IsReshapePermutable({-1, 4}, {2, 4}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_NonOneDimsDifferByValue) {
+  // {2,3,4} and {2,4,3} have the same set of non-1 dims but a different sequence.
+  // The sequences must be identical, not just multisets — order-preserving.
+  EXPECT_FALSE(qnn::IsReshapePermutable({2, 3, 4}, {2, 4, 3}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_NonOneDimsDifferByCount) {
+  // Extra 5 in the output has no counterpart in the input.
+  EXPECT_FALSE(qnn::IsReshapePermutable({2, 3, 4}, {2, 3, 5}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_SizeOneDimsCanMoveFreely) {
+  EXPECT_TRUE(qnn::IsReshapePermutable({3, 4, 1, 1}, {3, 1, 4, 1}));
+  EXPECT_TRUE(qnn::IsReshapePermutable({1, 4, 4, 1}, {1, 1, 4, 4}));
+  EXPECT_TRUE(qnn::IsReshapePermutable({1, 2, 1, 3}, {2, 1, 1, 3}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_AllOnesAllRanks) {
+  EXPECT_TRUE(qnn::IsReshapePermutable({1, 1, 1}, {1, 1, 1}));
+  EXPECT_TRUE(qnn::IsReshapePermutable({1}, {1}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_ZeroDimIsNotNegative) {
+  // Zero-size dims are non-1 and must appear in the same relative order as any
+  // other non-1 dim -- reordering them is not a legal Reshape-as-Transpose.
+  EXPECT_TRUE(qnn::IsReshapePermutable({0, 3}, {0, 3}));
+  EXPECT_FALSE(qnn::IsReshapePermutable({0, 3}, {3, 0}));
+  EXPECT_FALSE(qnn::IsReshapePermutable({0, 3}, {0, 4}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, IsReshapePermutable_EqualNonUnitDimsAtDifferentPositions) {
+  // Two non-1 dims of equal size at non-adjacent positions — still permutable
+  // because the non-1 sub-sequence [2, 2] matches on both sides.
+  EXPECT_TRUE(qnn::IsReshapePermutable({2, 1, 2, 1}, {2, 2, 1, 1}));
+  EXPECT_TRUE(qnn::IsReshapePermutable({2, 1, 2, 1}, {1, 1, 2, 2}));
+}
+
+// =============================================================================
+// qnn::ComputeReshapePerm
+//
+// Contract: output_shape[i] == input_shape[perm[i]]. Non-1 dims are matched
+// left-to-right (preserving their relative order); size-1 dims greedily take the
+// next unused slot.
+// =============================================================================
+
+// Helper: reconstruct the output shape from perm and check it matches expected.
+static bool ApplyPerm(const std::vector<int64_t>& input_shape,
+                      const std::vector<int64_t>& perm,
+                      const std::vector<int64_t>& expected_output) {
+  if (perm.size() != expected_output.size()) return false;
+  for (size_t i = 0; i < perm.size(); ++i) {
+    if (perm[i] < 0 || static_cast<size_t>(perm[i]) >= input_shape.size()) return false;
+    if (input_shape[static_cast<size_t>(perm[i])] != expected_output[i]) return false;
+  }
+  return true;
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_IdentityShapeIdentityPerm) {
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({2, 3, 4}, {2, 3, 4}, perm);
+  EXPECT_EQ(perm, (std::vector<int64_t>{0, 1, 2}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_ScalarIsEmptyPerm) {
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({}, {}, perm);
+  EXPECT_TRUE(perm.empty());
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_SwapSizeOneDim) {
+  // [3, 4, 1, 1] -> [3, 1, 4, 1]: 4 moves from index 1 to index 2. Size-1 dims
+  // greedily take the next unused slot: perm[1] picks input[2] (the first '1'),
+  // perm[3] picks input[3] (the remaining '1').
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({3, 4, 1, 1}, {3, 1, 4, 1}, perm);
+  EXPECT_EQ(perm, (std::vector<int64_t>{0, 2, 1, 3}));
+  EXPECT_TRUE(ApplyPerm({3, 4, 1, 1}, perm, {3, 1, 4, 1}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_MoveNonUnitDimAcrossOnes) {
+  // [1, 4, 4, 1] -> [1, 1, 4, 4]: first output '1' picks input[0], second output
+  // '1' picks input[3], then the two 4s pick input[1], input[2].
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({1, 4, 4, 1}, {1, 1, 4, 4}, perm);
+  EXPECT_EQ(perm, (std::vector<int64_t>{0, 3, 1, 2}));
+  EXPECT_TRUE(ApplyPerm({1, 4, 4, 1}, perm, {1, 1, 4, 4}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_EqualNonUnitDimsPreserveOrder) {
+  // [2, 1, 2, 1] -> [2, 2, 1, 1]: the two output '2's must map to input[0] and
+  // input[2] in that order (relative order of non-1 dims must be preserved). If
+  // the greedy walk instead picked input[2] for the first output '2', the
+  // resulting perm would be [2, 0, 1, 3] and represent a genuinely different
+  // data mapping.
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({2, 1, 2, 1}, {2, 2, 1, 1}, perm);
+  EXPECT_EQ(perm, (std::vector<int64_t>{0, 2, 1, 3}));
+  EXPECT_TRUE(ApplyPerm({2, 1, 2, 1}, perm, {2, 2, 1, 1}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_AllOnes) {
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({1, 1, 1}, {1, 1, 1}, perm);
+  // Greedy: each output '1' picks the next unused input '1' -> identity perm.
+  EXPECT_EQ(perm, (std::vector<int64_t>{0, 1, 2}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_ZeroSizeDim) {
+  // Zero-size dims are treated as any other non-1 dim -- matched left-to-right.
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({0, 3}, {0, 3}, perm);
+  EXPECT_EQ(perm, (std::vector<int64_t>{0, 1}));
+  EXPECT_TRUE(ApplyPerm({0, 3}, perm, {0, 3}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_Rank5MixedOnes) {
+  // [1, 2, 1, 3, 1] -> [2, 1, 3, 1, 1]. Non-1 order preserved: 2 goes first,
+  // then 3. Size-1 dims take the next unused input '1' slots left-to-right.
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({1, 2, 1, 3, 1}, {2, 1, 3, 1, 1}, perm);
+  EXPECT_EQ(perm, (std::vector<int64_t>{1, 0, 3, 2, 4}));
+  EXPECT_TRUE(ApplyPerm({1, 2, 1, 3, 1}, perm, {2, 1, 3, 1, 1}));
+}
+
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_ReversedNonUnitDims) {
+  // Distinct non-1 dims in reversed order across size-1 dims.
+  // [1, 5, 1, 7] -> [7, 1, 5, 1]. Non-1 output order 7,5 differs from input
+  // order 5,7 -- IsReshapePermutable would reject this, so ComputeReshapePerm
+  // makes no promise. Verify we do not crash and produce a rank-matching perm.
+  std::vector<int64_t> perm;
+  qnn::ComputeReshapePerm({1, 5, 1, 7}, {7, 1, 5, 1}, perm);
+  EXPECT_EQ(perm.size(), 4u);
+}
+
+// A perm returned for a permutable shape must be a valid permutation of
+// [0..rank-1] with no duplicates. Sweep across a handful of shapes.
+TEST(QnnUnit_NodeGroupUtilsTest, ComputeReshapePerm_ProducesValidPermutation) {
+  struct Case {
+    std::vector<int64_t> in;
+    std::vector<int64_t> out;
+  };
+  const Case cases[] = {
+      {{3, 4, 1, 1}, {3, 1, 4, 1}},
+      {{1, 4, 4, 1}, {1, 1, 4, 4}},
+      {{2, 1, 2, 1}, {2, 2, 1, 1}},
+      {{1, 2, 1, 3, 1}, {2, 1, 3, 1, 1}},
+      {{2, 3, 4}, {2, 3, 4}},
+      {{1, 1, 1}, {1, 1, 1}},
+  };
+  for (const auto& c : cases) {
+    ASSERT_TRUE(qnn::IsReshapePermutable(c.in, c.out))
+        << "precondition failed for case with in.size()=" << c.in.size();
+    std::vector<int64_t> perm;
+    qnn::ComputeReshapePerm(c.in, c.out, perm);
+    ASSERT_EQ(perm.size(), c.in.size());
+    std::vector<bool> seen(perm.size(), false);
+    for (int64_t p : perm) {
+      ASSERT_GE(p, 0);
+      ASSERT_LT(static_cast<size_t>(p), perm.size());
+      ASSERT_FALSE(seen[static_cast<size_t>(p)]) << "duplicate index in perm";
+      seen[static_cast<size_t>(p)] = true;
+    }
+    EXPECT_TRUE(ApplyPerm(c.in, perm, c.out));
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Add Reshape-transpose fusion qnn node group. When Reshape is acting as a transpose, this fusion will fuse 2 nodes in to (a) no-op reshape if the fused transpose perm is acceding from 0. e.g. [0, 1, 2] otherwise (b) a single transpose with new permutation.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
This fix ONNX model when having `Reshape -> Conv` after layout transformation, it gives `Reshape - Transpose - Conv`, and this feature can help fusing nodes to reduce ops and data mover overhead.

See issue https://github.com/qcom-ai-hub/tetracode/issues/19914
Original (SDK): https://workbench.aihub.qualcomm.com/jobs/jp24xj245 [4.6 ms]
Replayed (ORT): https://dev.aihub.qualcomm.com/jobs/jp3ee3yz5 [7.37 ms]
ORT with this change:  https://dev.aihub.qualcomm.com/jobs/j5w9lxojp [2.56 ms] -> 0.55x inference compare to base line (SDK)
