### PR TITLE
[QNN EP] Add QDQ HTP tests for Tan op

### DIFF
--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -385,6 +385,27 @@ TEST_F(QnnHTPBackendTests, UnaryOp_Tan_fp) {
   );
 }
 
+// Check that QNN compiles DQ -> Tan -> Q as a single unit.
+// Use an input of rank 3.
+TEST_F(QnnHTPBackendTests, UnaryOp_Tan_QDQ_U8) {
+  RunQDQOpTest<uint8_t>("Tan",
+                        {TestInputDef<float>({1, 2, 3}, false, -1.0f, 1.0f)},
+                        {},
+                        11,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// Tests accuracy of 16-bit QDQ Tan.
+TEST_F(QnnHTPBackendTests, UnaryOp_Tan_QDQ_U16) {
+  RunQDQOpTest<uint16_t>("Tan",
+                         {TestInputDef<float>({1, 2, 3}, false, -1.0f, 1.0f)},
+                         {},
+                         11,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,  // Tan op domain
+                         true);        // Use com.microsoft Q/DQ op domains
+}
+
 // disabled for QNN 2.28.0.241029 backendValidateOpConfig failed
 // still fails on QNN 2.28.2 and QNN 2.30.0
 // QnnDsp <E> [4294967295] has incorrect Value -32768, expected equal to 0.


### PR DESCRIPTION
## Description

Add `uint8_t` and `uint16_t` QDQ HTP tests for `Tan`, following the `Atan` sibling pattern. No op builder changes — test coverage only.

## Motivation

`simple_op_test.cc` has a float32 HTP test for `Tan` (`UnaryOp_Tan_fp`) but no quantized coverage.

Without these tests, a regression in quantized `Tan` dispatch (e.g. `IsOpSupported` returning false for U8/U16, or a broken QDQ fusion) would go undetected on HTP.