### PR TITLE
[QNN EP] Restore file mapping in SSR context recovery

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1281,6 +1281,27 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
   return Ort::Status();
 }
 
+Ort::Status QnnBackendManager::BuildContextBinaryConfigs(
+    int64_t max_spill_fill_size,
+    Qnn_ContextHandle_t first_group_handle,
+    QnnConfigsBuilder<QnnContext_Config_t, QnnHtpContext_CustomConfig_t>& configs_builder) {
+  gsl::not_null<QnnContext_Config_t*> priority_cfg = configs_builder.PushConfig();
+  RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, *priority_cfg));
+
+  if (max_spill_fill_size > 0) {
+    gsl::not_null<QnnHtpContext_CustomConfig_t*> spill_custom = configs_builder.PushCustomConfig();
+    spill_custom->option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
+    spill_custom->groupRegistration.firstGroupHandle = first_group_handle;
+    spill_custom->groupRegistration.maxSpillFillBuffer = max_spill_fill_size;
+
+    gsl::not_null<QnnContext_Config_t*> spill_cfg = configs_builder.PushConfig();
+    spill_cfg->option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+    spill_cfg->customConfig = spill_custom;
+  }
+
+  return Ort::Status();
+}
+
 Ort::Status QnnBackendManager::CreateContextHandleFromBinary(
     void* bin_buffer,
     uint64_t buffer_length,
@@ -1357,22 +1378,8 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
                                                    const qnn::EpContextIoDispatch& io_dispatch) {
   QnnConfigsBuilder<QnnContext_Config_t, QnnHtpContext_CustomConfig_t> configs_builder(
       QNN_CONTEXT_CONFIG_INIT, QnnHtpContext_CustomConfig_t{});
-
-  auto* priority_cfg = configs_builder.PushConfig();
-  RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, *priority_cfg));
-
-  // Spill-fill: re-register buffer allocation for the recovered context.
-  // Always a new group (firstGroupHandle = 0x0) since SSR invalidated all prior handles.
-  if (max_spill_fill_size > 0) {
-    auto* spill_custom = configs_builder.PushCustomConfig();
-    spill_custom->option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
-    spill_custom->groupRegistration.firstGroupHandle = 0x0;
-    spill_custom->groupRegistration.maxSpillFillBuffer = max_spill_fill_size;
-
-    auto* spill_cfg = configs_builder.PushConfig();
-    spill_cfg->option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
-    spill_cfg->customConfig = spill_custom;
-  }
+  // SSR always starts a new spill-fill group (firstGroupHandle = 0x0): all prior handles are invalid.
+  RETURN_IF_ERROR(BuildContextBinaryConfigs(max_spill_fill_size, 0x0, configs_builder));
 
   void* bin_buffer = nullptr;
   uint64_t buffer_length = 0;
@@ -1963,34 +1970,16 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
 
   } else {
 #endif
-    QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
-    RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
-
-    // Register spill fill buffer for multi context
-    QnnContext_Config_t spill_fill_config = QNN_CONTEXT_CONFIG_INIT;
-
-    // The spill fill buffer is available since 2.28, API version starts from 2.21
-#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 21)
-    QnnHtpContext_CustomConfig_t custom_config;
-    custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
-    QnnHtpContext_GroupRegistration_t group_info;
+    // Join the existing spill-fill group if one exists; otherwise start a new one.
     size_t current_contexts_size = GetQnnContextSize();
-    // set to 0x0 (new group) if this is the first context, otherwise point to the first context handle
-    // note that we already move the context with max spill fill size to the beginning of the list
-    group_info.firstGroupHandle = (max_spill_fill_size > 0 && current_contexts_size > 0) ? GetQnnContext(0) : 0x0;
-    group_info.maxSpillFillBuffer = max_spill_fill_size;  // Max spill-fill buffer across contexts. Must be >0
-    custom_config.groupRegistration = group_info;
-    spill_fill_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
-    spill_fill_config.customConfig = &custom_config;
-
-#endif
-
-    QnnContext_Config_t* spill_fill_config_pointer = max_spill_fill_size > 0 ? &spill_fill_config : nullptr;
-    ORT_CXX_LOG_PTR(logger_ptr_,
-                    ORT_LOGGING_LEVEL_VERBOSE,
+    Qnn_ContextHandle_t first_group_handle =
+        (max_spill_fill_size > 0 && current_contexts_size > 0) ? GetQnnContext(0) : 0x0;
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE,
                     ("Max spill fill buffer size: " + std::to_string(max_spill_fill_size)).c_str());
 
-    const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_config_pointer, nullptr};
+    QnnConfigsBuilder<QnnContext_Config_t, QnnHtpContext_CustomConfig_t> configs_builder(
+        QNN_CONTEXT_CONFIG_INIT, QnnHtpContext_CustomConfig_t{});
+    RETURN_IF_ERROR(BuildContextBinaryConfigs(max_spill_fill_size, first_group_handle, configs_builder));
 
     qnn::profile::ProfilingInfo profiling_info;
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
@@ -2000,8 +1989,8 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
 #endif
 
     RETURN_IF_ERROR(CreateContextHandleFromBinary(bin_buffer, buffer_length, use_file_mapping,
-                                                  context_configs, context_bin_filepath, io_dispatch,
-                                                  context));
+                                                  configs_builder.GetQnnConfigs(), context_bin_filepath,
+                                                  io_dispatch, context));
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
     if (ProfilingEnabled()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1281,6 +1281,76 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
   return Ort::Status();
 }
 
+Ort::Status QnnBackendManager::CreateContextHandleFromBinary(
+    void* bin_buffer,
+    uint64_t buffer_length,
+    bool use_file_mapping,
+    const QnnContext_Config_t** context_configs,
+    const std::string& context_bin_filepath,
+    const qnn::EpContextIoDispatch& io_dispatch,
+    Qnn_ContextHandle_t& context) {
+  RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinary,
+            "Invalid function pointer for contextCreateFromBinary.");
+
+  Qnn_ErrorHandle_t rt = QNN_SUCCESS;
+
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+  if (use_file_mapping && file_mapper_) {
+    RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinaryWithCallback,
+              "Invalid function pointer for contextCreateFromBinaryWithCallback.");
+
+    auto notify_param_ptr = std::make_unique<FileMappingCallbackInfo_t>(bin_buffer, buffer_length, this);
+
+    Qnn_ContextBinaryCallback_t callbacks;
+    callbacks.type = QNN_CONTEXT_CALLBACK_DMA_BUFFER;
+    callbacks.dmaBufferCallback.version = QNN_CONTEXT_CALLBACK_DMA_BUFFER_VERSION_1;
+    callbacks.dmaBufferCallback.v1.dataProvide = MapDmaDataCallback;
+    callbacks.dmaBufferCallback.v1.dataRelease = ReleaseDmaDataCallback;
+    callbacks.dmaBufferCallback.v1.notifyParam = reinterpret_cast<void*>(notify_param_ptr.get());
+
+    file_mapping_notify_params_.push_back(std::move(notify_param_ptr));
+
+    rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
+                                                            device_handle_,
+                                                            context_configs,
+                                                            &callbacks,
+                                                            bin_buffer,
+                                                            static_cast<Qnn_ContextBinarySize_t>(buffer_length),
+                                                            &context,
+                                                            profile_backend_handle_,
+                                                            NULL);
+    if (rt != QNN_SUCCESS) {
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING,
+                      ("contextCreateFromBinaryWithCallback failed (" + QnnErrorHandleToString(rt) +
+                       "). Retrying with direct read.")
+                          .c_str());
+    }
+  }
+#endif
+
+  if (!use_file_mapping || rt != QNN_SUCCESS) {
+    // Read from file if no pre-read buffer was supplied or if file mapping failed.
+    std::vector<char> file_buffer;
+    if (bin_buffer == nullptr || rt != QNN_SUCCESS) {
+      RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, file_buffer, io_dispatch));
+      bin_buffer = static_cast<void*>(file_buffer.data());
+      buffer_length = static_cast<uint64_t>(file_buffer.size());
+    }
+
+    rt = qnn_interface_.contextCreateFromBinary(backend_handle_,
+                                                device_handle_,
+                                                context_configs,
+                                                bin_buffer,
+                                                static_cast<Qnn_ContextBinarySize_t>(buffer_length),
+                                                &context,
+                                                profile_backend_handle_);
+  }
+
+  RETURN_IF(QNN_SUCCESS != rt,
+            ("contextCreateFromBinary failed. Error: " + QnnErrorHandleToString(rt)).c_str());
+  return Ort::Status();
+}
+
 Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bin_filepath,
                                                    int64_t max_spill_fill_size,
                                                    Qnn_ContextHandle_t& new_context,
