### PR TITLE
[QNN EP] Release folded Q/DQ chain inputs to keep peak memory flat

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -39,6 +39,42 @@ Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper
 
 namespace {
 
+// Releases a folded hop's input, so an N-hop chain does not hold all N intermediates until the
+// graph is composed. Safe only when this unit is the input's sole consumer: any other reader
+// resolves the name through model_tensors_map_, whether it folds too or emits a real QNN op.
+// Any failure or extra consumer leaves the tensor in place, as before this optimization existed.
+void TryReleaseFoldedChainInput(QnnModelWrapper& qnn_model_wrapper,
+                                const OrtNodeUnit& node_unit,
+                                const std::string& input_name) {
+  // Real initializers are left to the generic path; they are commonly shared weights.
+  // Graph outputs are excluded because consumer counts ignore graph-output-ness.
+  if (!qnn_model_wrapper.IsFoldedConstant(input_name) || qnn_model_wrapper.IsGraphOutput(input_name)) {
+    return;
+  }
+
+  const OrtApi& ort_api = qnn_model_wrapper.GetOrtApi();
+  const OrtNode& node = node_unit.GetNode();
+
+  // Q/DQ read the folded tensor on input 0 only; scale and zero_point must be initializers.
+  size_t num_inputs = 0;
+  RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetNumInputs(&node, &num_inputs), ort_api, void());
+  std::vector<const OrtValueInfo*> inputs(num_inputs, nullptr);
+  RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetInputs(&node, inputs.data(), inputs.size()), ort_api, void());
+  if (inputs.empty() || inputs[0] == nullptr) {
+    return;
+  }
+
+  // Counts usages, not distinct nodes, so this can only over-count relative to the single fold
+  // done here, which errs toward retaining the payload.
+  size_t num_consumers = 0;
+  RETURN_DEFAULT_IF_API_FAIL(ort_api.ValueInfo_GetValueNumConsumers(inputs[0], &num_consumers), ort_api, void());
+  if (num_consumers != 1) {
+    return;
+  }
+
+  qnn_model_wrapper.ReleaseTensorWrapper(input_name);
+}
+
 // SafeInt guards against overflow from an adversarial shape before allocation.
 Ort::Status ComputeNumElements(gsl::span<const uint32_t> shape, /*out*/ size_t& num_elems) {
   SafeInt<size_t> safe_num_elems = 1;
@@ -131,11 +167,14 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   std::vector<uint8_t> output_bytes(fp32_data.size() * sizeof(float));
   std::memcpy(output_bytes.data(), fp32_data.data(), output_bytes.size());
 
-  return RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
-                                    QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
-                                    std::vector<uint32_t>(output_info.shape),
-                                    std::move(output_bytes),
-                                    "Failed to add folded DequantizeLinear output tensor.");
+  RETURN_IF_ERROR(RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
+                                             QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
+                                             std::vector<uint32_t>(output_info.shape),
+                                             std::move(output_bytes),
+                                             "Failed to add folded DequantizeLinear output tensor."));
+
+  TryReleaseFoldedChainInput(qnn_model_wrapper, node_unit, input_def.name);
+  return Ort::Status();
 }
 
 // Only fp32 Q input is supported; fp16/bf16 sources fall back to the normal op.
@@ -146,13 +185,14 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
 
   RETURN_IF(!output_def.quant_param.has_value(), "Q output has no quant param.");
 
-  std::vector<uint8_t> input_bytes;
-  RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input_def.name, input_bytes));
-
+  // Check the dtype before unpacking, so an unsupported source falls back without copying it.
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));
   RETURN_IF(input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
             "Folded QuantizeLinear only supports float32 input.");
+
+  std::vector<uint8_t> input_bytes;
+  RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input_def.name, input_bytes));
 
   size_t num_elems = 0;
   RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(input_info.shape), num_elems));
@@ -179,12 +219,15 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
       gsl::make_span(scales), gsl::make_span(offsets),
       gsl::make_span(quant_bytes), output_info.qnn_data_type, axis));
 
