### PR TITLE
[QNN EP] Support int16 QDQ activations for MatMulNBits on HTP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -9,76 +9,78 @@
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_bq_utils.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_quant_params_wrapper.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 
 namespace onnxruntime {
 namespace qnn {
-/* Op Resolution
-  --> Incoming ONNX Node
-    1. MatMulNBits
-      Attributes : INT64
-        - bits            : 2(HTP), 4(GPU/HTP), 8(HTP)
-        - block_size      : 32(GPU), 16x(HTP if bits=2), 8x(HTP if bits=4), 4x(HTP if bits=8)
-        - K               :
-        - N               :
-      Inputs
-        - A           :                 : fp16/fp32 : [batch_size, sequence_len, K]
-        - B           : Init            : uint8     : [N, K / block_size, (block_size * bits) / 8]
-        - scales      : Init            : fp16/fp32 : [N, K / block_size]
-        - zero_points : (optional)Init  : uint8     : [N, (K / block_size) * bits / 8]
-      Outputs
-        -  Y          :                 : fp16/fp32 : [batch_size, sequence_len, N]
-  <-- Outgoing QNN Node (GPU)
-    1. FullyConnected
-      Attributes
-        -
-      Inputs
-        - Input           :        : fp16/fp32            : [batch_size, sequence_len, K]
-        - Weight          : Static : qint4(BlockEncoding) : [N, K]
-          - Scales        :        : fp32                 : [N * (K / block_size)]
-          - Offsets       :        : int32_t              : [N * (K / block_size)]
-      Outputs
-        - Output          :        : fp16/fp32            : [batch_size * sequence_len, N]
-    2. Reshape
-      Inputs
-        - Input           :        : fp16/fp32            : [batch_size * sequence_len, N]
-      Outputs
-        - Output          :        : fp16/fp32            : [batch_size, sequence_len, N]
-  <-- Outgoing QNN Node (HTP)
-    1. Reshape
-      Inputs
-        - Input           :        : fp16/fp32                    : [batch_size, sequence_len, K]
-      Outputs
-        - Output          :        : fp16/fp32                    : [batch_size, 1, sequence_len, K]
-    2. Cast (workaround for fp32)
-      Inputs
-        - Input           :        : fp32                         : [batch_size, 1, sequence_len, K]
-      Outputs
-        - Output          :        : fp16                         : [batch_size, 1, sequence_len, K]
-    3. Conv2d
-      Attributes : UINT32
-        - stride     : [1, 1]
-        - pad_amount : [[0, 0], [0, 0]]
-      Inputs
-        - Input           :        : fp16                         : [batch_size, 1, sequence_len, K]
-        - Weight          : Static : qint8(BwFloatBlockEncoding)  : [1, 1, K, N]
-          - Scales        :        : fp32                         : [N * (K / block_size)]
-          - Offsets       :        : fp32                         : [N * (K / block_size)]
-      Outputs
-        - Output          :        : fp16                         : [batch_size, 1, sequence_len, N]
-    4. Cast (workaround for fp32)
-      Inputs
-        - Input           :        : fp16                         : [batch_size, 1, sequence_len, N]
-      Outputs
-        - Output          :        : fp32                         : [batch_size, 1, sequence_len, N]
-    5. Reshape
-      Inputs
-        - Input           :        : fp16/fp32                    : [batch_size, 1, sequence_len, N]
-      Outputs
-        - Output          :        : fp16/fp32                    : [batch_size, sequence_len, N]
-*/
+/* Op resolution
+ *
+ * =============================================================================================
+ * Incoming ONNX node
+ * =============================================================================================
+ * MatMulNBits
+ *   Attributes (int64)
+ *     bits        : 2 (HTP), 4 (GPU/HTP), 8 (HTP)
+ *     block_size  : 32 (GPU); multiple of 16 / 8 / 4 (HTP, for bits = 2 / 4 / 8)
+ *     K           : contraction dim of input A
+ *     N           : output channels
+ *
+ *     Name           Kind        Data type                       Shape
+ *   Inputs
+ *     A              input       fp16/fp32 (GPU)                 [batch_size, sequence_len, K]
+ *                                fp16/fp32/uint16/int16 (HTP)
+ *     B              init        uint8 (packed)                  [N, K / block_size, (block_size * bits) / 8]
+ *     scales         init        fp16/fp32                       [N, K / block_size]
+ *     zero_points    init (opt)  uint8 (packed)                  [N, (K / block_size) * bits / 8]
+ *   Outputs
+ *     Y              output      same as A                       [batch_size, sequence_len, N]
+ *
+ * =============================================================================================
+ * Outgoing QNN nodes (GPU)
+ *   A -> FullyConnected -> Reshape -> Y
+ * =============================================================================================
+ * 1. FullyConnected
+ *      in   Input     fp16/fp32                [batch_size, sequence_len, K]
+ *      in   Weight    qint4 (BlockEncoding)    [N, K]
+ *                       scales   fp32          [N * (K / block_size)]
+ *                       offsets  int32_t       [N * (K / block_size)]
+ *      out  Output    fp16/fp32                [batch_size * sequence_len, N]
+ * 2. Reshape
+ *      in   Input     fp16/fp32                [batch_size * sequence_len, N]
+ *      out  Output    fp16/fp32                [batch_size, sequence_len, N]
+ *
+ * =============================================================================================
+ * Outgoing QNN nodes (HTP)
+ *   A -> Reshape -> [Cast | Dequantize] -> Conv2d -> [Cast | Quantize] -> Reshape -> Y
+ * =============================================================================================
+ * 1. Reshape
+ *      in   Input     fp16/fp32/uint16/int16   [batch_size, sequence_len, K]
+ *      out  Output    fp16/fp32/uint16/int16   [batch_size, 1, sequence_len, K]
+ * 2a. Cast
+ *      in   Input     fp32                     [batch_size, 1, sequence_len, K]
+ *      out  Output    fp16                     [batch_size, 1, sequence_len, K]
+ * 2b. Dequantize
+ *      in   Input     uint16/int16             [batch_size, 1, sequence_len, K]
+ *      out  Output    fp16                     [batch_size, 1, sequence_len, K]
+ * 3. Conv2d
+ *      in   Input     fp16                     [batch_size, 1, sequence_len, K]
+ *      in   Weight    qint8 (BwFloatBlock)     [1, 1, K, N]
+ *                       scales   fp32          [N * (K / block_size)]
+ *                       offsets  fp32          [N * (K / block_size)]
+ *      out  Output    fp16                     [batch_size, 1, sequence_len, N]
+ * 4a. Cast
+ *      in   Input     fp16                     [batch_size, 1, sequence_len, N]
+ *      out  Output    fp32                     [batch_size, 1, sequence_len, N]
+ * 4b. Quantize
+ *      in   Input     fp16                     [batch_size, 1, sequence_len, N]
+ *      out  Output    uint16/int16             [batch_size, 1, sequence_len, N]
+ * 5. Reshape
+ *      in   Input     fp16/fp32/uint16/int16   [batch_size, 1, sequence_len, N]
+ *      out  Output    fp16/fp32/uint16/int16   [batch_size, sequence_len, N]
+ */
 
 class MatMulNBitsOpBuilder : public BaseOpBuilder {
  public:
@@ -169,7 +171,9 @@ Ort::Status MatMulNBitsOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapp
   const int64_t num_zp_per_uint8 = K / block_size < num_elements_per_uint8 ? K / block_size : num_elements_per_uint8;
 
   const auto& inputs = node_unit.Inputs();
-  // 1. A: Input datatype should be float16 or float32.
+  // 1. A: Input datatype should be:
+  //   - GPU: float32, float16
+  //   - HTP: float32, float16, uint16, int16
   {
     const OrtNodeUnitIODef& input_tensor = inputs[0];
     TensorInfo input_info{};
@@ -180,12 +184,18 @@ Ort::Status MatMulNBitsOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapp
                                           input_tensor.type,
                                           input_datatype));
 
-    RETURN_IF(input_datatype != QNN_DATATYPE_FLOAT_32 && input_datatype != QNN_DATATYPE_FLOAT_16,
-              "Unsupported input A datatype, expecting float32 or float16.");
-
-    // Restrict to 3D input for HTP backend due to later inserted Reshape.
-    RETURN_IF(is_htp_backend && input_info.shape.size() != 3,
-              "Unsupported input A rank, expecting 3D for HTP backend.");
+    if (is_gpu_backend) {
+      RETURN_IF(input_datatype != QNN_DATATYPE_FLOAT_32 && input_datatype != QNN_DATATYPE_FLOAT_16,
+                "Unsupported input A datatype, expecting float32 or float16.");
+    } else {
+      RETURN_IF(input_datatype != QNN_DATATYPE_FLOAT_32 &&
+                    input_datatype != QNN_DATATYPE_FLOAT_16 &&
+                    input_datatype != QNN_DATATYPE_UFIXED_POINT_16 &&
+                    input_datatype != QNN_DATATYPE_SFIXED_POINT_16,
+                "Unsupported input A datatype, expecting float32, float16, uint16, or int16.");
+      // Restrict to 3D input due to later inserted Reshape.
+      RETURN_IF(input_info.shape.size() != 3, "Unsupported input A rank, expecting 3D shape.");
+    }
   }
 
   // 2. B: Weight is supported in packed uint8 format.
@@ -297,10 +307,11 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
 
   // 1. Add input A.
   {
+    // 1.1 Create QNN wrapper.
     RETURN_IF_ERROR(ProcessInput(qnn_model_wrapper, inputs[0], logger, input_names));
 
     if (is_htp_backend) {
-      // Add pre-Reshape to unsqueeze shape to 4D for HTP backend.
+      // 1.2 Add pre-Reshape to unsqueeze shape to 4D for HTP backend.
       TensorInfo input_info = {};
       RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input_info));
 
@@ -330,7 +341,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
       input_names[0] = reshape_output_name;
 
       if (input_info.qnn_data_type == QNN_DATATYPE_FLOAT_32) {
-        // Workaround: Add pre-Cast to cast float32 to float16 to pass HTP validation.
+        // 1.3 (Workaround) Add pre-Cast to cast float32 to float16 to pass HTP validation.
         // TODO: Remove the additional Cast once HTP supports float32.
         const std::string cast_output_name = utils::UniqueNameGenerator().New(input_names[0], "_cast_fp16");
         RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(node_unit, "_cast_fp16"),
@@ -344,6 +355,15 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
 
         // Reroute to pre-Cast output.
         input_names[0] = cast_output_name;
+      } else if (utils::IsQuant16bit(input_info.qnn_data_type)) {
+        // 1.3 Add Dequantize to UINT16/INT16 → FP16.
+        const std::string fp16_act_name = utils::UniqueNameGenerator().New(input_names[0], "_dq_fp16");
+        RETURN_IF_ERROR(bq::AddInt16ToFp16DequantForActivation(qnn_model_wrapper,
+                                                               input_names[0],
+                                                               fp16_act_name,
+                                                               do_op_validation,
+                                                               "MatMulNBits"));
+        input_names[0] = fp16_act_name;
       }
     }
   }