@@ -1304,22 +1374,14 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
     spill_cfg->customConfig = spill_custom;
   }
 
-  RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinary,
-            "Invalid function pointer for contextCreateFromBinary.");
-
-  Qnn_ErrorHandle_t rt = QNN_SUCCESS;
+  void* bin_buffer = nullptr;
   uint64_t buffer_length = 0;
   bool use_file_mapping = false;
 
 #ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
   // Attempt file mapping first if enabled (matches initial load behavior).
   if (file_mapped_weights_enabled_ && file_mapper_) {
-    RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinaryWithCallback,
-              "Invalid function pointer for contextCreateFromBinaryWithCallback.");
-
     RETURN_IF_ERROR(GetFileSizeIfValid(context_bin_filepath, buffer_length));
-
-    void* bin_buffer = nullptr;
     RETURN_IF_ERROR(file_mapper_->GetContextBinMappedMemoryPtr(context_bin_filepath, &bin_buffer));
 
     // Cannot use contextCreateFromBinaryWithCallback() unless context bin version is >= 3.3.3
@@ -1344,53 +1406,13 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
                           .c_str());
     } else {
       use_file_mapping = true;
-      auto notify_param_ptr = std::make_unique<FileMappingCallbackInfo_t>(bin_buffer, buffer_length, this);
-
-      Qnn_ContextBinaryCallback_t callbacks;
-      callbacks.type = QNN_CONTEXT_CALLBACK_DMA_BUFFER;
-      callbacks.dmaBufferCallback.version = QNN_CONTEXT_CALLBACK_DMA_BUFFER_VERSION_1;
-      callbacks.dmaBufferCallback.v1.dataProvide = MapDmaDataCallback;
-      callbacks.dmaBufferCallback.v1.dataRelease = ReleaseDmaDataCallback;
-      callbacks.dmaBufferCallback.v1.notifyParam = reinterpret_cast<void*>(notify_param_ptr.get());
-
-      file_mapping_notify_params_.push_back(std::move(notify_param_ptr));
-
-      rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
-                                                              device_handle_,
-                                                              configs_builder.GetQnnConfigs(),
-                                                              &callbacks,
-                                                              bin_buffer,
-                                                              static_cast<Qnn_ContextBinarySize_t>(buffer_length),
-                                                              &new_context,
-                                                              profile_backend_handle_,
-                                                              NULL);
-      if (rt != QNN_SUCCESS) {
-        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING,
-                        ("SSR recovery: file mapping failed (" + QnnErrorHandleToString(rt) +
-                         "). Retrying with direct read.")
-                            .c_str());
-      }
     }
   }
 #endif
 
-  if (!use_file_mapping || rt != QNN_SUCCESS) {
-    // Direct read fallback (or primary path when file mapping is disabled).
-    std::vector<char> buffer;
-    RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, buffer, io_dispatch));
-    buffer_length = static_cast<uint64_t>(buffer.size());
-
-    rt = qnn_interface_.contextCreateFromBinary(backend_handle_,
-                                                device_handle_,
+  RETURN_IF_ERROR(CreateContextHandleFromBinary(bin_buffer, buffer_length, use_file_mapping,
                                                 configs_builder.GetQnnConfigs(),
-                                                static_cast<void*>(buffer.data()),
-                                                static_cast<Qnn_ContextBinarySize_t>(buffer_length),
-                                                &new_context,
-                                                profile_backend_handle_);
-  }
-
-  RETURN_IF(QNN_SUCCESS != rt,
-            ("SSR recovery: contextCreateFromBinary failed. Error: " + QnnErrorHandleToString(rt)).c_str());
+                                                context_bin_filepath, io_dispatch, new_context));
   RETURN_IF_ERROR(AddQnnContextHandle(new_context));
   return Ort::Status();
 }
@@ -1970,30 +1992,6 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
 
     const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_config_pointer, nullptr};
 
-    RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinary,
-              "Invalid function pointer for contextCreateFromBinary.");
-
-    Qnn_ErrorHandle_t rt = QNN_SUCCESS;
-#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
-    Qnn_ContextBinaryCallback_t callbacks;
-    if (use_file_mapping && file_mapper_) {
-      RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinaryWithCallback,
-                "Invalid function pointer for contextCreateFromBinaryWithCallback.");
-
-      auto notify_param_ptr = std::make_unique<FileMappingCallbackInfo_t>(bin_buffer, buffer_length, this);
-
-      callbacks.type = QNN_CONTEXT_CALLBACK_DMA_BUFFER;
-      callbacks.dmaBufferCallback.version = QNN_CONTEXT_CALLBACK_DMA_BUFFER_VERSION_1;
-      callbacks.dmaBufferCallback.v1.dataProvide = MapDmaDataCallback;
-      callbacks.dmaBufferCallback.v1.dataRelease = ReleaseDmaDataCallback;
-      callbacks.dmaBufferCallback.v1.notifyParam = reinterpret_cast<void*>(notify_param_ptr.get());
-
-      file_mapping_notify_params_.push_back(std::move(notify_param_ptr));
-    }
-#else
-  ORT_UNUSED_PARAMETER(context_bin_filepath);
-#endif
-
     qnn::profile::ProfilingInfo profiling_info;
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
     if (ProfilingEnabled()) {
@@ -2001,40 +1999,9 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
     }
 #endif
 
-#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
-    std::vector<char> backup_buffer;
-    if (use_file_mapping && file_mapper_) {
-      rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
-                                                              device_handle_,
-                                                              context_configs,
-                                                              &callbacks,
-                                                              bin_buffer,
-                                                              buffer_length,
-                                                              &context,
-                                                              profile_backend_handle_,
-                                                              NULL);
-
-      if (rt != QNN_SUCCESS) {
-        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING, ("Failed to create context with file mapping enabled. Error: " + QnnErrorHandleToString(rt) + ", Code : " + std::to_string(rt) + ". Retrying with feature disabled.").c_str());
-
-        // Read context bin from file since file mapping has failed
-        RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, backup_buffer, io_dispatch));
-
-        bin_buffer = static_cast<void*>(backup_buffer.data());
-      }
-    }
-#else
-  ORT_UNUSED_PARAMETER(io_dispatch);
-#endif
-    if (!use_file_mapping || rt != QNN_SUCCESS) {
-      rt = qnn_interface_.contextCreateFromBinary(backend_handle_,
-                                                  device_handle_,
-                                                  context_configs,
-                                                  bin_buffer,
-                                                  buffer_length,
-                                                  &context,
-                                                  profile_backend_handle_);
-    }
+    RETURN_IF_ERROR(CreateContextHandleFromBinary(bin_buffer, buffer_length, use_file_mapping,
+                                                  context_configs, context_bin_filepath, io_dispatch,
+                                                  context));
 
 #ifdef QNN_SYSTEM_PROFILE_API_ENABLED
     if (ProfilingEnabled()) {
@@ -2044,10 +2011,7 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
     }
 #endif
 
