### PR TITLE
Reconcile RMSNorm scale rank with QNN RmsNorm OpDef

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Qualcomm. All rights reserved.
 // Licensed under the MIT License.
 
+#include <algorithm>
 #include <cassert>
 #include <optional>
 #include <string>
@@ -17,22 +18,21 @@ namespace qnn {
 namespace {
 
 // QNN's RmsNorm OpDef requires gamma (and beta) to be rank size(axes), whereas ONNX
-// RMSNormalization lets `scale` be any shape unidirectionally broadcastable to X. The two
-// only disagree by leading 1-dims, e.g. scale [1, 1, C] against X [1, S, C] with axes [2].
-// Returns the number of leading 1-dims to drop to reach `target_rank`, or std::nullopt if
-// the shape cannot be reconciled (a non-1 dim would have to be dropped).
-std::optional<size_t> GetNumLeadingOnesToSqueeze(const std::vector<uint32_t>& shape, size_t target_rank) {
+// RMSNormalization lets `scale` be any shape unidirectionally broadcastable to X, e.g. scale
+// [1, 1, C] against X [1, S, C]. Returns `shape` with leading 1-dims dropped to reach
+// `target_rank`, or std::nullopt if a non-1 dim would have to be dropped. A shape already at or
+// below `target_rank` is returned unchanged, leaving QNN to validate it as before.
+std::optional<std::vector<uint32_t>> TrySqueezeLeadingOnesTo(const std::vector<uint32_t>& shape,
+                                                             size_t target_rank) {
   if (shape.size() <= target_rank) {
-    return 0;  // Already at or below the required rank; nothing to squeeze.
+    return shape;
   }
 
-  const size_t num_leading = shape.size() - target_rank;
-  for (size_t i = 0; i < num_leading; ++i) {
-    if (shape[i] != 1) {
-      return std::nullopt;
-    }
+  const size_t num_leading_dims = shape.size() - target_rank;
+  if (std::any_of(shape.begin(), shape.begin() + num_leading_dims, [](uint32_t dim) { return dim != 1; })) {
+    return std::nullopt;
   }
-  return num_leading;
+  return std::vector<uint32_t>(shape.begin() + num_leading_dims, shape.end());
 }
 
 }  // namespace
@@ -57,7 +57,25 @@ class RMSNormalizationOpBuilder : public BaseOpBuilder {
                                           std::vector<std::string>&& input_names,
                                           const Ort::Logger& logger,
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
+
+ private:
+  // Number of trailing axes X is normalized over, i.e. size(axes) in QNN's RmsNorm OpDef.
+  Ort::Status GetAxesRank(const QnnModelWrapper& qnn_model_wrapper,
+                          const OrtNodeUnit& node_unit,
+                          size_t& axes_rank) const ORT_MUST_USE_RESULT;
 };
+
+Ort::Status RMSNormalizationOpBuilder::GetAxesRank(const QnnModelWrapper& qnn_model_wrapper,
+                                                   const OrtNodeUnit& node_unit,
+                                                   size_t& axes_rank) const {
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape),
+                "Cannot get shape of input 0");
+  int32_t axis = 0;
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+  axes_rank = input_shape.size() - static_cast<size_t>(axis);
+  return Ort::Status();
+}
 
 Ort::Status RMSNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
                                                      const OrtNodeUnit& node_unit,
@@ -87,29 +105,18 @@ Ort::Status RMSNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_
   const size_t output_rank = output_shape.size();
   RETURN_IF(output_rank > 4, "QNN RMSNorm only supports output rank <= 4");
 
-  int32_t axis = 0;
-  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+  size_t axes_rank = 0;
+  RETURN_IF_ERROR(GetAxesRank(qnn_model_wrapper, node_unit, axes_rank));
 
   // Additional constraints for NPU backend
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    RETURN_IF(static_cast<size_t>(axis) != input_rank - 1,
+    RETURN_IF(axes_rank != 1,
               "QNN RMSNorm for NPU backend only supports axis with last input dimension");
   }
 
-  // QNN's RmsNorm requires rank(gamma) == size(axes). ProcessInputs squeezes leading 1-dims off
-  // the scale to satisfy that, so reject here only when the shape genuinely cannot be reconciled.
-  // Without this the node is claimed and then fails deep inside QNN op validation, which surfaces
-  // as an opaque error code plus a graph split rather than a clean CPU fallback.
-  const size_t axes_rank = input_rank - static_cast<size_t>(axis);
-
-  std::vector<uint32_t> scale_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[SCALE_IDX].shape, scale_shape),
-                "Cannot get shape of input 1 (scale)");
-  RETURN_IF_NOT(GetNumLeadingOnesToSqueeze(scale_shape, axes_rank).has_value(),
-                "QNN RMSNorm requires the scale rank to equal the number of normalized axes; "
-                "this scale has non-1 leading dimensions and cannot be squeezed to match.");
-
+  // A scale rank that ProcessInputs cannot reconcile is rejected there, which propagates out of this
+  // call and leaves the node unclaimed.
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
 }
 