@@ -594,6 +614,20 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                     do_op_validation));
 
       reshape_input_name = cast_output_name;
+    } else if (utils::IsQuant16bit(output_info.qnn_data_type)) {
+      // 2. Add Quantize to FP16 → UINT16/INT16.
+      const std::string q_suffix = output_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_16 ? "_q_int16" : "_q_uint16";
+      const std::string q_output_name = utils::UniqueNameGenerator().New(output_tensor.name, q_suffix);
+      RETURN_IF_ERROR(bq::AddFp16ToInt16QuantizeOutput(qnn_model_wrapper,
+                                                       conv2d_output_name,
+                                                       q_output_name,
+                                                       QNN_TENSOR_TYPE_NATIVE,
+                                                       output_info.qnn_data_type,
+                                                       output_info.quant_param.Copy(),
+                                                       std::vector<uint32_t>(conv2d_output_shape),
+                                                       do_op_validation));
+
+      reshape_input_name = q_output_name;
     }
 
     // 3. Add post-Reshape to squeeze shape back.

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1373,6 +1373,30 @@ bool OrtRMSNormalizationNodeGroupSelector::Check(const OrtGraph* graph, const Or
   return (dt_input.value() == dt_output.value());
 }
 
+bool OrtMatMulNBitsNodeGroupSelector::Check(const OrtGraph* graph,
+                                            const OrtApi& ort_api,
+                                            const OrtNode* node,
+                                            const OrtNode* redundant_clip_node,
+                                            const std::vector<const OrtNode*>& dq_nodes,
+                                            const std::vector<const OrtNode*>& q_nodes) const {
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, /*num_dq_inputs*/ 1)) {
+    return false;
+  }
+
+  auto dt_input = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
+  auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
+
+  if (!dt_input.has_value() || !dt_output.has_value()) {
+    return false;
+  }
+
+  if (dt_input.value() != dt_output.value()) {
+    return false;
+  }
+
+  return true;
+}
+
 // Helper function to get QDQ selection for a node
 std::optional<OrtNodeGroup> GetOrtQDQSelection(const OrtGraph* graph, const OrtApi& ort_api,
                                                const OrtNode* node, const OrtNodeGroupSelector* selector) {
@@ -1780,6 +1804,10 @@ void OrtSelectorManager::CreateSelectors() {
       {"RMSNormalization", {}},
       {"SimplifiedLayerNormalization", {}}};
   ort_selectors_.RegisterSelector(rmsnorm_ops, std::make_unique<OrtRMSNormalizationNodeGroupSelector>());
+
+  // Register MatMulNBits ops.
+  OrtOpVersionsAndSelector::OpVersionsMap matmulnbits_ops = {{"MatMulNBits", {}}};
+  ort_selectors_.RegisterSelector(matmulnbits_ops, std::make_unique<OrtMatMulNBitsNodeGroupSelector>());
 }
 
 void OrtSelectorManager::InitializeSelectorsMap() {

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.h
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.h
@@ -378,6 +378,21 @@ class OrtRMSNormalizationNodeGroupSelector : public OrtNodeGroupSelector {
              const std::vector<const OrtNode*>& q_nodes) const override;
 };
 