-  return RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
-                                    output_info.qnn_data_type,
-                                    std::move(output_info.quant_param),
-                                    std::vector<uint32_t>(output_info.shape),
-                                    std::move(quant_bytes),
-                                    "Failed to add folded QuantizeLinear output tensor.");
+  RETURN_IF_ERROR(RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
+                                             output_info.qnn_data_type,
+                                             std::move(output_info.quant_param),
+                                             std::vector<uint32_t>(output_info.shape),
+                                             std::move(quant_bytes),
+                                             "Failed to add folded QuantizeLinear output tensor."));
+
+  TryReleaseFoldedChainInput(qnn_model_wrapper, node_unit, input_def.name);
+  return Ort::Status();
 }
 
 }  // namespace

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -26,15 +26,18 @@ Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper
     RETURN_IF(init == nullptr, "Constant initializer not found for tensor.");
     return qnn_model_wrapper.UnpackInitializerData(init, bytes);
   }
-  if (qnn_model_wrapper.IsFoldedConstant(tensor_name) &&
-      qnn_model_wrapper.IsQnnTensorWrapperExist(tensor_name)) {
+  if (qnn_model_wrapper.IsFoldedConstant(tensor_name)) {
+    // A folded name without a wrapper was released by TryReleaseFoldedChainInput, which only
+    // happens when the releasing unit was the sole consumer. Reaching here means it was not.
+    RETURN_IF(!qnn_model_wrapper.IsQnnTensorWrapperExist(tensor_name),
+              "Folded constant was released after its sole consumer folded; it must not be read again.");
     const QnnTensorWrapper& wrapper = qnn_model_wrapper.GetQnnTensorWrapper(tensor_name);
     const Qnn_ClientBuffer_t& buf = GetQnnTensorClientBuf(wrapper.GetQnnTensor());
     const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(buf.data);
     bytes.assign(data_ptr, data_ptr + buf.dataSize);
     return Ort::Status();
   }
-  return MAKE_EP_FAIL("Tensor is not a constant initializer or folded constant.");
+  return MAKE_EP_FAIL("Tensor is neither a constant initializer nor a folded constant.");
 }
 
 namespace {
@@ -58,14 +61,29 @@ void TryReleaseFoldedChainInput(QnnModelWrapper& qnn_model_wrapper,
   // Q/DQ read the folded tensor on input 0 only; scale and zero_point must be initializers.
   size_t num_inputs = 0;
   RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetNumInputs(&node, &num_inputs), ort_api, void());
+  if (num_inputs == 0) {
+    return;
+  }
   std::vector<const OrtValueInfo*> inputs(num_inputs, nullptr);
   RETURN_DEFAULT_IF_API_FAIL(ort_api.Node_GetInputs(&node, inputs.data(), inputs.size()), ort_api, void());
-  if (inputs.empty() || inputs[0] == nullptr) {
+  if (inputs[0] == nullptr) {
+    return;
+  }
+
+  // The count below is taken on the node's own input 0, so confirm it names the tensor being
+  // released rather than assuming the node and node-unit views agree.
+  const char* value_name = nullptr;
+  RETURN_DEFAULT_IF_API_FAIL(ort_api.GetValueInfoName(inputs[0], &value_name), ort_api, void());
+  if (value_name == nullptr || input_name != value_name) {
     return;
   }
 
   // Counts usages, not distinct nodes, so this can only over-count relative to the single fold
   // done here, which errs toward retaining the payload.
+  //
+  // This is the precondition that makes the release safe, and it does fire: ORT rewrites a shared
+  // DQ output into per-consumer values before the EP runs, but a Q output feeding several DQs
+  // reaches us with its fan-out intact (see Convf32_SharedFoldedWeight_NotReleasedWhileStillRead).
   size_t num_consumers = 0;
   RETURN_DEFAULT_IF_API_FAIL(ort_api.ValueInfo_GetValueNumConsumers(inputs[0], &num_consumers), ort_api, void());
   if (num_consumers != 1) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -159,6 +159,14 @@ bool QnnModelWrapper::AddParamWrapper(QnnParamWrapper&& param_wrapper) {
   return true;
 }
 
+void QnnModelWrapper::ReleaseTensorWrapper(const std::string& tensor_name) {
+  if (model_tensors_map_.erase(tensor_name) == 0) {
+    return;
+  }
+  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE,
+              ("Released folded constant tensor: " + tensor_name).c_str());
+}
+
 const QnnTensorWrapper& QnnModelWrapper::GetQnnTensorWrapper(const std::string& tensor_name) {
   auto map_iter = model_tensors_map_.find(tensor_name);
   if (map_iter != model_tensors_map_.end()) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -234,6 +234,11 @@ class QnnModelWrapper {
 
   bool IsQnnTensorWrapperExist(const std::string& tensor_name) const;
 
+  // Drops a tensor wrapper and the payload it owns. Only safe for a tensor that no QNN node
+  // references and that is not graph I/O; see TryReleaseFoldedChainInput. Releasing a still-needed
+  // name fails loudly rather than silently: GetQnnTensorWrapper throws.
+  void ReleaseTensorWrapper(const std::string& tensor_name);
+
   bool IsGraphOutput(const std::string& tensor_name) const {
     return graph_outputs_.indices.find(tensor_name) != graph_outputs_.indices.end();
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -234,9 +234,15 @@ class QnnModelWrapper {
 
   bool IsQnnTensorWrapperExist(const std::string& tensor_name) const;
 
-  // Drops a tensor wrapper and the payload it owns. Only safe for a tensor that no QNN node
-  // references and that is not graph I/O; see TryReleaseFoldedChainInput. Releasing a still-needed
-  // name fails loudly rather than silently: GetQnnTensorWrapper throws.
+  // Drops a tensor wrapper and the payload it owns. The caller must have established that no QNN
+  // node references the tensor and that it is not graph I/O; see TryReleaseFoldedChainInput, whose
+  // sole-consumer check is the only thing keeping this safe.
+  //
+  // Releasing a still-needed name does NOT fail loudly on the op-builder path: the name stays in
+  // folded_constant_tensors_, so a later BaseOpBuilder::ProcessInput rebuilds it via
+  // MakeTensorWrapper, where is_initializer is false for a folded name. That yields a STATIC tensor
+  // with an empty payload in place of the folded weights, silently. Only the folding path itself
+  // (GetEffectivelyConstantTensorBytes) detects the released state and fails the compile.
   void ReleaseTensorWrapper(const std::string& tensor_name);
 
   bool IsGraphOutput(const std::string& tensor_name) const {

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1016,6 +1016,68 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
 }
 
+// Builds: weight_q0 (int8 init) -> DQ0 -> Q1 -> weight_q1 -> {DQ1 -> Conv0, DQ2 -> Conv1}.
+// The fan-out is on a Q output on purpose: ORT rewrites a shared DQ output into per-consumer
+// "<name>/duplicated" values before the EP runs, so a DQ fan-out never reaches the EP with more
+// than one consumer, while a Q fan-out does.
+//
+// This is the fence for the sole-consumer guard in TryReleaseFoldedChainInput. weight_q1 is folded
+// and read by two Q/DQ units, so the first unit to fold must NOT release it. If that guard is
+// neutered to always release, the second unit's read fails and the fold no longer covers the graph,
+// so this test fails rather than silently reading an empty payload.
+static GetTestModelFn BuildSharedFoldedWeightConvTestCase() {
+  return [](ModelTestBuilder& builder) {
+    constexpr int64_t out_ch = 2;
+    constexpr int64_t in_ch = 3;
+    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
+    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
+
+    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
+
+    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, std::vector<int8_t>{1, 2, 3, 4, 5, 6});
+    builder.MakeInitializer<float>("scale0", {out_ch}, std::vector<float>{0.1f, 0.2f});
+    builder.MakeInitializer<int8_t>("zp0", {out_ch}, std::vector<int8_t>{0, 0});
+    builder.MakeInitializer<float>("scale1", {out_ch}, std::vector<float>{0.05f, 0.4f});
+    builder.MakeInitializer<int8_t>("zp1", {out_ch}, std::vector<int8_t>{-2, 3});
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
+    axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+
+    builder.AddNode("WeightDQ0", "DequantizeLinear", {"weight_q0", "scale0", "zp0"}, {"weight_dq0"},
+                    kOnnxDomain, axis_attrs);
+    builder.AddNode("WeightQ1", "QuantizeLinear", {"weight_dq0", "scale1", "zp1"}, {"weight_q1"},
+                    kOnnxDomain, axis_attrs);
+    // Both DQs read the folded weight_q1, giving it two consumers at the EP.
+    builder.AddNode("WeightDQ1", "DequantizeLinear", {"weight_q1", "scale1", "zp1"}, {"weight_dq1"},
+                    kOnnxDomain, axis_attrs);
+    builder.AddNode("WeightDQ2", "DequantizeLinear", {"weight_q1", "scale1", "zp1"}, {"weight_dq2"},
+                    kOnnxDomain, axis_attrs);
+
+    builder.MakeOutput("output0");
+    builder.MakeOutput("output1");
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+
+    builder.AddNode("Conv0", "Conv", {"input", "weight_dq1"}, {"output0"}, kOnnxDomain, conv_attrs);
+    builder.AddNode("Conv1", "Conv", {"input", "weight_dq2"}, {"output1"}, kOnnxDomain, conv_attrs);
+  };
+}
+
+TEST_F(QnnCPUBackendTests, Convf32_SharedFoldedWeight_NotReleasedWhileStillRead) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildSharedFoldedWeightConvTestCase(),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
+}
+
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).
 // Conv2d: reuse_sparse_indices should be added to the QNN node parameters.
 TEST_F(QnnCPUBackendTests, Conv2D_ReuseSparseIndices) {

--- a/onnxruntime/test/providers/qnn/unit/qnn_model_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_model_wrapper_test.cc
@@ -2520,6 +2520,40 @@ TEST(QnnUnit_ModelWrapperTest, FoldedConstant_GetTensorTypeIsStatic) {
   EXPECT_EQ(wrapper->GetTensorType("folded"), QNN_TENSOR_TYPE_STATIC);
 }
 
+// The name stays effectively constant after release, so a later hop still resolves it as folded
+// rather than as a runtime graph input.
+TEST(QnnUnit_ModelWrapperTest, ReleaseTensorWrapper_DropsPayloadButKeepsFoldedName) {
+  QnnModelWrapperTestContext ctx;
+  qnn::ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  std::vector<uint8_t> payload(1024, 0x7f);
+  qnn::QnnTensorWrapper tensor("w_dq", QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_FLOAT_32,
+                               qnn::QnnQuantParamsWrapper(), std::vector<uint32_t>{16, 16},
+                               std::move(payload));
+  ASSERT_TRUE(wrapper->AddTensorWrapper(std::move(tensor)));
+  wrapper->MarkTensorAsFoldedConstant("w_dq");
+  ASSERT_TRUE(wrapper->IsQnnTensorWrapperExist("w_dq"));
+
+  wrapper->ReleaseTensorWrapper("w_dq");
+
+  EXPECT_FALSE(wrapper->IsQnnTensorWrapperExist("w_dq"));
+  EXPECT_TRUE(wrapper->IsFoldedConstant("w_dq"));
+  EXPECT_TRUE(wrapper->IsEffectivelyConstantInput("w_dq"));
+  EXPECT_EQ(wrapper->GetTensorType("w_dq"), QNN_TENSOR_TYPE_STATIC);
+}
+
+// The release path is best-effort and may run on a tensor a failed fold never registered.
+TEST(QnnUnit_ModelWrapperTest, ReleaseTensorWrapper_UnknownNameIsNoOp) {
+  QnnModelWrapperTestContext ctx;
+  qnn::ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  wrapper->ReleaseTensorWrapper("never_added");
+
+  EXPECT_FALSE(wrapper->IsQnnTensorWrapperExist("never_added"));
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
## Summary

Constant folding of standalone Q/DQ node units (#339) registers each hop's result as a STATIC tensor but never releases the hop's input, so every intermediate of an N-hop constant chain is retained until the whole graph is composed. Peak working set therefore grows linearly in chain length.

This releases a hop's input once the fold has provably made it unreachable: when the node unit is the input's sole consumer and the input is not a graph output. Any other reader still resolves the name through `model_tensors_map_`, whether it folds too or emits a real QNN op, so the sole-consumer test is what makes the release safe. A failed or unknown consumer count leaves the tensor in place, matching the behavior before the optimization existed.

## Test plan

Peak working set, 24-weight model with consumed fp32 volume held constant:

| chain hops | before | after |
|---|---|---|
| 1 | 668 MB | 638 MB |
| 3 | 908 MB | 639 MB |
| 5 | 1151 MB | 645 MB |
| 8 | 1512 MB | 647 MB |

- Output checksums bit-identical to the pre-fix fold at every chain length (memory-only change).
- #339's regression tests pass; mixed fan-out (two consumers, one folding) correctly retains the payload and matches CPU.
- Two `QnnUnit_ModelWrapperTest` cases added for `ReleaseTensorWrapper`.