@@ -127,71 +134,63 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
   TensorInfo scale_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_info));
 
-  // QNN's RmsNorm requires rank(gamma) == size(axes), while ONNX allows any scale shape
-  // unidirectionally broadcastable to X (e.g. [1, 1, C] for X [1, S, C]). Squeeze the leading
-  // 1-dims so the tensor QNN sees matches the OpDef. IsOpSupported already rejected any shape
-  // that cannot be reconciled this way.
-  std::vector<uint32_t> x_shape;
-  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[X_IDX].shape, x_shape), "Cannot get shape of input 0");
-  int32_t axis = 0;
-  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
-  const size_t axes_rank = x_shape.size() - static_cast<size_t>(axis);
+  // Squeeze the scale's leading 1-dims so it satisfies QNN's rank(gamma) == size(axes).
+  size_t axes_rank = 0;
+  RETURN_IF_ERROR(GetAxesRank(qnn_model_wrapper, node_unit, axes_rank));
 
-  const std::optional<size_t> num_leading_ones = GetNumLeadingOnesToSqueeze(scale_info.shape, axes_rank);
-  RETURN_IF_NOT(num_leading_ones.has_value(),
-                "QNN RMSNorm requires the scale rank to equal the number of normalized axes.");
+  const std::optional<std::vector<uint32_t>> squeezed_shape =
+      TrySqueezeLeadingOnesTo(scale_info.shape, axes_rank);
+  RETURN_IF_NOT(squeezed_shape.has_value(),
+                "QNN RMSNorm requires the scale rank to equal the number of normalized axes; this scale has "
+                "non-1 leading dimensions and cannot be squeezed to match.");
 
-  if (*num_leading_ones > 0) {
-    const std::vector<uint32_t> squeezed_shape(scale_info.shape.begin() + *num_leading_ones,
-                                               scale_info.shape.end());
-    const std::string& orig_scale_name = inputs[SCALE_IDX].name;
+  if (squeezed_shape->size() == scale_info.shape.size()) {
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
+  } else {
+    const std::string& scale_name = inputs[SCALE_IDX].name;
 
-    // Squeezing shifts a per-channel quantization axis, and there is no helper to remap it for a
-    // rank reduction. This combination (per-channel gamma carrying leading 1-dims) has no known
-    // producer, so reject it rather than silently emitting a misaligned axis.
-    RETURN_IF(scale_info.quant_param.IsPerChannel() || scale_info.quant_param.IsLPBQ(),
-              "QNN RMSNorm does not support per-channel/LPBQ quantization on a scale that requires "
-              "squeezing to match the number of normalized axes");
+    // Any axis-bearing or per-block encoding describes the pre-squeeze rank, and there is no helper to
+    // remap one for a rank reduction. Such a gamma has no known producer, so reject it rather than
+    // silently emitting a misaligned encoding.
+    RETURN_IF(scale_info.quant_param.IsQuantized() && !scale_info.quant_param.IsPerTensor(/*include_bw=*/true),
+              "QNN RMSNorm only supports per-tensor quantization on a scale that requires squeezing to match "
+              "the number of normalized axes");
 
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-                ("RMSNorm node " + node_unit.Name() + ": squeezing scale `" + orig_scale_name +
-                 "` to rank " + std::to_string(squeezed_shape.size()) + " to match QNN RmsNorm's OpDef.")
+                ("RMSNorm node " + node_unit.Name() + ": squeezing scale `" + scale_name + "` to rank " +
+                 std::to_string(squeezed_shape->size()) + " to match QNN RmsNorm's OpDef.")
                     .c_str());
 
-    // Emit under a derived name so a scale shared with another consumer keeps its original rank
-    // for that consumer.
-    const std::string squeezed_scale_name = utils::UniqueNameGenerator().New(orig_scale_name, "_squeeze");
+    // Derived name so a scale shared with another consumer keeps its original rank there.
+    const std::string squeezed_scale_name = utils::UniqueNameGenerator().New(scale_name, "_squeeze");
 
     if (scale_info.is_initializer) {
-      // A static scale needs no Reshape node: dropping leading 1-dims does not change the element
-      // layout, so only the declared dims change.
+      // Dropping leading 1-dims does not change a static tensor's element layout.
       std::vector<uint8_t> scale_bytes;
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info.initializer_tensor, scale_bytes));
 