+// Input 1: DQ node for input A.
+// Input 2: no DQ node for input B.
+// Input 3: no DQ node for input scales.
+// Input 4: no DQ node for input zero_points.
+// Output: Q node for output Y.
+class OrtMatMulNBitsNodeGroupSelector : public OrtNodeGroupSelector {
+ private:
+  bool Check(const OrtGraph* graph,
+             const OrtApi& ort_api,
+             const OrtNode* node,
+             const OrtNode* redundant_clip_node,
+             const std::vector<const OrtNode*>& dq_nodes,
+             const std::vector<const OrtNode*>& q_nodes) const override;
+};
+
 // SelectorManager for OrtGraph
 class OrtSelectorManager {
  public:

--- a/onnxruntime/test/providers/qnn/matmulnbits_test.cc
+++ b/onnxruntime/test/providers/qnn/matmulnbits_test.cc
@@ -3,6 +3,8 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <type_traits>
+
 #include "gtest/gtest.h"
 
 #include "test/providers/qnn/qnn_test_utils.h"
@@ -50,10 +52,73 @@ struct TestParams {
   int64_t N;
   int64_t K;
   int64_t block_size;
-  int64_t accuracy_level{4};
+  // accuracy_level=1 selects fp32 compute in the CPU EP kernel, which keeps the CPU-side result an accurate
+  // reference to compare QNN EP against. QNN EP ignores this attribute entirely.
+  int64_t accuracy_level{1};
 
   bool has_zero_point{false};
 };
+
+// Adds the MatMulNBits weight B (packed uint8 BQ), float scales, and optional uint8 zero_point.
+template <int bits>
+static void AddMatMulNBitsWeightInputs(ModelTestBuilder& builder,
+                                       const TestParams& params,
+                                       std::vector<float>& input1_f_vals,
+                                       bool gpu_symmetric_zp,
+                                       std::vector<std::string>& input_names) {
+  const int64_t k_blocks = (params.K + params.block_size - 1) / params.block_size;
+  const int64_t blob_size = (params.block_size * bits + 7) / 8;
+  const size_t q_scale_size = static_cast<size_t>(params.N * k_blocks);
+  const size_t q_data_size_in_bytes = static_cast<size_t>(params.N * k_blocks * blob_size);  // packed as UInt4x2
+  const int64_t zero_point_blob_size = (k_blocks * bits + 7) / 8;
+  const size_t q_zp_size_in_bytes = static_cast<size_t>(params.N * zero_point_blob_size);  // packed as UInt4x2
+
+  std::vector<uint8_t> input1_vals(q_data_size_in_bytes);
+  std::vector<float> scales(q_scale_size);
+  std::vector<uint8_t> zp(q_zp_size_in_bytes);
+
+  // GPU backend only supports bits=4 with symmetric quantization. Hardcode zp instead of computing it.
+  if (gpu_symmetric_zp) {
+    std::fill(zp.begin(), zp.end(), 0b10001000);
+  }
+
+  QuantizeDequantize<bits>(input1_f_vals,
+                           input1_vals,
+                           scales,
+                           params.has_zero_point && !gpu_symmetric_zp ? &zp : nullptr,
+                           static_cast<int32_t>(params.N),
+                           static_cast<int32_t>(params.K),
+                           static_cast<int32_t>(params.block_size));
+
+  auto input1_def = TestInputDef<uint8_t>({params.N, k_blocks, blob_size}, true, input1_vals);
+  MakeTestInput<uint8_t>(builder, "input1", input1_def);
+  input_names.push_back("input1");
+
+  auto scales_def = TestInputDef<float>({params.N, k_blocks}, true, scales);
+  MakeTestInput<float>(builder, "scales", scales_def);
+  input_names.push_back("scales");
+
+  if (params.has_zero_point) {
+    auto zp_def = TestInputDef<uint8_t>({params.N, zero_point_blob_size}, true, zp);
+    MakeTestInput<uint8_t>(builder, "zero_point", zp_def);
+    input_names.push_back("zero_point");
+  }
+}
+
+// Adds the MatMulNBits contrib node (inputs `input_names` → "Y") with the K/N/block_size/bits/accuracy_level attrs.
+static void AddMatMulNBitsNode(ModelTestBuilder& builder,
+                               const TestParams& params,
+                               int64_t bits,
+                               const std::vector<std::string>& input_names) {
+  std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+  attributes.push_back(builder.MakeScalarAttribute("K", static_cast<int64_t>(params.K)));
+  attributes.push_back(builder.MakeScalarAttribute("N", static_cast<int64_t>(params.N)));
+  attributes.push_back(builder.MakeScalarAttribute("block_size", static_cast<int64_t>(params.block_size)));
+  attributes.push_back(builder.MakeScalarAttribute("bits", bits));
+  attributes.push_back(builder.MakeScalarAttribute("accuracy_level", static_cast<int64_t>(params.accuracy_level)));
+
+  builder.AddNode("matmul_nbits", "MatMulNBits", input_names, {"Y"}, kMSDomain, attributes);
+}
 
 template <int bits>
 static void RunMatMulNBitsTest(const TestParams params,
@@ -63,6 +128,12 @@ static void RunMatMulNBitsTest(const TestParams params,
   ProviderOptions provider_options;
   provider_options["backend_type"] = backend_name;
   provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_block_quant_weight_optimization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  if (backend_name == "htp") {
+    provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+  }
+#endif
 
   auto model_builder = [&params, &backend_name](ModelTestBuilder& builder) {
     std::vector<std::string> input_names;
@@ -77,68 +148,102 @@ static void RunMatMulNBitsTest(const TestParams params,
     MakeTestInput<float>(builder, "input0", input0_def);
     input_names.push_back("input0");
 
-    int64_t k_blocks = (params.K + params.block_size - 1) / params.block_size;
-    int64_t blob_size = (params.block_size * bits + 7) / 8;
-    size_t q_scale_size = static_cast<size_t>(params.N * k_blocks);
-    size_t q_data_size_in_bytes = static_cast<size_t>(params.N * k_blocks * blob_size);  // packed as UInt4x2
-    const int64_t zero_point_blob_size = (k_blocks * bits + 7) / 8;
-    size_t q_zp_size_in_bytes = static_cast<size_t>(params.N * zero_point_blob_size);  // packed as UInt4x2
-
-    std::vector<uint8_t> input1_vals(q_data_size_in_bytes);
-    std::vector<float> scales(q_scale_size);
-    std::vector<uint8_t> zp(q_zp_size_in_bytes);
-
-    // GPU backend only supports bits=4 with symmetric quantization. Hardcode zp instead of through calculation.
-    if constexpr (bits == 4) {
-      if (backend_name == "gpu") {
-        std::fill(zp.begin(), zp.end(), 0b10001000);
-      }
-    }
-
-    QuantizeDequantize<bits>(input1_f_vals,
-                             input1_vals,
-                             scales,
-                             params.has_zero_point && backend_name != "gpu" ? &zp : nullptr,
-                             static_cast<int32_t>(params.N),
-                             static_cast<int32_t>(params.K),
-                             static_cast<int32_t>(params.block_size));
-
-    auto input1_def = TestInputDef<uint8_t>({params.N, k_blocks, blob_size}, true, input1_vals);
-    MakeTestInput<uint8_t>(builder, "input1", input1_def);
-    input_names.push_back("input1");
-
-    auto scales_def = TestInputDef<float>({params.N, k_blocks}, true, scales);
-    MakeTestInput<float>(builder, "scales", scales_def);
-    input_names.push_back("scales");
-
-    if (params.has_zero_point) {
-      auto zp_def = TestInputDef<uint8_t>({params.N, zero_point_blob_size}, true, zp);
-      MakeTestInput<uint8_t>(builder, "zero_point", zp_def);
-      input_names.push_back("zero_point");
-    }
+    AddMatMulNBitsWeightInputs<bits>(builder,
+                                     params,
+                                     input1_f_vals,
+                                     /*gpu_symmetric_zp=*/bits == 4 && backend_name == "gpu",
+                                     input_names);
 
     builder.MakeOutput("Y");
 
-    // Create attributes
-    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
-    attributes.push_back(builder.MakeScalarAttribute("K", static_cast<int64_t>(params.K)));
-    attributes.push_back(builder.MakeScalarAttribute("N", static_cast<int64_t>(params.N)));
-    attributes.push_back(builder.MakeScalarAttribute("block_size", static_cast<int64_t>(params.block_size)));
-    attributes.push_back(builder.MakeScalarAttribute("bits", static_cast<int64_t>(bits)));
-    attributes.push_back(builder.MakeScalarAttribute("accuracy_level", static_cast<int64_t>(params.accuracy_level)));
-
-    builder.AddNode("matmul_nbits",
-                    "MatMulNBits",
-                    input_names,
-                    {"Y"},
-                    kMSDomain,
-                    attributes);
+    AddMatMulNBitsNode(builder, params, bits, input_names);
   };
 
   RunQnnModelTest(model_builder,
                   provider_options,
                   13,  // opset version for contrib ops
                   EPVerificationParams{expected_ep_assignment, ElementwiseAbsoluteVerifier(fp32_abs_err)});
+}
+
+// Tests the accuracy of a QDQ MatMulNBits graph that exercises the HTP block-quantized (BQ) *activation* paths:
+//   - activation A: float → Q(ActQType) → DQ → MatMulNBits input A
+//   - weight B    : packed uint8 BQ initializer (bits/block_size), symmetric unless has_zero_point
+//   - output Y    : MatMulNBits → Q(ActQType) → DQ → graph output
+template <int bits, typename ActQType>
+static void RunHtpQDQMatMulNBitsTest(const TestParams params,
+                                     ExpectedEPNodeAssignment expected_ep_assignment = ExpectedEPNodeAssignment::All,
+                                     QDQTolerance tolerance = QDQTolerance()) {
+  static_assert(std::is_same_v<ActQType, uint16_t> || std::is_same_v<ActQType, int16_t>,
+                "MatMulNBits QDQ activations on HTP must be uint16 or int16.");
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_block_quant_weight_optimization"] = "0";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  // Generate the raw float data once so that the float and QDQ models use identical inputs and weights.
+  RandomValueGenerator random{1234};
+  std::vector<float> input0_vals(random.Gaussian<float>(AsSpan({params.batch_count, params.M, params.K}),
+                                                        0.0f,
+                                                        0.25f));
+  const std::vector<float> weight_f_vals(random.Gaussian<float>(AsSpan({params.K, params.N}), 0.0f, 0.25f));
+
+  const TestInputDef<float> input0_def({params.batch_count, params.M, params.K}, false, input0_vals);
+
+  // ── Float baseline: input0 (float) → MatMulNBits → Y ──
+  auto f32_model_builder = [&params, &input0_def, &weight_f_vals](ModelTestBuilder& builder) {
+    std::vector<std::string> input_names;
+
+    MakeTestInput<float>(builder, "input0", input0_def);
+    input_names.push_back("input0");
+
+    // AddMatMulNBitsWeightInputs() overwrites its float weights with the dequantized values, so pass a copy.
+    std::vector<float> weight_vals(weight_f_vals);
+    AddMatMulNBitsWeightInputs<bits>(builder, params, weight_vals, /*gpu_symmetric_zp=*/false, input_names);
+
+    AddMatMulNBitsNode(builder, params, bits, input_names);
+    builder.MakeOutput("Y");
+  };
+
+  // ── QDQ model: input0 → Q(ActQType) → DQ → MatMulNBits → Q(ActQType) → DQ → output ──
+  auto qdq_model_builder = [&params, &input0_def, &weight_f_vals](
+                               ModelTestBuilder& builder,
+                               std::vector<QuantParams<ActQType>>& output_qparams) {
+    std::vector<std::string> input_names;
+
+    // ── Activation A: float → Q(ActQType) → DQ ──
+    MakeTestInput<float>(builder, "input0", input0_def);
+    QuantParams<ActQType> act_qparams = GetTestInputQuantParams<ActQType>(input0_def);
+    input_names.push_back(AddQDQNodePair<ActQType>(builder,
+                                                   "act",
+                                                   "input0",
+                                                   act_qparams.scale,
+                                                   act_qparams.zero_point));
+
+    // ── Weight B + scales (+ optional zero_point) ──
+    std::vector<float> weight_vals(weight_f_vals);
+    AddMatMulNBitsWeightInputs<bits>(builder, params, weight_vals, /*gpu_symmetric_zp=*/false, input_names);
+
+    // ── MatMulNBits → Y ──
+    AddMatMulNBitsNode(builder, params, bits, input_names);
+
+    // ── Output Y: → Q(ActQType) → DQ → graph output ──
+    AddQDQNodePairWithOutputAsGraphOutput<ActQType>(builder,
+                                                    "out",
+                                                    "Y",
+                                                    output_qparams[0].scale,
+                                                    output_qparams[0].zero_point);
+  };
+
+  TestQDQModelAccuracy<ActQType>(f32_model_builder,
+                                 qdq_model_builder,
+                                 provider_options,
+                                 21,  // opset 21 for 16-bit Q/DQ
+                                 expected_ep_assignment,
+                                 tolerance);
 }
 
 #if defined(_M_ARM64)
@@ -186,6 +291,8 @@ TEST_F(QnnGPUBackendTests, MatMulNBits_Basic_M10_N128_K512) {
 #endif  // defined(_M_ARM64)
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -196,6 +303,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS16) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS16_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -206,6 +315,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS16_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -216,6 +327,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS32) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -226,6 +339,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS32_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -236,6 +351,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS64) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -246,6 +363,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B2_BS64_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -256,6 +375,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS16) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS16_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -266,6 +387,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS16_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -276,6 +399,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS32) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -286,6 +411,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS32_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -296,6 +423,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS64) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -306,6 +435,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B4_BS64_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -316,6 +447,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS16) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS16_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -326,6 +459,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS16_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -336,6 +471,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS32) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -346,6 +483,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS32_ZP) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -356,6 +495,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS64) {
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
   TestParams params;
   params.M = 1;
   params.N = 2;
@@ -364,6 +505,443 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_M1_N2_K64_B8_BS64_ZP) {
   params.has_zero_point = true;
   RunMatMulNBitsTest<8>(params, "htp");
 }
