### PR TITLE
fix: perform backend validation while creating QNN node

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/instancenormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/instancenormalization_op_builder.cc
@@ -236,7 +236,8 @@ Ort::Status InstanceNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModel
                                                 GetQnnOpType(node_unit.OpType()),
                                                 std::move(input_names),
                                                 {op_output_name},
-                                                std::move(param_tensor_names)),
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
                 "Failed to add node.");
 
   const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(orig_output_name);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
@@ -193,7 +193,8 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                 GetQnnOpType(node_unit.OpType()),
                                                 std::move(input_names),
                                                 std::vector<std::string>(transpose_input_names),
-                                                std::move(param_tensor_names)),
+                                                std::move(param_tensor_names),
+                                                do_op_validation),
                 "Failed to add node.");
 
   // Add Transpose nodes for each output to permute back.


### PR DESCRIPTION
Minor bug fix - Call CreateQnnNode with do_op_validation.  

