### PR TITLE
[QNN EP] Add HTP option fp16_clamp_overflow to avoid NaN/Inf on Glymur

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -137,7 +137,7 @@ typedef struct HtpGraphConfigs {
   HtpGraphFinalizationOptimizationMode htp_graph_finalization_opt_mode = HtpGraphFinalizationOptimizationMode::kDefault;
   bool enable_htp_fp16_precision = false;
   bool enable_htp_monolithic_lstm = false;
-  bool fp16_clamp_overflow = false;
+  bool enable_htp_fp16_clamp_overflow = false;  // Intentionally undocumented; for internal/diagnostic use only.
 } HtpGraphConfigs_t;
 
 enum class QnnBackendType : uint8_t {

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -30,6 +30,13 @@ namespace qnn {
 #define QNN_SYSTEM_DLC_API_ENABLED
 #endif  // QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 37
 
+// QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW is available from QNN API 2.38
+// (QAIRT 2.49).
+#if QNN_API_VERSION_MAJOR > 2 || \
+    (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 38)
+#define QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+#endif
+
 #if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
 #if QNN_API_VERSION_MAJOR > 2 || ((QNN_API_VERSION_MAJOR) == 2 && (QNN_API_VERSION_MINOR >= 32))
 #define QNN_FILE_MAPPED_WEIGHTS_AVAILABLE
@@ -123,6 +130,7 @@ typedef struct HtpGraphConfigs {
   HtpGraphFinalizationOptimizationMode htp_graph_finalization_opt_mode = HtpGraphFinalizationOptimizationMode::kDefault;
   bool enable_htp_fp16_precision = false;
   bool enable_htp_monolithic_lstm = false;
+  bool fp16_clamp_overflow = false;
 } HtpGraphConfigs_t;
 
 enum class QnnBackendType : uint8_t {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -941,6 +941,14 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                                       FormatEPConfigKey(kEnableHtpFp16ClampOverflow),
                                                                       false,
                                                                       logger_);
+#ifndef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+  // Warn once at parse time (not per graph) if the option was requested but the SDK lacks support.
+  if (htp_graph_configs_.enable_htp_fp16_clamp_overflow) {
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                "enable_htp_fp16_clamp_overflow was requested but the QNN HTP SDK in use does "
+                "not support it (requires QAIRT >= 2.49). Ignoring.");
+  }
+#endif
 
   // Try to parse multi-SoC HTP options first. If not multi-SoC htp_arch/soc_model is given, fallback to normal parsing.
   ParsePerSocHtpConfigs();
@@ -1760,10 +1768,6 @@ void QnnEp::InitQnnHtpGraphConfigs(
       gsl::not_null<QnnGraph_Config_t*> graph_config = configs_builder.PushConfig();
       graph_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
       graph_config->customConfig = htp_fp16_clamp_config;
-#else
-      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
-                  "enable_htp_fp16_clamp_overflow was requested but the QNN HTP SDK in use does "
-                  "not support it (requires QAIRT >= 2.49). Ignoring.");
 #endif
     }
   }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -442,7 +442,8 @@ void QnnEp::ParsePerSocHtpConfigs() {
     qnn::HtpGraphConfigs_t config{vtcm_size_in_mb_per_soc[idx],
                                   htp_graph_configs_.htp_graph_finalization_opt_mode,
                                   htp_graph_configs_.enable_htp_fp16_precision,
-                                  htp_graph_configs_.enable_htp_monolithic_lstm};
+                                  htp_graph_configs_.enable_htp_monolithic_lstm,
+                                  htp_graph_configs_.fp16_clamp_overflow};
     htp_graph_configs_per_soc_.push_back(std::move(config));
   }
 
@@ -905,6 +906,17 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                                   false,
                                                                   logger_);
   model_settings_.enable_htp_monolithic_lstm = htp_graph_configs_.enable_htp_monolithic_lstm;