+
+// QDQ MatMulNBits with UINT16 (UFIXED_POINT_16) activations/output.
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B2_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B2_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B2_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B2_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B2_BS128) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B2_BS128_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B4_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B4_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B4_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B4_BS128) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B4_BS128_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<4, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B8_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K64_B8_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B8_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N32_K128_B8_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B8_BS128) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_U16_M1_N64_K256_B8_BS128_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<8, uint16_t>(params);
+}
+
+// QDQ MatMulNBits with INT16 (SFIXED_POINT_16) activations/output.
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B2_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B2_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B2_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B2_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B2_BS128) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B2_BS128_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B4_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B4_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B4_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B4_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B4_BS128) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B4_BS128_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B8_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K64_B8_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 64;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B8_BS64) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N32_K128_B8_BS64_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 32;
+  params.K = 128;
+  params.block_size = 64;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B8_BS128) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_QDQ_S16_M1_N64_K256_B8_BS128_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 64;
+  params.K = 256;
+  params.block_size = 128;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<8, int16_t>(params);
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
* qnn_ep_utils.h/cc - add OrtMatMulNBitsNodeGroupSelector: one DQ on input A (B/scales/zero_points stay plain initializers) + one Q on output Y, with matching element types. Registered for "MatMulNBits".

* matmulnbits_op_builder.cc
  - IsOpSupported: split the input A datatype check per backend — GPU keeps float32/float16, HTP also allows uint16/int16.
  - Insert Dequantize (int16 -> fp16) before Conv2d and Quantize (fp16 -> int16) after it when the weight BQ params aren't natively supported by HTP; Conv2d output dtype now follows the actual activation tensor instead of being hardcoded to float16. The native BQ probe is still a `false` placeholder (TODO), so int16 activations always take the DQ/Q path for now.
  - Refresh the op-resolution header comment.

* matmulnbits_test.cc - extract AddMatMulNBitsWeightInputs / AddMatMulNBitsNode helpers, add QDQ HTP tests.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Enable MatMulNBits to be selected as a QDQ node group and accept uint16/int16 activations on HTP, in addition to float32/float16.