-    RETURN_IF(QNN_SUCCESS != rt,
-              ("Failed to create context from binary. Error: " + QnnErrorHandleToString(rt)).c_str());
     RETURN_IF_ERROR(AddQnnContextHandle(context));
-
     RETURN_IF_ERROR(ExtractBackendProfilingInfo(profiling_info));
 
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 26)

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1309,6 +1309,7 @@ Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& cont
 
   Qnn_ErrorHandle_t rt = QNN_SUCCESS;
   uint64_t buffer_length = 0;
+  bool use_file_mapping = false;
 
 #ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
   // Attempt file mapping first if enabled (matches initial load behavior).
@@ -1321,36 +1322,59 @@ Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& cont
     void* bin_buffer = nullptr;
     RETURN_IF_ERROR(file_mapper_->GetContextBinMappedMemoryPtr(context_bin_filepath, &bin_buffer));
 
-    auto notify_param_ptr = std::make_unique<FileMappingCallbackInfo_t>(bin_buffer, buffer_length, this);
-
-    Qnn_ContextBinaryCallback_t callbacks;
-    callbacks.type = QNN_CONTEXT_CALLBACK_DMA_BUFFER;
-    callbacks.dmaBufferCallback.version = QNN_CONTEXT_CALLBACK_DMA_BUFFER_VERSION_1;
-    callbacks.dmaBufferCallback.v1.dataProvide = MapDmaDataCallback;
-    callbacks.dmaBufferCallback.v1.dataRelease = ReleaseDmaDataCallback;
-    callbacks.dmaBufferCallback.v1.notifyParam = reinterpret_cast<void*>(notify_param_ptr.get());
-
-    file_mapping_notify_params_.push_back(std::move(notify_param_ptr));
-
-    rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
-                                                            device_handle_,
-                                                            context_configs,
-                                                            &callbacks,
-                                                            bin_buffer,
-                                                            static_cast<Qnn_ContextBinarySize_t>(buffer_length),
-                                                            &new_context,
-                                                            profile_backend_handle_,
-                                                            NULL);
-    if (rt != QNN_SUCCESS) {
+    // Cannot use contextCreateFromBinaryWithCallback() unless context bin version is >= 3.3.3
+    auto sys_ctx_handle = GetSystemContextHandle();
+    RETURN_IF(sys_ctx_handle == nullptr, "System context handle is null.");
+    Qnn_Version_t blob_version = {0, 0, 0};
+    uint32_t graph_count = 0;
+    QnnSystemContext_GraphInfo_t* graphs_info = nullptr;
+    RETURN_IF_ERROR(GetGraphInfoAndBinVersion(sys_ctx_handle.get(),
+                                              bin_buffer,
+                                              static_cast<Qnn_ContextBinarySize_t>(buffer_length),
+                                              blob_version,
+                                              graph_count,
+                                              &graphs_info));
+    if (!MinVersionMet(blob_version, {3, 3, 3})) {
+      std::string version_str = std::to_string(blob_version.major) + "." +
+                                std::to_string(blob_version.minor) + "." +
+                                std::to_string(blob_version.patch);
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING,
-                      ("SSR recovery: file mapping failed (" + QnnErrorHandleToString(rt) +
-                       "). Retrying with direct read.")
+                      ("SSR recovery: context binary version " + version_str +
+                       " < 3.3.3, file mapping not supported. Falling back to direct read.")
                           .c_str());
+    } else {
+      use_file_mapping = true;
+      auto notify_param_ptr = std::make_unique<FileMappingCallbackInfo_t>(bin_buffer, buffer_length, this);
+
+      Qnn_ContextBinaryCallback_t callbacks;
+      callbacks.type = QNN_CONTEXT_CALLBACK_DMA_BUFFER;
+      callbacks.dmaBufferCallback.version = QNN_CONTEXT_CALLBACK_DMA_BUFFER_VERSION_1;
+      callbacks.dmaBufferCallback.v1.dataProvide = MapDmaDataCallback;
+      callbacks.dmaBufferCallback.v1.dataRelease = ReleaseDmaDataCallback;
+      callbacks.dmaBufferCallback.v1.notifyParam = reinterpret_cast<void*>(notify_param_ptr.get());
+
+      file_mapping_notify_params_.push_back(std::move(notify_param_ptr));
+
+      rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
+                                                              device_handle_,
+                                                              context_configs,
+                                                              &callbacks,
+                                                              bin_buffer,
+                                                              static_cast<Qnn_ContextBinarySize_t>(buffer_length),
+                                                              &new_context,
+                                                              profile_backend_handle_,
+                                                              NULL);
+      if (rt != QNN_SUCCESS) {
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING,
+                        ("SSR recovery: file mapping failed (" + QnnErrorHandleToString(rt) +
+                         "). Retrying with direct read.")
+                            .c_str());
+      }
     }
   }
 #endif
 
-  if (!file_mapped_weights_enabled_ || rt != QNN_SUCCESS) {
+  if (!use_file_mapping || rt != QNN_SUCCESS) {
     // Direct read fallback (or primary path when file mapping is disabled).
     std::vector<char> buffer;
     RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, buffer));

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1288,7 +1288,6 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
   QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
 
-#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 21)
   QnnContext_Config_t spill_fill_config = QNN_CONTEXT_CONFIG_INIT;
   QnnHtpContext_CustomConfig_t custom_config;
   custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
@@ -1299,9 +1298,6 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
   spill_fill_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
   spill_fill_config.customConfig = &custom_config;
   QnnContext_Config_t* spill_fill_ptr = max_spill_fill_size > 0 ? &spill_fill_config : nullptr;
-#else
-  QnnContext_Config_t* spill_fill_ptr = nullptr;
-#endif
 
   const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_ptr, nullptr};
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1285,21 +1285,24 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
                                                    int64_t max_spill_fill_size,
                                                    Qnn_ContextHandle_t& new_context,
                                                    const qnn::EpContextIoDispatch& io_dispatch) {
-  QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
-  RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
+  QnnConfigsBuilder<QnnContext_Config_t, QnnHtpContext_CustomConfig_t> configs_builder(
+      QNN_CONTEXT_CONFIG_INIT, QnnHtpContext_CustomConfig_t{});
 
-  QnnContext_Config_t spill_fill_config = QNN_CONTEXT_CONFIG_INIT;
-  QnnHtpContext_CustomConfig_t custom_config;
-  custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
-  QnnHtpContext_GroupRegistration_t group_info;
-  group_info.firstGroupHandle = 0x0;  // New group after SSR — this is the only context
-  group_info.maxSpillFillBuffer = max_spill_fill_size;
-  custom_config.groupRegistration = group_info;
-  spill_fill_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
-  spill_fill_config.customConfig = &custom_config;
-  QnnContext_Config_t* spill_fill_ptr = max_spill_fill_size > 0 ? &spill_fill_config : nullptr;
+  auto* priority_cfg = configs_builder.PushConfig();
+  RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, *priority_cfg));
 
-  const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_ptr, nullptr};
+  // Spill-fill: re-register buffer allocation for the recovered context.
+  // Always a new group (firstGroupHandle = 0x0) since SSR invalidated all prior handles.
+  if (max_spill_fill_size > 0) {
+    auto* spill_custom = configs_builder.PushCustomConfig();
+    spill_custom->option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
+    spill_custom->groupRegistration.firstGroupHandle = 0x0;
+    spill_custom->groupRegistration.maxSpillFillBuffer = max_spill_fill_size;
+
+    auto* spill_cfg = configs_builder.PushConfig();
+    spill_cfg->option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+    spill_cfg->customConfig = spill_custom;
+  }
 
   RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinary,
             "Invalid function pointer for contextCreateFromBinary.");
@@ -1354,7 +1357,7 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
 
       rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
                                                               device_handle_,
-                                                              context_configs,
+                                                              configs_builder.GetQnnConfigs(),
                                                               &callbacks,
                                                               bin_buffer,
                                                               static_cast<Qnn_ContextBinarySize_t>(buffer_length),