+
+  // HTP fp16 clamp overflow. Default false. On HTP Arch v79+ (e.g. Glymur/v81),
+  // fp16 Conv accumulator overflow becomes NaN and propagates to the output
+  // (pre-v79 kept it finite). When true, saturate such overflow to the fp16 max
+  // value instead of NaN. Requires QAIRT SDK > 2.49.
+  static constexpr const char* kFp16ClampOverflow = "fp16_clamp_overflow";
+  htp_graph_configs_.fp16_clamp_overflow = ParseBoolOption(ort_api,
+                                                           session_options_,
+                                                           FormatEPConfigKey(kFp16ClampOverflow),
+                                                           false,
+                                                           logger_);
 
   // Try to parse multi-SoC HTP options first. If not multi-SoC htp_arch/soc_model is given, fallback to normal parsing.
   ParsePerSocHtpConfigs();
@@ -1674,6 +1686,22 @@ void QnnEp::InitQnnHtpGraphConfigs(
       gsl::not_null<QnnGraph_Config_t*> graph_config = configs_builder.PushConfig();
       graph_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
       graph_config->customConfig = htp_graph_monolithic_lstm_config;
+    }
+
+    if (configs.fp16_clamp_overflow) {
+#ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+      gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_fp16_clamp_config = configs_builder.PushCustomConfig();
+      htp_fp16_clamp_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW;
+      htp_fp16_clamp_config->fp16ClampOverflow = true;
+
+      gsl::not_null<QnnGraph_Config_t*> graph_config = configs_builder.PushConfig();
+      graph_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+      graph_config->customConfig = htp_fp16_clamp_config;
+#else
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                  "fp16_clamp_overflow was requested but the QNN HTP SDK in use does "
+                  "not support it (requires QAIRT > 2.49). Ignoring.");
+#endif
     }
   }
 }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -467,7 +467,7 @@ void QnnEp::ParsePerSocHtpConfigs() {
                                   htp_graph_configs_.htp_graph_finalization_opt_mode,
                                   htp_graph_configs_.enable_htp_fp16_precision,
                                   htp_graph_configs_.enable_htp_monolithic_lstm,
-                                  htp_graph_configs_.fp16_clamp_overflow};
+                                  htp_graph_configs_.enable_htp_fp16_clamp_overflow};
     htp_graph_configs_per_soc_.push_back(std::move(config));
   }
 
@@ -934,13 +934,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
   // HTP fp16 clamp overflow. Default false. On HTP Arch v79+ (e.g. Glymur/v81),
   // fp16 Conv accumulator overflow becomes NaN and propagates to the output
   // (pre-v79 kept it finite). When true, saturate such overflow to the fp16 max
-  // value instead of NaN. Requires QAIRT SDK > 2.49.
-  static constexpr const char* kFp16ClampOverflow = "fp16_clamp_overflow";
-  htp_graph_configs_.fp16_clamp_overflow = ParseBoolOption(ort_api,
-                                                           session_options_,
-                                                           FormatEPConfigKey(kFp16ClampOverflow),
-                                                           false,
-                                                           logger_);
+  // value instead of NaN. Requires QAIRT SDK >= 2.49.
+  static constexpr const char* kEnableHtpFp16ClampOverflow = "enable_htp_fp16_clamp_overflow";
+  htp_graph_configs_.enable_htp_fp16_clamp_overflow = ParseBoolOption(ort_api,
+                                                                      session_options_,
+                                                                      FormatEPConfigKey(kEnableHtpFp16ClampOverflow),
+                                                                      false,
+                                                                      logger_);
 
   // Try to parse multi-SoC HTP options first. If not multi-SoC htp_arch/soc_model is given, fallback to normal parsing.
   ParsePerSocHtpConfigs();
@@ -1751,7 +1751,7 @@ void QnnEp::InitQnnHtpGraphConfigs(
       graph_config->customConfig = htp_graph_monolithic_lstm_config;
     }
 