-      QnnTensorWrapper scale_tensor_wrapper(squeezed_scale_name,
-                                            QNN_TENSOR_TYPE_STATIC,
-                                            scale_info.qnn_data_type,
-                                            scale_info.quant_param.Copy(),
-                                            std::vector<uint32_t>(squeezed_shape),
-                                            std::move(scale_bytes));
-      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(scale_tensor_wrapper)),
+      QnnTensorWrapper squeezed_scale(squeezed_scale_name,
+                                      QNN_TENSOR_TYPE_STATIC,
+                                      scale_info.qnn_data_type,
+                                      scale_info.quant_param.Copy(),
+                                      std::vector<uint32_t>(*squeezed_shape),
+                                      std::move(scale_bytes));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(squeezed_scale)),
                     "Failed to add squeezed scale tensor for QNN RMSNorm node.");
     } else {
-      // A dynamic scale is produced by another node, so its rank can only be changed in-graph.
-      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(orig_scale_name,
+      // A computed scale can only be reshaped in-graph.
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(scale_name,
                                                        squeezed_scale_name,
                                                        scale_info.shape,
-                                                       squeezed_shape,
+                                                       *squeezed_shape,
                                                        scale_info.qnn_data_type,
                                                        scale_info.quant_param,
                                                        do_op_validation,
-                                                       qnn_model_wrapper.IsGraphInput(orig_scale_name)));
+                                                       qnn_model_wrapper.IsGraphInput(scale_name)));
     }
 
     input_names.push_back(squeezed_scale_name);
-    scale_info.shape = squeezed_shape;
-  } else {
-    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
+    scale_info.shape = *squeezed_shape;
   }
 
 #if !defined(QNN_SDK_VERSION_MINOR) || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR < 49)
@@ -262,13 +261,11 @@ Ort::Status RMSNormalizationOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapp
   // Process axis attribute and create axes parameter
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(node_unit.Inputs()[0].shape, input_shape), "Cannot get shape of Input 0");
-  const size_t input_rank = input_shape.size();
-  int32_t axis = -1;
-  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
-  size_t axes_rank = input_rank - static_cast<size_t>(axis);
+  size_t axes_rank = 0;
+  RETURN_IF_ERROR(GetAxesRank(qnn_model_wrapper, node_unit, axes_rank));
   std::vector<uint32_t> axes(axes_rank, 0);
   std::vector<uint32_t> axes_shape{SafeInt<uint32_t>(axes_rank)};
-  axes[0] = static_cast<uint32_t>(axis);
+  axes[0] = static_cast<uint32_t>(input_shape.size() - axes_rank);
   for (size_t i = 1; i < axes.size(); ++i) {
     axes[i] = axes[i - 1] + 1;
   }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 #include <cassert>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