@@ -1379,7 +1382,7 @@ Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bi
 
     rt = qnn_interface_.contextCreateFromBinary(backend_handle_,
                                                 device_handle_,
-                                                context_configs,
+                                                configs_builder.GetQnnConfigs(),
                                                 static_cast<void*>(buffer.data()),
                                                 static_cast<Qnn_ContextBinarySize_t>(buffer_length),
                                                 &new_context,

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1283,7 +1283,8 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
 
 Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& context_bin_filepath,
                                                          int64_t max_spill_fill_size,
-                                                         Qnn_ContextHandle_t& new_context) {
+                                                         Qnn_ContextHandle_t& new_context,
+                                                         const qnn::EpContextIoDispatch& io_dispatch) {
   QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
 
@@ -1377,7 +1378,7 @@ Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& cont
   if (!use_file_mapping || rt != QNN_SUCCESS) {
     // Direct read fallback (or primary path when file mapping is disabled).
     std::vector<char> buffer;
-    RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, buffer));
+    RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, buffer, io_dispatch));
     buffer_length = static_cast<uint64_t>(buffer.size());
 
     rt = qnn_interface_.contextCreateFromBinary(backend_handle_,

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1347,7 +1347,8 @@ Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& cont
     if (rt != QNN_SUCCESS) {
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING,
                       ("SSR recovery: file mapping failed (" + QnnErrorHandleToString(rt) +
-                       "). Retrying with direct read.").c_str());
+                       "). Retrying with direct read.")
+                          .c_str());
     }
   }
 #endif

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1283,10 +1283,7 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
 
 Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& context_bin_filepath,
                                                          int64_t max_spill_fill_size,
-                                                         bool is_multi_soc_buffer,
                                                          Qnn_ContextHandle_t& new_context) {
-  ORT_UNUSED_PARAMETER(is_multi_soc_buffer);
-
   QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
 
@@ -2050,7 +2047,7 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
   // Seed recovery info for embed_mode=0 so ExecuteGraph can reload after SSR.
   if (!context_bin_filepath.empty()) {
     for (auto& [name, model] : qnn_models) {
-      model->SetContextRecoveryInfo(context_bin_filepath, max_spill_fill_size, context_priority_, is_multi_soc_buffer);
+      model->SetContextRecoveryInfo(context_bin_filepath, max_spill_fill_size, context_priority_);
     }
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1281,6 +1281,98 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
   return Ort::Status();
 }
 
+Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& context_bin_filepath,
+                                                         int64_t max_spill_fill_size,
+                                                         bool is_multi_soc_buffer,
+                                                         Qnn_ContextHandle_t& new_context) {
+  ORT_UNUSED_PARAMETER(is_multi_soc_buffer);
+
+  QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
+  RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
+
+#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 21)
+  QnnContext_Config_t spill_fill_config = QNN_CONTEXT_CONFIG_INIT;
+  QnnHtpContext_CustomConfig_t custom_config;
+  custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
+  QnnHtpContext_GroupRegistration_t group_info;
+  group_info.firstGroupHandle = 0x0;  // New group after SSR — this is the only context
+  group_info.maxSpillFillBuffer = max_spill_fill_size;
+  custom_config.groupRegistration = group_info;
+  spill_fill_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+  spill_fill_config.customConfig = &custom_config;
+  QnnContext_Config_t* spill_fill_ptr = max_spill_fill_size > 0 ? &spill_fill_config : nullptr;
+#else
+  QnnContext_Config_t* spill_fill_ptr = nullptr;
+#endif
+
+  const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_ptr, nullptr};
+
+  RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinary,
+            "Invalid function pointer for contextCreateFromBinary.");
+
+  Qnn_ErrorHandle_t rt = QNN_SUCCESS;
+  uint64_t buffer_length = 0;
+
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+  // Attempt file mapping first if enabled (matches initial load behavior).
+  if (file_mapped_weights_enabled_ && file_mapper_) {
+    RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinaryWithCallback,
+              "Invalid function pointer for contextCreateFromBinaryWithCallback.");
+
+    RETURN_IF_ERROR(GetFileSizeIfValid(context_bin_filepath, buffer_length));
+
+    void* bin_buffer = nullptr;
+    RETURN_IF_ERROR(file_mapper_->GetContextBinMappedMemoryPtr(context_bin_filepath, &bin_buffer));
+
+    auto notify_param_ptr = std::make_unique<FileMappingCallbackInfo_t>(bin_buffer, buffer_length, this);
+
+    Qnn_ContextBinaryCallback_t callbacks;
+    callbacks.type = QNN_CONTEXT_CALLBACK_DMA_BUFFER;
+    callbacks.dmaBufferCallback.version = QNN_CONTEXT_CALLBACK_DMA_BUFFER_VERSION_1;
+    callbacks.dmaBufferCallback.v1.dataProvide = MapDmaDataCallback;
+    callbacks.dmaBufferCallback.v1.dataRelease = ReleaseDmaDataCallback;
+    callbacks.dmaBufferCallback.v1.notifyParam = reinterpret_cast<void*>(notify_param_ptr.get());
+
+    file_mapping_notify_params_.push_back(std::move(notify_param_ptr));
+
+    rt = qnn_interface_.contextCreateFromBinaryWithCallback(backend_handle_,
+                                                            device_handle_,
+                                                            context_configs,
+                                                            &callbacks,
+                                                            bin_buffer,
+                                                            static_cast<Qnn_ContextBinarySize_t>(buffer_length),
+                                                            &new_context,
+                                                            profile_backend_handle_,
+                                                            NULL);
+    if (rt != QNN_SUCCESS) {
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_WARNING,
+                      ("SSR recovery: file mapping failed (" + QnnErrorHandleToString(rt) +
+                       "). Retrying with direct read.").c_str());
+    }
+  }
+#endif
+
+  if (!file_mapped_weights_enabled_ || rt != QNN_SUCCESS) {
+    // Direct read fallback (or primary path when file mapping is disabled).
+    std::vector<char> buffer;
+    RETURN_IF_ERROR(ReadContextBinIfValid(context_bin_filepath, buffer));
+    buffer_length = static_cast<uint64_t>(buffer.size());
+
+    rt = qnn_interface_.contextCreateFromBinary(backend_handle_,
+                                                device_handle_,
+                                                context_configs,
+                                                static_cast<void*>(buffer.data()),
+                                                static_cast<Qnn_ContextBinarySize_t>(buffer_length),
+                                                &new_context,
+                                                profile_backend_handle_);
+  }
+
+  RETURN_IF(QNN_SUCCESS != rt,
+            ("SSR recovery: contextCreateFromBinary failed. Error: " + QnnErrorHandleToString(rt)).c_str());
+  RETURN_IF_ERROR(AddQnnContextHandle(new_context));
+  return Ort::Status();
+}
+
 Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
     std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map,
     const qnn::EpContextIoDispatch& io_dispatch,
@@ -1957,7 +2049,7 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
   // Seed recovery info for embed_mode=0 so ExecuteGraph can reload after SSR.
   if (!context_bin_filepath.empty()) {
     for (auto& [name, model] : qnn_models) {
-      model->SetContextRecoveryInfo(context_bin_filepath, max_spill_fill_size, context_priority_);
+      model->SetContextRecoveryInfo(context_bin_filepath, max_spill_fill_size, context_priority_, is_multi_soc_buffer);
     }
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1281,10 +1281,10 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
   return Ort::Status();
 }
 