-    if (configs.fp16_clamp_overflow) {
+    if (configs.enable_htp_fp16_clamp_overflow) {
 #ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
       gsl::not_null<QnnHtpGraph_CustomConfig_t*> htp_fp16_clamp_config = configs_builder.PushCustomConfig();
       htp_fp16_clamp_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW;
@@ -1762,8 +1762,8 @@ void QnnEp::InitQnnHtpGraphConfigs(
       graph_config->customConfig = htp_fp16_clamp_config;
 #else
       ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
-                  "fp16_clamp_overflow was requested but the QNN HTP SDK in use does "
-                  "not support it (requires QAIRT > 2.49). Ignoring.");
+                  "enable_htp_fp16_clamp_overflow was requested but the QNN HTP SDK in use does "
+                  "not support it (requires QAIRT >= 2.49). Ignoring.");
 #endif
     }
   }

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1192,7 +1192,7 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
 }
 
-// Smoke test for the fp16_clamp_overflow HTP option
+// Smoke test for the enable_htp_fp16_clamp_overflow HTP option
 #ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
 #if defined(_WIN32)
@@ -1202,7 +1202,7 @@ TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
   provider_options["enable_htp_fp16_precision"] = "1";
-  provider_options["fp16_clamp_overflow"] = "1";
+  provider_options["enable_htp_fp16_clamp_overflow"] = "1";
 #if defined(__linux__) && !defined(__aarch64__)
   provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
 #endif

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1192,8 +1192,10 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
 }
 
-// Smoke test for the enable_htp_fp16_clamp_overflow HTP option
-#ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+// Smoke test for the enable_htp_fp16_clamp_overflow HTP option.
+// The option is compiled unconditionally: on QAIRT < 2.49 the EP logs a warning
+// and ignores it (see qnn_execution_provider.cc), so this degrades to a plain
+// fp16 Conv smoke test; on QAIRT >= 2.49 it exercises the clamp-overflow path.
 TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
   ProviderOptions provider_options;
@@ -1218,7 +1220,6 @@ TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(0.01f)});
 }
-#endif  // QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.
 // Tests bias as a dynamic input.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1192,6 +1192,36 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
 }
 
+// Smoke test for the fp16_clamp_overflow HTP option
+#ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
+#if defined(_WIN32)
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
+#endif
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_htp_fp16_precision"] = "1";
+  provider_options["fp16_clamp_overflow"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+
+  auto input_def = TestInputDef<float>({1, 2, 4, 4}, false, GetFloatDataInRange(-1.0f, 1.0f, 32));
+  auto weights_def = TestInputDef<float>({2, 2, 2, 2}, true, GetFloatDataInRange(-1.0f, 1.0f, 16));
+  auto bias_def = TestInputDef<float>({2}, true, {1.0f, -1.0f});
+
+  RunQnnModelTest(BuildF32ConvTestCase("Conv", input_def, weights_def, bias_def,
+                                       {1, 1},        // strides
+                                       {0, 0, 0, 0},  // pads
+                                       {1, 1},        // dilations
+                                       1),            // group
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(0.01f)});
+}
+#endif  // QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.
 // Tests bias as a dynamic input.
 TEST_F(QnnHTPBackendTests, ConvU8U8S32_bias_dynamic_input) {

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1195,9 +1195,7 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
 // Smoke test for the enable_htp_fp16_clamp_overflow HTP option
 #ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
-#if defined(_WIN32)
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
-#endif
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- The option is intentionally undocumented (changes HTP numerical behavior) and gated on QNN API version >= 2.38 (QAIRT 2.49). On older SDKs the option is parsed but logs a warning and is ignored.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- On Glymur, fp16 Conv operations on HTP can overflow fp16 range and produce NaN/Inf outputs. This adds a new HTP-backend-specific session config option `fp16_clamp_overflow` (default OFF) that sets the QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW graph config to clamp such overflow.