@@ -10,6 +13,29 @@
 
 namespace onnxruntime {
 namespace qnn {
+
+namespace {
+
+// QNN's RmsNorm OpDef requires gamma (and beta) to be rank size(axes), whereas ONNX
+// RMSNormalization lets `scale` be any shape unidirectionally broadcastable to X. The two
+// only disagree by leading 1-dims, e.g. scale [1, 1, C] against X [1, S, C] with axes [2].
+// Returns the number of leading 1-dims to drop to reach `target_rank`, or std::nullopt if
+// the shape cannot be reconciled (a non-1 dim would have to be dropped).
+std::optional<size_t> GetNumLeadingOnesToSqueeze(const std::vector<uint32_t>& shape, size_t target_rank) {
+  if (shape.size() <= target_rank) {
+    return 0;  // Already at or below the required rank; nothing to squeeze.
+  }
+
+  const size_t num_leading = shape.size() - target_rank;
+  for (size_t i = 0; i < num_leading; ++i) {
+    if (shape[i] != 1) {
+      return std::nullopt;
+    }
+  }
+  return num_leading;
+}
+
+}  // namespace
 
 class RMSNormalizationOpBuilder : public BaseOpBuilder {
  public:
@@ -61,14 +87,28 @@ Ort::Status RMSNormalizationOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_
   const size_t output_rank = output_shape.size();
   RETURN_IF(output_rank > 4, "QNN RMSNorm only supports output rank <= 4");
 
+  int32_t axis = 0;
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+
   // Additional constraints for NPU backend
   bool is_npu_backend = IsNpuBackend(qnn_model_wrapper.GetQnnBackendType());
   if (is_npu_backend) {
-    int32_t axis = 0;
-    RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
     RETURN_IF(static_cast<size_t>(axis) != input_rank - 1,
               "QNN RMSNorm for NPU backend only supports axis with last input dimension");
   }
+
+  // QNN's RmsNorm requires rank(gamma) == size(axes). ProcessInputs squeezes leading 1-dims off
+  // the scale to satisfy that, so reject here only when the shape genuinely cannot be reconciled.
+  // Without this the node is claimed and then fails deep inside QNN op validation, which surfaces
+  // as an opaque error code plus a graph split rather than a clean CPU fallback.
+  const size_t axes_rank = input_rank - static_cast<size_t>(axis);
+
+  std::vector<uint32_t> scale_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[SCALE_IDX].shape, scale_shape),
+                "Cannot get shape of input 1 (scale)");
+  RETURN_IF_NOT(GetNumLeadingOnesToSqueeze(scale_shape, axes_rank).has_value(),
+                "QNN RMSNorm requires the scale rank to equal the number of normalized axes; "
+                "this scale has non-1 leading dimensions and cannot be squeezed to match.");
 
   return AddToModelBuilder(qnn_model_wrapper, node_unit, logger, true);
 }
@@ -78,14 +118,81 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
                                                      const Ort::Logger& logger,
                                                      std::vector<std::string>& input_names,
                                                      bool do_op_validation) const {
-  ORT_UNUSED_PARAMETER(do_op_validation);
-
   const auto& inputs = node_unit.Inputs();
   constexpr size_t X_IDX = 0;
   constexpr size_t SCALE_IDX = 1;
 
   RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[X_IDX], logger, input_names));
