### PR TITLE
Adaptive backend routing

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/ort_graph_read_helpers.h
+++ b/onnxruntime/core/providers/qnn/builder/ort_graph_read_helpers.h
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Graph-structure reads through an injected OrtApi rather than the process-global Ort::Const*
+// wrappers, so snapshot handles resolve to the shim accessors at background compose time.
+namespace ort_read {
+
+inline std::string NodeOpType(const OrtApi& ort_api, const OrtNode* node) {
+  const char* op_type = nullptr;
+  Ort::ThrowOnError(ort_api.Node_GetOperatorType(node, &op_type));
+  return op_type != nullptr ? std::string(op_type) : std::string();
+}
+
+inline std::string NodeName(const OrtApi& ort_api, const OrtNode* node) {
+  const char* name = nullptr;
+  Ort::ThrowOnError(ort_api.Node_GetName(node, &name));
+  return name != nullptr ? std::string(name) : std::string();
+}
+
+inline std::string GraphName(const OrtApi& ort_api, const OrtGraph* graph) {
+  const char* name = nullptr;
+  Ort::ThrowOnError(ort_api.Graph_GetName(graph, &name));
+  return name != nullptr ? std::string(name) : std::string();
+}
+
+inline std::vector<const OrtValueInfo*> GraphInputs(const OrtApi& ort_api, const OrtGraph* graph) {
+  size_t num = 0;
+  Ort::ThrowOnError(ort_api.Graph_GetNumInputs(graph, &num));
+  std::vector<const OrtValueInfo*> inputs(num);
+  if (num > 0) {
+    Ort::ThrowOnError(ort_api.Graph_GetInputs(graph, inputs.data(), num));
+  }
+  return inputs;
+}
+
+inline std::vector<const OrtNode*> GraphNodes(const OrtApi& ort_api, const OrtGraph* graph) {
+  size_t num = 0;
+  Ort::ThrowOnError(ort_api.Graph_GetNumNodes(graph, &num));
+  std::vector<const OrtNode*> nodes(num);
+  if (num > 0) {
+    Ort::ThrowOnError(ort_api.Graph_GetNodes(graph, nodes.data(), num));
+  }
+  return nodes;
+}
+
+inline std::vector<const OrtValueInfo*> GraphInitializers(const OrtApi& ort_api, const OrtGraph* graph) {
+  size_t num = 0;
+  Ort::ThrowOnError(ort_api.Graph_GetNumInitializers(graph, &num));
+  std::vector<const OrtValueInfo*> initializers(num);
+  if (num > 0) {
+    Ort::ThrowOnError(ort_api.Graph_GetInitializers(graph, initializers.data(), num));
+  }
+  return initializers;
+}
+
+inline std::string ValueInfoName(const OrtApi& ort_api, const OrtValueInfo* value_info) {
+  const char* name = nullptr;
+  Ort::ThrowOnError(ort_api.GetValueInfoName(value_info, &name));
+  return name != nullptr ? std::string(name) : std::string();
+}
+
+inline bool IsGraphOutput(const OrtApi& ort_api, const OrtValueInfo* value_info) {
+  bool is_graph_output = false;
+  Ort::ThrowOnError(ort_api.ValueInfo_IsGraphOutput(value_info, &is_graph_output));
+  return is_graph_output;
+}
+
+inline std::vector<const OrtValueInfo*> NodeInputs(const OrtApi& ort_api, const OrtNode* node) {
+  size_t num = 0;
+  Ort::ThrowOnError(ort_api.Node_GetNumInputs(node, &num));
+  std::vector<const OrtValueInfo*> inputs(num);
+  if (num > 0) {
+    Ort::ThrowOnError(ort_api.Node_GetInputs(node, inputs.data(), num));
+  }
+  return inputs;
+}
+
+inline std::vector<const OrtValueInfo*> NodeOutputs(const OrtApi& ort_api, const OrtNode* node) {
+  size_t num = 0;
+  Ort::ThrowOnError(ort_api.Node_GetNumOutputs(node, &num));
+  std::vector<const OrtValueInfo*> outputs(num);
+  if (num > 0) {
+    Ort::ThrowOnError(ort_api.Node_GetOutputs(node, outputs.data(), num));
+  }
+  return outputs;
+}
+
+inline const OrtNode* ProducerNode(const OrtApi& ort_api, const OrtValueInfo* value_info) {
+  const OrtNode* producer = nullptr;
+  Ort::ThrowOnError(ort_api.ValueInfo_GetValueProducer(value_info, &producer, nullptr));
+  return producer;
+}
+
+inline std::vector<const OrtNode*> ConsumerNodes(const OrtApi& ort_api, const OrtValueInfo* value_info) {
+  size_t num = 0;
+  Ort::ThrowOnError(ort_api.ValueInfo_GetValueNumConsumers(value_info, &num));
+  std::vector<const OrtNode*> nodes(num);
+  if (num > 0) {
+    std::vector<int64_t> indices(num);
+    Ort::ThrowOnError(ort_api.ValueInfo_GetValueConsumers(value_info, nodes.data(), indices.data(), num));
+  }
+  return nodes;
+}
+
+inline ONNXTensorElementDataType ElemType(const OrtApi& ort_api, const OrtValueInfo* value_info) {
+  const OrtTypeInfo* type_info = nullptr;
+  Ort::ThrowOnError(ort_api.GetValueInfoTypeInfo(value_info, &type_info));
+  const OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+  Ort::ThrowOnError(ort_api.CastTypeInfoToTensorInfo(type_info, &tensor_info));
+  ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+  Ort::ThrowOnError(ort_api.GetTensorElementType(tensor_info, &elem_type));
+  return elem_type;
+}
+
+inline std::vector<int64_t> Shape(const OrtApi& ort_api, const OrtValueInfo* value_info) {
+  const OrtTypeInfo* type_info = nullptr;
+  Ort::ThrowOnError(ort_api.GetValueInfoTypeInfo(value_info, &type_info));
+  const OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+  Ort::ThrowOnError(ort_api.CastTypeInfoToTensorInfo(type_info, &tensor_info));
+  size_t num_dims = 0;
+  Ort::ThrowOnError(ort_api.GetDimensionsCount(tensor_info, &num_dims));
+  std::vector<int64_t> shape(num_dims);
+  if (num_dims > 0) {
+    Ort::ThrowOnError(ort_api.GetDimensions(tensor_info, shape.data(), num_dims));
+  }
+  return shape;
+}
+
+}  // namespace ort_read
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot.cc
@@ -1,0 +1,385 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/qnn_graph_snapshot.h"
+
+#include <unordered_set>
+#include <utility>
+
+#include "core/providers/qnn/builder/qnn_utils.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+// Ensure a SnapshotValueInfo exists for the given name and return it.
+SnapshotValueInfo* EnsureValueInfo(SnapshotGraph& snap, const std::string& name) {
+  if (name.empty()) {
+    return nullptr;
+  }
+  auto it = snap.value_info_by_name.find(name);
+  if (it != snap.value_info_by_name.end()) {
+    return it->second;
+  }
+  auto vi = std::make_unique<SnapshotValueInfo>();
+  vi->name = name;
+  SnapshotValueInfo* raw = vi.get();
+  snap.value_infos.push_back(std::move(vi));
+  snap.value_info_by_name.emplace(name, raw);
+  return raw;
+}
+
+// Fill elem_type / has_shape / shape from an OrtValueInfo's type info.
+void CaptureTypeAndShape(const OrtApi& ort_api, const OrtValueInfo* ort_vi, SnapshotValueInfo& out) {
+  const OrtTypeInfo* type_info = nullptr;
+  if (ort_api.GetValueInfoTypeInfo(ort_vi, &type_info) != nullptr || type_info == nullptr) {
+    return;
+  }
+  const OrtTensorTypeAndShapeInfo* ts = nullptr;
+  if (ort_api.CastTypeInfoToTensorInfo(type_info, &ts) != nullptr || ts == nullptr) {
+    return;
+  }
+  ort_api.GetTensorElementType(ts, &out.elem_type);
+
+  if (ort_api.TensorTypeAndShape_HasShape(ts)) {
+    size_t num_dims = 0;
+    if (ort_api.GetDimensionsCount(ts, &num_dims) == nullptr) {
+      out.shape.resize(num_dims);
+      if (num_dims == 0 || ort_api.GetDimensions(ts, out.shape.data(), num_dims) == nullptr) {
+        out.has_shape = true;
+      } else {
+        out.shape.clear();
+      }
+    }
+  }
+}
+
+void CaptureAttributes(const OrtNode& node, SnapshotNode& snap_node) {
+  Ort::ConstNode cn(&node);
+  for (const Ort::ConstOpAttr& attr : cn.GetAttributes()) {
+    SnapshotAttr sa;
+    sa.name = attr.GetName();
+    sa.type = attr.GetType();
+    switch (sa.type) {
+      case ORT_OP_ATTR_INT: {
+        int64_t v = 0;
+        if (attr.GetValue<int64_t>(v).IsOK()) sa.i = v;
+        break;
+      }
+      case ORT_OP_ATTR_INTS: {
+        std::vector<int64_t> v;
+        if (attr.GetValueArray<int64_t>(v).IsOK()) sa.ints = std::move(v);
+        break;
+      }
+      case ORT_OP_ATTR_FLOAT: {
+        float v = 0.f;
+        if (attr.GetValue<float>(v).IsOK()) sa.f = v;
+        break;
+      }
+      case ORT_OP_ATTR_FLOATS: {
+        std::vector<float> v;
+        if (attr.GetValueArray<float>(v).IsOK()) sa.floats = std::move(v);
+        break;
+      }
+      case ORT_OP_ATTR_STRING: {
+        std::string v;
+        if (attr.GetValue<std::string>(v).IsOK()) sa.s = std::move(v);
+        break;
+      }
+      case ORT_OP_ATTR_STRINGS: {
+        std::vector<std::string> v;
+        if (attr.GetValueArray<std::string>(v).IsOK()) sa.strings = std::move(v);
+        break;
+      }
+      default:
+        // GRAPH / TENSOR / UNDEFINED: not needed for the float path (deferred: nested subgraphs).
+        break;
+    }
+    snap_node.attributes.push_back(std::move(sa));
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<SnapshotGraph> SnapshotGraphFromOrt(const OrtApi& ort_api,
+                                                    const OrtGraph* graph,
+                                                    const OrtNode* fused_node,
+                                                    const Ort::Logger& logger) {
+  auto snap = std::make_unique<SnapshotGraph>();
+
+  const ORTCHAR_T* model_path = nullptr;
+  if (ort_api.Graph_GetModelPath(graph, &model_path) == nullptr && model_path != nullptr) {
+    snap->model_path = std::filesystem::path(model_path);
+  }
+
+  const char* graph_name = nullptr;
+  if (ort_api.Graph_GetName(graph, &graph_name) == nullptr && graph_name != nullptr) {
+    snap->name = graph_name;
+  }
+
+  // 1. Nodes, in declaration order.
+  size_t num_nodes = 0;
+  if (auto* st = ort_api.Graph_GetNumNodes(graph, &num_nodes)) {
+    ort_api.ReleaseStatus(st);
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_ERROR, "SnapshotGraphFromOrt: Graph_GetNumNodes failed.");
+    return nullptr;
+  }
+  std::vector<const OrtNode*> ort_nodes(num_nodes);
+  if (auto* st = ort_api.Graph_GetNodes(graph, ort_nodes.data(), ort_nodes.size())) {
+    ort_api.ReleaseStatus(st);
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_ERROR, "SnapshotGraphFromOrt: Graph_GetNodes failed.");
+    return nullptr;
+  }
+
+  snap->nodes.reserve(num_nodes);
+  snap->node_order.reserve(num_nodes);
+
+  const auto capture_ios = [&](const OrtNode* ort_node, size_t num,
+                               OrtStatus* (ORT_API_CALL* get_num)(const OrtNode*, size_t*),
+                               OrtStatus* (ORT_API_CALL* get)(const OrtNode*, const OrtValueInfo**, size_t),
+                               std::vector<SnapshotValueInfo*>& out) {
+    (void)num;
+    size_t count = 0;
+    if (get_num(ort_node, &count) != nullptr) return;
+    std::vector<const OrtValueInfo*> vis(count);
+    if (count > 0 && get(ort_node, vis.data(), vis.size()) != nullptr) return;
+    out.reserve(count);
+    for (const OrtValueInfo* vi : vis) {
+      if (vi == nullptr) {
+        out.push_back(nullptr);
+        continue;
+      }
+      const char* nm = nullptr;
+      std::string name = (ort_api.GetValueInfoName(vi, &nm) == nullptr && nm) ? nm : std::string{};
+      SnapshotValueInfo* svi = EnsureValueInfo(*snap, name);
+      if (svi && svi->elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED && !svi->has_shape) {
+        CaptureTypeAndShape(ort_api, vi, *svi);
+      }
+      out.push_back(svi);
+    }
+  };
+
+  for (const OrtNode* ort_node : ort_nodes) {
+    auto sn = std::make_unique<SnapshotNode>();
+    Ort::ConstNode cn(ort_node);
+    sn->op_type = cn.GetOperatorType();
+    sn->domain = cn.GetDomain();
+    sn->name = cn.GetName();
+    sn->since_version = cn.GetSinceVersion();
+    sn->id = cn.GetId();
+
+    capture_ios(ort_node, 0, ort_api.Node_GetNumInputs, ort_api.Node_GetInputs, sn->inputs);
+    capture_ios(ort_node, 0, ort_api.Node_GetNumOutputs, ort_api.Node_GetOutputs, sn->outputs);
+    capture_ios(ort_node, 0, ort_api.Node_GetNumImplicitInputs, ort_api.Node_GetImplicitInputs,
+                sn->implicit_inputs);
+
+    CaptureAttributes(*ort_node, *sn);
+
+    snap->node_order.push_back(sn.get());
+    snap->nodes.push_back(std::move(sn));
+  }
+
+  // 2. Precompute producer/consumer edges.
+  for (SnapshotNode* sn : snap->node_order) {
+    for (size_t out_idx = 0; out_idx < sn->outputs.size(); ++out_idx) {
+      if (SnapshotValueInfo* vi = sn->outputs[out_idx]) {
+        vi->producer_node = sn;
+        vi->producer_output_index = out_idx;
+      }
+    }
+  }
+  for (SnapshotNode* sn : snap->node_order) {
+    for (size_t in_idx = 0; in_idx < sn->inputs.size(); ++in_idx) {
+      if (SnapshotValueInfo* vi = sn->inputs[in_idx]) {
+        vi->consumers.emplace_back(sn, static_cast<int64_t>(in_idx));
+      }
+    }
+    for (SnapshotValueInfo* vi : sn->implicit_inputs) {
+      if (vi) vi->consumers.emplace_back(sn, static_cast<int64_t>(-1));
+    }
+  }
+
+  // 3. Graph inputs / outputs / initializers.
+  const auto capture_graph_ios = [&](OrtStatus* (ORT_API_CALL* get_num)(const OrtGraph*, size_t*),
+                                     OrtStatus* (ORT_API_CALL* get)(const OrtGraph*, const OrtValueInfo**, size_t),
+                                     std::vector<SnapshotValueInfo*>& out) -> std::vector<const OrtValueInfo*> {
+    size_t count = 0;
+    if (get_num(graph, &count) != nullptr) return {};
+    std::vector<const OrtValueInfo*> vis(count);
+    if (count > 0 && get(graph, vis.data(), vis.size()) != nullptr) return {};
+    out.reserve(count);
+    for (const OrtValueInfo* vi : vis) {
+      const char* nm = nullptr;
+      std::string name = (ort_api.GetValueInfoName(vi, &nm) == nullptr && nm) ? nm : std::string{};
+      SnapshotValueInfo* svi = EnsureValueInfo(*snap, name);
+      if (svi) {
+        if (svi->elem_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED && !svi->has_shape) {
+          CaptureTypeAndShape(ort_api, vi, *svi);
+        }
+        out.push_back(svi);
+      }
+    }
+    return vis;
+  };
+
+  capture_graph_ios(ort_api.Graph_GetNumInputs, ort_api.Graph_GetInputs, snap->graph_inputs);
+  std::vector<const OrtValueInfo*> ort_outputs =
+      capture_graph_ios(ort_api.Graph_GetNumOutputs, ort_api.Graph_GetOutputs, snap->graph_outputs);
+  std::vector<const OrtValueInfo*> ort_inits =
+      capture_graph_ios(ort_api.Graph_GetNumInitializers, ort_api.Graph_GetInitializers, snap->initializers);
+
+  for (SnapshotValueInfo* vi : snap->graph_outputs) {
+    if (vi) vi->is_graph_output = true;
+  }
+
+  // Initializer flags + copied bytes.
+  for (size_t i = 0; i < snap->initializers.size(); ++i) {
+    SnapshotValueInfo* vi = snap->initializers[i];
+    if (!vi) continue;
+    vi->is_initializer = true;
+
+    const OrtValueInfo* ort_vi = ort_inits[i];
+    bool is_const = false;
+    if (ort_api.ValueInfo_IsConstantInitializer(ort_vi, &is_const) == nullptr) {
+      vi->is_constant_initializer = is_const;
+    }
+
+    std::vector<uint8_t> bytes;
+    Ort::Status unpack = qnn::utils::UnpackInitializerData(ort_api, ort_vi, snap->model_path, bytes);
+    if (unpack.IsOK()) {
+      vi->initializer_bytes = std::move(bytes);
+    } else {
+      ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_WARNING,
+                  ("SnapshotGraphFromOrt: failed to copy initializer bytes for " + vi->name).c_str());
+    }
+  }
+
+  // 4. The EP fused node.
+  if (fused_node != nullptr) {
+    auto fn = std::make_unique<SnapshotNode>();
+    Ort::ConstNode cn(fused_node);
+    fn->op_type = cn.GetOperatorType();
+    fn->domain = cn.GetDomain();
+    fn->name = cn.GetName();
+    fn->since_version = cn.GetSinceVersion();
+    fn->id = cn.GetId();
+    capture_ios(fused_node, 0, ort_api.Node_GetNumInputs, ort_api.Node_GetInputs, fn->inputs);
+    capture_ios(fused_node, 0, ort_api.Node_GetNumOutputs, ort_api.Node_GetOutputs, fn->outputs);
+    snap->fused_node = std::move(fn);
+  }
+
+  return snap;
+}
+
+std::vector<SegmentDesc> SplitSnapshotIntoSegments(
+    const SnapshotGraph& parent,
+    const std::unordered_set<std::string>& gpu_only_names) {
+  struct RawSegment {
+    std::vector<SnapshotNode*> nodes;
+    bool is_gpu = false;
+  };
+  std::vector<RawSegment> raw_segments;
+
+  for (SnapshotNode* node : parent.node_order) {
+    bool is_gpu = gpu_only_names.count(node->name) > 0;
+    if (raw_segments.empty() || raw_segments.back().is_gpu != is_gpu) {
+      raw_segments.push_back({{}, is_gpu});
+    }
+    raw_segments.back().nodes.push_back(node);
+  }
+
+  // Determine graph I/O per segment: a value is a segment input if produced outside, a segment
+  // output if consumed outside or is a parent graph output.
+  std::unordered_set<std::string> parent_output_names;
+  for (SnapshotValueInfo* vi : parent.graph_outputs) {
+    parent_output_names.insert(vi->name);
+  }
+
+  std::vector<SegmentDesc> result;
+  result.reserve(raw_segments.size());
+
+  for (size_t seg_idx = 0; seg_idx < raw_segments.size(); ++seg_idx) {
+    auto& raw = raw_segments[seg_idx];
+    auto view = std::make_unique<SnapshotSegmentView>();
+    view->parent = &parent;
+    view->node_order = raw.nodes;
+    view->model_path = parent.model_path;
+    view->name = parent.name + "_seg" + std::to_string(seg_idx);
+
+    std::unordered_set<SnapshotNode*> segment_node_set(raw.nodes.begin(), raw.nodes.end());
+
+    std::unordered_set<std::string> seen_inputs;
+    std::unordered_set<std::string> seen_outputs;
+
+    for (SnapshotNode* node : raw.nodes) {
+      for (SnapshotValueInfo* vi : node->inputs) {
+        if (!vi) continue;
+        if (seen_inputs.count(vi->name)) continue;
+        bool producer_outside = (vi->producer_node == nullptr) ||
+                                (segment_node_set.count(vi->producer_node) == 0);
+        if (producer_outside && !vi->is_initializer) {
+          view->graph_inputs.push_back(vi);
+          seen_inputs.insert(vi->name);
+        }
+      }
+      for (SnapshotValueInfo* vi : node->outputs) {
+        if (!vi) continue;
+        if (seen_outputs.count(vi->name)) continue;
+        bool consumed_outside = parent_output_names.count(vi->name) > 0;
+        if (!consumed_outside) {
+          for (auto& [consumer, _] : vi->consumers) {
+            if (segment_node_set.count(consumer) == 0) {
+              consumed_outside = true;
+              break;
+            }
+          }
+        }
+        if (consumed_outside) {
+          view->graph_outputs.push_back(vi);
+          seen_outputs.insert(vi->name);
+        }
+      }
+    }
+
+    for (SnapshotNode* node : raw.nodes) {
+      for (SnapshotValueInfo* vi : node->inputs) {
+        if (!vi) continue;
+        if (vi->is_initializer) {
+          view->initializers.push_back(vi);
+        }
+      }
+    }
+
+    for (SnapshotNode* node : raw.nodes) {
+      for (SnapshotValueInfo* vi : node->inputs) {
+        if (vi) view->value_info_by_name[vi->name] = vi;
+      }
+      for (SnapshotValueInfo* vi : node->outputs) {
+        if (vi) view->value_info_by_name[vi->name] = vi;
+      }
+    }
+    for (SnapshotValueInfo* vi : view->graph_inputs) {
+      view->value_info_by_name[vi->name] = vi;
+    }
+
+    auto fused = std::make_unique<SnapshotNode>();
+    fused->op_type = "QnnPartialMigrationSegment";
+    fused->domain = "";
+    fused->name = view->name;
+    fused->since_version = 1;
+    fused->id = seg_idx;
+    fused->inputs.reserve(view->graph_inputs.size() + view->initializers.size());
+    for (auto* vi : view->graph_inputs) fused->inputs.push_back(vi);
+    for (auto* vi : view->initializers) fused->inputs.push_back(vi);
+    fused->outputs = view->graph_outputs;
+    view->fused_node = std::move(fused);
+
+    result.push_back({std::move(view), raw.is_gpu});
+  }
+
+  return result;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot.h
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Hot Migration (Phase 2 extension) - Background NPU Compose.
+//
+// GraphSnapshot is an EP-owned copy of the structural information ComposeGraph reads out of the
+// live OrtGraph, captured during CompileImpl while the OrtGraph* pointers are still valid. The
+// compose pipeline is later driven from this snapshot (off the CompileImpl critical path) via a
+// copy of OrtApi whose graph/node/valueinfo read accessors are repointed at readers over these
+// structures. See qnn_graph_snapshot_accessors.* for the accessors and shim.
+//
+// The opaque handles the accessors hand out (OrtGraph*/OrtNode*/OrtValueInfo*/OrtOpAttr*) are
+// reinterpret_cast pointers to the SnapshotGraph/SnapshotNode/SnapshotValueInfo/SnapshotAttr
+// objects below. Only our accessors dereference them; ORT never does. Addresses must stay stable
+// for the snapshot's lifetime, so nodes/value-infos/attrs are held by stable-address containers
+// and never reallocated after the walk completes.
+
+struct SnapshotNode;
+struct SnapshotGraph;
+
+// One ONNX attribute captured from a node.
+struct SnapshotAttr {
+  std::string name;
+  OrtOpAttrType type;
+
+  std::optional<int64_t> i;
+  std::optional<float> f;
+  std::optional<std::string> s;
+  std::vector<int64_t> ints;
+  std::vector<float> floats;
+  std::vector<std::string> strings;
+};
+
+// A snapshotted value (tensor edge). Producer/consumer edges are precomputed during the walk.
+struct SnapshotValueInfo {
+  std::string name;
+
+  // Type/shape. has_shape distinguishes "scalar / rank-0" from "unknown shape".
+  ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+  bool has_shape = false;
+  std::vector<int64_t> shape;
+
+  bool is_constant_initializer = false;
+  bool is_graph_output = false;
+
+  SnapshotNode* producer_node = nullptr;
+  size_t producer_output_index = 0;
+
+  // (node, input index) pairs. Input index is -1 for implicit inputs.
+  std::vector<std::pair<SnapshotNode*, int64_t>> consumers;
+
+  std::vector<uint8_t> initializer_bytes;
+  bool is_initializer = false;
+};
+
+struct SnapshotNode {
+  std::string op_type;
+  std::string domain;
+  std::string name;
+  int since_version = 0;
+  size_t id = 0;
+
+  // Ordered inputs/outputs by pointer into SnapshotGraph::value_infos. A missing optional input
+  // is represented by a nullptr entry to preserve positional indices.
+  std::vector<SnapshotValueInfo*> inputs;
+  std::vector<SnapshotValueInfo*> outputs;
+  std::vector<SnapshotValueInfo*> implicit_inputs;
+
+  std::vector<SnapshotAttr> attributes;
+};
+
+struct SnapshotGraph {
+  // Stable-address storage. Populated once by SnapshotGraphFromOrt, never resized afterward.
+  std::vector<std::unique_ptr<SnapshotNode>> nodes;
+  std::vector<std::unique_ptr<SnapshotValueInfo>> value_infos;
+
+  // The EP fused node (subgraph boundary). Not part of node_order and never a producer/consumer.
+  std::unique_ptr<SnapshotNode> fused_node;
+
+  std::vector<SnapshotNode*> node_order;
+  std::vector<SnapshotValueInfo*> graph_inputs;
+  std::vector<SnapshotValueInfo*> graph_outputs;
+  std::vector<SnapshotValueInfo*> initializers;
+
+  std::filesystem::path model_path;
+  std::string name;
+
+  // Name -> value-info lookup.
+  std::unordered_map<std::string, SnapshotValueInfo*> value_info_by_name;
+
+  SnapshotValueInfo* FindValueInfo(const std::string& value_name) const {
+    auto it = value_info_by_name.find(value_name);
+    return it == value_info_by_name.end() ? nullptr : it->second;
+  }
+
+  // Release heavy payload (initializer bytes, attributes) after HTP compilation completes.
+  size_t ReleasePayload() {
+    size_t freed = 0;
+    for (auto& vi : value_infos) {
+      freed += vi->initializer_bytes.capacity();
+      std::vector<uint8_t>().swap(vi->initializer_bytes);
+    }
+    for (auto& node : nodes) {
+      freed += node->attributes.capacity() * sizeof(SnapshotAttr);
+      std::vector<SnapshotAttr>().swap(node->attributes);
+    }
+    if (fused_node) {
+      freed += fused_node->attributes.capacity() * sizeof(SnapshotAttr);
+      std::vector<SnapshotAttr>().swap(fused_node->attributes);
+    }
+    value_info_by_name.clear();
+    return freed;
+  }
+};
+
+// View over a subset of a SnapshotGraph's nodes for partial migration. The parent SnapshotGraph
+// must outlive this view. Represented as a SnapshotGraph so existing SnapshotShim/accessors work
+// unchanged. `nodes` and `value_infos` owning vectors are empty; `node_order` etc. hold
+// non-owning pointers into the parent's stable storage.
+struct SnapshotSegmentView : SnapshotGraph {
+  const SnapshotGraph* parent = nullptr;
+};
+
+// Build segment views by splitting a snapshot at nodes whose names are in `gpu_only_names`.
+struct SegmentDesc {
+  std::unique_ptr<SnapshotSegmentView> view;
+  bool is_gpu;  // true if this segment contains GPU-only nodes
+};
+std::vector<SegmentDesc> SplitSnapshotIntoSegments(
+    const SnapshotGraph& parent,
+    const std::unordered_set<std::string>& gpu_only_names);
+
+// Walk the live OrtGraph and populate a heap-allocated SnapshotGraph. Must be called while the
+// OrtGraph* is valid (inside CompileImpl).
+std::unique_ptr<SnapshotGraph> SnapshotGraphFromOrt(const OrtApi& ort_api,
+                                                    const OrtGraph* graph,
+                                                    const OrtNode* fused_node,
+                                                    const Ort::Logger& logger);
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot_accessors.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot_accessors.cc
@@ -1,0 +1,516 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/qnn_graph_snapshot_accessors.h"
+
+#include <cstring>
+#include <string>
+
+namespace onnxruntime {
+namespace qnn {
+
+// Cast helpers between fake opaque handles and snapshot objects.
+namespace {
+
+const SnapshotGraph* AsGraph(const OrtGraph* h) { return reinterpret_cast<const SnapshotGraph*>(h); }
+const SnapshotNode* AsNode(const OrtNode* h) { return reinterpret_cast<const SnapshotNode*>(h); }
+const SnapshotValueInfo* AsValueInfo(const OrtValueInfo* h) {
+  return reinterpret_cast<const SnapshotValueInfo*>(h);
+}
+const SnapshotAttr* AsAttr(const OrtOpAttr* h) { return reinterpret_cast<const SnapshotAttr*>(h); }
+
+const OrtGraph* Handle(const SnapshotGraph* g) { return reinterpret_cast<const OrtGraph*>(g); }
+const OrtNode* Handle(const SnapshotNode* n) { return reinterpret_cast<const OrtNode*>(n); }
+const OrtValueInfo* Handle(const SnapshotValueInfo* v) { return reinterpret_cast<const OrtValueInfo*>(v); }
+const OrtOpAttr* Handle(const SnapshotAttr* a) { return reinterpret_cast<const OrtOpAttr*>(a); }
+
+// Thread-local active shim, set by ActiveShimGuard around a compose call.
+const SnapshotShim*& ActiveShim() {
+  thread_local const SnapshotShim* active = nullptr;
+  return active;
+}
+
+template <typename SnapT>
+OrtStatus* CopyHandles(const std::vector<SnapT*>& src, const void** dst, size_t count) {
+  if (count < src.size()) {
+    return nullptr;
+  }
+  for (size_t i = 0; i < src.size(); ++i) {
+    dst[i] = Handle(src[i]);
+  }
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetNumNodes(const OrtGraph* graph, size_t* out) noexcept {
+  *out = AsGraph(graph)->node_order.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetNodes(const OrtGraph* graph, const OrtNode** nodes, size_t count) noexcept {
+  return CopyHandles(AsGraph(graph)->node_order, reinterpret_cast<const void**>(nodes), count);
+}
+
+OrtStatus* ORT_API_CALL Graph_GetNumInputs(const OrtGraph* graph, size_t* out) noexcept {
+  *out = AsGraph(graph)->graph_inputs.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetInputs(const OrtGraph* graph, const OrtValueInfo** vis, size_t count) noexcept {
+  return CopyHandles(AsGraph(graph)->graph_inputs, reinterpret_cast<const void**>(vis), count);
+}
+
+OrtStatus* ORT_API_CALL Graph_GetNumOutputs(const OrtGraph* graph, size_t* out) noexcept {
+  *out = AsGraph(graph)->graph_outputs.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetOutputs(const OrtGraph* graph, const OrtValueInfo** vis, size_t count) noexcept {
+  return CopyHandles(AsGraph(graph)->graph_outputs, reinterpret_cast<const void**>(vis), count);
+}
+
+OrtStatus* ORT_API_CALL Graph_GetNumInitializers(const OrtGraph* graph, size_t* out) noexcept {
+  *out = AsGraph(graph)->initializers.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetInitializers(const OrtGraph* graph, const OrtValueInfo** vis, size_t count) noexcept {
+  return CopyHandles(AsGraph(graph)->initializers, reinterpret_cast<const void**>(vis), count);
+}
+
+OrtStatus* ORT_API_CALL Graph_GetParentNode(const OrtGraph* /*graph*/, const OrtNode** node) noexcept {
+  *node = nullptr;  // No parent; nested subgraphs not supported.
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetModelPath(const OrtGraph* graph, const ORTCHAR_T** out) noexcept {
+  *out = AsGraph(graph)->model_path.c_str();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Graph_GetName(const OrtGraph* graph, const char** out) noexcept {
+  *out = AsGraph(graph)->name.c_str();
+  return nullptr;
+}
+
+// Defensive stubs for accessors the float path is not expected to call.
+OrtStatus* ORT_API_CALL Graph_GetModelMetadata(const OrtGraph*, OrtModelMetadata**) noexcept {
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "shim: Graph_GetModelMetadata");
+}
+OrtStatus* ORT_API_CALL Graph_GetGraphView(const OrtGraph*, const OrtNode**, size_t, OrtGraph**) noexcept {
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "shim: Graph_GetGraphView");
+}
+OrtStatus* ORT_API_CALL Graph_GetNumOperatorSets(const OrtGraph*, size_t*) noexcept {
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "shim: Graph_GetNumOperatorSets");
+}
+OrtStatus* ORT_API_CALL Graph_GetOnnxIRVersion(const OrtGraph*, int64_t*) noexcept {
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "shim: Graph_GetOnnxIRVersion");
+}
+OrtStatus* ORT_API_CALL Graph_GetOperatorSets(const OrtGraph*, const char**, int64_t*, size_t) noexcept {
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "shim: Graph_GetOperatorSets");
+}
+OrtStatus* ORT_API_CALL Node_GetGraph(const OrtNode*, const OrtGraph** out) noexcept {
+  *out = nullptr;
+  return nullptr;
+}
+OrtStatus* ORT_API_CALL ValueInfo_IsFromOuterScope(const OrtValueInfo*, bool* out) noexcept {
+  *out = false;
+  return nullptr;
+}
+OrtStatus* ORT_API_CALL ValueInfo_IsRequiredGraphInput(const OrtValueInfo*, bool* out) noexcept {
+  *out = false;
+  return nullptr;
+}
+OrtStatus* ORT_API_CALL ValueInfo_IsOptionalGraphInput(const OrtValueInfo*, bool* out) noexcept {
+  *out = false;
+  return nullptr;
+}
+OrtStatus* ORT_API_CALL OpAttr_GetTensorAttributeAsOrtValue(const OrtOpAttr*, OrtValue**) noexcept {
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "shim: OpAttr_GetTensorAttributeAsOrtValue");
+}
+
+OrtStatus* ORT_API_CALL Node_GetId(const OrtNode* node, size_t* out) noexcept {
+  *out = AsNode(node)->id;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetName(const OrtNode* node, const char** out) noexcept {
+  *out = AsNode(node)->name.c_str();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetOperatorType(const OrtNode* node, const char** out) noexcept {
+  *out = AsNode(node)->op_type.c_str();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetDomain(const OrtNode* node, const char** out) noexcept {
+  *out = AsNode(node)->domain.c_str();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetSinceVersion(const OrtNode* node, int* out) noexcept {
+  *out = AsNode(node)->since_version;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetNumInputs(const OrtNode* node, size_t* out) noexcept {
+  *out = AsNode(node)->inputs.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetInputs(const OrtNode* node, const OrtValueInfo** vis, size_t count) noexcept {
+  return CopyHandles(AsNode(node)->inputs, reinterpret_cast<const void**>(vis), count);
+}
+
+OrtStatus* ORT_API_CALL Node_GetNumOutputs(const OrtNode* node, size_t* out) noexcept {
+  *out = AsNode(node)->outputs.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetOutputs(const OrtNode* node, const OrtValueInfo** vis, size_t count) noexcept {
+  return CopyHandles(AsNode(node)->outputs, reinterpret_cast<const void**>(vis), count);
+}
+
+OrtStatus* ORT_API_CALL Node_GetNumImplicitInputs(const OrtNode* node, size_t* out) noexcept {
+  *out = AsNode(node)->implicit_inputs.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetImplicitInputs(const OrtNode* node, const OrtValueInfo** vis, size_t count) noexcept {
+  return CopyHandles(AsNode(node)->implicit_inputs, reinterpret_cast<const void**>(vis), count);
+}
+
+OrtStatus* ORT_API_CALL Node_GetNumAttributes(const OrtNode* node, size_t* out) noexcept {
+  *out = AsNode(node)->attributes.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetAttributes(const OrtNode* node, const OrtOpAttr** attrs, size_t count) noexcept {
+  const SnapshotNode* sn = AsNode(node);
+  if (count < sn->attributes.size()) {
+    return nullptr;
+  }
+  for (size_t i = 0; i < sn->attributes.size(); ++i) {
+    attrs[i] = Handle(&sn->attributes[i]);
+  }
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetAttributeByName(const OrtNode* node, const char* name,
+                                                const OrtOpAttr** out) noexcept {
+  const SnapshotNode* sn = AsNode(node);
+  for (const SnapshotAttr& attr : sn->attributes) {
+    if (attr.name == name) {
+      *out = Handle(&attr);
+      return nullptr;
+    }
+  }
+  *out = nullptr;
+  return ActiveShim()->ShimmedApi().CreateStatus(ORT_FAIL, "attribute not found");
+}
+
+OrtStatus* ORT_API_CALL Node_GetNumSubgraphs(const OrtNode* /*node*/, size_t* out) noexcept {
+  *out = 0;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetSubgraphs(const OrtNode* /*node*/, const OrtGraph** /*subgraphs*/,
+                                          size_t /*num_subgraphs*/, const char** /*attribute_names*/) noexcept {
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL Node_GetEpName(const OrtNode* /*node*/, const char** out) noexcept {
+  *out = nullptr;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL GetValueInfoName(const OrtValueInfo* vi, const char** out) noexcept {
+  *out = AsValueInfo(vi)->name.c_str();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL GetValueInfoTypeInfo(const OrtValueInfo* vi, const OrtTypeInfo** out) noexcept {
+  const OrtTypeInfo* ti = ActiveShim()->TypeInfoFor(AsValueInfo(vi));
+  if (ti == nullptr) {
+    return ActiveShim()->ShimmedApi().CreateStatus(ORT_FAIL, "no type info for value");
+  }
+  *out = ti;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_IsConstantInitializer(const OrtValueInfo* vi, bool* out) noexcept {
+  *out = AsValueInfo(vi)->is_constant_initializer;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_IsGraphOutput(const OrtValueInfo* vi, bool* out) noexcept {
+  *out = AsValueInfo(vi)->is_graph_output;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_GetValueProducer(const OrtValueInfo* vi, const OrtNode** node,
+                                                   size_t* output_index) noexcept {
+  const SnapshotValueInfo* svi = AsValueInfo(vi);
+  *node = Handle(svi->producer_node);
+  if (output_index != nullptr) {
+    *output_index = svi->producer_output_index;
+  }
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_GetValueNumConsumers(const OrtValueInfo* vi, size_t* out) noexcept {
+  *out = AsValueInfo(vi)->consumers.size();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_GetValueConsumers(const OrtValueInfo* vi, const OrtNode** nodes,
+                                                    int64_t* input_indices, size_t count) noexcept {
+  const SnapshotValueInfo* svi = AsValueInfo(vi);
+  if (count < svi->consumers.size()) {
+    return nullptr;
+  }
+  for (size_t i = 0; i < svi->consumers.size(); ++i) {
+    nodes[i] = Handle(svi->consumers[i].first);
+    input_indices[i] = svi->consumers[i].second;
+  }
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_GetInitializerValue(const OrtValueInfo* vi, const OrtValue** out) noexcept {
+  const OrtValue* v = ActiveShim()->InitializerValueFor(AsValueInfo(vi));
+  if (v == nullptr) {
+    return ActiveShim()->ShimmedApi().CreateStatus(ORT_FAIL, "no initializer value for value");
+  }
+  *out = v;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL ValueInfo_GetExternalInitializerInfo(const OrtValueInfo* /*vi*/,
+                                                             OrtExternalInitializerInfo** out) noexcept {
+  // Snapshot stores initializer bytes in-line; null means UnpackInitializerData uses the OrtValue path.
+  *out = nullptr;
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL OpAttr_GetName(const OrtOpAttr* attr, const char** out) noexcept {
+  *out = AsAttr(attr)->name.c_str();
+  return nullptr;
+}
+
+OrtStatus* ORT_API_CALL OpAttr_GetType(const OrtOpAttr* attr, OrtOpAttrType* out) noexcept {
+  *out = AsAttr(attr)->type;
+  return nullptr;
+}
+
+// ReadOpAttr implements the two-phase protocol: called with data=nullptr it returns byte size in
+// `out`; called with a buffer it fills it.
+OrtStatus* ORT_API_CALL ReadOpAttr(const OrtOpAttr* attr, OrtOpAttrType type, void* data, size_t len,
+                                   size_t* out) noexcept {
+  const SnapshotAttr* sa = AsAttr(attr);
+  if (sa->type != type) {
+    return ActiveShim()->ShimmedApi().CreateStatus(ORT_INVALID_ARGUMENT, "attribute type mismatch");
+  }
+
+  const auto fill = [&](const void* src, size_t bytes) -> OrtStatus* {
+    *out = bytes;
+    if (data == nullptr || len == 0) {
+      return nullptr;
+    }
+    if (len < bytes) {
+      return ActiveShim()->ShimmedApi().CreateStatus(ORT_INVALID_ARGUMENT, "buffer too small");
+    }
+    if (bytes > 0) {
+      std::memcpy(data, src, bytes);
+    }
+    return nullptr;
+  };
+
+  switch (type) {
+    case ORT_OP_ATTR_INT:
+      return fill(&sa->i.value(), sizeof(int64_t));
+    case ORT_OP_ATTR_INTS:
+      return fill(sa->ints.data(), sa->ints.size() * sizeof(int64_t));
+    case ORT_OP_ATTR_FLOAT:
+      return fill(&sa->f.value(), sizeof(float));
+    case ORT_OP_ATTR_FLOATS:
+      return fill(sa->floats.data(), sa->floats.size() * sizeof(float));
+    case ORT_OP_ATTR_STRING:
+      return fill(sa->s.value().data(), sa->s.value().size());
+    case ORT_OP_ATTR_STRINGS: {
+      size_t total = 0;
+      for (const std::string& str : sa->strings) {
+        total += str.size() + 1;
+      }
+      *out = total;
+      if (data == nullptr || len == 0) {
+        return nullptr;
+      }
+      if (len < total) {
+        return ActiveShim()->ShimmedApi().CreateStatus(ORT_INVALID_ARGUMENT, "buffer too small");
+      }
+      char* cursor = static_cast<char*>(data);
+      for (const std::string& str : sa->strings) {
+        std::memcpy(cursor, str.data(), str.size());
+        cursor[str.size()] = '\0';
+        cursor += str.size() + 1;
+      }
+      return nullptr;
+    }
+    default:
+      return ActiveShim()->ShimmedApi().CreateStatus(ORT_NOT_IMPLEMENTED, "unsupported attribute type");
+  }
+}
+
+}  // namespace
+
+SnapshotShim::SnapshotShim(const OrtApi& real_api, const OrtModelEditorApi& model_editor_api,
+                           const SnapshotGraph& snapshot)
+    : real_api_(real_api),
+      model_editor_api_(model_editor_api),
+      snapshot_(snapshot),
+      shimmed_api_(real_api) {
+  shimmed_api_.Graph_GetNumNodes = &qnn::Graph_GetNumNodes;
+  shimmed_api_.Graph_GetNodes = &qnn::Graph_GetNodes;
+  shimmed_api_.Graph_GetNumInputs = &qnn::Graph_GetNumInputs;
+  shimmed_api_.Graph_GetInputs = &qnn::Graph_GetInputs;
+  shimmed_api_.Graph_GetNumOutputs = &qnn::Graph_GetNumOutputs;
+  shimmed_api_.Graph_GetOutputs = &qnn::Graph_GetOutputs;
+  shimmed_api_.Graph_GetNumInitializers = &qnn::Graph_GetNumInitializers;
+  shimmed_api_.Graph_GetInitializers = &qnn::Graph_GetInitializers;
+  shimmed_api_.Graph_GetParentNode = &qnn::Graph_GetParentNode;
+  shimmed_api_.Graph_GetModelPath = &qnn::Graph_GetModelPath;
+  shimmed_api_.Graph_GetName = &qnn::Graph_GetName;
+  shimmed_api_.Graph_GetModelMetadata = &qnn::Graph_GetModelMetadata;
+  shimmed_api_.Graph_GetGraphView = &qnn::Graph_GetGraphView;
+  shimmed_api_.Graph_GetNumOperatorSets = &qnn::Graph_GetNumOperatorSets;
+  shimmed_api_.Graph_GetOnnxIRVersion = &qnn::Graph_GetOnnxIRVersion;
+  shimmed_api_.Graph_GetOperatorSets = &qnn::Graph_GetOperatorSets;
+
+  shimmed_api_.Node_GetId = &qnn::Node_GetId;
+  shimmed_api_.Node_GetName = &qnn::Node_GetName;
+  shimmed_api_.Node_GetOperatorType = &qnn::Node_GetOperatorType;
+  shimmed_api_.Node_GetDomain = &qnn::Node_GetDomain;
+  shimmed_api_.Node_GetSinceVersion = &qnn::Node_GetSinceVersion;
+  shimmed_api_.Node_GetNumInputs = &qnn::Node_GetNumInputs;
+  shimmed_api_.Node_GetInputs = &qnn::Node_GetInputs;
+  shimmed_api_.Node_GetNumOutputs = &qnn::Node_GetNumOutputs;
+  shimmed_api_.Node_GetOutputs = &qnn::Node_GetOutputs;
+  shimmed_api_.Node_GetNumImplicitInputs = &qnn::Node_GetNumImplicitInputs;
+  shimmed_api_.Node_GetImplicitInputs = &qnn::Node_GetImplicitInputs;
+  shimmed_api_.Node_GetNumAttributes = &qnn::Node_GetNumAttributes;
+  shimmed_api_.Node_GetAttributes = &qnn::Node_GetAttributes;
+  shimmed_api_.Node_GetAttributeByName = &qnn::Node_GetAttributeByName;
+  shimmed_api_.Node_GetNumSubgraphs = &qnn::Node_GetNumSubgraphs;
+  shimmed_api_.Node_GetSubgraphs = &qnn::Node_GetSubgraphs;
+  shimmed_api_.Node_GetGraph = &qnn::Node_GetGraph;
+  shimmed_api_.Node_GetEpName = &qnn::Node_GetEpName;
+
+  shimmed_api_.GetValueInfoName = &qnn::GetValueInfoName;
+  shimmed_api_.GetValueInfoTypeInfo = &qnn::GetValueInfoTypeInfo;
+  shimmed_api_.ValueInfo_IsConstantInitializer = &qnn::ValueInfo_IsConstantInitializer;
+  shimmed_api_.ValueInfo_IsGraphOutput = &qnn::ValueInfo_IsGraphOutput;
+  shimmed_api_.ValueInfo_GetValueProducer = &qnn::ValueInfo_GetValueProducer;
+  shimmed_api_.ValueInfo_GetValueNumConsumers = &qnn::ValueInfo_GetValueNumConsumers;
+  shimmed_api_.ValueInfo_GetValueConsumers = &qnn::ValueInfo_GetValueConsumers;
+  shimmed_api_.ValueInfo_GetInitializerValue = &qnn::ValueInfo_GetInitializerValue;
+  shimmed_api_.ValueInfo_GetExternalInitializerInfo = &qnn::ValueInfo_GetExternalInitializerInfo;
+  shimmed_api_.ValueInfo_IsFromOuterScope = &qnn::ValueInfo_IsFromOuterScope;
+  shimmed_api_.ValueInfo_IsRequiredGraphInput = &qnn::ValueInfo_IsRequiredGraphInput;
+  shimmed_api_.ValueInfo_IsOptionalGraphInput = &qnn::ValueInfo_IsOptionalGraphInput;
+
+  shimmed_api_.OpAttr_GetName = &qnn::OpAttr_GetName;
+  shimmed_api_.OpAttr_GetType = &qnn::OpAttr_GetType;
+  shimmed_api_.ReadOpAttr = &qnn::ReadOpAttr;
+  shimmed_api_.OpAttr_GetTensorAttributeAsOrtValue = &qnn::OpAttr_GetTensorAttributeAsOrtValue;
+
+  real_api_.CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &cpu_memory_info_);
+
+  // Eagerly synthesize a real OrtTypeInfo per value-info and a real OrtValue per initializer.
+  // When value_infos is empty (SnapshotSegmentView), iterate value_info_by_name instead.
+  auto synthesize_for_vi = [&](SnapshotValueInfo* vi) {
+    if (vi->elem_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED) {
+      OrtTensorTypeAndShapeInfo* ts = nullptr;
+      if (real_api_.CreateTensorTypeAndShapeInfo(&ts) == nullptr && ts != nullptr) {
+        real_api_.SetTensorElementType(ts, vi->elem_type);
+        if (vi->has_shape) {
+          real_api_.SetDimensions(ts, vi->shape.data(), vi->shape.size());
+        }
+        OrtTypeInfo* ti = nullptr;
+        if (model_editor_api_.CreateTensorTypeInfo(ts, &ti) == nullptr && ti != nullptr) {
+          type_infos_.emplace(vi, ti);
+        }
+        real_api_.ReleaseTensorTypeAndShapeInfo(ts);
+      }
+    }
+
+    if (vi->is_initializer && !vi->initializer_bytes.empty() && cpu_memory_info_ != nullptr) {
+      OrtValue* value = nullptr;
+      if (real_api_.CreateTensorWithDataAsOrtValue(
+              cpu_memory_info_, vi->initializer_bytes.data(), vi->initializer_bytes.size(),
+              vi->shape.data(), vi->shape.size(), vi->elem_type, &value) == nullptr &&
+          value != nullptr) {
+        initializer_values_.emplace(vi, value);
+      }
+    }
+  };
+
+  if (!snapshot_.value_infos.empty()) {
+    for (const std::unique_ptr<SnapshotValueInfo>& vi_owned : snapshot_.value_infos) {
+      synthesize_for_vi(vi_owned.get());
+    }
+  } else {
+    for (auto& [_, vi] : snapshot_.value_info_by_name) {
+      synthesize_for_vi(vi);
+    }
+  }
+}
+
+SnapshotShim::~SnapshotShim() {
+  for (auto& [vi, value] : initializer_values_) {
+    real_api_.ReleaseValue(value);
+  }
+  for (auto& [vi, ti] : type_infos_) {
+    real_api_.ReleaseTypeInfo(ti);
+  }
+  if (cpu_memory_info_ != nullptr) {
+    real_api_.ReleaseMemoryInfo(cpu_memory_info_);
+  }
+}
+
+void SnapshotShim::ReleaseSynthesizedData() {
+  for (auto& [vi, value] : initializer_values_) {
+    real_api_.ReleaseValue(value);
+  }
+  initializer_values_.clear();
+  for (auto& [vi, ti] : type_infos_) {
+    real_api_.ReleaseTypeInfo(ti);
+  }
+  type_infos_.clear();
+  if (cpu_memory_info_ != nullptr) {
+    real_api_.ReleaseMemoryInfo(cpu_memory_info_);
+    cpu_memory_info_ = nullptr;
+  }
+}
+
+const OrtGraph* SnapshotShim::GraphHandle() const { return Handle(&snapshot_); }
+
+const OrtNode* SnapshotShim::FusedNodeHandle() const { return Handle(snapshot_.fused_node.get()); }
+
+const OrtTypeInfo* SnapshotShim::TypeInfoFor(const SnapshotValueInfo* vi) const {
+  auto it = type_infos_.find(vi);
+  return it == type_infos_.end() ? nullptr : it->second;
+}
+
+const OrtValue* SnapshotShim::InitializerValueFor(const SnapshotValueInfo* vi) const {
+  auto it = initializer_values_.find(vi);
+  return it == initializer_values_.end() ? nullptr : it->second;
+}
+
+ActiveShimGuard::ActiveShimGuard(const SnapshotShim* shim) : previous_(ActiveShim()) {
+  ActiveShim() = shim;
+}
+
+ActiveShimGuard::~ActiveShimGuard() { ActiveShim() = previous_; }
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot_accessors.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_graph_snapshot_accessors.h
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_graph_snapshot.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+// Hot Migration (Phase 2) - OrtApi shim over a SnapshotGraph.
+//
+// SnapshotShim builds a copy of a real OrtApi whose graph/node/valueinfo/opattr read accessors are
+// repointed at readers over a SnapshotGraph. The compose pipeline reads through this copy without
+// knowing the OrtGraph*/OrtNode*/OrtValueInfo*/OrtOpAttr* handles are reinterpret_cast pointers
+// into snapshot objects.
+//
+// Type/shape/tensor-data accessors are left pointing at the real OrtApi: GetValueInfoTypeInfo
+// returns a synthesized real OrtTypeInfo and ValueInfo_GetInitializerValue returns a synthesized
+// real OrtValue, so downstream calls operate on genuine ORT objects.
+class SnapshotShim {
+ public:
+  // Builds the shimmed OrtApi over `snapshot`.
+  SnapshotShim(const OrtApi& real_api, const OrtModelEditorApi& model_editor_api,
+               const SnapshotGraph& snapshot);
+  ~SnapshotShim();
+
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(SnapshotShim);
+
+  // The shimmed copy. Feed this where ComposeGraph expects an OrtApi.
+  const OrtApi& ShimmedApi() const { return shimmed_api_; }
+
+  const OrtGraph* GraphHandle() const;
+
+  // Null if the snapshot has no fused node.
+  const OrtNode* FusedNodeHandle() const;
+
+  // Release synthesized OrtValue/OrtTypeInfo objects early (same work the destructor does).
+  void ReleaseSynthesizedData();
+
+  const OrtTypeInfo* TypeInfoFor(const SnapshotValueInfo* vi) const;
+  const OrtValue* InitializerValueFor(const SnapshotValueInfo* vi) const;
+
+ private:
+  const OrtApi& real_api_;
+  const OrtModelEditorApi& model_editor_api_;
+  const SnapshotGraph& snapshot_;
+  OrtApi shimmed_api_;
+
+  OrtMemoryInfo* cpu_memory_info_ = nullptr;
+  std::unordered_map<const SnapshotValueInfo*, OrtTypeInfo*> type_infos_;
+  std::unordered_map<const SnapshotValueInfo*, OrtValue*> initializer_values_;
+};
+
+// RAII scope that publishes `shim` as the thread-local active shim for accessor routing.
+class ActiveShimGuard {
+ public:
+  explicit ActiveShimGuard(const SnapshotShim* shim);
+  ~ActiveShimGuard();
+  ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(ActiveShimGuard);
+
+ private:
+  const SnapshotShim* previous_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -648,6 +648,36 @@ Ort::Status QnnModel::ExecuteGraph(OrtKernelContext* context,
   return Ort::Status();
 }
 
+Ort::Status QnnModel::ExecuteGraphDirect(Qnn_Tensor_t* inputs, uint32_t num_inputs,
+                                         Qnn_Tensor_t* outputs, uint32_t num_outputs,
+                                         const Ort::Logger& logger) {
+  const auto& qnn_interface = qnn_backend_manager_->GetQnnInterface();
+  std::lock_guard<std::mutex> lock(graph_exec_mutex_);
+
+  auto thread_id = std::this_thread::get_id();
+  RETURN_IF_ERROR(qnn_backend_manager_->SetPerThreadHtpPowerConfigs(thread_id, true));
+
+  Qnn_ErrorHandle_t execute_status = qnn_interface.graphExecute(
+      graph_info_->Graph(), inputs, num_inputs, outputs, num_outputs, nullptr, nullptr);
+
+  RETURN_IF_ERROR(qnn_backend_manager_->SetPerThreadHtpPowerConfigs(thread_id, false));
+
+  if (QNN_COMMON_ERROR_SYSTEM_COMMUNICATION == execute_status) {
+    std::ostringstream oss;
+    oss << "NPU crashed. SSR detected. Error code: " << execute_status;
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_ERROR, oss.str().c_str());
+    return MAKE_EP_FAIL(oss.str().c_str());
+  }
+
+  if (QNN_GRAPH_NO_ERROR != execute_status) {
+    return MAKE_EP_FAIL(("QNN graph execute error (direct). " +
+                         utils::FormatQnnError(qnn_interface, execute_status))
+                            .c_str());
+  }
+
+  return Ort::Status();
+}
+
 // Setup information for Qnn inputs/outputs used during execution.
 Ort::Status QnnModel::SetupTensors(std::vector<QnnTensorInfo>& qnn_tensor_infos,
                                    const std::vector<QnnTensorWrapper>& tensor_wrappers,

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -11,6 +11,7 @@
 #include "QnnOpDef.h"
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/ort_graph_read_helpers.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_profile_serializer.h"
@@ -78,18 +79,18 @@ bool QnnModel::GetGraphInfoFromModel(QnnModelWrapper& model_wrapper, const Ort::
 
 Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
   const OrtGraph& ort_graph = context.ort_graph;
+  const OrtApi& ort_api = api_ptrs_.ort_api;
 
   graph_inputs_.Clear();
   graph_outputs_.Clear();
 
-  Ort::ConstNode fused_node{&context.fused_node};
-  std::vector<Ort::ConstValueInfo> input_defs = fused_node.GetInputs();
+  std::vector<const OrtValueInfo*> input_defs = ort_read::NodeInputs(ort_api, &context.fused_node);
 
   // Collect non-initializer inputs
   std::unordered_set<std::string> fused_input_names;
   std::vector<std::string> fused_input_order;
-  for (const auto& input : input_defs) {
-    std::string name = input.GetName();
+  for (const auto* input : input_defs) {
+    std::string name = ort_read::ValueInfoName(ort_api, input);
     if (!IsConstantInitializer(ort_graph, name)) {
       fused_input_names.insert(name);
       fused_input_order.push_back(name);
@@ -116,13 +117,12 @@ Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
   }
 
   for (size_t i = 0; i < input_defs.size(); ++i) {
-    const auto& value_info = input_defs[i];
-    std::string name = value_info.GetName();
+    const auto* value_info = input_defs[i];
+    std::string name = ort_read::ValueInfoName(ort_api, value_info);
     if (IsConstantInitializer(ort_graph, name)) continue;
 
-    auto shape_info = value_info.TypeInfo().GetTensorTypeAndShapeInfo();
-    ONNXTensorElementDataType elem_type = shape_info.GetElementType();
-    std::vector<int64_t> shape = shape_info.GetShape();
+    ONNXTensorElementDataType elem_type = ort_read::ElemType(ort_api, value_info);
+    std::vector<int64_t> shape = ort_read::Shape(ort_api, value_info);
 
     for (const auto& s : shape) {
       RETURN_IF(s < 0, ("Dynamic shape is not supported yet, for input: " + name).c_str());
@@ -133,12 +133,12 @@ Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
                                   std::forward_as_tuple(i, static_cast<int32_t>(elem_type), std::move(shape)));
   }
 
-  std::vector<Ort::ConstValueInfo> output_defs = fused_node.GetOutputs();
+  std::vector<const OrtValueInfo*> output_defs = ort_read::NodeOutputs(ort_api, &context.fused_node);
 
   std::unordered_set<std::string> fused_output_names;
   std::vector<std::string> fused_output_order;
-  for (const auto& output : output_defs) {
-    std::string name = output.GetName();
+  for (const auto* output : output_defs) {
+    std::string name = ort_read::ValueInfoName(ort_api, output);
     fused_output_names.insert(name);
     fused_output_order.push_back(name);
   }
@@ -156,12 +156,11 @@ Ort::Status QnnModel::SetGraphInputOutputInfo(const QnnModelContext& context) {
   }
 
   for (size_t i = 0; i < output_defs.size(); ++i) {
-    const auto& value_info = output_defs[i];
-    std::string name = value_info.GetName();
+    const auto* value_info = output_defs[i];
+    std::string name = ort_read::ValueInfoName(ort_api, value_info);
 
-    auto shape_info = value_info.TypeInfo().GetTensorTypeAndShapeInfo();
-    ONNXTensorElementDataType elem_type = shape_info.GetElementType();
-    std::vector<int64_t> shape = shape_info.GetShape();
+    ONNXTensorElementDataType elem_type = ort_read::ElemType(ort_api, value_info);
+    std::vector<int64_t> shape = ort_read::Shape(ort_api, value_info);
 
     for (const auto& s : shape) {
       RETURN_IF(s < 0, ("Dynamic shape is not supported yet, for output: " + name).c_str());
@@ -266,7 +265,7 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
 
   ORT_CXX_LOG(logger,
               ORT_LOGGING_LEVEL_VERBOSE,
-              ("ComposeGraph Graph name: " + Ort::ConstGraph(&ort_graph).GetName()).c_str());
+              ("ComposeGraph Graph name: " + ort_read::GraphName(api_ptrs_.ort_api, &ort_graph)).c_str());
 
   // Holder for the OrtNodes in the graph, this will guarantee the OrtNodes is
   // valid throughout the lifetime of the ModelBuilder
@@ -276,7 +275,7 @@ Ort::Status QnnModel::ComposeGraph(const QnnModelContext& context) {
   std::tie(node_unit_holder, node_unit_map) = GetAllOrtNodeUnits(api_ptrs_.ort_api, &ort_graph, logger);
 
   // This name must be same with the EPContext node name
-  const auto& graph_name = Ort::ConstNode(&fused_node).GetName();
+  const std::string graph_name = ort_read::NodeName(api_ptrs_.ort_api, &fused_node);
   RETURN_IF_ERROR(SetGraphInputOutputInfo(context));
 
   // Framework op trace: create collector before QnnModelWrapper so it can be
@@ -747,9 +746,10 @@ void QnnModel::LogTensorDetails(QnnModelWrapper& qnn_model_wrapper,
   size_t num_initializers = 0;
 
   // Collect input tensor information
-  const Ort::ConstGraph graph(&qnn_model_wrapper.GetOrtGraph());
-  for (const Ort::ConstValueInfo& input : graph.GetInputs()) {
-    const std::string input_name = input.GetName();
+  const OrtApi& ort_api = api_ptrs_.ort_api;
+  const OrtGraph* graph = &qnn_model_wrapper.GetOrtGraph();
+  for (const OrtValueInfo* input : ort_read::GraphInputs(ort_api, graph)) {
+    const std::string input_name = ort_read::ValueInfoName(ort_api, input);
 
     // Skip if it's an initializer
     if (qnn_model_wrapper.IsConstantInput(input_name)) {
@@ -781,21 +781,21 @@ void QnnModel::LogTensorDetails(QnnModelWrapper& qnn_model_wrapper,
   // Build a map of initializer names to the operators that use them
   std::unordered_map<std::string, std::vector<std::string>> initializer_to_ops;
 
-  for (const Ort::ConstNode& node : graph.GetNodes()) {
-    if (static_cast<const OrtNode*>(node) == nullptr) {
+  for (const OrtNode* node : ort_read::GraphNodes(ort_api, graph)) {
+    if (node == nullptr) {
       continue;
     }
 
-    const std::string op_type = node.GetOperatorType();
-    const std::string node_name = node.GetName();
+    const std::string op_type = ort_read::NodeOpType(ort_api, node);
+    const std::string node_name = ort_read::NodeName(ort_api, node);
 
     // Check each input of the node
-    for (const Ort::ConstValueInfo& input : node.GetInputs()) {
-      if (static_cast<const OrtValueInfo*>(input) == nullptr) {
+    for (const OrtValueInfo* input : ort_read::NodeInputs(ort_api, node)) {
+      if (input == nullptr) {
         continue;
       }
 
-      const std::string input_name = input.GetName();
+      const std::string input_name = ort_read::ValueInfoName(ort_api, input);
 
       // Check if this input is an initializer
       if (qnn_model_wrapper.IsConstantInput(input_name)) {
@@ -807,8 +807,8 @@ void QnnModel::LogTensorDetails(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // Collect initializer tensor information with operator usage
-  for (const Ort::ConstValueInfo& initializer : graph.GetInitializers()) {
-    const std::string initializer_name = initializer.GetName();
+  for (const OrtValueInfo* initializer : ort_read::GraphInitializers(ort_api, graph)) {
+    const std::string initializer_name = ort_read::ValueInfoName(ort_api, initializer);
 
     // Check if this tensor exists in the QNN model
     if (qnn_model_wrapper.IsQnnTensorWrapperExist(initializer_name)) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -63,6 +63,12 @@ class QnnModel {
 
   Ort::Status ExecuteGraph(OrtKernelContext* context, const Ort::Logger& logger);
 
+  // Acquires and immediately releases graph_exec_mutex_ to guarantee no graphExecute()
+  // is in progress. Used by the hot-migration drain sequence before GPU teardown.
+  void WaitForInflightExecution() {
+    std::lock_guard<std::mutex> lock(graph_exec_mutex_);
+  }
+
   const OnnxTensorInfo* GetOutputInfo(const std::string& name) const {
     auto it = graph_outputs_.tensors.find(name);
     if (it == graph_outputs_.tensors.end()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -63,6 +63,12 @@ class QnnModel {
 
   Ort::Status ExecuteGraph(OrtKernelContext* context, const Ort::Logger& logger);
 
+  // Execute with pre-bound tensor arrays (no KernelContext). Used by partial migration to chain
+  // subgraph executions with intermediate buffers.
+  Ort::Status ExecuteGraphDirect(Qnn_Tensor_t* inputs, uint32_t num_inputs,
+                                 Qnn_Tensor_t* outputs, uint32_t num_outputs,
+                                 const Ort::Logger& logger);
+
   // Acquires and immediately releases graph_exec_mutex_ to guarantee no graphExecute()
   // is in progress. Used by the hot-migration drain sequence before GPU teardown.
   void WaitForInflightExecution() {
@@ -150,6 +156,9 @@ class QnnModel {
   }
 
   const std::string& Name() const { return graph_info_->Name(); }
+
+  const std::vector<QnnTensorInfo>& InputInfos() const { return qnn_input_infos_; }
+  const std::vector<QnnTensorInfo>& OutputInfos() const { return qnn_output_infos_; }
 
  private:
   const OrtNodeUnit& GetNodeUnit(const OrtNode* node,

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_classifier.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_classifier.cc
@@ -1,0 +1,210 @@
+#include "core/providers/qnn/builder/qnn_model_classifier.h"
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace onnxruntime {
+namespace qnn {
+
+namespace {
+
+constexpr float kMinDecisionScore = 10.0f;
+
+// -- GenAI signal weights --
+constexpr float kMatMulNBitsScore    = 10.0f;  // Int4-quantized LLM weights (triggers early return, not actually accumulated)
+constexpr float kHeavyAttnOpScore    = 10.0f;  // MHA / GQA / Attention contrib ops
+constexpr float kLightAttnOpScore    =  3.0f;  // RotaryEmbedding / SkipLayerNorm / GELU variants
+constexpr float kKvCacheInputScore   =  5.0f;  // Per KV-cache input name match
+constexpr float kDecomposedAttnScore =  5.0f;  // MatMul + Softmax co-occurrence
+constexpr float kLayerNormDenseScore = 10.0f;  // LayerNorm density > 5%
+
+// -- NonGenAI signal weights --
+constexpr float kConvDenseScore      = 10.0f;  // Conv density > 30%
+constexpr float kBatchNormDenseScore =  5.0f;  // BatchNorm density > 10%
+constexpr float kClassifHeadScore    =  5.0f;  // GlobalAveragePool + (Softmax | Gemm)
+constexpr float k4DImageScore        =  5.0f;  // 4D spatial input (H, W >= 224)
+
+// -- Density thresholds --
+constexpr float kConvDensityThreshold      = 0.30f;
+constexpr float kBatchNormDensityThreshold = 0.10f;
+constexpr float kLayerNormDensityThreshold = 0.05f;
+
+// Minimum value of a spatial dimension to count as an image-shaped input
+constexpr int64_t kMinSpatialDim = 224;
+
+// -- Op tables --
+constexpr std::string_view kMsDomain = "com.microsoft";
+constexpr std::string_view kHeavyAttnOps[] = {
+  "MultiHeadAttention",
+  "GroupQueryAttention",
+  "Attention"
+};
+constexpr std::string_view kLightAttnOps[] = {
+  "RotaryEmbedding",
+  "SkipLayerNormalization",
+  "FastGelu",
+  "BiasGelu"
+};
+// Standard HuggingFace LLM export naming for KV-cache inputs
+constexpr std::string_view kKvCacheHints[] = {
+  "past_key_values",
+  "past_",
+  "present",
+  "input_ids",
+  "attention_mask",
+  "position_ids"
+};
+
+template <size_t N>
+constexpr bool InArray(const std::string_view (&arr)[N], std::string_view v) {
+  return std::find(std::begin(arr), std::end(arr), v) != std::end(arr);
+}
+
+bool MatchesKvCacheHint(std::string_view name) {
+  for (std::string_view hint : kKvCacheHints)
+    if (name.find(hint) != std::string_view::npos) return true;
+  return false;
+}
+
+// Used for optional signals so that a failing call skips the signal rather than aborting classification
+inline bool OkOrSkip(OrtStatus* s, const OrtApi& ort_api) {
+  if (!s) return true;
+  ort_api.ReleaseStatus(s);
+  return false;
+}
+
+}  // namespace
+
+ModelClass ClassifyModel(const OrtGraph* graph,
+                         const OrtApi& ort_api,
+                         const Ort::Logger& logger) {
+  size_t num_nodes = 0;
+  if (!OkOrSkip(ort_api.Graph_GetNumNodes(graph, &num_nodes), ort_api) ||
+      num_nodes == 0)
+    return ModelClass::Unknown;
+
+  std::vector<const OrtNode*> nodes(num_nodes);
+  if (!OkOrSkip(ort_api.Graph_GetNodes(graph, nodes.data(), num_nodes), ort_api))
+    return ModelClass::Unknown;
+
+  float genai_score     = 0.0f;
+  float non_genai_score = 0.0f;
+
+  // Pre-scan graph inputs before the node loop so KV-cache evidence can trigger early classification
+  size_t num_inputs = 0;
+  if (OkOrSkip(ort_api.Graph_GetNumInputs(graph, &num_inputs), ort_api) && num_inputs > 0) {
+    std::vector<const OrtValueInfo*> inputs(num_inputs);
+    if (OkOrSkip(ort_api.Graph_GetInputs(graph, inputs.data(), num_inputs), ort_api)) {
+
+      // KV-cache / LLM input names
+      for (const OrtValueInfo* vi : inputs) {
+        const char* name = nullptr;
+        if (!OkOrSkip(ort_api.GetValueInfoName(vi, &name), ort_api) || !name) continue;
+        if (MatchesKvCacheHint(name)) genai_score += kKvCacheInputScore;
+      }
+
+      // 4D image-shaped first input
+      const OrtTypeInfo* type_info = nullptr;
+      const OrtTensorTypeAndShapeInfo* shape_info = nullptr;
+      if (OkOrSkip(ort_api.GetValueInfoTypeInfo(inputs[0], &type_info), ort_api) &&
+          type_info &&
+          OkOrSkip(ort_api.CastTypeInfoToTensorInfo(type_info, &shape_info), ort_api) &&
+          shape_info) {
+        size_t rank = 0;
+        if (OkOrSkip(ort_api.GetDimensionsCount(shape_info, &rank), ort_api) && rank == 4) {
+          int64_t dims[4] = {};
+          if (OkOrSkip(ort_api.GetDimensions(shape_info, dims, 4), ort_api) &&
+              dims[2] >= kMinSpatialDim && dims[3] >= kMinSpatialDim) {
+            non_genai_score += k4DImageScore;
+          }
+        }
+      }
+    }
+  }
+
+  if (genai_score >= kMinDecisionScore && genai_score > non_genai_score) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("QNN ModelClassifier: GenAI (early return, kv-cache score: " + std::to_string(genai_score) + ")").c_str());
+    return ModelClass::GenAI;
+  }
+
+  size_t conv_count       = 0;
+  size_t layer_norm_count = 0;
+  size_t batch_norm_count = 0;
+  bool   has_matmul       = false;
+  bool   has_softmax      = false;
+  bool   has_global_avg   = false;
+  bool   has_gemm         = false;
+
+  for (const OrtNode* node : nodes) {
+    const char* op_cstr = nullptr;
+    if (!OkOrSkip(ort_api.Node_GetOperatorType(node, &op_cstr), ort_api) || !op_cstr)
+      continue;
+    const std::string_view op{op_cstr};
+
+    const char* domain_cstr = nullptr;
+    OkOrSkip(ort_api.Node_GetDomain(node, &domain_cstr), ort_api);
+    const bool is_ms = domain_cstr && std::string_view{domain_cstr} == kMsDomain;
+
+    if (is_ms) {
+      if (InArray(kHeavyAttnOps, op) || op == "MatMulNBits") {
+        ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                    ("QNN ModelClassifier: GenAI (early return, decisive op: " + std::string(op) + ")").c_str());
+        return ModelClass::GenAI;
+      }
+
+      if (InArray(kLightAttnOps, op))
+        genai_score += kLightAttnOpScore;
+      // Also count LayerNorm exported under the ms domain
+      else if (op == "LayerNormalization" ||
+               op == "SimplifiedLayerNormalization")
+        ++layer_norm_count;
+    } else {
+      if      (op == "Conv" || op == "ConvTranspose" || op == "ConvInteger")
+        ++conv_count;
+      else if (op == "LayerNormalization" ||
+               op == "SimplifiedLayerNormalization")
+        ++layer_norm_count;
+      else if (op == "BatchNormalization")
+        ++batch_norm_count;
+      else if (op == "GlobalAveragePool")
+        has_global_avg = true;
+      else if (op == "Softmax" || op == "LogSoftmax")
+        has_softmax = true;
+      else if (op == "Gemm")
+        has_gemm   = true;
+      else if (op == "MatMul")
+        has_matmul = true;
+    }
+  }
+
+  const float nf = static_cast<float>(num_nodes);
+
+  // Density-based and co-occurrence signals
+  if (conv_count       / nf > kConvDensityThreshold)      non_genai_score += kConvDenseScore;
+  if (batch_norm_count / nf > kBatchNormDensityThreshold) non_genai_score += kBatchNormDenseScore;
+  if (layer_norm_count / nf > kLayerNormDensityThreshold) genai_score     += kLayerNormDenseScore;
+
+  // Decomposed attention: MatMul -> (Mask+Softmax) -> MatMul (appears in models exported without contrib ops)
+  if (has_matmul && has_softmax)
+    genai_score += kDecomposedAttnScore;
+
+  // ImageNet-style classification tail: pool -> flatten -> linear -> softmax.
+  if (has_global_avg && (has_softmax || has_gemm))
+    non_genai_score += kClassifHeadScore;
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("QNN ModelClassifier:"
+                                                  " genai_score=" + std::to_string(genai_score) +
+                                                  " non_genai_score=" + std::to_string(non_genai_score)).c_str());
+
+  if (genai_score >= kMinDecisionScore && genai_score > non_genai_score)
+    return ModelClass::GenAI;
+  if (non_genai_score >= kMinDecisionScore && non_genai_score > genai_score)
+    return ModelClass::NonGenAI;
+  return ModelClass::Unknown;
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_classifier.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_classifier.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+enum class ModelClass { GenAI, NonGenAI, Unknown };
+
+ModelClass ClassifyModel(const OrtGraph* graph,
+                         const OrtApi& ort_api,
+                         const Ort::Logger& logger);
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/ort_graph_read_helpers.h"
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_node_group/utils.h"
@@ -20,6 +21,8 @@
 
 namespace onnxruntime {
 namespace qnn {
+
+using namespace ort_read;
 
 namespace {
 
@@ -126,9 +129,10 @@ bool CheckShape(const QnnModelWrapper& qnn_model_wrapper, const OrtNode& reshape
 // duplicating the Reshape; for now we conservatively skip to keep correctness.
 static bool InputReshapeIsShared(const OrtNodeUnit* input_reshape) {
   if (input_reshape == nullptr) return false;
-  const Ort::ConstNode reshape_node(&input_reshape->GetNode());
-  auto reshape_outputs = reshape_node.GetOutputs();
-  return !reshape_outputs.empty() && reshape_outputs[0].GetConsumers().size() > 1;
+  const OrtApi& ort_api = input_reshape->GetOrtApi();
+  const OrtNode* reshape_node = &input_reshape->GetNode();
+  std::vector<const OrtValueInfo*> reshape_outputs = NodeOutputs(ort_api, reshape_node);
+  return !reshape_outputs.empty() && ConsumerNodes(ort_api, reshape_outputs[0]).size() > 1;
 }
 
 // Get the input Reshape node unit that feeds into the Gemm node

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.cc
@@ -19,12 +19,16 @@
 #include <vector>
 
 #include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/ort_graph_read_helpers.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_node_group/utils.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
 namespace onnxruntime {
 namespace qnn {
+
+using namespace ort_read;
+
 namespace {
 
 constexpr char kAttrTransposePerm[] = "perm";
@@ -743,11 +747,12 @@ std::unique_ptr<IQnnNodeGroup> SpaceToDepthFusion::TryFusion(
     const MapNodeToNodeUnit& node_to_node_unit,
     const MapNodeUnitToGroup& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
-  const Ort::ConstNode start_node(&reshape_node_unit.GetNode());
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
+  const OrtNode* start_node = &reshape_node_unit.GetNode();
 
   // 1. Skip fusion if the pattern Start Node is graph output.
-  const std::vector<Ort::ConstValueInfo> outputs = start_node.GetOutputs();
-  if (!outputs.empty() && outputs[0].IsGraphOutput()) {
+  const std::vector<const OrtValueInfo*> outputs = NodeOutputs(ort_api, start_node);
+  if (!outputs.empty() && IsGraphOutput(ort_api, outputs[0])) {
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -12,11 +12,14 @@
 #include <unordered_map>
 #include <vector>
 
+#include "core/providers/qnn/builder/ort_graph_read_helpers.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 
 namespace onnxruntime {
 namespace qnn {
+
+using namespace ort_read;
 
 std::optional<std::vector<uint32_t>> GetReduceAxes(const QnnModelWrapper& qmw,
                                                    const OrtNodeUnit& node_unit) {
@@ -70,31 +73,32 @@ std::optional<std::vector<uint32_t>> GetReduceAxes(const QnnModelWrapper& qmw,
   return axes;
 }
 
-const OrtNodeUnit* GetOnlyChildOfType(const QnnModelWrapper& /*qnn_model_wrapper*/,
+const OrtNodeUnit* GetOnlyChildOfType(const QnnModelWrapper& qnn_model_wrapper,
                                       const OrtNodeUnit& parent_node_unit,
                                       gsl::span<const std::string_view> child_op_types,
                                       const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                       const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
-  const Ort::ConstNode parent_node(&parent_node_unit.GetNode());
-  std::vector<Ort::ConstValueInfo> outputs = parent_node.GetOutputs();
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
+  const OrtNode* parent_node = &parent_node_unit.GetNode();
+  std::vector<const OrtValueInfo*> outputs = NodeOutputs(ort_api, parent_node);
 
   // Parent must have a single child and must not produce a graph output.
   if (outputs.size() != 1) {
     return nullptr;
   }
-  for (const Ort::ConstValueInfo& output_info : outputs) {
-    if (output_info.IsGraphOutput()) {
+  for (const OrtValueInfo* output_info : outputs) {
+    if (IsGraphOutput(ort_api, output_info)) {
       return nullptr;
     }
   }
 
-  std::vector<Ort::ValueInfoConsumerProducerInfo> consumers = outputs[0].GetConsumers();
-  if (consumers.size() != 1 || consumers[0].node == nullptr) {
+  std::vector<const OrtNode*> consumers = ConsumerNodes(ort_api, outputs[0]);
+  if (consumers.size() != 1 || consumers[0] == nullptr) {
     return nullptr;
   }
 
-  const Ort::ConstNode child_node = consumers[0].node;
-  const std::string& child_type = child_node.GetOperatorType();
+  const OrtNode* child_node = consumers[0];
+  const std::string child_type = NodeOpType(ort_api, child_node);
   bool is_valid_child_type = false;
 
   for (const auto& valid_op_type : child_op_types) {
@@ -129,13 +133,14 @@ const OrtNodeUnit* GetOnlyChildOfType(const QnnModelWrapper& /*qnn_model_wrapper
 }
 
 const OrtNodeUnit* GetChildNodeUnitAllowQdq(
-    const QnnModelWrapper& /*qnn_model_wrapper*/,
+    const QnnModelWrapper& qnn_model_wrapper,
     const OrtNodeUnit& parent_node_unit,
     const std::string& child_op_type,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
   try {
-    const Ort::ConstNode parent_node(&parent_node_unit.GetNode());
+    const OrtNode* parent_node = &parent_node_unit.GetNode();
 
     // 1. For QDQ NodeUnits (DQ->op->Q), look at the Q node's output instead of the target node's output.
     const OrtNode* search_node = parent_node;
@@ -147,42 +152,42 @@ const OrtNodeUnit* GetChildNodeUnitAllowQdq(
     }
 
     // 2. Search node must have a single child and must not produce a graph output.
-    const std::vector<Ort::ConstValueInfo> outputs = Ort::ConstNode(search_node).GetOutputs();
-    if (outputs.size() != 1 || outputs[0].IsGraphOutput()) {
+    const std::vector<const OrtValueInfo*> outputs = NodeOutputs(ort_api, search_node);
+    if (outputs.size() != 1 || IsGraphOutput(ort_api, outputs[0])) {
       return nullptr;
     }
 
     // 3. Search node must have exactly one consumer.
-    const std::vector<Ort::ValueInfoConsumerProducerInfo> consumers = outputs[0].GetConsumers();
-    if (consumers.size() != 1 || consumers[0].node == nullptr) {
+    const std::vector<const OrtNode*> consumers = ConsumerNodes(ort_api, outputs[0]);
+    if (consumers.size() != 1 || consumers[0] == nullptr) {
       return nullptr;
     }
 
-    const OrtNode* potential_child = consumers[0].node;
+    const OrtNode* potential_child = consumers[0];
 
     // 4. If the child is Q/DQ wrapper(s), skip through them and look at the next math child.
     // Example: DQ -> op -> Q -> DQ -> ...
     while (potential_child != nullptr) {
-      const std::string child_op = Ort::ConstNode(potential_child).GetOperatorType();
+      const std::string child_op = NodeOpType(ort_api, potential_child);
       if (child_op != QUANTIZE_LINEAR && child_op != DEQUANTIZE_LINEAR) {
         break;
       }
 
-      const std::vector<Ort::ConstValueInfo> qdq_outputs = Ort::ConstNode(potential_child).GetOutputs();
+      const std::vector<const OrtValueInfo*> qdq_outputs = NodeOutputs(ort_api, potential_child);
       if (qdq_outputs.size() != 1) {
         return nullptr;
       }
 
-      const std::vector<Ort::ValueInfoConsumerProducerInfo> qdq_consumers = qdq_outputs[0].GetConsumers();
-      if (qdq_consumers.size() != 1 || qdq_consumers[0].node == nullptr) {
+      const std::vector<const OrtNode*> qdq_consumers = ConsumerNodes(ort_api, qdq_outputs[0]);
+      if (qdq_consumers.size() != 1 || qdq_consumers[0] == nullptr) {
         return nullptr;
       }
 
-      potential_child = qdq_consumers[0].node;
+      potential_child = qdq_consumers[0];
     }
 
     // 5. Check if the child node is of the expected type.
-    if (Ort::ConstNode(potential_child).GetOperatorType() != child_op_type) {
+    if (NodeOpType(ort_api, potential_child) != child_op_type) {
       return nullptr;
     }
 
@@ -227,11 +232,9 @@ std::optional<std::vector<int64_t>> GetInitializerDataAsInt64(
 
   ONNXTensorElementDataType elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
   size_t element_count = 0;
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
   try {
-    // 3. Read element type from CXX type wrappers.
-    const Ort::ConstValueInfo shape_tensor(tensor);
-    const Ort::ConstTensorTypeAndShapeInfo tensor_info = shape_tensor.TypeInfo().GetTensorTypeAndShapeInfo();
-    elem_type = tensor_info.GetElementType();
+    elem_type = ElemType(ort_api, tensor);
 
     // 4. Use NodeUnit I/O shape metadata to get the expected number of entries in the shape tensor.
     std::vector<uint32_t> shape_tensor_dims;
@@ -283,26 +286,27 @@ std::optional<std::vector<int64_t>> GetInitializerDataAsInt64(
   return values;
 }
 
-const OrtNodeUnit* GetParentOfType(const QnnModelWrapper& /*qnn_model_wrapper*/,
+const OrtNodeUnit* GetParentOfType(const QnnModelWrapper& qnn_model_wrapper,
                                    const OrtNodeUnit& child_node_unit,
                                    gsl::span<const std::string_view> parent_op_types,
                                    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
-  const Ort::ConstNode child_node(&child_node_unit.GetNode());
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
+  const OrtNode* child_node = &child_node_unit.GetNode();
 
-  for (const Ort::ConstValueInfo& input_info : child_node.GetInputs()) {
-    const Ort::ConstNode parent_node = input_info.GetProducerNode().node;
-    if (static_cast<const OrtNode*>(parent_node) == nullptr) {
+  for (const OrtValueInfo* input_info : NodeInputs(ort_api, child_node)) {
+    const OrtNode* parent_node = ProducerNode(ort_api, input_info);
+    if (parent_node == nullptr) {
       continue;
     }
-    for (const Ort::ConstValueInfo& parent_output_info : parent_node.GetOutputs()) {
-      if (parent_output_info.IsGraphOutput()) {
+    for (const OrtValueInfo* parent_output_info : NodeOutputs(ort_api, parent_node)) {
+      if (IsGraphOutput(ort_api, parent_output_info)) {
         // Node is producing a graph output
         return nullptr;
       }
     }
 
-    const std::string parent_type = parent_node.GetOperatorType();
+    const std::string parent_type = NodeOpType(ort_api, parent_node);
     bool is_valid_parent_type = false;
 
     for (const auto& valid_op_type : parent_op_types) {
@@ -338,16 +342,17 @@ const OrtNodeUnit* GetParentOfType(const QnnModelWrapper& /*qnn_model_wrapper*/,
   return nullptr;
 }
 
-const OrtNodeUnit* GetParentOfInput(const QnnModelWrapper& /*qnn_model_wrapper*/,
+const OrtNodeUnit* GetParentOfInput(const QnnModelWrapper& qnn_model_wrapper,
                                     const OrtNodeUnit& node_unit,
                                     const OrtNodeUnitIODef& input,
                                     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
   const OrtNode* p_child_node = nullptr;
 
   for (const OrtNode* node : node_unit.GetAllNodesInGroup()) {
-    for (const Ort::ConstValueInfo& input_info : Ort::ConstNode(node).GetInputs()) {
-      if (input_info.GetName() == input.name) {
+    for (const OrtValueInfo* input_info : NodeInputs(ort_api, node)) {
+      if (ValueInfoName(ort_api, input_info) == input.name) {
         p_child_node = node;
         break;
       }
@@ -362,19 +367,17 @@ const OrtNodeUnit* GetParentOfInput(const QnnModelWrapper& /*qnn_model_wrapper*/
     return nullptr;
   }
 
-  const Ort::ConstNode child_node(p_child_node);
-
-  for (const Ort::ConstValueInfo& input_info : child_node.GetInputs()) {
-    if (input_info.GetName() != input.name) {
+  for (const OrtValueInfo* input_info : NodeInputs(ort_api, p_child_node)) {
+    if (ValueInfoName(ort_api, input_info) != input.name) {
       continue;
     }
 
-    const Ort::ConstNode parent_node = input_info.GetProducerNode().node;
-    if (static_cast<const OrtNode*>(parent_node) == nullptr) {
+    const OrtNode* parent_node = ProducerNode(ort_api, input_info);
+    if (parent_node == nullptr) {
       return nullptr;
     }
-    for (const Ort::ConstValueInfo& parent_output_info : parent_node.GetOutputs()) {
-      if (parent_output_info.IsGraphOutput()) {
+    for (const OrtValueInfo* parent_output_info : NodeOutputs(ort_api, parent_node)) {
+      if (IsGraphOutput(ort_api, parent_output_info)) {
         // Node is producing a graph output
         return nullptr;
       }
@@ -397,16 +400,17 @@ const OrtNodeUnit* GetParentOfInput(const QnnModelWrapper& /*qnn_model_wrapper*/
   return nullptr;
 }
 
-const OrtNodeUnit* GetOnlyChildOfOutput(const QnnModelWrapper& /*qnn_model_wrapper*/,
+const OrtNodeUnit* GetOnlyChildOfOutput(const QnnModelWrapper& qnn_model_wrapper,
                                         const OrtNodeUnit& node_unit,
                                         const OrtNodeUnitIODef& output,
                                         const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                         const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
   const OrtNode* p_parent_node = nullptr;
 
   for (const OrtNode* node : node_unit.GetAllNodesInGroup()) {
-    for (const Ort::ConstValueInfo& output_info : Ort::ConstNode(node).GetOutputs()) {
-      if (output_info.GetName() == output.name) {
+    for (const OrtValueInfo* output_info : NodeOutputs(ort_api, node)) {
+      if (ValueInfoName(ort_api, output_info) == output.name) {
         p_parent_node = node;
         break;
       }
@@ -422,29 +426,27 @@ const OrtNodeUnit* GetOnlyChildOfOutput(const QnnModelWrapper& /*qnn_model_wrapp
     return nullptr;
   }
 
-  const Ort::ConstNode parent_node(p_parent_node);
-
-  for (const Ort::ConstValueInfo& parent_output_info : parent_node.GetOutputs()) {
-    if (parent_output_info.IsGraphOutput()) {
+  for (const OrtValueInfo* parent_output_info : NodeOutputs(ort_api, p_parent_node)) {
+    if (IsGraphOutput(ort_api, parent_output_info)) {
       // Node is producing a graph output.
       return nullptr;
     }
   }
 
-  for (const Ort::ConstValueInfo& output_info : parent_node.GetOutputs()) {
+  for (const OrtValueInfo* output_info : NodeOutputs(ort_api, p_parent_node)) {
     // Check if this is the output we're looking for.
-    if (output_info.GetName() != output.name) {
+    if (ValueInfoName(ort_api, output_info) != output.name) {
       continue;
     }
 
-    std::vector<Ort::ValueInfoConsumerProducerInfo> consumers = output_info.GetConsumers();
+    std::vector<const OrtNode*> consumers = ConsumerNodes(ort_api, output_info);
     // Check if there is exactly one child.
     // The returned consumer info should not be nullptr node but check to be safe.
-    if (consumers.size() != 1 || consumers[0].node == nullptr) {
+    if (consumers.size() != 1 || consumers[0] == nullptr) {
       return nullptr;
     }
 
-    const Ort::ConstNode child_node = consumers[0].node;
+    const OrtNode* child_node = consumers[0];
     const auto child_node_unit_it = node_unit_map.find(child_node);
     if (child_node_unit_it == node_unit_map.end()) {
       return nullptr;
@@ -463,28 +465,29 @@ const OrtNodeUnit* GetOnlyChildOfOutput(const QnnModelWrapper& /*qnn_model_wrapp
   return nullptr;
 }
 
-const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& /*qnn_model_wrapper*/,
+const OrtNodeUnit* GetParentOfInputByName(const QnnModelWrapper& qnn_model_wrapper,
                                           const OrtNodeUnit& node_unit,
                                           const std::string& input_name,
                                           const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                           const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map) {
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
   // Iterate through all nodes in the group
   for (const OrtNode* node : node_unit.GetAllNodesInGroup()) {
     // Check if this node has the input we're looking for
-    for (const Ort::ConstValueInfo& input_info : Ort::ConstNode(node).GetInputs()) {
-      if (input_info.GetName() != input_name) {
+    for (const OrtValueInfo* input_info : NodeInputs(ort_api, node)) {
+      if (ValueInfoName(ort_api, input_info) != input_name) {
         continue;
       }
 
-      const Ort::ConstNode parent_node = input_info.GetProducerNode().node;
+      const OrtNode* parent_node = ProducerNode(ort_api, input_info);
 
-      if (static_cast<const OrtNode*>(parent_node) == nullptr) {
+      if (parent_node == nullptr) {
         // Node is not in this graph
         return nullptr;
       }
 
-      for (const Ort::ConstValueInfo& parent_output_info : parent_node.GetOutputs()) {
-        if (parent_output_info.IsGraphOutput()) {
+      for (const OrtValueInfo* parent_output_info : NodeOutputs(ort_api, parent_node)) {
+        if (IsGraphOutput(ort_api, parent_output_info)) {
           // Node is producing a graph output
           return nullptr;
         }

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1813,6 +1813,10 @@ Ort::Status UnpackInitializerData(const OrtApi& ort_api,
                                   const OrtValueInfo* initializer,
                                   const std::filesystem::path& model_path,
                                   std::vector<uint8_t>& unpacked_tensor) {
+  const uint64_t unpack_start_us = GetTimeStampInUs();
+  auto accumulate_on_exit = gsl::finally([unpack_start_us]() {
+    UnpackInitializerTimeUs() += GetTimeStampInUs() - unpack_start_us;
+  });
   OrtExternalInitializerInfo* external_initializer = nullptr;
   ORT_CXX_RETURN_ON_API_FAIL(ort_api.ValueInfo_GetExternalInitializerInfo(initializer, &external_initializer));
   if (external_initializer) {
@@ -1861,6 +1865,11 @@ Ort::Status UnpackInitializerData(const OrtApi& ort_api,
 
 std::string PtrToString(const void* const ptr) {
   return (std::ostringstream() << ptr).str();
+}
+
+uint64_t& UnpackInitializerTimeUs() {
+  thread_local uint64_t unpack_time_us = 0;
+  return unpack_time_us;
 }
 
 }  // namespace utils

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -838,6 +838,9 @@ Ort::Status UnpackInitializerData(const OrtApi& ort_api,
                                   const std::filesystem::path& model_path,
                                   std::vector<uint8_t>& unpacked_tensor);
 
+// Thread-local accumulator (microseconds) of time spent inside UnpackInitializerData.
+uint64_t& UnpackInitializerTimeUs();
+
 /*
    Converts a pointer into a string
    Intended for ORT logging

--- a/onnxruntime/core/providers/qnn/ort_api.cc
+++ b/onnxruntime/core/providers/qnn/ort_api.cc
@@ -229,7 +229,8 @@ std::vector<OrtNodeUnitIODef> GetQDQIODefs(const OrtNode* target_node,
 
 }  // namespace
 
-OrtNodeUnit::OrtNodeUnit(const OrtNode* node, const OrtApi& ort_api) : target_node_(node), type_(Type::SingleNode) {
+OrtNodeUnit::OrtNodeUnit(const OrtNode* node, const OrtApi& ort_api)
+    : target_node_(node), type_(Type::SingleNode), ort_api_(ort_api) {
   OrtStatus* status = InitForSingleNode(ort_api);
   if (status != nullptr) {
     ort_api.ReleaseStatus(status);
@@ -246,7 +247,8 @@ OrtNodeUnit::OrtNodeUnit(const OrtGraph* /* graph */, const QDQ::OrtNodeGroup& n
       q_nodes_(node_group.q_nodes),
       type_(Type::QDQGroup),
       inputs_(GetQDQIODefs(target_node_, node_group, true, ort_api)),
-      outputs_(GetQDQIODefs((redundant_clip_node_ ? redundant_clip_node_ : target_node_), node_group, false, ort_api)) {
+      outputs_(GetQDQIODefs((redundant_clip_node_ ? redundant_clip_node_ : target_node_), node_group, false, ort_api)),
+      ort_api_(ort_api) {
 }
 
 OrtStatus* OrtNodeUnit::InitForSingleNode(const OrtApi& ort_api) {
@@ -450,92 +452,174 @@ std::vector<const OrtNode*> OrtNodeUnit::GetOutputNodes(const OrtApi& ort_api) c
 
 #define NODE_ATTR_ITER_VAL(iter) (iter)->second()
 
-OrtNodeAttrHelper::OrtNodeAttrHelper(const OrtNode& node) : node_(node) {}
+OrtNodeAttrHelper::OrtNodeAttrHelper(const OrtNode& node) : node_(node), ort_api_(Ort::GetApi()) {}
 
-OrtNodeAttrHelper::OrtNodeAttrHelper(const OrtNodeUnit& node_unit) : node_(node_unit.GetNode()) {}
+OrtNodeAttrHelper::OrtNodeAttrHelper(const OrtNodeUnit& node_unit)
+    : node_(node_unit.GetNode()), ort_api_(node_unit.GetOrtApi()) {}
+
+namespace {
+const OrtOpAttr* LookupAttr(const OrtApi& api, const OrtNode& node, const std::string& key) {
+  const OrtOpAttr* attr = nullptr;
+  OrtStatus* status = api.Node_GetAttributeByName(&node, key.c_str(), &attr);
+  if (status != nullptr) {
+    api.ReleaseStatus(status);
+    return nullptr;
+  }
+  return attr;
+}
+
+bool AttrTypeIs(const OrtApi& api, const OrtOpAttr* attr, OrtOpAttrType want) {
+  OrtOpAttrType type;
+  OrtStatus* status = api.OpAttr_GetType(attr, &type);
+  if (status != nullptr) {
+    api.ReleaseStatus(status);
+    return false;
+  }
+  return type == want;
+}
+
+size_t AttrDataSize(const OrtApi& api, const OrtOpAttr* attr, OrtOpAttrType type) {
+  size_t size = 0;
+  OrtStatus* status = api.ReadOpAttr(attr, type, nullptr, 0, &size);
+  if (status != nullptr) {
+    api.ReleaseStatus(status);
+  }
+  return size;
+}
+
+template <typename T>
+bool ReadNumeric(const OrtApi& api, const OrtOpAttr* attr, OrtOpAttrType type, T& out) {
+  size_t size = 0;
+  OrtStatus* status = api.ReadOpAttr(attr, type, &out, sizeof(out), &size);
+  if (status != nullptr) {
+    api.ReleaseStatus(status);
+    return false;
+  }
+  return true;
+}
+
+template <typename T>
+bool ReadNumericArray(const OrtApi& api, const OrtOpAttr* attr, OrtOpAttrType type, std::vector<T>& out) {
+  if (!AttrTypeIs(api, attr, type)) {
+    return false;
+  }
+  size_t size = AttrDataSize(api, attr, type);
+  std::vector<T> result(size / sizeof(T));
+  if (size > 0) {
+    OrtStatus* status = api.ReadOpAttr(attr, type, result.data(), size, &size);
+    if (status != nullptr) {
+      api.ReleaseStatus(status);
+      return false;
+    }
+  }
+  out.swap(result);
+  return true;
+}
+
+bool ReadStringAttr(const OrtApi& api, const OrtOpAttr* attr, std::string& out) {
+  if (!AttrTypeIs(api, attr, ORT_OP_ATTR_STRING)) {
+    return false;
+  }
+  size_t size = AttrDataSize(api, attr, ORT_OP_ATTR_STRING);
+  std::string result;
+  if (size > 0) {
+    result.resize(size);
+    OrtStatus* status = api.ReadOpAttr(attr, ORT_OP_ATTR_STRING, &result[0], size, &size);
+    if (status != nullptr) {
+      api.ReleaseStatus(status);
+      return false;
+    }
+  }
+  out.swap(result);
+  return true;
+}
+
+bool ReadStringsAttr(const OrtApi& api, const OrtOpAttr* attr, std::vector<std::string>& out) {
+  if (!AttrTypeIs(api, attr, ORT_OP_ATTR_STRINGS)) {
+    return false;
+  }
+  size_t total = AttrDataSize(api, attr, ORT_OP_ATTR_STRINGS);
+  std::vector<std::string> result;
+  if (total > 0) {
+    std::vector<char> buffer(total);
+    OrtStatus* status = api.ReadOpAttr(attr, ORT_OP_ATTR_STRINGS, buffer.data(), total, &total);
+    if (status != nullptr) {
+      api.ReleaseStatus(status);
+      return false;
+    }
+    const char* data = buffer.data();
+    const char* end = data + total;
+    while (data < end) {
+      result.emplace_back(data);
+      data += result.back().size() + 1;
+    }
+  }
+  out.swap(result);
+  return true;
+}
+}  // namespace
 
 float OrtNodeAttrHelper::Get(const std::string& key, float def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   float val;
-  status = attr.GetValue<float>(val);
-  return status.IsOK() ? val : def_val;
+  return ReadNumeric(ort_api_, attr, ORT_OP_ATTR_FLOAT, val) ? val : def_val;
 }
 
 int32_t OrtNodeAttrHelper::Get(const std::string& key, int32_t def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   int64_t val;
-  status = attr.GetValue<int64_t>(val);
-  return status.IsOK() ? gsl::narrow<int32_t>(val) : def_val;
+  return ReadNumeric(ort_api_, attr, ORT_OP_ATTR_INT, val) ? gsl::narrow<int32_t>(val) : def_val;
 }
 
 uint32_t OrtNodeAttrHelper::Get(const std::string& key, uint32_t def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   int64_t val;
-  status = attr.GetValue<int64_t>(val);
-  return status.IsOK() ? gsl::narrow<uint32_t>(val) : def_val;
+  return ReadNumeric(ort_api_, attr, ORT_OP_ATTR_INT, val) ? gsl::narrow<uint32_t>(val) : def_val;
 }
 
 int64_t OrtNodeAttrHelper::Get(const std::string& key, int64_t def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   int64_t val;
-  status = attr.GetValue<int64_t>(val);
-  return status.IsOK() ? val : def_val;
+  return ReadNumeric(ort_api_, attr, ORT_OP_ATTR_INT, val) ? val : def_val;
 }
 
 std::string OrtNodeAttrHelper::Get(const std::string& key, std::string def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   std::string val;
-  status = attr.GetValue<std::string>(val);
-  return status.IsOK() ? val : def_val;
+  return ReadStringAttr(ort_api_, attr, val) ? val : def_val;
 }
 
 std::vector<std::string> OrtNodeAttrHelper::Get(const std::string& key, const std::vector<std::string>& def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   std::vector<std::string> val;
-  status = attr.GetValueArray<std::string>(val);
-  return status.IsOK() ? val : def_val;
+  return ReadStringsAttr(ort_api_, attr, val) ? val : def_val;
 }
 
 std::vector<int32_t> OrtNodeAttrHelper::Get(const std::string& key, const std::vector<int32_t>& def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   std::vector<int64_t> val_int64;
-  status = attr.GetValueArray<int64_t>(val_int64);
-  if (!status.IsOK()) {
+  if (!ReadNumericArray(ort_api_, attr, ORT_OP_ATTR_INTS, val_int64)) {
     return def_val;
   }
 
@@ -549,15 +633,12 @@ std::vector<int32_t> OrtNodeAttrHelper::Get(const std::string& key, const std::v
 }
 
 std::vector<uint32_t> OrtNodeAttrHelper::Get(const std::string& key, const std::vector<uint32_t>& def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   std::vector<int64_t> val_int64;
-  status = attr.GetValueArray<int64_t>(val_int64);
-  if (!status.IsOK()) {
+  if (!ReadNumericArray(ort_api_, attr, ORT_OP_ATTR_INTS, val_int64)) {
     return def_val;
   }
 
@@ -571,93 +652,70 @@ std::vector<uint32_t> OrtNodeAttrHelper::Get(const std::string& key, const std::
 }
 
 std::vector<int64_t> OrtNodeAttrHelper::Get(const std::string& key, const std::vector<int64_t>& def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   std::vector<int64_t> val;
-  status = attr.GetValueArray<int64_t>(val);
-  return status.IsOK() ? val : def_val;
+  return ReadNumericArray(ort_api_, attr, ORT_OP_ATTR_INTS, val) ? val : def_val;
 }
 
 std::vector<float> OrtNodeAttrHelper::Get(const std::string& key, const std::vector<float>& def_val) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return def_val;
   }
-
   std::vector<float> val;
-  status = attr.GetValueArray<float>(val);
-  return status.IsOK() ? val : def_val;
+  return ReadNumericArray(ort_api_, attr, ORT_OP_ATTR_FLOATS, val) ? val : def_val;
 }
 
 std::optional<float> OrtNodeAttrHelper::GetFloat(const std::string& key) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return std::nullopt;
   }
-
   float val;
-  status = attr.GetValue<float>(val);
-  return status.IsOK() ? std::make_optional(val) : std::nullopt;
+  return ReadNumeric(ort_api_, attr, ORT_OP_ATTR_FLOAT, val) ? std::make_optional(val) : std::nullopt;
 }
 
 std::optional<int64_t> OrtNodeAttrHelper::GetInt64(const std::string& key) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return std::nullopt;
   }
-
   int64_t val;
-  status = attr.GetValue<int64_t>(val);
-  return status.IsOK() ? std::make_optional(val) : std::nullopt;
+  return ReadNumeric(ort_api_, attr, ORT_OP_ATTR_INT, val) ? std::make_optional(val) : std::nullopt;
 }
 
 std::optional<std::vector<float>> OrtNodeAttrHelper::GetFloats(const std::string& key) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return std::nullopt;
   }
-
   std::vector<float> val;
-  status = attr.GetValueArray<float>(val);
-  return status.IsOK() ? std::make_optional(val) : std::nullopt;
+  return ReadNumericArray(ort_api_, attr, ORT_OP_ATTR_FLOATS, val) ? std::make_optional(val) : std::nullopt;
 }
 
 std::optional<std::vector<int64_t>> OrtNodeAttrHelper::GetInt64s(const std::string& key) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return std::nullopt;
   }
-
   std::vector<int64_t> val;
-  status = attr.GetValueArray<int64_t>(val);
-  return status.IsOK() ? std::make_optional(val) : std::nullopt;
+  return ReadNumericArray(ort_api_, attr, ORT_OP_ATTR_INTS, val) ? std::make_optional(val) : std::nullopt;
 }
 
 std::optional<std::string> OrtNodeAttrHelper::GetString(const std::string& key) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  if (!status.IsOK() || attr == nullptr) {
+  const OrtOpAttr* attr = LookupAttr(ort_api_, node_, key);
+  if (attr == nullptr) {
     return std::nullopt;
   }
-
   std::string val;
-  status = attr.GetValue<std::string>(val);
-  return status.IsOK() ? std::make_optional(val) : std::nullopt;
+  return ReadStringAttr(ort_api_, attr, val) ? std::make_optional(val) : std::nullopt;
 }
 
 bool OrtNodeAttrHelper::HasAttr(const std::string& key) const {
-  Ort::ConstOpAttr attr;
-  Ort::Status status = Ort::ConstNode(&node_).GetAttributeByName(key, attr);
-  return status.IsOK() && attr != nullptr;
+  return LookupAttr(ort_api_, node_, key) != nullptr;
 }
 
 OrtStatus* GetSessionConfigEntryOrDefault(const OrtApi& ort_api,

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -281,13 +281,22 @@ class OrtNodeUnit {
   const std::vector<OrtNodeUnitIODef>& Inputs() const noexcept { return inputs_; }
   const std::vector<OrtNodeUnitIODef>& Outputs() const noexcept { return outputs_; }
 
-  std::string Domain() const noexcept { return Ort::ConstNode(target_node_).GetDomain(); }
-  std::string OpType() const noexcept { return Ort::ConstNode(target_node_).GetOperatorType(); }
-  std::string Name() const noexcept { return Ort::ConstNode(target_node_).GetName(); }
-  int SinceVersion() const noexcept { return Ort::ConstNode(target_node_).GetSinceVersion(); }
+  std::string Domain() const noexcept { return NodeString(ort_api_.Node_GetDomain); }
+  std::string OpType() const noexcept { return NodeString(ort_api_.Node_GetOperatorType); }
+  std::string Name() const noexcept { return NodeString(ort_api_.Node_GetName); }
+  int SinceVersion() const noexcept {
+    int since_version = 0;
+    ort_api_.Node_GetSinceVersion(target_node_, &since_version);
+    return since_version;
+  }
   // Align NodeUnit to name as Index although returning Id since index is inaccessible.
-  size_t Index() const noexcept { return Ort::ConstNode(target_node_).GetId(); }
+  size_t Index() const noexcept {
+    size_t id = 0;
+    ort_api_.Node_GetId(target_node_, &id);
+    return id;
+  }
 
+  const OrtApi& GetOrtApi() const noexcept { return ort_api_; }
   const OrtNode& GetNode() const noexcept { return *target_node_; }
   const OrtNode* GetRedundantClipNode() const noexcept { return redundant_clip_node_; }
   const std::vector<const OrtNode*>& GetDQNodes() const noexcept { return dq_nodes_; }
@@ -311,6 +320,13 @@ class OrtNodeUnit {
   // // Initialization for a NodeUnit that contains a single node
   OrtStatus* InitForSingleNode(const OrtApi& ort_api);
 
+  // Read a node string field through the injected api.
+  std::string NodeString(OrtStatus* (ORT_API_CALL* getter)(const OrtNode*, const char**)) const noexcept {
+    const char* value = nullptr;
+    getter(target_node_, &value);
+    return value != nullptr ? std::string(value) : std::string();
+  }
+
   const std::vector<const OrtNode*> dq_nodes_;  // dq nodes for this NodeUnit, not necessarily all inputs
   const OrtNode* target_node_;
   const OrtNode* redundant_clip_node_ = nullptr;  // Optional redundant clip node for the QDQ group, nullptr if not present.
@@ -319,6 +335,7 @@ class OrtNodeUnit {
 
   std::vector<OrtNodeUnitIODef> inputs_;
   std::vector<OrtNodeUnitIODef> outputs_;
+  const OrtApi& ort_api_;
 };
 
 /**
@@ -329,7 +346,6 @@ class OrtNodeAttrHelper {
  public:
   explicit OrtNodeAttrHelper(const OrtNode& node);
 
-  // Get the attributes from the target node of the node_unit
   explicit OrtNodeAttrHelper(const OrtNodeUnit& node_unit);
 
   /*
@@ -367,6 +383,7 @@ class OrtNodeAttrHelper {
 
  private:
   const OrtNode& node_;
+  const OrtApi& ort_api_;
 };
 
 OrtStatus* GetSessionConfigEntryOrDefault(const OrtApi& ort_api,

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1369,7 +1369,9 @@ std::optional<OrtNodeGroup> GetOrtQDQSelection(const OrtGraph* graph, const OrtA
     }
 
     // Check if this is a DQ node
-    if (Ort::ConstNode(producer_node).GetOperatorType() == "DequantizeLinear") {
+    const char* producer_op_type = nullptr;
+    ORT_CONTINUE_ON_ERROR(ort_api.Node_GetOperatorType(producer_node, &producer_op_type), ort_api);
+    if (std::string(producer_op_type) == "DequantizeLinear") {
       dq_nodes.push_back(producer_node);
     }
   }
@@ -1400,7 +1402,9 @@ std::optional<OrtNodeGroup> GetOrtQDQSelection(const OrtGraph* graph, const OrtA
       RETURN_DEFAULT_IF_API_FAIL(ort_api.ValueInfo_GetValueConsumers(value_info, &next_node, &input_index, 1), ort_api, std::nullopt);
 
       // Check if it's a Relu or Clip node
-      const std::string next_node_op_type = Ort::ConstNode(next_node).GetOperatorType();
+      const char* next_node_op_type_cstr = nullptr;
+      RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetOperatorType(next_node, &next_node_op_type_cstr), ort_api, std::nullopt);
+      const std::string next_node_op_type(next_node_op_type_cstr);
       if (next_node_op_type == "Relu" || next_node_op_type == "Clip") {
         // Get the outputs of the next node to check count
         size_t next_output_count = 0;
@@ -1460,7 +1464,15 @@ std::optional<OrtNodeGroup> GetOrtQDQSelection(const OrtGraph* graph, const OrtA
               ORT_CONTINUE_ON_ERROR(ort_api.ValueInfo_GetValueConsumers(relu_out_info, &q_after_clip, &unused_idx, 1), ort_api);
             }
 
-            if (q_after_clip != nullptr && Ort::ConstNode(q_after_clip).GetOperatorType() == "QuantizeLinear") {
+            const char* q_after_clip_op_type = nullptr;
+            if (q_after_clip != nullptr) {
+              if (OrtStatus* s = ort_api.Node_GetOperatorType(q_after_clip, &q_after_clip_op_type)) {
+                ort_api.ReleaseStatus(s);
+                q_after_clip_op_type = nullptr;
+              }
+            }
+            if (q_after_clip != nullptr && q_after_clip_op_type != nullptr &&
+                std::string(q_after_clip_op_type) == "QuantizeLinear") {
               float scale_val = 0.0f;
               int64_t zero_point = 0;
               Qnn_DataType_t qnn_dt = QNN_DATATYPE_UNDEFINED;
@@ -1528,7 +1540,9 @@ std::optional<OrtNodeGroup> GetOrtQDQSelection(const OrtGraph* graph, const OrtA
         const OrtNode* consumer_node = consumer_nodes_vec[j];
 
         // Check if this is a Q node
-        if (Ort::ConstNode(consumer_node).GetOperatorType() == "QuantizeLinear") {
+        const char* consumer_op_type = nullptr;
+        ORT_CONTINUE_ON_ERROR(ort_api.Node_GetOperatorType(consumer_node, &consumer_op_type), ort_api);
+        if (std::string(consumer_op_type) == "QuantizeLinear") {
           q_nodes.push_back(consumer_node);
         }
       }
@@ -1781,7 +1795,9 @@ std::vector<OrtNodeGroup> OrtSelectorManager::GetOrtQDQSelections(const OrtGraph
     const OrtNode* node = nodes[i];
 
     // Get node op type
-    std::string op_type = Ort::ConstNode(node).GetOperatorType();
+    const char* op_type_cstr = nullptr;
+    ORT_CONTINUE_ON_ERROR(ort_api.Node_GetOperatorType(node, &op_type_cstr), ort_api);
+    std::string op_type(op_type_cstr);
 
     // Get node domain
     const char* domain = nullptr;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2220,32 +2220,27 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
 
     RETURN_IF_NOT_NULL(gpu_status);
     RETURN_IF_NOT_NULL(htp_status);
-    // Intersection: only claim nodes both backends can compile. Nodes supported by HTP but not
-    // GPU fall back to CPU EP for the entire session (partitioning is fixed at session creation).
+    // Claim the full GPU set - pre-migration inference is identical to standalone --backend gpu.
+    // Nodes unsupported by HTP stay on GPU post-migration (partial migration). Store their names
+    // so the background thread knows which nodes to split out into a residual GPU graph.
+    supported_nodes = std::move(gpu_supported_nodes);
+
     std::unordered_set<const OrtNode*> htp_set(htp_supported_nodes.begin(),
                                                htp_supported_nodes.end());
-    supported_nodes.reserve(gpu_supported_nodes.size());
-    for (const OrtNode* node : gpu_supported_nodes) {
-      if (htp_set.count(node)) {
-        supported_nodes.push_back(node);
-      }
-    }
-
-    size_t gpu_only_count = 0;
-    for (const OrtNode* node : gpu_supported_nodes) {
+    for (const OrtNode* node : supported_nodes) {
       if (!htp_set.count(node)) {
-        ++gpu_only_count;
         Ort::ConstNode const_node(node);
-        ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_VERBOSE,
+        ep->gpu_only_node_names_.insert(const_node.GetName());
+        ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                     (std::string("QNN hot migration: node '") + const_node.GetName() +
                      "' (op=" + const_node.GetOperatorType() +
-                     ") supported by GPU but not HTP - falling back to CPU EP for this session.")
+                     ") supported by GPU but not HTP - will remain on GPU post-migration.")
                         .c_str());
       }
     }
 
-    std::unordered_set<const OrtNode*> gpu_set(gpu_supported_nodes.begin(),
-                                               gpu_supported_nodes.end());
+    std::unordered_set<const OrtNode*> gpu_set(supported_nodes.begin(),
+                                               supported_nodes.end());
     size_t htp_only_count = 0;
     for (const OrtNode* node : htp_supported_nodes) {
       if (!gpu_set.count(node)) {
@@ -2254,14 +2249,14 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
         ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_VERBOSE,
                     (std::string("QNN hot migration: node '") + const_node.GetName() +
                      "' (op=" + const_node.GetOperatorType() +
-                     ") supported by HTP but not GPU - falling back to CPU EP for this session.")
+                     ") supported by HTP but not GPU - not included in partition.")
                         .c_str());
       }
     }
     if (htp_only_count > 0) {
       ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                   ("QNN hot migration: " + std::to_string(htp_only_count) +
-                   " node(s) supported by HTP but not GPU; falling back to CPU EP for this session.")
+                   " node(s) supported by HTP but not GPU; not included in claimed partition.")
                       .c_str());
     }
   } else if (!ep->enable_multi_soc_ep_context_) {
@@ -3054,7 +3049,152 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
       const QnnGraph_Config_t** htp_graph_configs_ptr =
           htp_all_graph_configs.empty() ? nullptr : htp_all_graph_configs.data();
 
-      // Compose all HTP subgraphs serially, then finalize through the thread pool.
+      if (!ep->gpu_only_node_names_.empty()) {
+        // Partial migration: split snapshot into segments, compile each independently.
+        for (auto& [node_name, snapshot_ptr] : ep->htp_snapshots_) {
+          auto segments = qnn::SplitSnapshotIntoSegments(*snapshot_ptr, ep->gpu_only_node_names_);
+
+          auto plan = std::make_unique<PartialMigrationPlan>();
+
+          for (size_t seg_idx = 0; seg_idx < segments.size(); ++seg_idx) {
+            auto& seg = segments[seg_idx];
+            qnn::SnapshotSegmentView& view = *seg.view;
+
+            auto* backend_mgr = seg.is_gpu ? ep->qnn_backend_manager_.get()
+                                           : ep->htp_backend_manager_.get();
+
+            auto shim = std::make_unique<qnn::SnapshotShim>(ep->ort_api, ep->model_editor_api, view);
+            auto model = std::make_unique<qnn::QnnModel>(
+                backend_mgr, ApiPtrs{shim->ShimmedApi(), ep->ep_api, ep->model_editor_api});
+
+            const OrtGraph* seg_graph = shim->GraphHandle();
+            const OrtNode* seg_fused = shim->FusedNodeHandle();
+
+            qnn::QnnModelContext seg_context{
+                *seg_graph, *seg_fused, ep->logger_,
+                &onnx_input_names, &onnx_output_names,
+                &ep->model_settings_,
+                seg.is_gpu ? nullptr : htp_graph_configs_ptr,
+                &tensor_name_overrides,
+                /*json_qnn_graph_path=*/std::string{}};
+
+            qnn::ActiveShimGuard active_shim(shim.get());
+            Ort::Status status = model->ComposeGraph(seg_context);
+
+            if (!status.IsOK()) {
+              ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
+                          ("QNN hot migration: segment " + std::to_string(seg_idx) +
+                           (seg.is_gpu ? " (GPU)" : " (HTP)") +
+                           " ComposeGraph failed: " + status.GetErrorMessage())
+                              .c_str());
+              ep->htp_compile_failed_.store(true, std::memory_order_release);
+              return;
+            }
+
+            status = model->FinalizeGraphs(ep->logger_);
+
+            if (!status.IsOK()) {
+              ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
+                          ("QNN hot migration: segment " + std::to_string(seg_idx) +
+                           (seg.is_gpu ? " (GPU)" : " (HTP)") +
+                           " FinalizeGraphs failed: " + status.GetErrorMessage())
+                              .c_str());
+              ep->htp_compile_failed_.store(true, std::memory_order_release);
+              return;
+            }
+
+            status = model->SetupQnnInputOutput(ep->logger_);
+            if (!status.IsOK()) {
+              ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
+                          ("QNN hot migration: segment " + std::to_string(seg_idx) +
+                           " SetupQnnInputOutput failed: " + status.GetErrorMessage())
+                              .c_str());
+              ep->htp_compile_failed_.store(true, std::memory_order_release);
+              return;
+            }
+
+            SegmentInfo seg_info;
+            seg_info.model = model.get();
+            seg_info.is_gpu = seg.is_gpu;
+            plan->segments.push_back(std::move(seg_info));
+
+            ep->htp_shims_.emplace(view.name, std::move(shim));
+            plan->owned_models.push_back(std::move(model));
+          }
+
+          std::unordered_set<std::string> parent_input_names;
+          std::unordered_set<std::string> parent_output_names_set;
+          for (auto* vi : snapshot_ptr->graph_inputs) parent_input_names.insert(vi->name);
+          for (auto* vi : snapshot_ptr->graph_outputs) parent_output_names_set.insert(vi->name);
+
+          auto slot_it = ep->model_slots_.find(node_name);
+          qnn::QnnModel* full_gpu_model = slot_it->second->active.load(std::memory_order_acquire);
+
+          std::unordered_map<std::string, int> intermediate_name_to_buffer_idx;
+
+          for (auto& seg_info : plan->segments) {
+            const auto& output_infos = seg_info.model->OutputInfos();
+            for (const auto& out_info : output_infos) {
+              const std::string& name = out_info.tensor_wrapper->GetName();
+              if (parent_output_names_set.count(name)) continue;
+              if (intermediate_name_to_buffer_idx.count(name)) continue;
+              int buf_idx = static_cast<int>(plan->buffers.size());
+              intermediate_name_to_buffer_idx[name] = buf_idx;
+              IntermediateBuffer buf;
+              buf.data.resize(out_info.tensor_byte_size);
+              buf.tensor = out_info.tensor_wrapper->GetQnnTensor();
+              qnn::SetQnnTensorMemType(buf.tensor, QNN_TENSORMEMTYPE_RAW);
+              qnn::SetQnnTensorClientBuf(buf.tensor, buf.data.data(),
+                                         static_cast<uint32_t>(buf.data.size()));
+              plan->buffers.push_back(std::move(buf));
+            }
+          }
+
+          for (auto& seg_info : plan->segments) {
+            const auto& input_infos = seg_info.model->InputInfos();
+            seg_info.input_buffer_indices.resize(input_infos.size(), -1);
+            seg_info.external_input_indices.resize(input_infos.size(), SIZE_MAX);
+            for (size_t i = 0; i < input_infos.size(); ++i) {
+              const std::string& name = input_infos[i].tensor_wrapper->GetName();
+              auto inter_it = intermediate_name_to_buffer_idx.find(name);
+              if (inter_it != intermediate_name_to_buffer_idx.end()) {
+                seg_info.input_buffer_indices[i] = inter_it->second;
+              } else if (parent_input_names.count(name)) {
+                seg_info.external_input_indices[i] = full_gpu_model->GetOrtInputIndex(name);
+              }
+            }
+
+            const auto& output_infos = seg_info.model->OutputInfos();
+            seg_info.output_buffer_indices.resize(output_infos.size(), -1);
+            seg_info.external_output_indices.resize(output_infos.size(), SIZE_MAX);
+            for (size_t i = 0; i < output_infos.size(); ++i) {
+              const std::string& name = output_infos[i].tensor_wrapper->GetName();
+              auto inter_it = intermediate_name_to_buffer_idx.find(name);
+              if (inter_it != intermediate_name_to_buffer_idx.end()) {
+                seg_info.output_buffer_indices[i] = inter_it->second;
+              } else if (parent_output_names_set.count(name)) {
+                seg_info.external_output_indices[i] = full_gpu_model->GetOutputIndex(name);
+              }
+            }
+          }
+
+          ep->partial_migration_plans_.emplace(node_name, std::move(plan));
+        }
+
+        for (auto& [name, shim_ptr] : ep->htp_shims_) {
+          shim_ptr->ReleaseSynthesizedData();
+        }
+        for (auto& [name, snapshot_ptr] : ep->htp_snapshots_) {
+          snapshot_ptr->ReleasePayload();
+        }
+
+        ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                    "QNN hot migration: partial migration compilation complete.");
+        ep->htp_compile_complete_.store(true, std::memory_order_release);
+        return;
+      }
+
+      // Full migration path (all nodes supported by both backends).
       struct HtpModelInfo {
         std::string node_name;
         std::unique_ptr<qnn::SnapshotShim> shim;
@@ -3331,7 +3471,12 @@ OrtStatus* ORT_API_CALL QnnEp::OnRunStartImpl(_In_ OrtEp* this_ptr, _In_ const :
   }
 
   auto backend_type = ep->qnn_backend_manager_->GetQnnBackendType();
-  if (qnn::QnnBackendType::HTP != backend_type && qnn::QnnBackendType::DSP != backend_type) {
+  // In partial migration the active manager is GPU, but HTP segments run on htp_backend_manager_
+  // and need their per-thread power config installed there.
+  qnn::QnnBackendManager* htp_mgr =
+      ep->partial_migration_active_ ? ep->htp_backend_manager_.get() : ep->qnn_backend_manager_.get();
+  if (!ep->partial_migration_active_ &&
+      qnn::QnnBackendType::HTP != backend_type && qnn::QnnBackendType::DSP != backend_type) {
     return nullptr;
   }
 
@@ -3341,8 +3486,8 @@ OrtStatus* ORT_API_CALL QnnEp::OnRunStartImpl(_In_ OrtEp* this_ptr, _In_ const :
     qnn::PerThreadHtpPowerConfigs_t per_thread_htp_power_configs;
     if (ep->GetPerThreadHtpPowerConfigs(per_thread_htp_power_configs, run_options)) {
       per_thread_htp_power_configs.power_config_id = htp_power_config_id;
-      RETURN_IF_ERROR(ep->qnn_backend_manager_->AddPerThreadHtpPowerConfigMapping(thread_id,
-                                                                                  per_thread_htp_power_configs));
+      RETURN_IF_ERROR(htp_mgr->AddPerThreadHtpPowerConfigMapping(thread_id,
+                                                                 per_thread_htp_power_configs));
     }
   }
 
@@ -3368,14 +3513,17 @@ OrtStatus* ORT_API_CALL QnnEp::OnRunEndImpl(_In_ OrtEp* this_ptr,
   }
 
   auto backend_type = ep->qnn_backend_manager_->GetQnnBackendType();
-  if (qnn::QnnBackendType::HTP != backend_type && qnn::QnnBackendType::DSP != backend_type) {
+  qnn::QnnBackendManager* htp_mgr =
+      ep->partial_migration_active_ ? ep->htp_backend_manager_.get() : ep->qnn_backend_manager_.get();
+  if (!ep->partial_migration_active_ &&
+      qnn::QnnBackendType::HTP != backend_type && qnn::QnnBackendType::DSP != backend_type) {
     return nullptr;
   }
 
   uint32_t htp_power_config_id;
   if (ep->GetHtpPowerConfigId(htp_power_config_id)) {
     auto thread_id = std::this_thread::get_id();
-    ep->qnn_backend_manager_->RemovePerThreadHtpPowerConfigMapping(thread_id);
+    htp_mgr->RemovePerThreadHtpPowerConfigMapping(thread_id);
   }
 
   return nullptr;
@@ -3605,24 +3753,26 @@ bool QnnEp::GetHtpPowerConfigId(uint32_t& htp_power_config_id) {
   return true;
 }
 
-void QnnEp::CreateHtpPowerConfigId() const {
+void QnnEp::CreateHtpPowerConfigId(qnn::QnnBackendManager* backend_manager) const {
   std::lock_guard<std::mutex> lock(config_id_mutex_);
   if (htp_power_config_id_.has_value()) {
     return;
   }
 
+  qnn::QnnBackendManager* mgr = backend_manager ? backend_manager : qnn_backend_manager_.get();
+
   constexpr uint32_t core_id = 0;
   uint32_t htp_power_config_id;
 
-  Ort::Status rt = qnn_backend_manager_->CreateHtpPowerCfgId(device_id_, core_id, htp_power_config_id);
+  Ort::Status rt = mgr->CreateHtpPowerCfgId(device_id_, core_id, htp_power_config_id);
 
   if (rt.IsOK()) {
     htp_power_config_id_ = htp_power_config_id;
 
-    rt = qnn_backend_manager_->SetHtpPowerConfigs(htp_power_config_id,
-                                                  default_htp_performance_mode_,
-                                                  default_rpc_polling_time_,
-                                                  default_rpc_control_latency_);
+    rt = mgr->SetHtpPowerConfigs(htp_power_config_id,
+                                 default_htp_performance_mode_,
+                                 default_rpc_polling_time_,
+                                 default_rpc_control_latency_);
 
     if (!rt.IsOK()) {
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Unable to set HTP power configurations.");
@@ -3699,12 +3849,15 @@ void QnnEp::TryMigrateIfReady() {
     }
   }
 
-  DrainAndReleaseGpu();
-
-  qnn_backend_manager_ = htp_backend_manager_;
-  htp_backend_manager_.reset();
-
-  CreateHtpPowerConfigId();
+  if (!partial_migration_plans_.empty()) {
+    partial_migration_active_ = true;
+    CreateHtpPowerConfigId(htp_backend_manager_.get());
+  } else {
+    DrainAndReleaseGpu();
+    qnn_backend_manager_ = htp_backend_manager_;
+    htp_backend_manager_.reset();
+    CreateHtpPowerConfigId();
+  }
 
   migration_done_.store(true, std::memory_order_release);
 
@@ -3781,6 +3934,83 @@ OrtStatus* QnnEp::QnnNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
   // Hot migration: polled per-call so the swap lands on a Run() boundary.
   if (!ep.model_slots_.empty()) {
     ep.TryMigrateIfReady();
+
+    if (ep.partial_migration_active_) {
+      // Find the plan for this fused node.
+      std::string fused_node_name;
+      // compute_state is QnnModelSlot* - find matching plan by checking model_slots_ keys.
+      for (auto& [name, slot_ptr] : ep.model_slots_) {
+        if (slot_ptr.get() == reinterpret_cast<QnnModelSlot*>(compute_state)) {
+          fused_node_name = name;
+          break;
+        }
+      }
+      auto plan_it = ep.partial_migration_plans_.find(fused_node_name);
+      if (plan_it != ep.partial_migration_plans_.end()) {
+        auto& plan = *plan_it->second;
+
+        for (auto& seg : plan.segments) {
+          const auto& input_infos = seg.model->InputInfos();
+          const auto& output_infos = seg.model->OutputInfos();
+
+          std::vector<Qnn_Tensor_t> qnn_inputs(input_infos.size());
+          for (size_t i = 0; i < input_infos.size(); ++i) {
+            qnn_inputs[i] = input_infos[i].tensor_wrapper->GetQnnTensor();
+            qnn::SetQnnTensorMemType(qnn_inputs[i], QNN_TENSORMEMTYPE_RAW);
+
+            if (seg.input_buffer_indices[i] >= 0) {
+              auto& buf = plan.buffers[seg.input_buffer_indices[i]];
+              qnn::SetQnnTensorClientBuf(qnn_inputs[i], buf.data.data(),
+                                         static_cast<uint32_t>(buf.data.size()));
+            } else if (seg.external_input_indices[i] != SIZE_MAX) {
+              const OrtValue* ort_input = nullptr;
+              if (auto* s = ep.ort_api.KernelContext_GetInput(
+                      kernel_context, seg.external_input_indices[i], &ort_input))
+                return s;
+              const void* raw_data;
+              if (auto* s = ep.ort_api.GetTensorData(ort_input, &raw_data))
+                return s;
+              qnn::SetQnnTensorClientBuf(qnn_inputs[i],
+                                         const_cast<void*>(raw_data),
+                                         input_infos[i].tensor_byte_size);
+            }
+          }
+
+          std::vector<Qnn_Tensor_t> qnn_outputs(output_infos.size());
+          for (size_t i = 0; i < output_infos.size(); ++i) {
+            qnn_outputs[i] = output_infos[i].tensor_wrapper->GetQnnTensor();
+            qnn::SetQnnTensorMemType(qnn_outputs[i], QNN_TENSORMEMTYPE_RAW);
+
+            if (seg.output_buffer_indices[i] >= 0) {
+              auto& buf = plan.buffers[seg.output_buffer_indices[i]];
+              qnn::SetQnnTensorClientBuf(qnn_outputs[i], buf.data.data(),
+                                         static_cast<uint32_t>(buf.data.size()));
+            } else if (seg.external_output_indices[i] != SIZE_MAX) {
+              const auto* out_info = seg.model->GetOutputInfo(
+                  output_infos[i].tensor_wrapper->GetName());
+              OrtValue* ort_output = nullptr;
+              if (auto* s = ep.ort_api.KernelContext_GetOutput(
+                      kernel_context, seg.external_output_indices[i],
+                      out_info->shape_.data(), out_info->shape_.size(), &ort_output))
+                return s;
+              void* mutable_data;
+              if (auto* s = ep.ort_api.GetTensorMutableData(ort_output, &mutable_data))
+                return s;
+              qnn::SetQnnTensorClientBuf(qnn_outputs[i], mutable_data,
+                                         output_infos[i].tensor_byte_size);
+            }
+          }
+
+          RETURN_IF_NOT_OK(seg.model->ExecuteGraphDirect(
+              qnn_inputs.data(), static_cast<uint32_t>(qnn_inputs.size()),
+              qnn_outputs.data(), static_cast<uint32_t>(qnn_outputs.size()),
+              ep.logger_));
+        }
+
+        return nullptr;
+      }
+    }
+
     auto* slot = reinterpret_cast<QnnModelSlot*>(compute_state);
     qnn::QnnModel* model = slot->active.load(std::memory_order_acquire);
     RETURN_IF_NOT_OK(model->ExecuteGraph(kernel_context, ep.logger_));

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -35,6 +35,7 @@
 #include "core/providers/qnn/builder/qnn_ep_sanitize_utils.h"
 #include "core/providers/qnn/genie/genie_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_configs_helper.h"
+#include "core/providers/qnn/builder/qnn_model_classifier.h"
 #include "core/providers/qnn/builder/qnn_model.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/qnn_thread_pool.h"
@@ -671,6 +672,7 @@ QnnEp::QnnEp(QnnEpFactory& factory,
   }
 
   std::string backend_path = kDefaultHtpBackendPath;
+  bool explicit_backend_set = false;
   {
     std::optional<std::string> backend_path_from_options{};
 
@@ -690,7 +692,10 @@ QnnEp::QnnEp(QnnEpFactory& factory,
       throw std::runtime_error("Only one of 'backend_type' and 'backend_path' should be set.");
     }
     if (!backend_type.empty()) {
-      if (std::string parsed_backend_path; ParseBackendTypeName(backend_type, parsed_backend_path, logger_)) {
+      if (backend_type == "auto") {
+        ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE,
+                    "Backend type set to 'auto': deferring backend selection to model classifier.");
+      } else if (std::string parsed_backend_path; ParseBackendTypeName(backend_type, parsed_backend_path, logger_)) {
         backend_path_from_options = parsed_backend_path;
       } else {
         ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_ERROR, "Failed to parse 'backend_type' value.");
@@ -702,7 +707,8 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     // Use the determined backend path or default
     if (backend_path_from_options.has_value()) {
       backend_path = std::move(*backend_path_from_options);
-    } else {
+      explicit_backend_set = true;
+    } else if (backend_type != "auto") {
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, ("Using default backend path: " + backend_path).c_str());
     }
 
@@ -1276,6 +1282,22 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     if (stop_share_ep_contexts_) {
       SharedContext::GetInstance().ResetSharedQnnBackendManager();
     }
+  } else if (!explicit_backend_set)  {
+    // Defer backend selection. qnn_backend_manager_ will remain null, then get
+    // created after model classification in GetCapabilityImpl().
+    auto_select_backend_ = true;
+    // Create config with placeholder backend path, which gets overwritten at classification time
+    deferred_backend_config_ = qnn::QnnBackendManagerConfig{kDefaultHtpBackendPath,
+                                                            profiling_level_etw,
+                                                            profiling_level,
+                                                            profiling_file_path,
+                                                            context_priority,
+                                                            std::move(qnn_serializer_config),
+                                                            device_id_,
+                                                            htp_arch,
+                                                            soc_model,
+                                                            op_packages,
+                                                            skip_qnn_version_check};
   } else {
     qnn_backend_manager_ = qnn::QnnBackendManager::Create(
         qnn::QnnBackendManagerConfig{backend_path,
@@ -1297,8 +1319,10 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     }
   }
 
-  // Initialize compatibility manager with backend manager.
-  qnn_cache_compatibility_manager_ = std::make_shared<qnn::QnnCacheCompatibilityManager>(qnn_backend_manager_.get());
+  if (!auto_select_backend_) {
+    // Initialize compatibility manager with backend manager.
+    qnn_cache_compatibility_manager_ = std::make_shared<qnn::QnnCacheCompatibilityManager>(qnn_backend_manager_.get());
+  }
 
   // Choose EP allocator. Must be done after creating the backend manager.
   static const std::string QNN_HTP_SHARED_MEMORY_ALLOCATOR_ENABLED = "enable_htp_shared_memory_allocator";
@@ -1335,8 +1359,10 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                    "QNN allocator already set to type: %s. Option '%s' will be ignored.",
                    qnn::QnnAllocatorTypeToString(qnn_allocator_type_).data(),
                    QNN_DX12_SHARED_MEMORY_ALLOCATOR_ENABLED.c_str());
-    } else {
+    } else if (qnn_backend_manager_) {
       if (qnn_backend_manager_->IsDx12SharedMemoryAllocatorSupported()) {
+      // qnn_backend_manager_ is null here when backend_type=auto (deferred to GetCapabilityImpl).
+      // Store the type and apply it after the backend is created.
         qnn_allocator_type_ = qnn::QnnAllocatorType::DX12_SHARED;
       } else {
         ORT_CXX_LOGF(logger_,
@@ -1346,7 +1372,9 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     }
   }
 
-  qnn_backend_manager_->SetQnnAllocatorType(qnn_allocator_type_);
+  if (qnn_backend_manager_) {
+    qnn_backend_manager_->SetQnnAllocatorType(qnn_allocator_type_);
+  }
   if (qnn_allocator_type_ != qnn::QnnAllocatorType::NONE) {
     ORT_CXX_LOGF(logger_,
                  ORT_LOGGING_LEVEL_VERBOSE,
@@ -1396,7 +1424,7 @@ QnnEp::QnnEp(QnnEpFactory& factory,
 
           if (IsEnabled == EVENT_CONTROL_CODE_DISABLE_PROVIDER) {
             // (void)qnn_backend_manager_->SetProfilingLevelETW(qnn::ProfilingLevel::INVALID);
-            (void)qnn_backend_manager_->ResetQnnLogLevel(std::nullopt);
+            if (qnn_backend_manager_) (void)qnn_backend_manager_->ResetQnnLogLevel(std::nullopt);
           }
         });
     etwRegistrationManager.RegisterInternalCallback(callback_ETWSink_provider_);
@@ -1962,6 +1990,40 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
 
   Ort::Status rt;
   if (!ep->enable_multi_soc_ep_context_) {
+    if (ep->auto_select_backend_ &&
+        !is_qnn_ctx_model &&
+        ep->deferred_backend_config_.has_value()) {
+      // Auto-detect backend via model classifier.
+      // Skipped for pre-compiled context models (backend is already baked into those).
+      auto model_class = qnn::ClassifyModel(graph, ep->ort_api, ep->logger_);
+      const bool route_to_gpu = (model_class == qnn::ModelClass::GenAI);
+      const std::string& selected_path = route_to_gpu ? kDefaultGpuBackendPath
+                                                      : kDefaultHtpBackendPath;
+      const char* class_label = route_to_gpu ? "GenAI -> GPU"
+                                             : (model_class == qnn::ModelClass::NonGenAI) ? "NonGenAI -> HTP"
+                                                                                          : "Unknown -> HTP (default)";
+      ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                  ("QNN auto-backend selection: " + std::string(class_label)).c_str());
+
+      ep->deferred_backend_config_->backend_path = selected_path;
+      ep->qnn_backend_manager_ = qnn::QnnBackendManager::Create(
+          *ep->deferred_backend_config_,
+          ApiPtrs{ep->ort_api, ep->ep_api, ep->model_editor_api},
+          ep->logger_);
+
+      ep->qnn_cache_compatibility_manager_ = std::make_shared<qnn::QnnCacheCompatibilityManager>(ep->qnn_backend_manager_.get());
+      ep->qnn_backend_manager_->SetQnnAllocatorType(ep->qnn_allocator_type_);
+
+      if (ep->htp_share_resource_optimization_ == 1) {
+        if (!SharedContext::GetInstance().SetSharedQnnBackendManager(ep->qnn_backend_manager_)) {
+          return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Failed to set shared QnnBackendManager.");
+        }
+      }
+
+      ep->auto_select_backend_ = false;
+      ep->deferred_backend_config_.reset();
+    }
+
     rt = ep->qnn_backend_manager_->SetupBackend(is_qnn_ctx_model,
                                                 ep->context_cache_enabled_,
                                                 ep->share_ep_contexts_,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -35,6 +35,8 @@
 #include "core/providers/qnn/builder/qnn_ep_sanitize_utils.h"
 #include "core/providers/qnn/genie/genie_backend_manager.h"
 #include "core/providers/qnn/builder/qnn_configs_helper.h"
+#include "core/providers/qnn/builder/qnn_graph_snapshot.h"
+#include "core/providers/qnn/builder/qnn_graph_snapshot_accessors.h"
 #include "core/providers/qnn/builder/qnn_model_classifier.h"
 #include "core/providers/qnn/builder/qnn_model.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
@@ -1441,7 +1443,7 @@ QnnEp::QnnEp(QnnEpFactory& factory,
           if (IsEnabled == EVENT_CONTROL_CODE_ENABLE_PROVIDER) {
             if ((MatchAnyKeyword & static_cast<ULONGLONG>(qnn::ORTTraceLoggingKeyword::Logs)) != 0) {
               auto ortETWSeverity = etwRegistrationManager.MapLevelToOrtLoggingLevel();
-              (void)qnn_backend_manager_->ResetQnnLogLevel(ortETWSeverity);
+              if (qnn_backend_manager_) (void)qnn_backend_manager_->ResetQnnLogLevel(ortETWSeverity);
             }
             if ((MatchAnyKeyword & static_cast<ULONGLONG>(qnn::ORTTraceLoggingKeyword::Profiling)) != 0) {
               if (Level != 0) {
@@ -1487,8 +1489,10 @@ QnnEp::~QnnEp() {
     }
   }
 
-  // Explicitly clear the QNN models map to ensure proper cleanup
+  // Drop HTP models before shims/snapshots (models hold OrtApi references into shims).
   htp_models_.clear();
+  htp_shims_.clear();
+  htp_snapshots_.clear();
   if (!qnn_models_.empty()) {
     qnn_models_.clear();
   }
@@ -2194,18 +2198,28 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
   // claimed partition is guaranteed to compile on GPU (migration window) and HTP (post-migration).
   std::vector<const OrtNode*> supported_nodes;
   if (ep->hot_migration_enabled_ && ep->htp_backend_manager_) {
+    // Validate on both backends concurrently; only nodes supported by both are claimed.
     std::vector<const OrtNode*> gpu_supported_nodes;
-    RETURN_IF_NOT_NULL(ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(),
-                                             gpu_supported_nodes,
-                                             ep->trace_.unsupported_nodes,
-                                             ep->qnn_backend_manager_.get()));
-
     std::vector<const OrtNode*> htp_supported_nodes;
-    RETURN_IF_NOT_NULL(ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(),
-                                             htp_supported_nodes,
-                                             ep->trace_.unsupported_nodes,
-                                             ep->htp_backend_manager_.get()));
+    std::vector<qnn::UnsupportedNodeInfo> htp_unsupported_nodes;
+    OrtStatus* htp_status = nullptr;
+    auto gpu_pass = [&] {
+      return ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(),
+                                   gpu_supported_nodes, ep->trace_.unsupported_nodes,
+                                   ep->qnn_backend_manager_.get());
+    };
+    auto htp_pass = [&] {
+      htp_status = ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(),
+                                         htp_supported_nodes, htp_unsupported_nodes,
+                                         ep->htp_backend_manager_.get());
+    };
 
+    std::thread htp_thread(htp_pass);
+    OrtStatus* gpu_status = gpu_pass();
+    htp_thread.join();
+
+    RETURN_IF_NOT_NULL(gpu_status);
+    RETURN_IF_NOT_NULL(htp_status);
     // Intersection: only claim nodes both backends can compile. Nodes supported by HTP but not
     // GPU fall back to CPU EP for the entire session (partitioning is fixed at session creation).
     std::unordered_set<const OrtNode*> htp_set(htp_supported_nodes.begin(),
@@ -2214,6 +2228,19 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     for (const OrtNode* node : gpu_supported_nodes) {
       if (htp_set.count(node)) {
         supported_nodes.push_back(node);
+      }
+    }
+
+    size_t gpu_only_count = 0;
+    for (const OrtNode* node : gpu_supported_nodes) {
+      if (!htp_set.count(node)) {
+        ++gpu_only_count;
+        Ort::ConstNode const_node(node);
+        ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_VERBOSE,
+                    (std::string("QNN hot migration: node '") + const_node.GetName() +
+                     "' (op=" + const_node.GetOperatorType() +
+                     ") supported by GPU but not HTP - falling back to CPU EP for this session.")
+                        .c_str());
       }
     }
 
@@ -2442,8 +2469,6 @@ OrtStatus* QnnEp::CompileOnnxModel(const OrtGraph** graphs,
       total_finalize_time += std::chrono::duration_cast<std::chrono::milliseconds>(end - finalize_start);
 #endif
 
-      // SetupQnnInputOutput populates qnn_input_infos_/qnn_output_infos_ which are only consumed
-      // in ExecuteGraph during inference. In prepare_only mode inference never runs, so skip.
       if (!prepare_only_) {
         RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(logger_));
       }
@@ -2925,9 +2950,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
     return ep->CompileDlcContextModel(this_ptr, graphs, fused_nodes, count, node_compute_infos);
   }
 
-  // Hot migration compile path: compose both GPU and HTP graphs while OrtGraph* pointers
-  // are still valid, finalize GPU synchronously, defer HTP finalization to a background
-  // thread. compute_state is wired to model_slots_ for atomic backend switching at runtime.
+  // Hot migration: compose GPU + snapshot graphs synchronously, defer HTP finalization to background.
   if (ep->hot_migration_enabled_ && ep->htp_backend_manager_) {
     ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                 "QNN hot migration: composing GPU and HTP graphs in CompileImpl.");
@@ -2939,21 +2962,9 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
     const auto& onnx_input_names = ep->onnx_graph_io_names_->first;
     const auto& onnx_output_names = ep->onnx_graph_io_names_->second;
 
-    qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t> htp_graph_configs_builder(
-        QNN_GRAPH_CONFIG_INIT, QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT);
-    if (ep->htp_backend_manager_->GetQnnBackendType() == qnn::QnnBackendType::HTP) {
-      ep->InitQnnHtpGraphConfigs(ep->htp_graph_configs_, htp_graph_configs_builder);
-    }
-    std::vector<const QnnGraph_Config_t*> htp_all_graph_configs;
-    if (const QnnGraph_Config_t** htp_configs = htp_graph_configs_builder.GetQnnConfigs()) {
-      htp_all_graph_configs.reserve(htp_graph_configs_builder.GetSize() + 1);
-      for (const QnnGraph_Config_t** cfg = htp_configs; *cfg; ++cfg) {
-        htp_all_graph_configs.push_back(*cfg);
-      }
-      htp_all_graph_configs.push_back(nullptr);
-    }
-    const QnnGraph_Config_t** htp_graph_configs_ptr =
-        htp_all_graph_configs.empty() ? nullptr : htp_all_graph_configs.data();
+    // Compose all GPU subgraphs (and snapshot the live graphs) serially, then finalize together.
+    std::vector<GraphFinalizationInfo_t> gpu_model_infos;
+    gpu_model_infos.reserve(count);
 
     for (size_t graph_idx = 0; graph_idx < count; ++graph_idx) {
       const OrtGraph* graph = graphs[graph_idx];
@@ -2972,64 +2983,185 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
           /*json_qnn_graph_path=*/std::string{}};
 
       RETURN_IF_NOT_OK(gpu_model->ComposeGraph(gpu_context));
-      RETURN_IF_NOT_OK(gpu_model->FinalizeGraphs(ep->logger_));
-      RETURN_IF_NOT_OK(gpu_model->SetupQnnInputOutput(ep->logger_));
 
-      // HTP: compose only. Finalize + SetupQnnInputOutput run on htp_prepare_thread_.
-      auto htp_model = std::make_unique<qnn::QnnModel>(
-          ep->htp_backend_manager_.get(), ApiPtrs{ep->ort_api, ep->ep_api, ep->model_editor_api});
+      std::unique_ptr<qnn::SnapshotGraph> snapshot =
+          qnn::SnapshotGraphFromOrt(ep->ort_api, graph, fused_node, ep->logger_);
+      if (snapshot == nullptr) {
+        return ep->ort_api.CreateStatus(ORT_EP_FAIL, "QNN hot migration: SnapshotGraphFromOrt failed.");
+      }
+      ep->htp_snapshots_.emplace(fused_node_name, std::move(snapshot));
 
-      qnn::QnnModelContext htp_context{
-          *graph, *fused_node, ep->logger_,
-          &onnx_input_names, &onnx_output_names,
-          &ep->model_settings_,
-          htp_graph_configs_ptr,
-          &ep->tensor_name_overrides_,
-          /*json_qnn_graph_path=*/std::string{}};
-
-      RETURN_IF_NOT_OK(htp_model->ComposeGraph(htp_context));
-
-      auto slot = std::make_unique<QnnModelSlot>();
-      slot->active.store(gpu_model.get(), std::memory_order_relaxed);
-      ep->model_slots_.emplace(fused_node_name, std::move(slot));
-
-      ep->qnn_models_.emplace(fused_node_name, std::move(gpu_model));
-      ep->htp_models_.emplace(fused_node_name, std::move(htp_model));
-
-      auto node_compute_info = std::make_unique<QnnNodeComputeInfo>(*ep);
-      node_compute_infos[graph_idx] = node_compute_info.release();
+      auto& model_info = gpu_model_infos.emplace_back();
+      model_info.model_name = fused_node_name;
+      model_info.model = std::move(gpu_model);
+      model_info.graph_idx = graph_idx;
     }
 
-    // OrtGraph* pointers become invalid once CompileImpl returns.
-    ep->onnx_graph_io_names_.reset();
-    ep->tensor_name_overrides_.clear();
+    // GPU finalize phase.
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+    {
+      qnn::thread::QnnJobThreadPool tp(ep->num_graph_prepare_threads_);
+      tp.Start();
+      for (auto& model_info : gpu_model_infos) {
+        tp.SubmitJob([qnn_model = model_info.model.get(), &logger = ep->logger_, res = &model_info.result] {
+          *res = qnn_model->FinalizeGraphs(logger);
+        });
+      }
+      tp.WaitForQueuedJobsToFinish();
+      for (auto& model_info : gpu_model_infos) {
+        RETURN_IF_NOT_OK(std::move(model_info.result));
+      }
+    }
+#else
+    for (auto& model_info : gpu_model_infos) {
+      RETURN_IF_NOT_OK(model_info.model->FinalizeGraphs(ep->logger_));
+    }
+#endif
 
-    // Thread captures ep; joined in ~QnnEp so it never outlives ep's members.
-    ep->htp_prepare_thread_ = std::thread([ep]() {
-      for (auto& [node_name, htp_model] : ep->htp_models_) {
-        Ort::Status status = htp_model->FinalizeGraphs(ep->logger_);
+    // Per-model setup + slot registration (serial).
+    for (auto& model_info : gpu_model_infos) {
+      RETURN_IF_NOT_OK(model_info.model->SetupQnnInputOutput(ep->logger_));
+
+      auto slot = std::make_unique<QnnModelSlot>();
+      slot->active.store(model_info.model.get(), std::memory_order_relaxed);
+      ep->model_slots_.emplace(model_info.model_name, std::move(slot));
+
+      ep->qnn_models_.emplace(model_info.model_name, std::move(model_info.model));
+
+      auto node_compute_info = std::make_unique<QnnNodeComputeInfo>(*ep);
+      node_compute_infos[model_info.graph_idx] = node_compute_info.release();
+    }
+
+    // OrtGraph* pointers become invalid after CompileImpl returns. The background thread reads
+    // only from EP-owned snapshots; name maps and I/O lists are moved into the lambda here.
+    ep->htp_prepare_thread_ = std::thread([ep,
+                                           onnx_input_names = std::move(ep->onnx_graph_io_names_->first),
+                                           onnx_output_names = std::move(ep->onnx_graph_io_names_->second),
+                                           tensor_name_overrides = std::move(ep->tensor_name_overrides_)]() mutable {
+      qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t> htp_graph_configs_builder(
+          QNN_GRAPH_CONFIG_INIT, QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT);
+      if (ep->htp_backend_manager_->GetQnnBackendType() == qnn::QnnBackendType::HTP) {
+        ep->InitQnnHtpGraphConfigs(ep->htp_graph_configs_, htp_graph_configs_builder);
+      }
+      std::vector<const QnnGraph_Config_t*> htp_all_graph_configs;
+      if (const QnnGraph_Config_t** htp_configs = htp_graph_configs_builder.GetQnnConfigs()) {
+        htp_all_graph_configs.reserve(htp_graph_configs_builder.GetSize() + 1);
+        for (const QnnGraph_Config_t** cfg = htp_configs; *cfg; ++cfg) {
+          htp_all_graph_configs.push_back(*cfg);
+        }
+        htp_all_graph_configs.push_back(nullptr);
+      }
+      const QnnGraph_Config_t** htp_graph_configs_ptr =
+          htp_all_graph_configs.empty() ? nullptr : htp_all_graph_configs.data();
+
+      // Compose all HTP subgraphs serially, then finalize through the thread pool.
+      struct HtpModelInfo {
+        std::string node_name;
+        std::unique_ptr<qnn::SnapshotShim> shim;
+        std::unique_ptr<qnn::QnnModel> model;
+        Ort::Status result;
+      };
+      std::vector<HtpModelInfo> htp_model_infos;
+      htp_model_infos.reserve(ep->htp_snapshots_.size());
+
+      for (auto& [node_name, snapshot_ptr] : ep->htp_snapshots_) {
+        auto shim = std::make_unique<qnn::SnapshotShim>(ep->ort_api, ep->model_editor_api, *snapshot_ptr);
+        auto htp_model = std::make_unique<qnn::QnnModel>(
+            ep->htp_backend_manager_.get(),
+            ApiPtrs{shim->ShimmedApi(), ep->ep_api, ep->model_editor_api});
+
+        const OrtGraph* snap_graph = shim->GraphHandle();
+        const OrtNode* snap_fused_node = shim->FusedNodeHandle();
+
+        qnn::QnnModelContext htp_context{
+            *snap_graph, *snap_fused_node, ep->logger_,
+            &onnx_input_names, &onnx_output_names,
+            &ep->model_settings_,
+            htp_graph_configs_ptr,
+            &tensor_name_overrides,
+            /*json_qnn_graph_path=*/std::string{}};
+
+        qnn::ActiveShimGuard active_shim(shim.get());
+        Ort::Status status = htp_model->ComposeGraph(htp_context);
         if (!status.IsOK()) {
           ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
-                      ("QNN hot migration: HTP FinalizeGraphs failed for " + node_name +
+                      ("QNN hot migration: HTP ComposeGraph failed for " + node_name +
                        ": " + status.GetErrorMessage() + " Migration will not proceed.")
                           .c_str());
           ep->htp_compile_failed_.store(true, std::memory_order_release);
           return;
         }
-        status = htp_model->SetupQnnInputOutput(ep->logger_);
-        if (!status.IsOK()) {
+
+        auto& info = htp_model_infos.emplace_back();
+        info.node_name = node_name;
+        info.shim = std::move(shim);
+        info.model = std::move(htp_model);
+      }
+
+      // HTP finalize phase.
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+      {
+        qnn::thread::QnnJobThreadPool tp(ep->num_graph_prepare_threads_);
+        tp.Start();
+        for (auto& info : htp_model_infos) {
+          tp.SubmitJob([qnn_model = info.model.get(), &logger = ep->logger_, res = &info.result] {
+            *res = qnn_model->FinalizeGraphs(logger);
+          });
+        }
+        tp.WaitForQueuedJobsToFinish();
+      }
+#else
+      for (auto& info : htp_model_infos) {
+        info.result = info.model->FinalizeGraphs(ep->logger_);
+      }
+#endif
+
+      for (auto& info : htp_model_infos) {
+        if (!info.result.IsOK()) {
           ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
-                      ("QNN hot migration: HTP SetupQnnInputOutput failed for " + node_name +
-                       ": " + status.GetErrorMessage() + " Migration will not proceed.")
+                      ("QNN hot migration: HTP FinalizeGraphs failed for " + info.node_name +
+                       ": " + info.result.GetErrorMessage() + " Migration will not proceed.")
                           .c_str());
           ep->htp_compile_failed_.store(true, std::memory_order_release);
           return;
         }
       }
+
+      // Per-model setup + registration (serial). Emplace shim before model for destruction order.
+      for (auto& info : htp_model_infos) {
+        Ort::Status status = info.model->SetupQnnInputOutput(ep->logger_);
+        if (!status.IsOK()) {
+          ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
+                      ("QNN hot migration: HTP SetupQnnInputOutput failed for " + info.node_name +
+                       ": " + status.GetErrorMessage() + " Migration will not proceed.")
+                          .c_str());
+          ep->htp_compile_failed_.store(true, std::memory_order_release);
+          return;
+        }
+
+        ep->htp_shims_.emplace(info.node_name, std::move(info.shim));
+        ep->htp_models_.emplace(info.node_name, std::move(info.model));
+      }
+
+      // Release heavy snapshot payload (initializer bytes, attributes). The shim remains alive
+      // (QnnModel references shimmed_api_) but the data is no longer read after compile.
+      for (auto& [node_name, shim_ptr] : ep->htp_shims_) {
+        shim_ptr->ReleaseSynthesizedData();
+      }
+      for (auto& [node_name, snapshot_ptr] : ep->htp_snapshots_) {
+        snapshot_ptr->ReleasePayload();
+      }
+
       ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                   "QNN hot migration: HTP compilation complete. Migration will occur on next Run().");
       ep->htp_compile_complete_.store(true, std::memory_order_release);
     });
+
+    // Lambda captures already moved from these members above; reset/clear now to preserve
+    // the "consumed in Compile" invariant (has_value()==false, empty map) that the rest of
+    // the EP relies on. Safe: lambda captures were constructed before std::thread returned.
+    ep->onnx_graph_io_names_.reset();
+    ep->tensor_name_overrides_.clear();
 
     return nullptr;
   }
@@ -3545,6 +3677,8 @@ void QnnEp::TryMigrateIfReady() {
     ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
                 "QNN hot migration: HTP compilation failed. Session will remain on GPU for its lifetime.");
     htp_models_.clear();
+    htp_shims_.clear();
+    htp_snapshots_.clear();
     htp_backend_manager_.reset();
     migration_done_.store(true, std::memory_order_release);
     return;
@@ -3654,6 +3788,7 @@ OrtStatus* QnnEp::QnnNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
   }
 
   qnn::QnnModel* model = reinterpret_cast<qnn::QnnModel*>(compute_state);
+
   RETURN_IF_NOT_OK(model->ExecuteGraph(kernel_context, ep.logger_));
 
   return nullptr;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1269,6 +1269,24 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                     false,
                                                     logger_);
 
+  // Hot migration: when enabled, QNN EP starts inference on GPU immediately and
+  // prepares the HTP graph in parallel. Once HTP compilation finishes, the
+  // session atomically migrates to HTP for the remainder of inference.
+  // Requires the GPU backend to be explicitly set.
+  static const std::string HOT_MIGRATION = "hot_migration";
+  hot_migration_enabled_ = ParseBoolOption(ort_api,
+                                           session_options_,
+                                           FormatEPConfigKey(HOT_MIGRATION),
+                                           false,
+                                           logger_);
+  if (hot_migration_enabled_) {
+    if (!explicit_backend_set || backend_path != kDefaultGpuBackendPath) {
+      throw std::runtime_error("hot_migration=1 requires the GPU backend to be explicitly set.");
+    }
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+                "QNN hot migration enabled: GPU-first inference with parallel HTP preparation.");
+  }
+
   // For context binary generation with weight sharing enabled, use the QnnBackendManager from the shared context if it exits
   // So that all graphs from later sessions will be compiled into the same QNN context
   if (
@@ -1316,6 +1334,25 @@ QnnEp::QnnEp(QnnEpFactory& factory,
         ApiPtrs{ort_api, ep_api, model_editor_api}, logger_);
     if (htp_share_resource_optimization_ == 1) {
       SharedContext::GetInstance().SetSharedQnnBackendManager(qnn_backend_manager_);
+    }
+    if (hot_migration_enabled_) {
+      // Save HTP config for use in GetCapabilityImpl. The active backend is GPU
+      // (validated above); this parallel HTP config reuses the same session settings.
+      // Serializer is intentionally null: it is a debug/dump aid tied to the primary
+      // compile path and is not needed for the shadow HTP compile.
+      htp_backend_config_ = qnn::QnnBackendManagerConfig{kDefaultHtpBackendPath,
+                                                         profiling_level_etw,
+                                                         profiling_level,
+                                                         profiling_file_path,
+                                                         context_priority,
+                                                         /*qnn_serializer_config=*/nullptr,
+                                                         device_id_,
+                                                         htp_arch,
+                                                         soc_model,
+                                                         op_packages,
+                                                         skip_qnn_version_check,
+                                                         enable_framework_op_trace_,
+                                                         skip_backend_op_validation};
     }
   }
 
@@ -1433,6 +1470,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
 }
 
 QnnEp::~QnnEp() {
+  // Join the HTP background compilation thread if the session is destroyed before migration
+  // completes (e.g., early session teardown). Ensures no background thread outlives the EP
+  // object and its model / backend manager members.
+  if (htp_prepare_thread_.joinable()) {
+    htp_prepare_thread_.join();
+  }
+
   if (qnn_backend_manager_) {
     auto thread_id = std::this_thread::get_id();
     qnn_backend_manager_->RemovePerThreadHtpPowerConfigMapping(thread_id);
@@ -1444,6 +1488,7 @@ QnnEp::~QnnEp() {
   }
 
   // Explicitly clear the QNN models map to ensure proper cleanup
+  htp_models_.clear();
   if (!qnn_models_.empty()) {
     qnn_models_.clear();
   }
@@ -1501,6 +1546,16 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
                                     const size_t node_unit_size,
                                     std::vector<const OrtNode*>& supported_nodes,
                                     std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes) const {
+  return GetSupportedNodes(graph, node_unit_map, node_unit_size, supported_nodes,
+                           unsupported_nodes, qnn_backend_manager_.get());
+}
+
+OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
+                                    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
+                                    const size_t node_unit_size,
+                                    std::vector<const OrtNode*>& supported_nodes,
+                                    std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes,
+                                    qnn::QnnBackendManager* backend_manager) const {
   size_t num_graph_inputs = 0;
   size_t num_graph_outputs = 0;
   RETURN_IF_NOT_NULL(ort_api.Graph_GetNumInputs(graph, &num_graph_inputs));
@@ -1540,13 +1595,13 @@ OrtStatus* QnnEp::GetSupportedNodes(const OrtGraph* graph,
   auto qnn_model_wrapper = qnn::QnnModelWrapper(*graph,
                                                 ApiPtrs{ort_api, ep_api, model_editor_api},
                                                 logger_,
-                                                qnn_backend_manager_->GetQnnInterface(),
-                                                qnn_backend_manager_->GetQnnBackendHandle(),
-                                                qnn_backend_manager_->GetQnnValidatorInterface(),
-                                                qnn_backend_manager_->GetQnnValidatorBackendHandle(),
+                                                backend_manager->GetQnnInterface(),
+                                                backend_manager->GetQnnBackendHandle(),
+                                                backend_manager->GetQnnValidatorInterface(),
+                                                backend_manager->GetQnnValidatorBackendHandle(),
                                                 model_inputs,
                                                 model_outputs,
-                                                qnn_backend_manager_->GetQnnBackendType(),
+                                                backend_manager->GetQnnBackendType(),
                                                 model_settings_,
                                                 &tensor_name_overrides_);
 
@@ -1643,47 +1698,48 @@ OrtStatus* QnnEp::GetMultiSocSupportedNodes(const OrtGraph* graph,
 void QnnEp::InitQnnHtpGraphConfigs(
     const qnn::HtpGraphConfigs_t& configs,
     qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t>& configs_builder) const {
-  if (qnn_backend_manager_->GetQnnBackendType() == qnn::QnnBackendType::HTP) {
-    if (configs.htp_graph_finalization_opt_mode != qnn::HtpGraphFinalizationOptimizationMode::kDefault) {
-      gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_opt_config = configs_builder.PushCustomConfig();
-      htp_graph_opt_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
-      htp_graph_opt_config->optimizationOption.type = QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
-      htp_graph_opt_config->optimizationOption.floatValue = static_cast<float>(configs.htp_graph_finalization_opt_mode);
+  // NOTE: Callers must ensure the relevant backend manager is HTP before calling. The
+  // guard is intentionally at the call site (not inside this function) so hot migration
+  // can populate HTP graph configs while qnn_backend_manager_ still points to GPU.
+  if (configs.htp_graph_finalization_opt_mode != qnn::HtpGraphFinalizationOptimizationMode::kDefault) {
+    gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_opt_config = configs_builder.PushCustomConfig();
+    htp_graph_opt_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    htp_graph_opt_config->optimizationOption.type = QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
+    htp_graph_opt_config->optimizationOption.floatValue = static_cast<float>(configs.htp_graph_finalization_opt_mode);
 
-      gsl::not_null<QnnGraph_Config_t*> graph_opt_config = configs_builder.PushConfig();
-      graph_opt_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-      graph_opt_config->customConfig = htp_graph_opt_config;
-    }
+    gsl::not_null<QnnGraph_Config_t*> graph_opt_config = configs_builder.PushConfig();
+    graph_opt_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_opt_config->customConfig = htp_graph_opt_config;
+  }
 
-    if (configs.vtcm_size_in_mb > 0) {
-      gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_opt_config_vtcm = configs_builder.PushCustomConfig();
-      htp_graph_opt_config_vtcm->option = QNN_HTP_GRAPH_CONFIG_OPTION_VTCM_SIZE;
-      htp_graph_opt_config_vtcm->vtcmSizeInMB = static_cast<uint32_t>(configs.vtcm_size_in_mb);
+  if (configs.vtcm_size_in_mb > 0) {
+    gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_opt_config_vtcm = configs_builder.PushCustomConfig();
+    htp_graph_opt_config_vtcm->option = QNN_HTP_GRAPH_CONFIG_OPTION_VTCM_SIZE;
+    htp_graph_opt_config_vtcm->vtcmSizeInMB = static_cast<uint32_t>(configs.vtcm_size_in_mb);
 
-      gsl::not_null<QnnGraph_Config_t*> graph_opt_config_vtcm = configs_builder.PushConfig();
-      graph_opt_config_vtcm->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-      graph_opt_config_vtcm->customConfig = htp_graph_opt_config_vtcm;
-    }
+    gsl::not_null<QnnGraph_Config_t*> graph_opt_config_vtcm = configs_builder.PushConfig();
+    graph_opt_config_vtcm->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_opt_config_vtcm->customConfig = htp_graph_opt_config_vtcm;
+  }
 
-    if (configs.enable_htp_fp16_precision) {
-      gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_precision_config = configs_builder.PushCustomConfig();
-      htp_graph_precision_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION;
-      htp_graph_precision_config->precision = QNN_PRECISION_FLOAT16;
+  if (configs.enable_htp_fp16_precision) {
+    gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_precision_config = configs_builder.PushCustomConfig();
+    htp_graph_precision_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION;
+    htp_graph_precision_config->precision = QNN_PRECISION_FLOAT16;
 
-      gsl::not_null<QnnGraph_Config_t*> graph_precision_config = configs_builder.PushConfig();
-      graph_precision_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-      graph_precision_config->customConfig = htp_graph_precision_config;
-    }
+    gsl::not_null<QnnGraph_Config_t*> graph_precision_config = configs_builder.PushConfig();
+    graph_precision_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_precision_config->customConfig = htp_graph_precision_config;
+  }
 
-    if (!configs.disable_htp_monolithic_lstm) {
-      gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_monolithic_lstm_config = configs_builder.PushCustomConfig();
-      htp_graph_monolithic_lstm_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM;
-      htp_graph_monolithic_lstm_config->monolithicLstm = true;
+  if (!configs.disable_htp_monolithic_lstm) {
+    gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_graph_monolithic_lstm_config = configs_builder.PushCustomConfig();
+    htp_graph_monolithic_lstm_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_MONOLITHIC_LSTM;
+    htp_graph_monolithic_lstm_config->monolithicLstm = true;
 
-      gsl::not_null<QnnGraph_Config_t*> graph_config = configs_builder.PushConfig();
-      graph_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-      graph_config->customConfig = htp_graph_monolithic_lstm_config;
-    }
+    gsl::not_null<QnnGraph_Config_t*> graph_config = configs_builder.PushConfig();
+    graph_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    graph_config->customConfig = htp_graph_monolithic_lstm_config;
   }
 }
 
@@ -2045,9 +2101,46 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     return ep->ort_api.CreateStatus(ORT_EP_FAIL, message.c_str());
   }
 
+  // Hot migration: initialize the shadow HTP backend manager here so its QNN context handle
+  // is ready for CompileImpl's HTP ComposeGraph step. SetupBackend loads QnnHtp.so and creates
+  // the HTP device + context; graph compilation (FinalizeGraphs) runs later on the background
+  // thread. The active backend must be GPU here (validated at construction).
+  if (ep->hot_migration_enabled_ && ep->htp_backend_config_.has_value()) {
+    ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                "QNN hot migration: initializing HTP backend for parallel compilation.");
+    ep->htp_backend_manager_ = qnn::QnnBackendManager::Create(
+        *ep->htp_backend_config_,
+        ApiPtrs{ep->ort_api, ep->ep_api, ep->model_editor_api},
+        ep->logger_);
+    ep->htp_backend_config_.reset();
+
+    std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>> empty_bin_map;
+    Ort::Status htp_rt = ep->htp_backend_manager_->SetupBackend(
+        /*load_from_cached_context=*/false,
+        /*need_load_system_lib=*/false,
+        /*share_ep_contexts=*/false,
+        /*htp_share_resource_optimization=*/-1,
+        ep->enable_file_mapped_weights_,
+        ep->rpcmem_library_,
+        empty_bin_map,
+        ep->enable_htp_extended_udma_mode_,
+        /*enable_htp_prepare_only=*/false);
+
+    if (!htp_rt.IsOK()) {
+      ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_WARNING,
+                  ("QNN hot migration: HTP SetupBackend failed: " + htp_rt.GetErrorMessage() +
+                   ". Falling back to GPU-only session.")
+                      .c_str());
+      ep->htp_backend_manager_.reset();
+      ep->hot_migration_enabled_ = false;
+    }
+  }
+
   if (qnn::IsNpuBackend(ep->qnn_backend_manager_->GetQnnBackendType()) && !ep->enable_multi_soc_ep_context_) {
     // Set the power config id and the default power mode from provider option for main thread,
     // otherwise it will mess up the power mode if user just create session without run it.
+    // In the hot migration path the active backend is GPU here; power config creation is
+    // deferred to TryMigrateIfReady() after the session has switched to HTP.
     ep->CreateHtpPowerConfigId();
 
     ep->WarnIfHnrdPathActive();
@@ -2096,9 +2189,55 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
 
   std::tie(node_unit_holder, node_unit_map) = GetAllOrtNodeUnits(ep->ort_api, graph, ep->logger_);
 
-  // Analyze nodes for QNN support
+  // Analyze nodes for QNN support.
+  // In the hot migration path both backends are initialized; take the intersection so every
+  // claimed partition is guaranteed to compile on GPU (migration window) and HTP (post-migration).
   std::vector<const OrtNode*> supported_nodes;
-  if (!ep->enable_multi_soc_ep_context_) {
+  if (ep->hot_migration_enabled_ && ep->htp_backend_manager_) {
+    std::vector<const OrtNode*> gpu_supported_nodes;
+    RETURN_IF_NOT_NULL(ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(),
+                                             gpu_supported_nodes,
+                                             ep->trace_.unsupported_nodes,
+                                             ep->qnn_backend_manager_.get()));
+
+    std::vector<const OrtNode*> htp_supported_nodes;
+    RETURN_IF_NOT_NULL(ep->GetSupportedNodes(graph, node_unit_map, node_unit_holder.size(),
+                                             htp_supported_nodes,
+                                             ep->trace_.unsupported_nodes,
+                                             ep->htp_backend_manager_.get()));
+
+    // Intersection: only claim nodes both backends can compile. Nodes supported by HTP but not
+    // GPU fall back to CPU EP for the entire session (partitioning is fixed at session creation).
+    std::unordered_set<const OrtNode*> htp_set(htp_supported_nodes.begin(),
+                                               htp_supported_nodes.end());
+    supported_nodes.reserve(gpu_supported_nodes.size());
+    for (const OrtNode* node : gpu_supported_nodes) {
+      if (htp_set.count(node)) {
+        supported_nodes.push_back(node);
+      }
+    }
+
+    std::unordered_set<const OrtNode*> gpu_set(gpu_supported_nodes.begin(),
+                                               gpu_supported_nodes.end());
+    size_t htp_only_count = 0;
+    for (const OrtNode* node : htp_supported_nodes) {
+      if (!gpu_set.count(node)) {
+        ++htp_only_count;
+        Ort::ConstNode const_node(node);
+        ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_VERBOSE,
+                    (std::string("QNN hot migration: node '") + const_node.GetName() +
+                     "' (op=" + const_node.GetOperatorType() +
+                     ") supported by HTP but not GPU - falling back to CPU EP for this session.")
+                        .c_str());
+      }
+    }
+    if (htp_only_count > 0) {
+      ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                  ("QNN hot migration: " + std::to_string(htp_only_count) +
+                   " node(s) supported by HTP but not GPU; falling back to CPU EP for this session.")
+                      .c_str());
+    }
+  } else if (!ep->enable_multi_soc_ep_context_) {
     RETURN_IF_NOT_NULL(ep->GetSupportedNodes(graph,
                                              node_unit_map,
                                              node_unit_holder.size(),
@@ -2222,7 +2361,9 @@ OrtStatus* QnnEp::CompileOnnxModel(const OrtGraph** graphs,
 
     qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t> htp_graph_configs_builder(
         QNN_GRAPH_CONFIG_INIT, QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT);
-    InitQnnHtpGraphConfigs(htp_graph_configs, htp_graph_configs_builder);
+    if (qnn_backend_manager_->GetQnnBackendType() == qnn::QnnBackendType::HTP) {
+      InitQnnHtpGraphConfigs(htp_graph_configs, htp_graph_configs_builder);
+    }
 
     std::vector<const QnnGraph_Config_t*> all_graph_configs;
     const QnnGraph_Config_t** htp_configs = htp_graph_configs_builder.GetQnnConfigs();
@@ -2784,6 +2925,115 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
     return ep->CompileDlcContextModel(this_ptr, graphs, fused_nodes, count, node_compute_infos);
   }
 
+  // Hot migration compile path: compose both GPU and HTP graphs while OrtGraph* pointers
+  // are still valid, finalize GPU synchronously, defer HTP finalization to a background
+  // thread. compute_state is wired to model_slots_ for atomic backend switching at runtime.
+  if (ep->hot_migration_enabled_ && ep->htp_backend_manager_) {
+    ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                "QNN hot migration: composing GPU and HTP graphs in CompileImpl.");
+
+    if (!ep->onnx_graph_io_names_.has_value()) {
+      return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                      "ONNX I/O names not found. GetCapability must be called before Compile.");
+    }
+    const auto& onnx_input_names = ep->onnx_graph_io_names_->first;
+    const auto& onnx_output_names = ep->onnx_graph_io_names_->second;
+
+    qnn::QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t> htp_graph_configs_builder(
+        QNN_GRAPH_CONFIG_INIT, QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT);
+    if (ep->htp_backend_manager_->GetQnnBackendType() == qnn::QnnBackendType::HTP) {
+      ep->InitQnnHtpGraphConfigs(ep->htp_graph_configs_, htp_graph_configs_builder);
+    }
+    std::vector<const QnnGraph_Config_t*> htp_all_graph_configs;
+    if (const QnnGraph_Config_t** htp_configs = htp_graph_configs_builder.GetQnnConfigs()) {
+      htp_all_graph_configs.reserve(htp_graph_configs_builder.GetSize() + 1);
+      for (const QnnGraph_Config_t** cfg = htp_configs; *cfg; ++cfg) {
+        htp_all_graph_configs.push_back(*cfg);
+      }
+      htp_all_graph_configs.push_back(nullptr);
+    }
+    const QnnGraph_Config_t** htp_graph_configs_ptr =
+        htp_all_graph_configs.empty() ? nullptr : htp_all_graph_configs.data();
+
+    for (size_t graph_idx = 0; graph_idx < count; ++graph_idx) {
+      const OrtGraph* graph = graphs[graph_idx];
+      const OrtNode* fused_node = fused_nodes[graph_idx];
+      const std::string fused_node_name = Ort::ConstNode(fused_node).GetName();
+
+      auto gpu_model = std::make_unique<qnn::QnnModel>(
+          ep->qnn_backend_manager_.get(), ApiPtrs{ep->ort_api, ep->ep_api, ep->model_editor_api});
+
+      qnn::QnnModelContext gpu_context{
+          *graph, *fused_node, ep->logger_,
+          &onnx_input_names, &onnx_output_names,
+          &ep->model_settings_,
+          /*graph_configs=*/nullptr,
+          &ep->tensor_name_overrides_,
+          /*json_qnn_graph_path=*/std::string{}};
+
+      RETURN_IF_NOT_OK(gpu_model->ComposeGraph(gpu_context));
+      RETURN_IF_NOT_OK(gpu_model->FinalizeGraphs(ep->logger_));
+      RETURN_IF_NOT_OK(gpu_model->SetupQnnInputOutput(ep->logger_));
+
+      // HTP: compose only. Finalize + SetupQnnInputOutput run on htp_prepare_thread_.
+      auto htp_model = std::make_unique<qnn::QnnModel>(
+          ep->htp_backend_manager_.get(), ApiPtrs{ep->ort_api, ep->ep_api, ep->model_editor_api});
+
+      qnn::QnnModelContext htp_context{
+          *graph, *fused_node, ep->logger_,
+          &onnx_input_names, &onnx_output_names,
+          &ep->model_settings_,
+          htp_graph_configs_ptr,
+          &ep->tensor_name_overrides_,
+          /*json_qnn_graph_path=*/std::string{}};
+
+      RETURN_IF_NOT_OK(htp_model->ComposeGraph(htp_context));
+
+      auto slot = std::make_unique<QnnModelSlot>();
+      slot->active.store(gpu_model.get(), std::memory_order_relaxed);
+      ep->model_slots_.emplace(fused_node_name, std::move(slot));
+
+      ep->qnn_models_.emplace(fused_node_name, std::move(gpu_model));
+      ep->htp_models_.emplace(fused_node_name, std::move(htp_model));
+
+      auto node_compute_info = std::make_unique<QnnNodeComputeInfo>(*ep);
+      node_compute_infos[graph_idx] = node_compute_info.release();
+    }
+
+    // OrtGraph* pointers become invalid once CompileImpl returns.
+    ep->onnx_graph_io_names_.reset();
+    ep->tensor_name_overrides_.clear();
+
+    // Thread captures ep; joined in ~QnnEp so it never outlives ep's members.
+    ep->htp_prepare_thread_ = std::thread([ep]() {
+      for (auto& [node_name, htp_model] : ep->htp_models_) {
+        Ort::Status status = htp_model->FinalizeGraphs(ep->logger_);
+        if (!status.IsOK()) {
+          ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
+                      ("QNN hot migration: HTP FinalizeGraphs failed for " + node_name +
+                       ": " + status.GetErrorMessage() + " Migration will not proceed.")
+                          .c_str());
+          ep->htp_compile_failed_.store(true, std::memory_order_release);
+          return;
+        }
+        status = htp_model->SetupQnnInputOutput(ep->logger_);
+        if (!status.IsOK()) {
+          ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_ERROR,
+                      ("QNN hot migration: HTP SetupQnnInputOutput failed for " + node_name +
+                       ": " + status.GetErrorMessage() + " Migration will not proceed.")
+                          .c_str());
+          ep->htp_compile_failed_.store(true, std::memory_order_release);
+          return;
+        }
+      }
+      ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+                  "QNN hot migration: HTP compilation complete. Migration will occur on next Run().");
+      ep->htp_compile_complete_.store(true, std::memory_order_release);
+    });
+
+    return nullptr;
+  }
+
 #if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
   auto compile_start = std::chrono::steady_clock::now();
 #endif
@@ -3277,6 +3527,57 @@ void QnnEp::WarnIfHnrdPathActive() {
               "QnnHtpPrepare/Stub/Skel libs missing from backend lib dir.");
 }
 
+void QnnEp::DrainAndReleaseGpu() {
+  // Acquire-and-release each GPU model's execution mutex to flush any in-flight
+  // graphExecute. Slots are already swapped to HTP, so nothing new can start.
+  for (auto& [name, gpu_model] : qnn_models_) {
+    gpu_model->WaitForInflightExecution();
+  }
+  qnn_models_.clear();
+}
+
+void QnnEp::TryMigrateIfReady() {
+  if (migration_done_.load(std::memory_order_relaxed)) return;
+
+  if (htp_compile_failed_.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> lock(migration_mutex_);
+    if (migration_done_.load(std::memory_order_relaxed)) return;
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                "QNN hot migration: HTP compilation failed. Session will remain on GPU for its lifetime.");
+    htp_models_.clear();
+    htp_backend_manager_.reset();
+    migration_done_.store(true, std::memory_order_release);
+    return;
+  }
+
+  if (!htp_compile_complete_.load(std::memory_order_acquire)) return;
+
+  std::lock_guard<std::mutex> lock(migration_mutex_);
+  if (migration_done_.load(std::memory_order_relaxed)) return;
+
+  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+              "QNN hot migration: HTP compilation complete. Migrating session to HTP.");
+
+  for (auto& [name, slot] : model_slots_) {
+    auto it = htp_models_.find(name);
+    if (it != htp_models_.end()) {
+      slot->active.store(it->second.get(), std::memory_order_release);
+    }
+  }
+
+  DrainAndReleaseGpu();
+
+  qnn_backend_manager_ = htp_backend_manager_;
+  htp_backend_manager_.reset();
+
+  CreateHtpPowerConfigId();
+
+  migration_done_.store(true, std::memory_order_release);
+
+  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
+              "QNN hot migration: session is now running on HTP.");
+}
+
 QnnEp::QnnNodeComputeInfo::QnnNodeComputeInfo(QnnEp& ep) : ep(ep) {
   ort_version_supported = ORT_API_VERSION;
   CreateState = CreateStateImpl;
@@ -3298,6 +3599,21 @@ OrtStatus* QnnEp::QnnNodeComputeInfo::CreateStateImpl(OrtNodeComputeInfo* this_p
   }
 
   std::string fused_node_name = ep.ep_api.NodeComputeContext_NodeName(compute_context);
+
+  // Hot migration: compute_state is a QnnModelSlot* (atomic dispatch), not a QnnModel*.
+  if (!ep.model_slots_.empty()) {
+    auto slot_it = ep.model_slots_.find(fused_node_name);
+    if (slot_it == ep.model_slots_.end()) {
+      slot_it = ep.model_slots_.begin();
+    }
+    if (slot_it == ep.model_slots_.end()) {
+      std::string message = "Unable to get QnnModelSlot with name " + fused_node_name;
+      return ep.ort_api.CreateStatus(ORT_EP_FAIL, message.c_str());
+    }
+    *compute_state = slot_it->second.get();
+    return nullptr;
+  }
+
   auto qnn_model_it = ep.qnn_models_.find(fused_node_name);
 
   // If not found with the fused_node_name, try to find with any available key
@@ -3326,6 +3642,15 @@ OrtStatus* QnnEp::QnnNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
     return ep.ort_api.CreateStatus(ORT_EP_FAIL,
                                    "QNN EP is in prepare_only mode. Session.Run() is not supported. "
                                    "Load the generated context model for inference.");
+  }
+
+  // Hot migration: polled per-call so the swap lands on a Run() boundary.
+  if (!ep.model_slots_.empty()) {
+    ep.TryMigrateIfReady();
+    auto* slot = reinterpret_cast<QnnModelSlot*>(compute_state);
+    qnn::QnnModel* model = slot->active.load(std::memory_order_acquire);
+    RETURN_IF_NOT_OK(model->ExecuteGraph(kernel_context, ep.logger_));
+    return nullptr;
   }
 
   qnn::QnnModel* model = reinterpret_cast<qnn::QnnModel*>(compute_state);

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -304,6 +304,10 @@ class QnnEp : public OrtEp, public ApiPtrs {
   mutable std::shared_ptr<GenieApiLoader> genie_api_loader_;
   GenieLog_Level_t genie_log_level_ = GENIE_LOG_LEVEL_ERROR;
   mutable std::atomic<uint64_t> genie_kv_cache_rewind_{1};
+
+  // When no explicit backend_type is set, QnnBackendManager creation is deferred to GetCapabilityImpl
+  bool auto_select_backend_ = false;
+  std::optional<qnn::QnnBackendManagerConfig> deferred_backend_config_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -34,10 +34,11 @@
 namespace onnxruntime {
 class QnnEpFactory;
 
-// Forward declaration for QnnBackendManager, GenieBackendManager
 namespace qnn {
 class QnnBackendManager;
 class GenieBackendManager;
+struct SnapshotGraph;
+class  SnapshotShim;
 }  // namespace qnn
 
 class QnnEp : public OrtEp, public ApiPtrs {
@@ -341,8 +342,11 @@ class QnnEp : public OrtEp, public ApiPtrs {
   bool hot_migration_enabled_ = false;
   std::optional<qnn::QnnBackendManagerConfig> htp_backend_config_;
   std::shared_ptr<qnn::QnnBackendManager> htp_backend_manager_;
+  // Declared BEFORE htp_models_ so destruction order tears models down before their shims.
+  std::unordered_map<std::string, std::unique_ptr<qnn::SnapshotGraph>> htp_snapshots_;
+  std::unordered_map<std::string, std::unique_ptr<qnn::SnapshotShim>> htp_shims_;
   std::unordered_map<std::string, std::unique_ptr<qnn::QnnModel>> htp_models_;
-  // compute_state points to entries here (instead of a raw QnnModel*) in the migration path.
+
   // unique_ptr keeps the slot at a stable address; std::atomic is not movable/copyable.
   std::unordered_map<std::string, std::unique_ptr<QnnModelSlot>> model_slots_;
   std::atomic<bool> htp_compile_complete_{false};

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -101,6 +102,15 @@ class QnnEp : public OrtEp, public ApiPtrs {
                                std::vector<const OrtNode*>& supported_nodes,
                                std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes) const;
 
+  // Overload that queries a specific backend manager. Used in the hot-migration path where
+  // GPU and NPU support sets must be computed independently and intersected.
+  OrtStatus* GetSupportedNodes(const OrtGraph* graph,
+                               const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
+                               const size_t node_unit_size,
+                               std::vector<const OrtNode*>& supported_nodes,
+                               std::vector<qnn::UnsupportedNodeInfo>& unsupported_nodes,
+                               qnn::QnnBackendManager* backend_manager) const;
+
   OrtStatus* GetMultiSocSupportedNodes(const OrtGraph* graph,
                                        const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                        const size_t node_unit_size,
@@ -158,6 +168,13 @@ class QnnEp : public OrtEp, public ApiPtrs {
     return GetProviderOptionPrefix(name_) + key;
   }
 
+  // Indirection target for compute_state in the hot-migration path.
+  // After migration, `active` is atomically swapped from the GPU model to the NPU model.
+  // Non-owning: the pointed-to model is owned by qnn_models_ / npu_models_.
+  struct QnnModelSlot {
+    std::atomic<qnn::QnnModel*> active{nullptr};
+  };
+
   struct QnnNodeComputeInfo : QnnNodeComputeInfoBase {
     explicit QnnNodeComputeInfo(QnnEp& ep);
 
@@ -195,6 +212,14 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // Will return true if any power config options need to be updated
   bool GetPerThreadHtpPowerConfigs(qnn::PerThreadHtpPowerConfigs_t& per_thread_htp_power_configs,
                                    const ::OrtRunOptions* run_options);
+
+  // Hot migration helpers.
+  // TryMigrateIfReady: called at the top of every ComputeImpl when migration is active.
+  // Cheap no-op until htp_compile_complete_ or htp_compile_failed_ is set; performs the
+  // atomic slot swap exactly once (or releases HTP resources on failure).
+  void TryMigrateIfReady();
+  // DrainAndReleaseGpu: waits for any in-flight GPU graphExecute to finish, then frees GPU models.
+  void DrainAndReleaseGpu();
 
   void CreateHtpPowerConfigId() const;
   // Will return false if htp_power_config_id_ has no value
@@ -308,6 +333,23 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // When no explicit backend_type is set, QnnBackendManager creation is deferred to GetCapabilityImpl
   bool auto_select_backend_ = false;
   std::optional<qnn::QnnBackendManagerConfig> deferred_backend_config_;
+
+  // === Hot migration state (populated only when hot_migration_enabled_ is true) ===
+  // qnn_backend_manager_ / qnn_models_ hold the GPU (active) side. After migration completes,
+  // htp_backend_manager_ is promoted into qnn_backend_manager_ and both htp_backend_manager_
+  // and qnn_models_ are cleared.
+  bool hot_migration_enabled_ = false;
+  std::optional<qnn::QnnBackendManagerConfig> htp_backend_config_;
+  std::shared_ptr<qnn::QnnBackendManager> htp_backend_manager_;
+  std::unordered_map<std::string, std::unique_ptr<qnn::QnnModel>> htp_models_;
+  // compute_state points to entries here (instead of a raw QnnModel*) in the migration path.
+  // unique_ptr keeps the slot at a stable address; std::atomic is not movable/copyable.
+  std::unordered_map<std::string, std::unique_ptr<QnnModelSlot>> model_slots_;
+  std::atomic<bool> htp_compile_complete_{false};
+  std::atomic<bool> htp_compile_failed_{false};
+  std::atomic<bool> migration_done_{false};
+  std::thread htp_prepare_thread_;
+  std::mutex migration_mutex_;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -176,6 +176,28 @@ class QnnEp : public OrtEp, public ApiPtrs {
     std::atomic<qnn::QnnModel*> active{nullptr};
   };
 
+  // Partial migration: post-swap execution plan for a fused node with mixed HTP/GPU segments.
+  struct SegmentInfo {
+    qnn::QnnModel* model = nullptr;
+    bool is_gpu = false;
+    // -1 means the tensor maps to external I/O (KernelContext).
+    std::vector<int> input_buffer_indices;
+    std::vector<int> output_buffer_indices;
+    std::vector<size_t> external_input_indices;
+    std::vector<size_t> external_output_indices;
+  };
+
+  struct IntermediateBuffer {
+    std::vector<uint8_t> data;
+    Qnn_Tensor_t tensor;  // pre-configured, clientBuf points into `data`
+  };
+
+  struct PartialMigrationPlan {
+    std::vector<SegmentInfo> segments;
+    std::vector<IntermediateBuffer> buffers;
+    std::vector<std::unique_ptr<qnn::QnnModel>> owned_models;
+  };
+
   struct QnnNodeComputeInfo : QnnNodeComputeInfoBase {
     explicit QnnNodeComputeInfo(QnnEp& ep);
 
@@ -222,7 +244,7 @@ class QnnEp : public OrtEp, public ApiPtrs {
   // DrainAndReleaseGpu: waits for any in-flight GPU graphExecute to finish, then frees GPU models.
   void DrainAndReleaseGpu();
 
-  void CreateHtpPowerConfigId() const;
+  void CreateHtpPowerConfigId(qnn::QnnBackendManager* backend_manager = nullptr) const;
   // Will return false if htp_power_config_id_ has no value
   bool GetHtpPowerConfigId(uint32_t& htp_power_config_id);
 
@@ -342,6 +364,7 @@ class QnnEp : public OrtEp, public ApiPtrs {
   bool hot_migration_enabled_ = false;
   std::optional<qnn::QnnBackendManagerConfig> htp_backend_config_;
   std::shared_ptr<qnn::QnnBackendManager> htp_backend_manager_;
+  std::unordered_set<std::string> gpu_only_node_names_;
   // Declared BEFORE htp_models_ so destruction order tears models down before their shims.
   std::unordered_map<std::string, std::unique_ptr<qnn::SnapshotGraph>> htp_snapshots_;
   std::unordered_map<std::string, std::unique_ptr<qnn::SnapshotShim>> htp_shims_;
@@ -349,9 +372,13 @@ class QnnEp : public OrtEp, public ApiPtrs {
 
   // unique_ptr keeps the slot at a stable address; std::atomic is not movable/copyable.
   std::unordered_map<std::string, std::unique_ptr<QnnModelSlot>> model_slots_;
+  // Partial migration execution plans (one per fused node that has GPU-only nodes).
+  // Built by the background thread; installed at migration time.
+  std::unordered_map<std::string, std::unique_ptr<PartialMigrationPlan>> partial_migration_plans_;
   std::atomic<bool> htp_compile_complete_{false};
   std::atomic<bool> htp_compile_failed_{false};
   std::atomic<bool> migration_done_{false};
+  bool partial_migration_active_ = false;
   std::thread htp_prepare_thread_;
   std::mutex migration_mutex_;
 };


### PR DESCRIPTION
### Description

**Auto backend selection (`backend_type|auto`)**

Defers backend selection to `GetCapabilityImpl` where the ONNX graph is available. A single-pass model classifier categorizes the model as GenAI, NonGenAI, or Unknown based on graph structure. GenAI routes to GPU and the others route to NPU.

**Hot migration (`hot_migration|1`)**

Composes both GPU and NPU graphs synchronously in `CompileImpl` (ORT frees graph pointers after Compile returns, so both must be composed before that point), finalizes GPU in-place, then launches a background thread for NPU finalization. Once NPU is ready, `TryMigrateIfReady` atomically swaps all subgraphs from GPU to NPU, drains in-flight GPU work, and promotes the NPU backend manager. On background failure, the session continues on GPU permanently.

NPU compose on the critical path adds overhead to session creation - GPU inference only begins after both graphs are composed. Only the NPU finalization step runs in the background.

Partitioning claims only the intersection of GPU and NPU support sets to prevent post-migration failures. Requires `backend_type|gpu` to be set explicitly.

### Motivation and Context

**Auto backend selection:**
Applications currently must know which QNN backend suits a given model. The classifier lets the EP make this decision based on model architecture, removing that burden.

**Hot migration:**
NPU graph finalization adds seconds to session creation before the first token can be generated. GPU compiles fast but has lower sustained throughput. The goal of hot migration is to reduce the time-to-first-token by deferring NPU finalization to a background thread, serving initial inference on GPU, then transparently switching to NPU for higher throughput once finalization completes.