-Ort::Status QnnBackendManager::CreateContextFromFilePath(const std::string& context_bin_filepath,
-                                                         int64_t max_spill_fill_size,
-                                                         Qnn_ContextHandle_t& new_context,
-                                                         const qnn::EpContextIoDispatch& io_dispatch) {
+Ort::Status QnnBackendManager::ReloadContextForSSR(const std::string& context_bin_filepath,
+                                                   int64_t max_spill_fill_size,
+                                                   Qnn_ContextHandle_t& new_context,
+                                                   const qnn::EpContextIoDispatch& io_dispatch) {
   QnnContext_Config_t qnn_context_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, qnn_context_config));
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "CPU/QnnCpuCommon.h"
+#include "HTP/QnnHtpContext.h"
 #include "HTP/QnnHtpDevice.h"
 #include "GPU/QnnGpuBackend.h"
 #include "QnnCommon.h"
@@ -33,6 +34,7 @@
 #include "core/providers/qnn/builder/op_builder_factory.h"
 #include "core/providers/qnn/builder/op_package/op_package.h"
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing_types.h"
+#include "core/providers/qnn/builder/qnn_configs_helper.h"
 #include "core/providers/qnn/builder/qnn_context_mem_handle_manager.h"
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_htp_power_config_manager.h"
@@ -218,6 +220,15 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
                                   int64_t max_spill_fill_size,
                                   Qnn_ContextHandle_t& new_context,
                                   const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
+
+  // Builds the common context configs (priority + spill-fill) used by both binary-load paths.
+  // first_group_handle: 0x0 for SSR (always a new group); GetQnnContext(0) for initial multi-
+  // context load (joins the existing spill-fill group).
+  // Adding a new config here propagates to both LoadCachedQnnContextFromBuffer and ReloadContextForSSR.
+  Ort::Status BuildContextBinaryConfigs(
+      int64_t max_spill_fill_size,
+      Qnn_ContextHandle_t first_group_handle,
+      QnnConfigsBuilder<QnnContext_Config_t, QnnHtpContext_CustomConfig_t>& configs_builder);
 
   // Shared dispatch helper used by ReloadContextForSSR and LoadCachedQnnContextFromBuffer.
   // Attempts contextCreateFromBinaryWithCallback when use_file_mapping is true; falls back to

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -208,7 +208,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // callback is dispatched instead of reading from disk.
   Ort::Status ReadContextBinIfValid(const std::string& context_bin_filepath,
                                     std::vector<char>& buffer,
-                                    const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
+                                    const qnn::EpContextIoDispatch& io_dispatch);
 
   // Reloads a QNN context from its binary file after an SSR event. Handles both file-mapped
   // and direct-read paths to match initial-load behavior. Always starts a new spill-fill

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -215,7 +215,6 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // The new context handle is registered via AddQnnContextHandle on success.
   Ort::Status CreateContextFromFilePath(const std::string& context_bin_filepath,
                                         int64_t max_spill_fill_size,
-                                        bool is_multi_soc_buffer,
                                         Qnn_ContextHandle_t& new_context);
 
   // Returns true if the given context handle is still tracked (not yet freed).

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -210,13 +210,14 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
                                     std::vector<char>& buffer,
                                     const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
 
-  // Creates a new QNN context from a binary file, handling both file-mapped and direct-read
-  // paths. Used by SSR recovery so it matches the file mapping behavior of the initial load.
+  // Reloads a QNN context from its binary file after an SSR event. Handles both file-mapped
+  // and direct-read paths to match initial-load behavior. Always starts a new spill-fill
+  // group (firstGroupHandle = 0x0) since SSR invalidates all prior context handles.
   // The new context handle is registered via AddQnnContextHandle on success.