-  RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
+
+  TensorInfo scale_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_info));
+
+  // QNN's RmsNorm requires rank(gamma) == size(axes), while ONNX allows any scale shape
+  // unidirectionally broadcastable to X (e.g. [1, 1, C] for X [1, S, C]). Squeeze the leading
+  // 1-dims so the tensor QNN sees matches the OpDef. IsOpSupported already rejected any shape
+  // that cannot be reconciled this way.
+  std::vector<uint32_t> x_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[X_IDX].shape, x_shape), "Cannot get shape of input 0");
+  int32_t axis = 0;
+  RETURN_IF_ERROR(GetCanonicalizedAxisAttribute(qnn_model_wrapper, node_unit, "axis", -1, axis));
+  const size_t axes_rank = x_shape.size() - static_cast<size_t>(axis);
+
+  const std::optional<size_t> num_leading_ones = GetNumLeadingOnesToSqueeze(scale_info.shape, axes_rank);
+  RETURN_IF_NOT(num_leading_ones.has_value(),
+                "QNN RMSNorm requires the scale rank to equal the number of normalized axes.");
+
+  if (*num_leading_ones > 0) {
+    const std::vector<uint32_t> squeezed_shape(scale_info.shape.begin() + *num_leading_ones,
+                                               scale_info.shape.end());
+    const std::string& orig_scale_name = inputs[SCALE_IDX].name;
+
+    // Squeezing shifts a per-channel quantization axis, and there is no helper to remap it for a
+    // rank reduction. This combination (per-channel gamma carrying leading 1-dims) has no known
+    // producer, so reject it rather than silently emitting a misaligned axis.
+    RETURN_IF(scale_info.quant_param.IsPerChannel() || scale_info.quant_param.IsLPBQ(),
+              "QNN RMSNorm does not support per-channel/LPBQ quantization on a scale that requires "
+              "squeezing to match the number of normalized axes");
+
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("RMSNorm node " + node_unit.Name() + ": squeezing scale `" + orig_scale_name +
+                 "` to rank " + std::to_string(squeezed_shape.size()) + " to match QNN RmsNorm's OpDef.")
+                    .c_str());
+
+    // Emit under a derived name so a scale shared with another consumer keeps its original rank
+    // for that consumer.
+    const std::string squeezed_scale_name = utils::UniqueNameGenerator().New(orig_scale_name, "_squeeze");
+
+    if (scale_info.is_initializer) {
+      // A static scale needs no Reshape node: dropping leading 1-dims does not change the element
+      // layout, so only the declared dims change.
+      std::vector<uint8_t> scale_bytes;
+      RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_info.initializer_tensor, scale_bytes));
+
+      QnnTensorWrapper scale_tensor_wrapper(squeezed_scale_name,
+                                            QNN_TENSOR_TYPE_STATIC,
+                                            scale_info.qnn_data_type,
+                                            scale_info.quant_param.Copy(),
+                                            std::vector<uint32_t>(squeezed_shape),
+                                            std::move(scale_bytes));
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(scale_tensor_wrapper)),
+                    "Failed to add squeezed scale tensor for QNN RMSNorm node.");
+    } else {
+      // A dynamic scale is produced by another node, so its rank can only be changed in-graph.
+      RETURN_IF_ERROR(qnn_model_wrapper.AddReshapeNode(orig_scale_name,
+                                                       squeezed_scale_name,
+                                                       scale_info.shape,
+                                                       squeezed_shape,
+                                                       scale_info.qnn_data_type,
+                                                       scale_info.quant_param,
+                                                       do_op_validation,
+                                                       qnn_model_wrapper.IsGraphInput(orig_scale_name)));
+    }
+
+    input_names.push_back(squeezed_scale_name);
+    scale_info.shape = squeezed_shape;
+  } else {
+    RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[SCALE_IDX], logger, input_names));
+  }
 
 #if !defined(QNN_SDK_VERSION_MINOR) || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR < 49)
   // QNN SDK < 2.49 requires an explicit beta/bias input for QNN_OP_RMS_NORM on NPU.
@@ -96,9 +203,8 @@ Ort::Status RMSNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_
   if (is_npu_backend) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
                 ("RMSNorm node " + node_unit.Name() + ": adding dummy beta tensor (SDK < 2.49).").c_str());
-    TensorInfo scale_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[SCALE_IDX], scale_info));
 
+    // scale_info.shape is the post-squeeze shape, so beta inherits the OpDef-conformant rank.
     std::vector<uint32_t> beta_shape = scale_info.shape;
 
     // Match beta datatype to scale for float types, use UFIXED_POINT_8 for INT types

--- a/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
@@ -168,6 +168,80 @@ TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis_DynamicScale) {
                                       ExpectedEPNodeAssignment::All);
 }
 
+// ONNX RMSNormalization allows `scale` to be any shape unidirectionally broadcastable to X, but
+// QNN's RmsNorm OpDef requires rank(gamma) == size(axes). The builder squeezes the leading 1-dims
+// to bridge the two; these tests cover the shapes that squeeze is responsible for.
+//
+// The rank-3 scale cases below are extracted from Pi05ActionExpert (tetracode issue #20549), whose
+// 18 transformer blocks each normalize X [1, 50, 1024] with a scale of shape [1, 1, 1024]. Before
+// the squeeze, every one of those 37 RMSNorm nodes was rejected by QNN op validation
+// (QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE) and fell back to CPU, splitting the graph into 38 QNN
+// partitions. Dims are scaled down here to keep the test fast; the rank relationship is what matters.
+static void RunRMSNormFp32Test(const TestInputDef<float>& input_def,
+                               const TestInputDef<float>& scale_def,
+                               const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
+                               ExpectedEPNodeAssignment expected_ep_assignment,
+                               float fp32_abs_err = 0.01f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_htp_fp16_precision"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  RunQnnModelTest(BuildOpTestCase<float>("rms_norm", "RMSNormalization", {input_def, scale_def}, {}, attrs),
+                  provider_options,
+                  23,  // opset
+                  EPVerificationParams{expected_ep_assignment, ElementwiseAbsoluteVerifier(fp32_abs_err)});
+}
+
+// Static rank-3 scale [1, 1, C] against X [1, S, C]: squeezed in place, no Reshape node needed
+// because dropping leading 1-dims does not change the element layout.
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_StaticScale) {
+  RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+                     TestInputDef<float>({1, 1, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
+                     {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                     ExpectedEPNodeAssignment::All);
+}
+
+// Dynamic rank-3 scale [1, 1, C] -- the exact Pi05ActionExpert shape, where every scale is a
+// computed Add output rather than an initializer, so the rank can only be fixed by an in-graph
+// Reshape. This is the case the original failure hinged on.
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_DynamicScale) {
+  RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+                     TestInputDef<float>({1, 1, 3}, false, GetFloatDataInRange(0.5f, 1.5f, 3)),
+                     {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                     ExpectedEPNodeAssignment::All);
+}
+
+// Rank-2 scale [1, C] also needs one dim squeezed; verifies the squeeze is driven by size(axes)
+// rather than by a hardcoded "rank 3 -> rank 1" assumption.
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank2Scale_LeadingOnes) {
+  RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+                     TestInputDef<float>({1, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
+                     {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                     ExpectedEPNodeAssignment::All);
+}
+
+// Rank-4 X with a rank-4 scale [1, 1, 1, C]: squeeze must drop all three leading 1-dims.
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank4Scale_LeadingOnes) {
+  RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 18)),
+                     TestInputDef<float>({1, 1, 1, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
+                     {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                     ExpectedEPNodeAssignment::All);
+}
+
+// A scale whose leading dim is not 1 cannot be squeezed to size(axes). IsOpSupported must reject it
+// so the node falls back to CPU with a clear message, instead of being claimed and then failing
+// inside QNN op validation.
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_NonOneLeadingDim_Unsupported) {
+  RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
+                     TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
+                     {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                     ExpectedEPNodeAssignment::None);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/rmsnormalization_test.cc
@@ -169,19 +169,20 @@ TEST_F(QnnHTPBackendTests, RMSNorm1D_LastAxis_DynamicScale) {
 }
 
 // ONNX RMSNormalization allows `scale` to be any shape unidirectionally broadcastable to X, but
-// QNN's RmsNorm OpDef requires rank(gamma) == size(axes). The builder squeezes the leading 1-dims
-// to bridge the two; these tests cover the shapes that squeeze is responsible for.
+// QNN's RmsNorm OpDef requires rank(gamma) == size(axes). The builder squeezes leading 1-dims to
+// bridge the two; the tests below cover the shapes that squeeze is responsible for.
 //
-// The rank-3 scale cases below are extracted from Pi05ActionExpert (tetracode issue #20549), whose
-// 18 transformer blocks each normalize X [1, 50, 1024] with a scale of shape [1, 1, 1024]. Before
-// the squeeze, every one of those 37 RMSNorm nodes was rejected by QNN op validation
-// (QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE) and fell back to CPU, splitting the graph into 38 QNN
-// partitions. Dims are scaled down here to keep the test fast; the rank relationship is what matters.
+// The rank-3 scale shape comes from Pi05ActionExpert (tetracode issue #20549), which normalizes
+// X [1, 50, 1024] with a scale of shape [1, 1, 1024]. Dims are scaled down here for speed; the
+// rank relationship is what is under test.
 static void RunRMSNormFp32Test(const TestInputDef<float>& input_def,
                                const TestInputDef<float>& scale_def,
                                const std::vector<ONNX_NAMESPACE::AttributeProto>& attrs,
                                ExpectedEPNodeAssignment expected_ep_assignment,
                                float fp32_abs_err = 0.01f) {
+#if defined(_WIN32)
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#endif
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -196,8 +197,7 @@ static void RunRMSNormFp32Test(const TestInputDef<float>& input_def,
                   EPVerificationParams{expected_ep_assignment, ElementwiseAbsoluteVerifier(fp32_abs_err)});
 }
 
-// Static rank-3 scale [1, 1, C] against X [1, S, C]: squeezed in place, no Reshape node needed
-// because dropping leading 1-dims does not change the element layout.
+// Static scale: squeezed by re-declaring the dims, no Reshape node.
 TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_StaticScale) {
   RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
                      TestInputDef<float>({1, 1, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
@@ -205,9 +205,7 @@ TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_StaticScale) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// Dynamic rank-3 scale [1, 1, C] -- the exact Pi05ActionExpert shape, where every scale is a
-// computed Add output rather than an initializer, so the rank can only be fixed by an in-graph
-// Reshape. This is the case the original failure hinged on.
+// Computed (non-initializer) scale, as in Pi05ActionExpert: only an in-graph Reshape can fix the rank.
 TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_DynamicScale) {
   RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
                      TestInputDef<float>({1, 1, 3}, false, GetFloatDataInRange(0.5f, 1.5f, 3)),
@@ -215,8 +213,7 @@ TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_DynamicScale) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// Rank-2 scale [1, C] also needs one dim squeezed; verifies the squeeze is driven by size(axes)
-// rather than by a hardcoded "rank 3 -> rank 1" assumption.
+// Squeeze is driven by size(axes), not by a fixed source rank.
 TEST_F(QnnHTPBackendTests, RMSNorm_Rank2Scale_LeadingOnes) {
   RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
                      TestInputDef<float>({1, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
@@ -224,7 +221,7 @@ TEST_F(QnnHTPBackendTests, RMSNorm_Rank2Scale_LeadingOnes) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// Rank-4 X with a rank-4 scale [1, 1, 1, C]: squeeze must drop all three leading 1-dims.
+// Multiple leading 1-dims must all be dropped.
 TEST_F(QnnHTPBackendTests, RMSNorm_Rank4Scale_LeadingOnes) {
   RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 18)),
                      TestInputDef<float>({1, 1, 1, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 3)),
@@ -232,14 +229,29 @@ TEST_F(QnnHTPBackendTests, RMSNorm_Rank4Scale_LeadingOnes) {
                      ExpectedEPNodeAssignment::All);
 }
 
-// A scale whose leading dim is not 1 cannot be squeezed to size(axes). IsOpSupported must reject it
-// so the node falls back to CPU with a clear message, instead of being claimed and then failing
-// inside QNN op validation.
-TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_NonOneLeadingDim_Unsupported) {
-  RunRMSNormFp32Test(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(-1.0f, 1.0f, 6)),
-                     TestInputDef<float>({1, 2, 3}, true, GetFloatDataInRange(0.5f, 1.5f, 6)),
-                     {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
-                     ExpectedEPNodeAssignment::None);
+// Quantized squeeze: exercises the scale's quant params being carried onto the squeezed tensor and
+// the dummy beta (SDK < 2.49) inheriting the post-squeeze rank.
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_QDQ_StaticScale) {
+  RunRMSNormQDQTest<uint8_t, uint8_t>(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+                                      TestInputDef<float>({1, 1, 3}, true, GetFloatDataInRange(0.0f, 1.0f, 3)),
+                                      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                      ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, RMSNorm_Rank3Scale_LeadingOnes_QDQ_DynamicScale) {
+  RunRMSNormQDQTest<uint8_t, uint8_t>(TestInputDef<float>({1, 2, 3}, false, GetFloatDataInRange(0.0f, 10.0f, 6)),
+                                      TestInputDef<float>({1, 1, 3}, false, GetFloatDataInRange(0.0f, 1.0f, 3)),
+                                      {test::MakeAttribute("axis", static_cast<int64_t>(-1))},
+                                      ExpectedEPNodeAssignment::All);
+}
+
+// axis=1 over X {2, 3, 4} normalizes 2 axes, so the scale squeezes to rank 2 rather than rank 1.
+// Uses the CPU backend because the HTP path requires the last axis only.
+TEST_F(QnnCPUBackendTests, RMSNorm_Rank3Scale_LeadingOne_MultipleAxes) {
+  RunRMSNormCpuTest(TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(0.0f, 10.0f, 24)),
+                    TestInputDef<float>({1, 3, 4}, false, GetFloatDataInRange(0.0f, 10.0f, 12)),
+                    {test::MakeAttribute("axis", static_cast<int64_t>(1))},
+                    ExpectedEPNodeAssignment::All);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
## Summary

QNN's `RmsNorm` OpDef requires **`rank(gamma) == size(axes)`**, while ONNX `RMSNormalization` (opset 23) allows `Scale` to be *any* shape unidirectionally broadcastable to `X`. A graph with `X [1, 50, 1024]` and `scale [1, 1, 1024]` (axis `-1`) is therefore perfectly valid ONNX but is rejected by QNN op validation with `QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE` (error code `3110`).

`RMSNormalizationOpBuilder` previously passed the scale through verbatim, and the SDK-<2.49 dummy-beta path copied `scale_info.shape`, propagating the bad rank to beta as well. Every such node was therefore rejected during partitioning and fell back to CPU EP, fragmenting the graph into one QNN subgraph per surviving span.

This PR makes the EP reconcile the rank, which is the correct layer for it: the EP is what knows the QNN OpDef.

## Changes

`onnxruntime/core/providers/qnn/builder/opbuilder/rmsnormalization_op_builder.cc`

1. **`ProcessInputs` — squeeze leading 1-dims off the scale** to reach `size(axes)`:
   - **static scale**: re-declared at the reduced rank via a new `QnnTensorWrapper`. Dropping leading 1-dims doesn't change the element layout, so no `Reshape` node is needed — only the declared dims change. Emitted under a `_squeeze`-suffixed unique name so a scale shared with another consumer keeps its original rank there.
   - **dynamic scale**: `qnn_model_wrapper.AddReshapeNode(...)` — the established in-graph shape-reconciliation idiom already used by the conv, softmax, instancenorm, einsum and rotary_embedding builders.
2. **Dummy beta inherits the squeezed rank** — `scale_info.shape` is updated post-squeeze, so the existing `beta_shape = scale_info.shape` becomes correct with no extra logic.
3. A scale that genuinely cannot be reconciled (non-1 leading dim) is rejected in `ProcessInputs` with an explicit message. Because `IsOpSupported` builds the node with `do_op_validation=true`, that rejection propagates out during partitioning and the node is simply never claimed — no separate `IsOpSupported` check is needed.
4. Only per-tensor quantization is accepted on a scale that needs squeezing. Axis-bearing and per-block encodings describe the pre-squeeze rank and there is no helper to remap one for a rank reduction (`QnnQuantParamsWrapper` has `HandleUnsqueeze`/`HandleTranspose` but no rank-reducing counterpart), so they are rejected rather than silently emitted misaligned.

The reconciliation is driven by `size(axes)`, not by a hardcoded rank, so rank-2/3/4 scales are all handled by the same path.

## Motivation — real model

Found while triaging **Pi05ActionExpert** (the π0.5 action expert) in [qcom-ai-hub/tetracode#20549](https://github.com/qcom-ai-hub/tetracode/issues/20549). Its 18 transformer blocks each normalize `X [1, 50, 1024]` with a scale of shape `[1, 1, 1024]` — 37 `RMSNormalization` sites in total, every scale a *computed* `Add` output (the `weight + 1` idiom), so constant folding cannot flatten it. Measured on the real model through the full compile pipeline:

| Configuration | `RMSNormalization` ops | QNN subgraphs (DLCs) | Result |
|---|---|---|---|
| Rank-3 scale (as shipped) | 37 | **38** | ❌ 107 × `backendValidateOpConfig() failed ... error code 3110`, 37 nodes on CPU EP |
| RMSNorm fusion disabled | 0 (37 `ReduceMean` decompositions) | **1** | ✅ compiles, but loses the fused op |
| Rank-1 scale | 37 | **1** | ✅ compiles, `RmsNorm` retained |

The constraint is **rank**, not dims — verified by isolation:

```
gamma=[1024]     x=[1,50,1024]  -> PASS   (rank == size(axes))
gamma=[1]        x=[1,50,1024]  -> PASS   (rank 1 accepted even though dim != 1024)
gamma=[1,1024]   x=[1,50,1024]  -> FAIL 3110
gamma=[1,1,1024] x=[1,50,1024]  -> FAIL 3110
gamma=[1,1,1]    x=[1,50,1024]  -> FAIL 3110
```

After the equivalent rank fix, the DLC contains 37 `RmsNorm` ops with `axes: [2]` and rank-1 `[1024]` betas, and numerics match the original ONNX on CPU EP to `max_abs_diff = 7.15e-07` / `max_rel_diff = 4.61e-07`.