-  Ort::Status CreateContextFromFilePath(const std::string& context_bin_filepath,
-                                        int64_t max_spill_fill_size,
-                                        Qnn_ContextHandle_t& new_context,
-                                        const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
+  Ort::Status ReloadContextForSSR(const std::string& context_bin_filepath,
+                                  int64_t max_spill_fill_size,
+                                  Qnn_ContextHandle_t& new_context,
+                                  const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
 
   // Returns true if the given context handle is still tracked (not yet freed).
   bool HasContextHandle(Qnn_ContextHandle_t context_handle) const {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -219,6 +219,19 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
                                   Qnn_ContextHandle_t& new_context,
                                   const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
 
+  // Shared dispatch helper used by ReloadContextForSSR and LoadCachedQnnContextFromBuffer.
+  // Attempts contextCreateFromBinaryWithCallback when use_file_mapping is true; falls back to
+  // contextCreateFromBinary on failure or when file mapping is disabled/unavailable.
+  // bin_buffer: pre-acquired mapped or pre-read buffer; pass nullptr to read from context_bin_filepath.
+  // Does NOT call AddQnnContextHandle — callers are responsible for registering the handle.
+  Ort::Status CreateContextHandleFromBinary(void* bin_buffer,
+                                            uint64_t buffer_length,
+                                            bool use_file_mapping,
+                                            const QnnContext_Config_t** context_configs,
+                                            const std::string& context_bin_filepath,
+                                            const qnn::EpContextIoDispatch& io_dispatch,
+                                            Qnn_ContextHandle_t& context);
+
   // Returns true if the given context handle is still tracked (not yet freed).
   bool HasContextHandle(Qnn_ContextHandle_t context_handle) const {
     return context_map_.find(context_handle) != context_map_.end();

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -208,14 +208,15 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // callback is dispatched instead of reading from disk.
   Ort::Status ReadContextBinIfValid(const std::string& context_bin_filepath,
                                     std::vector<char>& buffer,
-                                    const qnn::EpContextIoDispatch& io_dispatch);
+                                    const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
 
   // Creates a new QNN context from a binary file, handling both file-mapped and direct-read
-  // paths.  Used by SSR recovery so it matches the file mapping behavior of the initial load.
+  // paths. Used by SSR recovery so it matches the file mapping behavior of the initial load.
   // The new context handle is registered via AddQnnContextHandle on success.
   Ort::Status CreateContextFromFilePath(const std::string& context_bin_filepath,
                                         int64_t max_spill_fill_size,
-                                        Qnn_ContextHandle_t& new_context);
+                                        Qnn_ContextHandle_t& new_context,
+                                        const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr));
 
   // Returns true if the given context handle is still tracked (not yet freed).
   bool HasContextHandle(Qnn_ContextHandle_t context_handle) const {

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -210,6 +210,14 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
                                     std::vector<char>& buffer,
                                     const qnn::EpContextIoDispatch& io_dispatch);
 
+  // Creates a new QNN context from a binary file, handling both file-mapped and direct-read
+  // paths.  Used by SSR recovery so it matches the file mapping behavior of the initial load.
+  // The new context handle is registered via AddQnnContextHandle on success.
+  Ort::Status CreateContextFromFilePath(const std::string& context_bin_filepath,
+                                        int64_t max_spill_fill_size,
+                                        bool is_multi_soc_buffer,
+                                        Qnn_ContextHandle_t& new_context);
+
   // Returns true if the given context handle is still tracked (not yet freed).
   bool HasContextHandle(Qnn_ContextHandle_t context_handle) const {
     return context_map_.find(context_handle) != context_map_.end();

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -8,7 +8,6 @@
 #include <gsl/gsl>
 #include <thread>
 
-#include "HTP/QnnHtpContext.h"
 #include "HTP/QnnHtpGraph.h"
 #include "QnnOpDef.h"
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -549,7 +549,7 @@ Ort::Status QnnModel::RecoverFromSSR(const Ort::Logger& logger, const qnn::EpCon
       // We are the first model to recover from this SSR event.
       // Free the old (shared) context and create a new one from the binary.
       qnn_backend_manager_->ReleaseSpecificContextHandle(old_context);
-      RETURN_IF_ERROR(qnn_backend_manager_->CreateContextFromFilePath(
+      RETURN_IF_ERROR(qnn_backend_manager_->ReloadContextForSSR(
           context_bin_filepath_, max_spill_fill_size_, new_context, io_dispatch));
     } else {
       // Another model already recovered and recreated the context from this binary.

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -548,11 +548,10 @@ Ort::Status QnnModel::RecoverFromSSR(const Ort::Logger& logger, const qnn::EpCon
 
     if (qnn_backend_manager_->HasContextHandle(old_context)) {
       // We are the first model to recover from this SSR event.
-      // Free the old (shared) context and create a new one from the binary, respecting
-      // the original file mapping and multi-SoC settings used at initial load time.
+      // Free the old (shared) context and create a new one from the binary.
       qnn_backend_manager_->ReleaseSpecificContextHandle(old_context);
       RETURN_IF_ERROR(qnn_backend_manager_->CreateContextFromFilePath(
-          context_bin_filepath_, max_spill_fill_size_, is_multi_soc_buffer_, new_context));
+          context_bin_filepath_, max_spill_fill_size_, new_context));
     } else {
       // Another model already recovered and recreated the context from this binary.
       // Reuse it — it's the only context remaining in context_map_.

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -548,47 +548,11 @@ Ort::Status QnnModel::RecoverFromSSR(const Ort::Logger& logger, const qnn::EpCon
 
     if (qnn_backend_manager_->HasContextHandle(old_context)) {
       // We are the first model to recover from this SSR event.
-      // Free the old (shared) context and create a new one from the binary.
+      // Free the old (shared) context and create a new one from the binary, respecting
+      // the original file mapping and multi-SoC settings used at initial load time.
       qnn_backend_manager_->ReleaseSpecificContextHandle(old_context);
-
-      // Use the unified file I/O helper instead of duplicating the read logic.
-      std::vector<char> buffer;
-      RETURN_IF_ERROR(qnn_backend_manager_->ReadContextBinIfValid(context_bin_filepath_, buffer, io_dispatch));
-
-      const auto& qnn_interface = qnn_backend_manager_->GetQnnInterface();
-
-      // Build context configs: priority + spill fill buffer.
-      QnnContext_Config_t priority_config = QNN_CONTEXT_CONFIG_INIT;
-      RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, priority_config));
-
-#if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 21)
-      QnnContext_Config_t spill_fill_config = QNN_CONTEXT_CONFIG_INIT;
-      QnnHtpContext_CustomConfig_t spill_fill_custom_config;
-      spill_fill_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REGISTER_MULTI_CONTEXTS;
-      QnnHtpContext_GroupRegistration_t group_info;
-      group_info.firstGroupHandle = 0x0;  // New group (this is the only context after SSR)
-      group_info.maxSpillFillBuffer = max_spill_fill_size_;
-      spill_fill_custom_config.groupRegistration = group_info;
-      spill_fill_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
-      spill_fill_config.customConfig = &spill_fill_custom_config;
-      QnnContext_Config_t* spill_fill_ptr = max_spill_fill_size_ > 0 ? &spill_fill_config : nullptr;
-#else
-      QnnContext_Config_t* spill_fill_ptr = nullptr;
-#endif
-
-      const QnnContext_Config_t* context_configs[] = {&priority_config, spill_fill_ptr, nullptr};
-
-      auto rt = qnn_interface.contextCreateFromBinary(
-          qnn_backend_manager_->GetQnnBackendHandle(),
-          qnn_backend_manager_->GetQnnDeviceHandle(),
-          context_configs,
-          static_cast<void*>(buffer.data()),
-          static_cast<Qnn_ContextBinarySize_t>(buffer.size()),
-          &new_context,
-          qnn_backend_manager_->GetQnnProfileHandle());
-      RETURN_IF(QNN_SUCCESS != rt,
-                ("SSR recovery: contextCreateFromBinary failed. Error code: " + std::to_string(rt)).c_str());
-      RETURN_IF_ERROR(qnn_backend_manager_->AddQnnContextHandle(new_context));
+      RETURN_IF_ERROR(qnn_backend_manager_->CreateContextFromFilePath(
+          context_bin_filepath_, max_spill_fill_size_, is_multi_soc_buffer_, new_context));
     } else {
       // Another model already recovered and recreated the context from this binary.
       // Reuse it — it's the only context remaining in context_map_.

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -550,7 +550,7 @@ Ort::Status QnnModel::RecoverFromSSR(const Ort::Logger& logger, const qnn::EpCon
       // Free the old (shared) context and create a new one from the binary.
       qnn_backend_manager_->ReleaseSpecificContextHandle(old_context);
       RETURN_IF_ERROR(qnn_backend_manager_->CreateContextFromFilePath(
-          context_bin_filepath_, max_spill_fill_size_, new_context));
+          context_bin_filepath_, max_spill_fill_size_, new_context, io_dispatch));
     } else {
       // Another model already recovered and recreated the context from this binary.
       // Reuse it — it's the only context remaining in context_map_.

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -158,11 +158,10 @@ class QnnModel {
   // Only applicable to embed_mode=0 (external context binary file); the filepath is empty
   // for embed_mode=1, which disables SSR recovery for that model.
   void SetContextRecoveryInfo(std::string filepath, int64_t max_spill_fill_size,
-                              ContextPriority context_priority, bool is_multi_soc_buffer) {
+                              ContextPriority context_priority) {
     context_bin_filepath_ = std::move(filepath);
     max_spill_fill_size_ = max_spill_fill_size;
     context_priority_ = context_priority;
-    is_multi_soc_buffer_ = is_multi_soc_buffer;
   }
 
   // Attempt to recover from an SSR (NPU Subsystem Restart) by reloading the QNN context

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -219,8 +219,6 @@ class QnnModel {
   // Runtime graph configs recorded by ApplyRuntimeGraphConfigs for re-application after an SSR
   // re-retrieves the graph handle. See the single-call contract in the .cc.
   HtpGraphConfigs_t runtime_graph_configs_;
-
-  bool is_multi_soc_buffer_ = false;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -158,10 +158,11 @@ class QnnModel {
   // Only applicable to embed_mode=0 (external context binary file); the filepath is empty
   // for embed_mode=1, which disables SSR recovery for that model.
   void SetContextRecoveryInfo(std::string filepath, int64_t max_spill_fill_size,
-                              ContextPriority context_priority) {
+                              ContextPriority context_priority, bool is_multi_soc_buffer) {
     context_bin_filepath_ = std::move(filepath);
     max_spill_fill_size_ = max_spill_fill_size;
     context_priority_ = context_priority;
+    is_multi_soc_buffer_ = is_multi_soc_buffer;
   }
 
   // Attempt to recover from an SSR (NPU Subsystem Restart) by reloading the QNN context
@@ -219,6 +220,8 @@ class QnnModel {
   // Runtime graph configs recorded by ApplyRuntimeGraphConfigs for re-application after an SSR
   // re-retrieves the graph handle. See the single-call contract in the .cc.
   HtpGraphConfigs_t runtime_graph_configs_;
+
+  bool is_multi_soc_buffer_ = false;
 };
 
 }  // namespace qnn

--- a/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
@@ -42,6 +42,12 @@ extern "C" void SetMockSSRAlwaysCrash(bool always_crash) {
 // QNN >= 2.32); always false on other platforms since the API doesn't exist there.
 static bool g_file_mapping_used_for_recovery = false;
 
+// When true, contextCreateFromBinaryWithCallback returns QNN_COMMON_ERROR_NOT_SUPPORTED
+// during SSR recovery without forwarding to the real backend, simulating the behavior
+// seen with a pre-3.3.3 context binary (file mapping not supported).
+// NOT reset by QnnInterface_getProviders; tests must set/clear this explicitly.
+static bool g_simulate_old_blob_version = false;
+
 namespace {
 #if defined(_WIN32)
 // Load QnnHtp.dll at DLL startup and resolve the real QnnInterface_getProviders.
@@ -109,6 +115,12 @@ Qnn_ErrorHandle_t QnnContext_createFromBinaryWithCallback(
     Qnn_ProfileHandle_t profileHandle,
     void* reserved) {
   if (g_ssr_fired) {
+    if (g_simulate_old_blob_version) {
+      // Simulate a pre-3.3.3 context binary: reject the callback API and do NOT record
+      // this as a successful file-mapping recovery.  The caller should fall back to
+      // contextCreateFromBinary (direct read).
+      return QNN_COMMON_ERROR_NOT_SUPPORTED;
+    }
     g_file_mapping_used_for_recovery = true;
   }
   if (!real_providerList) {
@@ -127,6 +139,14 @@ Qnn_ErrorHandle_t QnnContext_createFromBinaryWithCallback(
 // file mapping was used for recovery.
 extern "C" bool QnnMockSSR_WasFileMappingUsedForRecovery() {
   return g_file_mapping_used_for_recovery;
+}
+
+// When set to true, the contextCreateFromBinaryWithCallback interceptor will return
+// QNN_COMMON_ERROR_NOT_SUPPORTED during SSR recovery instead of forwarding to the real
+// backend, simulating a pre-3.3.3 context binary where the callback API is unsupported.
+// This flag is NOT reset by QnnInterface_getProviders; callers must reset it explicitly.
+extern "C" void QnnMockSSR_SetSimulateOldBlobVersion(bool simulate) {
+  g_simulate_old_blob_version = simulate;
 }
 
 // 'interface' is #defined as 'struct' in <objbase.h> (pulled in via <windows.h>).

--- a/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
@@ -36,6 +36,12 @@ extern "C" void SetMockSSRAlwaysCrash(bool always_crash) {
   g_always_crash_mode = always_crash;
 }
 
+// Tracks whether contextCreateFromBinaryWithCallback was invoked during SSR recovery
+// (i.e., after g_ssr_fired became true).  Reset alongside g_ssr_fired each session.
+// Only meaningful when QNN_FILE_MAPPED_WEIGHTS_AVAILABLE is defined (Windows ARM64,
+// QNN >= 2.32); always false on other platforms since the API doesn't exist there.
+static bool g_file_mapping_used_for_recovery = false;
+
 namespace {
 #if defined(_WIN32)
 // Load QnnHtp.dll at DLL startup and resolve the real QnnInterface_getProviders.
@@ -77,6 +83,7 @@ Qnn_ErrorHandle_t QnnGraph_execute(Qnn_GraphHandle_t graphHandle,
   }
   if (!g_ssr_fired) {
     g_ssr_fired = true;
+    g_file_mapping_used_for_recovery = false;  // Reset: anything after this is recovery.
     return QNN_COMMON_ERROR_SYSTEM_COMMUNICATION;
   }
   if (!real_providerList) {
@@ -86,7 +93,41 @@ Qnn_ErrorHandle_t QnnGraph_execute(Qnn_GraphHandle_t graphHandle,
       graphHandle, inputs, numInputs, outputs, numOutputs, profileHandle, signalHandle);
 }
 
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+// Intercepts contextCreateFromBinaryWithCallback: records whether it was called during
+// SSR recovery (g_ssr_fired == true).  Calls before SSR are the initial load and are
+// not counted.
+QNN_API
+Qnn_ErrorHandle_t QnnContext_createFromBinaryWithCallback(
+    Qnn_BackendHandle_t backendHandle,
+    Qnn_DeviceHandle_t deviceHandle,
+    const QnnContext_Config_t** config,
+    const Qnn_ContextBinaryCallback_t* callbacks,
+    const void* binaryBuffer,
+    Qnn_ContextBinarySize_t binaryBufferSize,
+    Qnn_ContextHandle_t* context,
+    Qnn_ProfileHandle_t profileHandle,
+    void* reserved) {
+  if (g_ssr_fired) {
+    g_file_mapping_used_for_recovery = true;
+  }
+  if (!real_providerList) {
+    return QNN_COMMON_ERROR_GENERAL;
+  }
+  return real_providerList[0]->QNN_INTERFACE_VER_NAME.contextCreateFromBinaryWithCallback(
+      backendHandle, deviceHandle, config, callbacks, binaryBuffer, binaryBufferSize,
+      context, profileHandle, reserved);
+}
+#endif  // QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+
 #endif  // defined(_WIN32)
+
+// Returns true if contextCreateFromBinaryWithCallback was invoked during SSR recovery
+// in the current session.  Can be queried by tests after triggering SSR to verify that
+// file mapping was used for recovery.
+extern "C" bool QnnMockSSR_WasFileMappingUsedForRecovery() {
+  return g_file_mapping_used_for_recovery;
+}
 
 // 'interface' is #defined as 'struct' in <objbase.h> (pulled in via <windows.h>).
 // Use a different name to avoid that macro collision.
@@ -94,6 +135,7 @@ extern "C" Qnn_ErrorHandle_t QnnInterface_getProviders(const QnnInterface_t*** p
                                                        uint32_t* numProviders) {
   // Reset mock state for each new session that loads this provider.
   g_ssr_fired = false;
+  g_file_mapping_used_for_recovery = false;
 
   static QnnInterface_t mock_interface;
 #if defined(_WIN32)
@@ -112,6 +154,11 @@ extern "C" Qnn_ErrorHandle_t QnnInterface_getProviders(const QnnInterface_t*** p
     mock_interface.QNN_INTERFACE_VER_NAME = real_providerList[0]->QNN_INTERFACE_VER_NAME;
     // Intercept graphExecute to simulate SSR.
     mock_interface.QNN_INTERFACE_VER_NAME.graphExecute = QnnGraph_execute;
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+    // Intercept contextCreateFromBinaryWithCallback to detect file mapping during recovery.
+    mock_interface.QNN_INTERFACE_VER_NAME.contextCreateFromBinaryWithCallback =
+        QnnContext_createFromBinaryWithCallback;
+#endif
   }
 #endif  // defined(_WIN32)
   static std::vector<const QnnInterface_t*> m_providerPtrs = {&mock_interface};

--- a/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_mock_ssr.cc
@@ -38,8 +38,6 @@ extern "C" void SetMockSSRAlwaysCrash(bool always_crash) {
 
 // Tracks whether contextCreateFromBinaryWithCallback was invoked during SSR recovery
 // (i.e., after g_ssr_fired became true).  Reset alongside g_ssr_fired each session.
-// Only meaningful when QNN_FILE_MAPPED_WEIGHTS_AVAILABLE is defined (Windows ARM64,
-// QNN >= 2.32); always false on other platforms since the API doesn't exist there.
 static bool g_file_mapping_used_for_recovery = false;
 
 // When true, contextCreateFromBinaryWithCallback returns QNN_COMMON_ERROR_NOT_SUPPORTED

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -39,6 +39,11 @@ extern std::unique_ptr<Ort::Env> ort_env;
 // always returns false on other platforms.
 extern "C" bool QnnMockSSR_WasFileMappingUsedForRecovery();
 
+// Exported from QnnMockSSR.dll: when set to true, contextCreateFromBinaryWithCallback
+// returns QNN_COMMON_ERROR_NOT_SUPPORTED during SSR recovery (simulating a pre-3.3.3
+// context binary).  Must be reset to false explicitly after the test.
+extern "C" void QnnMockSSR_SetSimulateOldBlobVersion(bool simulate);
+
 using namespace ONNX_NAMESPACE;
 
 namespace onnxruntime {
@@ -174,6 +179,82 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedMode) {
   EXPECT_TRUE(QnnMockSSR_WasFileMappingUsedForRecovery())
       << "SSR recovery should have used contextCreateFromBinaryWithCallback (file mapping) "
          "but it did not. Check CreateContextFromFilePath in qnn_backend_manager.cc.";
+#endif
+
+  CleanUpCtxFile(context_model_file);
+}
+
+// Test that SSR recovery falls back to direct read (contextCreateFromBinary) and produces
+// correct outputs when contextCreateFromBinaryWithCallback fails during recovery —
+// simulating the behavior expected for a pre-3.3.3 context binary.
+//
+// Because producing an actual pre-3.3.3 binary is not feasible in these tests, we use
+// QnnMockSSR_SetSimulateOldBlobVersion(true) to make the mock reject the callback API with
+// QNN_COMMON_ERROR_NOT_SUPPORTED, which exercises the same reactive-fallback branch of
+// CreateContextFromFilePath.  The test asserts:
+//   (a) WasFileMappingUsedForRecovery() == false  (callback API was not successfully used)
+//   (b) session outputs match the CPU reference  (direct-read fallback produced a working context)
+TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedModeFileMappingRejected) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  const std::string context_model_file = "./ssr_ep_ctx_fm_rejected_test.onnx";
+  std::remove(context_model_file.c_str());
+
+  const std::string op_type = "Atan";
+  const TestInputDef<float> input_def_qdq({1, 2, 3}, false, -10.0f, 10.0f);
+
+  // -----------------------------------------------------------------------
+  // Step 1: Generate the embed_mode=0 context binary with the real HTP backend.
+  // -----------------------------------------------------------------------
+  ProviderOptions htp_options;
+  htp_options["backend_type"] = "htp";
+  htp_options["offload_graph_io_quantization"] = "0";
+
+  std::unordered_map<std::string, std::string> gen_session_opts;
+  gen_session_opts.emplace(kOrtSessionOptionEpContextEnable, "1");
+  gen_session_opts.emplace(kOrtSessionOptionEpContextFilePath, context_model_file);
+  gen_session_opts.emplace(kOrtSessionOptionEpContextEmbedMode, "0");
+
+  TestQDQModelAccuracy(BuildOpTestCase<float>(op_type + "_node", op_type, {input_def_qdq}, {}, {}),
+                       BuildQDQOpTestCase<uint8_t>(op_type + "_node", op_type, {input_def_qdq}, {}, {}),
+                       htp_options,
+                       14,
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(),
+                       OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                       "",
+                       gen_session_opts);
+
+  ASSERT_TRUE(std::filesystem::exists(context_model_file))
+      << "Context model file was not generated: " << context_model_file;
+
+  // -----------------------------------------------------------------------
+  // Step 2: Load the context model via QnnMockSSR.dll with the callback API
+  //         rejected, simulating a pre-3.3.3 blob.  Recovery must succeed via
+  //         the direct-read fallback.
+  // -----------------------------------------------------------------------
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+  QnnMockSSR_SetSimulateOldBlobVersion(true);
+#endif
+
+  std::unordered_map<std::string, std::string> run_session_opts;
+  run_session_opts.emplace(kOrtSessionOptionEpContextFilePath, context_model_file);
+
+  TestQDQModelAccuracy(BuildOpTestCase<float>(op_type + "_node", op_type, {input_def_qdq}, {}, {}),
+                       BuildQDQOpTestCase<uint8_t>(op_type + "_node", op_type, {input_def_qdq}, {}, {}),
+                       provider_options,  // QnnMockSSR.dll
+                       14,
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(),
+                       OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
+                       context_model_file,
+                       run_session_opts);
+
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+  EXPECT_FALSE(QnnMockSSR_WasFileMappingUsedForRecovery())
+      << "SSR recovery should NOT have used contextCreateFromBinaryWithCallback when "
+         "the callback API is rejected (pre-3.3.3 simulation). Direct read should be used.";
+  QnnMockSSR_SetSimulateOldBlobVersion(false);
 #endif
 
   CleanUpCtxFile(context_model_file);

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -33,6 +33,12 @@
 // in test_main.cc
 extern std::unique_ptr<Ort::Env> ort_env;
 
+// Exported from QnnMockSSR.dll: returns true if contextCreateFromBinaryWithCallback
+// was called after SSR was injected (i.e., file mapping was used for recovery).
+// Only meaningful on Windows ARM64 with QNN >= 2.32 (QNN_FILE_MAPPED_WEIGHTS_AVAILABLE);
+// always returns false on other platforms.
+extern "C" bool QnnMockSSR_WasFileMappingUsedForRecovery();
+
 using namespace ONNX_NAMESPACE;
 
 namespace onnxruntime {
@@ -160,6 +166,15 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedMode) {
                        OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR,
                        context_model_file,  // Load from the generated context model
                        run_session_opts);
+
+  // Verify that SSR recovery used file mapping (contextCreateFromBinaryWithCallback)
+  // when the feature is available.  On platforms without file mapping support this
+  // assertion is vacuously true (the function always returns false there).
+#ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+  EXPECT_TRUE(QnnMockSSR_WasFileMappingUsedForRecovery())
+      << "SSR recovery should have used contextCreateFromBinaryWithCallback (file mapping) "
+         "but it did not. Check CreateContextFromFilePath in qnn_backend_manager.cc.";
+#endif
 
   CleanUpCtxFile(context_model_file);
 }

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -234,6 +234,10 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedModeFileMappingRe
   //         the direct-read fallback.
   // -----------------------------------------------------------------------
 #ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
+  // RAII guard: ensures the flag is always cleared even if an ASSERT_* exits the test early.
+  struct OldBlobGuard {
+    ~OldBlobGuard() { QnnMockSSR_SetSimulateOldBlobVersion(false); }
+  } old_blob_guard;
   QnnMockSSR_SetSimulateOldBlobVersion(true);
 #endif
 
@@ -254,7 +258,6 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedModeFileMappingRe
   EXPECT_FALSE(QnnMockSSR_WasFileMappingUsedForRecovery())
       << "SSR recovery should NOT have used contextCreateFromBinaryWithCallback when "
          "the callback API is rejected (pre-3.3.3 simulation). Direct read should be used.";
-  QnnMockSSR_SetSimulateOldBlobVersion(false);
 #endif
 
   CleanUpCtxFile(context_model_file);

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -178,7 +178,7 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedMode) {
 #ifdef QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
   EXPECT_TRUE(QnnMockSSR_WasFileMappingUsedForRecovery())
       << "SSR recovery should have used contextCreateFromBinaryWithCallback (file mapping) "
-         "but it did not. Check CreateContextFromFilePath in qnn_backend_manager.cc.";
+         "but it did not. Check ReloadContextForSSR in qnn_backend_manager.cc.";
 #endif
 
   CleanUpCtxFile(context_model_file);
@@ -191,7 +191,7 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedMode) {
 // Because producing an actual pre-3.3.3 binary is not feasible in these tests, we use
 // QnnMockSSR_SetSimulateOldBlobVersion(true) to make the mock reject the callback API with
 // QNN_COMMON_ERROR_NOT_SUPPORTED, which exercises the same reactive-fallback branch of
-// CreateContextFromFilePath.  The test asserts:
+// ReloadContextForSSR.  The test asserts:
 //   (a) WasFileMappingUsedForRecovery() == false  (callback API was not successfully used)
 //   (b) session outputs match the CPU reference  (direct-read fallback produced a working context)
 TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextNonEmbedModeFileMappingRejected) {


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- File mapping continuity after SSR
- Test coverage for file mapping recovery
    - Add `QnnMockSSR_WasFileMappingUsedForRecovery()` export to `QnnMockSSR.dll` — intercepts `contextCreateFromBinaryWithCallback` after SSR injection (`g_ssr_fired == true`) to distinguish recovery calls from initial load calls.
    - `SSRGraphExecuteEpContextNonEmbedMode` now asserts that file mapping was used during recovery when the platform supports it.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- After SSR, RecoverFromSSR recreated the QNN context using only the direct read path (`ReadContextBinIfValid` + `contextCreateFromBinary`), even when the session was originally loaded with **file mapping** enabled. This meant SSR recovery silently lost the performance benefit of file mapping on production Windows ARM64 devices.                                                                                                                                                                                                      
- The **WindowsFileMapper** already keeps the MapViewOfFile alive across SSR events (the file mapping itself is session-scoped, not context-scoped), so recovery can safely reuse the existing mapped memory pointer via `GetContextBinMappedMemoryPtr` and re-register it with the new context via the DMA callbacks.

