### PR TITLE
[QNN EP] Add support variadic inputs for Sum/Max/Min

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -299,7 +299,7 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
       (output_info.qnn_data_type == QNN_DATATYPE_INT_64) ? QNN_DATATYPE_INT_32 : QNN_DATATYPE_UINT_32;
 
   const Qnn_DataType_t intermediate_dtype =
-      output_quantized         ? QNN_DATATYPE_FLOAT_32
+      output_quantized   ? QNN_DATATYPE_FLOAT_32
       : needs_int64_cast ? cast_dtype
                          : output_info.qnn_data_type;
 
@@ -334,7 +334,7 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
     }
     const std::string dq_name = utils::UniqueNameGenerator().New(input_names[i], "_to_f32");
     RETURN_IF_ERROR(qnn_model_wrapper.AddDequantizeNode(input_names[i], dq_name, QNN_DATATYPE_FLOAT_32,
-                                                       shapes[i], do_op_validation));
+                                                        shapes[i], do_op_validation));
     input_names[i] = dq_name;
   }
 
@@ -355,12 +355,11 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
                                QnnQuantParamsWrapper(), std::vector<uint32_t>(running_shape)),
                     "AddTensorWrapper failed for fold output.");
     } else {
-
       // Last binary node writes directly to the graph output tensor. No need for further quantize or cast node.
       const Qnn_TensorType_t output_tensor_type =
           is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
       out_name = output.name;
-      
+
       RETURN_IF_NOT(add_tensor(out_name, output_tensor_type, output_info.qnn_data_type,
                                output_info.quant_param.Copy(), std::vector<uint32_t>(output_info.shape)),
                     "AddTensorWrapper failed for output.");
@@ -375,8 +374,8 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
     const Qnn_TensorType_t out_type =
         is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
     RETURN_IF_ERROR(qnn_model_wrapper.AddQuantizeNode(lhs_name, output.name, out_type, output_info.qnn_data_type,
-                                                     output_info.quant_param.Copy(), output_info.shape,
-                                                     do_op_validation));
+                                                      output_info.quant_param.Copy(), output_info.shape,
+                                                      do_op_validation));
   } else if (needs_int64_cast) {
     RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(node_unit, "_cast_int64"),
                                                   lhs_name, output.name, QNN_TENSOR_TYPE_APP_READ,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -65,20 +65,12 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
               "QNN EP does not support PRelu op on CPU backend. Falling back to ORT CPU.");
   }
 
-  // ONNX's Min, Max, and Sum operators accept a variable number of inputs (i.e., variadic).
-  // However, QNN's Min, Max, and Add operators must take in exactly two inputs.
-  if (op_type == "Min" || op_type == "Max") {
-    RETURN_IF_NOT(node_unit.Inputs().size() == 2,
-                  ("QNN EP only supports " + op_type + " operator with exactly 2 inputs.").c_str());
-  }
-
-  if (op_type == "Sum") {
-    size_t inputs_num = node_unit.Inputs().size();
-    RETURN_IF_NOT(inputs_num == 2,
-                  ("QNN EP supports Sum operator with QNN_OP_ELEMENT_WISE_ADD, which takes exactly 2 inputs."
-                   "Got ONNX's Sum operator with " +
-                   std::to_string(inputs_num) + " inputs.")
-                      .c_str());
+  // ONNX Min/Max/Sum are variadic. QNN's fine-grained Minimum/Maximum/Add ops take exactly 2 inputs.
+  // The 2-input case maps to a single QNN op node; >2-input cases are decomposed into a
+  // left-folded chain of those QNN ops (see ProcessVariadicToBinaryChain).
+  if (op_type == "Min" || op_type == "Max" || op_type == "Sum") {
+    RETURN_IF_NOT(node_unit.Inputs().size() >= 2,
+                  ("QNN EP requires " + op_type + " to have at least 2 inputs.").c_str());
   }
 
   if (op_type == "DequantizeLinear") {
@@ -278,6 +270,123 @@ Ort::Status ProcessGridSampleAttributes(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
+// Left-folds a variadic ONNX Sum/Max/Min (>=2 inputs) into a chain of QNN binary ops and builds
+// the final output node itself.
+// For quantized output: input->DQ->float32->Q->output
+//    The DQ process should've been added in ProcessInputs, written here to keep ProcessInputs clean
+// For non-quantized output: the fold happens in the output dtype
+Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
+                                         const OrtNodeUnit& node_unit,
+                                         std::vector<std::string>& input_names,
+                                         uint32_t binary_operation,
+                                         bool do_op_validation) {
+  const auto& inputs = node_unit.Inputs();
+  const auto& output = node_unit.Outputs()[0];
+  TensorInfo output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output, output_info));
+
+  const size_t num_inputs = input_names.size();
+
+  const bool output_quantized = output.quant_param.has_value();
+
+  // Check if we need to add an output cast node for int64
+  const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output.name);
+  const bool needs_int64_cast =
+      !output_quantized && is_graph_output &&
+      (output_info.qnn_data_type == QNN_DATATYPE_INT_64 ||
+       output_info.qnn_data_type == QNN_DATATYPE_UINT_64);
+  const Qnn_DataType_t cast_dtype =
+      (output_info.qnn_data_type == QNN_DATATYPE_INT_64) ? QNN_DATATYPE_INT_32 : QNN_DATATYPE_UINT_32;
+
+  const Qnn_DataType_t intermediate_dtype =
+      output_quantized         ? QNN_DATATYPE_FLOAT_32
+      : needs_int64_cast ? cast_dtype
+                         : output_info.qnn_data_type;
+
+  auto add_tensor = [&qnn_model_wrapper](std::string name, Qnn_TensorType_t type, Qnn_DataType_t dtype,
+                                         QnnQuantParamsWrapper quant_param, std::vector<uint32_t> shape) {
+    QnnTensorWrapper wrapper(std::move(name), type, dtype, std::move(quant_param), std::move(shape));
+    return qnn_model_wrapper.AddTensorWrapper(std::move(wrapper));
+  };
+
+  auto add_binary = [&](const std::string& lhs, const std::string& rhs,
+                        const std::string& out_name) -> Ort::Status {
+    const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
+    std::vector<std::string> params;
+    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, binary_operation,
+                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, params));
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_BINARY, {lhs, rhs}, {out_name},
+                                                  std::move(params), do_op_validation),
+                  "Failed to add binary node.");
+    return Ort::Status();
+  };
+
+  std::vector<std::vector<uint32_t>> shapes(num_inputs);
+  for (size_t i = 0; i < num_inputs; ++i) {
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(inputs[i].shape, shapes[i]), "Failed to get input shape.");
+  }
+
+  // Add DQ node for each quantized input, dequantized to float32 so the fold chain can run in float space.
+  for (size_t i = 0; i < num_inputs; ++i) {
+    if (!inputs[i].quant_param.has_value()) {
+      continue;
+    }
+    const std::string dq_name = utils::UniqueNameGenerator().New(input_names[i], "_to_f32");
+    RETURN_IF_ERROR(qnn_model_wrapper.AddDequantizeNode(input_names[i], dq_name, QNN_DATATYPE_FLOAT_32,
+                                                       shapes[i], do_op_validation));
+    input_names[i] = dq_name;
+  }
+
+  // Fold all inputs into a chain of binary ops. Every binary node is created in this loop.
+  std::string lhs_name = input_names[0];
+  std::vector<uint32_t> running_shape = shapes[0];
+
+  for (size_t i = 1; i < num_inputs; ++i) {
+    std::vector<uint32_t> next;
+    RETURN_IF_ERROR(utils::BroadcastShape(running_shape, shapes[i], next));
+    running_shape = std::move(next);
+    const bool is_last = (i == num_inputs - 1);
+    std::string out_name;
+
+    if (!is_last || output_quantized || needs_int64_cast) {
+      out_name = utils::UniqueNameGenerator().New(node_unit, "_fold" + std::to_string(i));
+      RETURN_IF_NOT(add_tensor(out_name, QNN_TENSOR_TYPE_NATIVE, intermediate_dtype,
+                               QnnQuantParamsWrapper(), std::vector<uint32_t>(running_shape)),
+                    "AddTensorWrapper failed for fold output.");
+    } else {
+
+      // Last binary node writes directly to the graph output tensor. No need for further quantize or cast node.
+      const Qnn_TensorType_t output_tensor_type =
+          is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+      out_name = output.name;
+      
+      RETURN_IF_NOT(add_tensor(out_name, output_tensor_type, output_info.qnn_data_type,
+                               output_info.quant_param.Copy(), std::vector<uint32_t>(output_info.shape)),
+                    "AddTensorWrapper failed for output.");
+    }
+
+    RETURN_IF_ERROR(add_binary(lhs_name, input_names[i], out_name));
+    lhs_name = out_name;
+  }
+
+  // Add the Quantize/cast node after the last binary operate node that produces the actual output tensor.
+  if (output_quantized) {
+    const Qnn_TensorType_t out_type =
+        is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+    RETURN_IF_ERROR(qnn_model_wrapper.AddQuantizeNode(lhs_name, output.name, out_type, output_info.qnn_data_type,
+                                                     output_info.quant_param.Copy(), output_info.shape,
+                                                     do_op_validation));
+  } else if (needs_int64_cast) {
+    RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(node_unit, "_cast_int64"),
+                                                  lhs_name, output.name, QNN_TENSOR_TYPE_APP_READ,
+                                                  output_info.qnn_data_type, output_info.quant_param.Copy(),
+                                                  std::vector<uint32_t>(output_info.shape), false));
+  }
+
+  return Ort::Status();
+}
+
 Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
                                                          const OrtNodeUnit& node_unit,
                                                          std::vector<std::string>&& input_names,
@@ -391,7 +500,22 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_ERROR(ProcessGridSampleAttributes(qnn_model_wrapper, node_unit, param_tensor_names));
   }
 
-  return ProcessOutputs(qnn_model_wrapper, node_unit,
+  // Variadic Sum/Max/Min with > 2 inputs.  left-folded chain of QNN binary ops. The helper does its
+  // own dequantize/fold/requantize and builds the output node itself, returns directly and
+  // bypasses the base ProcessOutputs.
+  // The 2-input case falls through to the ProcessOutputs path below (GetQnnOpType).
+  static const std::unordered_map<std::string, uint32_t> variadic_op_to_operation = {
+      {"Sum", QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD},
+      {"Max", QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MAXIMUM},
+      {"Min", QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MINIMUM},
+  };
+  auto variadic_it = variadic_op_to_operation.find(op_type);
+  if (variadic_it != variadic_op_to_operation.end() && input_names.size() > 2) {
+    return ProcessVariadicToBinaryChain(qnn_model_wrapper, node_unit, input_names,
+                                        variadic_it->second, do_op_validation);
+  }
+
+
                         std::move(input_names),
                         std::move(param_tensor_names),
                         logger, do_op_validation, GetQnnOpType(op_type));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -270,7 +270,7 @@ Ort::Status ProcessGridSampleAttributes(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// Left-folds a variadic ONNX Sum/Max/Min (>=2 inputs) into a chain of QNN binary ops and builds
+// Left-folds a variadic ONNX Sum/Max/Min (>=2 inputs) into a chain of fine-grained QNN ops and builds
 // the final output node itself.
 // For quantized output: input->DQ->float32->Q->output
 //    The DQ process should've been added in ProcessInputs, written here to keep ProcessInputs clean
@@ -278,7 +278,7 @@ Ort::Status ProcessGridSampleAttributes(QnnModelWrapper& qnn_model_wrapper,
 Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit,
                                          std::vector<std::string>& input_names,
-                                         uint32_t binary_operation,
+                                         const std::string& qnn_op_type,
                                          bool do_op_validation) {
   const auto& inputs = node_unit.Inputs();
   const auto& output = node_unit.Outputs()[0];
@@ -311,13 +311,10 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
 
   auto add_binary = [&](const std::string& lhs, const std::string& rhs,
                         const std::string& out_name) -> Ort::Status {
-    const std::string node_name = utils::UniqueNameGenerator().New(node_unit, QNN_OP_ELEMENT_WISE_BINARY);
-    std::vector<std::string> params;
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_name, binary_operation,
-                                           QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, params));
+    const std::string node_name = utils::UniqueNameGenerator().New(node_unit, qnn_op_type);
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_ELEMENT_WISE_BINARY, {lhs, rhs}, {out_name},
-                                                  std::move(params), do_op_validation),
+                                                  qnn_op_type, {lhs, rhs}, {out_name},
+                                                  {}, do_op_validation),
                   "Failed to add binary node.");
     return Ort::Status();
   };
@@ -499,22 +496,16 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_ERROR(ProcessGridSampleAttributes(qnn_model_wrapper, node_unit, param_tensor_names));
   }
 
-  // Variadic Sum/Max/Min with > 2 inputs.  left-folded chain of QNN binary ops. The helper does its
+  // Variadic Sum/Max/Min with > 2 inputs.  left-folded chain of fine-grained QNN ops. The helper does its
   // own dequantize/fold/requantize and builds the output node itself, returns directly and
   // bypasses the base ProcessOutputs.
   // The 2-input case falls through to the ProcessOutputs path below (GetQnnOpType).
-  static const std::unordered_map<std::string, uint32_t> variadic_op_to_operation = {
-      {"Sum", QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD},
-      {"Max", QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MAXIMUM},
-      {"Min", QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MINIMUM},
-  };
-  auto variadic_it = variadic_op_to_operation.find(op_type);
-  if (variadic_it != variadic_op_to_operation.end() && input_names.size() > 2) {
+  if ((op_type == "Sum" || op_type == "Max" || op_type == "Min") && input_names.size() > 2) {
     return ProcessVariadicToBinaryChain(qnn_model_wrapper, node_unit, input_names,
-                                        variadic_it->second, do_op_validation);
+                                        GetQnnOpType(op_type), do_op_validation);
   }
 
-
+  return ProcessOutputs(qnn_model_wrapper, node_unit,
                         std::move(input_names),
                         std::move(param_tensor_names),
                         logger, do_op_validation, GetQnnOpType(op_type));

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -503,6 +503,31 @@ Ort::Status PermuteShape(gsl::span<const T> input_shape, gsl::span<const P> perm
   return Ort::Status();
 }
 
+// Computes the broadcasted shape of two shapes following NumPy/ONNX broadcasting rules
+// (right-aligned dimensions; a dim of 1 broadcasts against any dim).
+template <typename T>
+Ort::Status BroadcastShape(const std::vector<T>& a, const std::vector<T>& b,
+                           /*out*/ std::vector<T>& out) {
+  const size_t rank = std::max(a.size(), b.size());
+  out.assign(rank, 1);
+  for (size_t i = 0; i < rank; ++i) {
+    const T da = (i < a.size()) ? a[a.size() - 1 - i] : 1;
+    const T db = (i < b.size()) ? b[b.size() - 1 - i] : 1;
+    T dim = 0;
+    if (da == db) {
+      dim = da;
+    } else if (da == 1) {
+      dim = db;
+    } else if (db == 1) {
+      dim = da;
+    } else {
+      return MAKE_EP_FAIL("BroadcastShape: incompatible dimensions, cannot broadcast.");
+    }
+    out[rank - 1 - i] = dim;
+  }
+  return Ort::Status();
+}
+
 // Gets error message associated with QNN error handle value.
 std::string GetQnnErrorMessage(const QNN_INTERFACE_VER_TYPE& qnn_interface,
                                Qnn_ErrorHandle_t qnn_error_handle);

--- a/onnxruntime/test/providers/qnn/max_min_test.cc
+++ b/onnxruntime/test/providers/qnn/max_min_test.cc
@@ -35,14 +35,16 @@ template <typename QType = uint8_t>
 static void RunQDQMinOrMaxOpTest(const std::string& op_type,
                                  const std::vector<TestInputDef<float>>& input_defs,
                                  ExpectedEPNodeAssignment expected_ep_assignment,
-                                 int opset = 13) {
+                                 int opset = 13,
+                                 bool use_contrib_qdq = false) {
   ProviderOptions provider_options;
 
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
 
-  TestQDQModelAccuracy(BuildOpTestCase<float>(op_type + "_node", op_type, input_defs, {}, {}, kOnnxDomain),     // baseline float32 model
-                       BuildQDQOpTestCase<QType>(op_type + "_node", op_type, input_defs, {}, {}, kOnnxDomain),  // QDQ model
+  TestQDQModelAccuracy(BuildOpTestCase<float>(op_type + "_node", op_type, input_defs, {}, {}, kOnnxDomain),  // baseline float32 model
+                       BuildQDQOpTestCase<QType>(op_type + "_node", op_type, input_defs, {}, {}, kOnnxDomain,
+                                                 use_contrib_qdq),  // QDQ model
                        provider_options,
                        opset,
                        expected_ep_assignment);
@@ -62,6 +64,25 @@ static void RunInt32MinOrMaxOpTest(const std::string& op_type,
   provider_options["offload_graph_io_quantization"] = "0";
 
   RunQnnModelTest(BuildOpTestCase<int32_t>(op_type + "_node", op_type, input_defs, {}, {}, kOnnxDomain),
+                  provider_options,
+                  opset,
+                  EPVerificationParams{expected_ep_assignment});
+}
+
+// Runs an int64 Max/Min model on the given QNN backend ("cpu" or "htp"). An int64 graph output
+// exercises the needs_int64_cast path (fold in int32, trailing Cast back to int64). Checks the
+// graph node assignment, and that inference outputs for QNN EP and ORT CPU EP match exactly.
+static void RunInt64MinOrMaxOpTest(const std::string& op_type,
+                                   const std::vector<TestInputDef<int64_t>>& input_defs,
+                                   ExpectedEPNodeAssignment expected_ep_assignment,
+                                   const std::string& backend_name,
+                                   int opset = 13) {
+  ProviderOptions provider_options;
+
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildOpTestCase<int64_t>(op_type + "_node", op_type, input_defs, {}, {}, kOnnxDomain),
                   provider_options,
                   opset,
                   EPVerificationParams{expected_ep_assignment});
@@ -120,6 +141,93 @@ TEST_F(QnnCPUBackendTests, Max_2Inputs_Int32) {
   RunInt32MinOrMaxOpTest("Max",
                          {TestInputDef<int32_t>({3, 4}, false, input0_data),
                           TestInputDef<int32_t>({3, 4}, false, input1_data)},
+                         ExpectedEPNodeAssignment::All, "cpu", 13);
+}
+
+// Variadic (>2 input) Min/Max are decomposed into a left-folded QNN binary-op chain.
+
+// Test float Min with 3 inputs on CPU backend.
+TEST_F(QnnCPUBackendTests, Min_3Inputs) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunCPUMinOrMaxOpTest("Min",
+                       {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                       ExpectedEPNodeAssignment::All, 13);
+}
+
+// Test float Max with 3 inputs on CPU backend.
+TEST_F(QnnCPUBackendTests, Max_3Inputs) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunCPUMinOrMaxOpTest("Max",
+                       {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                       ExpectedEPNodeAssignment::All, 13);
+}
+
+// Test float Max with 4 inputs on CPU backend (chain depth > 1).
+TEST_F(QnnCPUBackendTests, Max_4Inputs) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunCPUMinOrMaxOpTest("Max",
+                       {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                        TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                       ExpectedEPNodeAssignment::All, 13);
+}
+
+// Variadic float Min with mixed-rank broadcasting on CPU backend: {2,3,4},{4},{3,1} -> {2,3,4}.
+TEST_F(QnnCPUBackendTests, Min_3Inputs_BroadcastMixedRank) {
+  RunCPUMinOrMaxOpTest("Min",
+                       {TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 24)),
+                        TestInputDef<float>({4}, false, GetFloatDataInRange(-10.0f, 10.0f, 4)),
+                        TestInputDef<float>({3, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 3))},
+                       ExpectedEPNodeAssignment::All, 13);
+}
+
+// Variadic float Max with mixed-rank broadcasting on CPU backend: {2,3,4},{4},{3,1} -> {2,3,4}.
+TEST_F(QnnCPUBackendTests, Max_3Inputs_BroadcastMixedRank) {
+  RunCPUMinOrMaxOpTest("Max",
+                       {TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 24)),
+                        TestInputDef<float>({4}, false, GetFloatDataInRange(-10.0f, 10.0f, 4)),
+                        TestInputDef<float>({3, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 3))},
+                       ExpectedEPNodeAssignment::All, 13);
+}
+
+// Test int32 Max with 3 inputs on CPU backend (non-quantized integer fold branch).
+TEST_F(QnnCPUBackendTests, Max_3Inputs_Int32) {
+  std::vector<int32_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int32_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int32_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+  RunInt32MinOrMaxOpTest("Max",
+                         {TestInputDef<int32_t>({3, 4}, false, input0_data),
+                          TestInputDef<int32_t>({3, 4}, false, input1_data),
+                          TestInputDef<int32_t>({3, 4}, false, input2_data)},
+                         ExpectedEPNodeAssignment::All, "cpu", 13);
+}
+
+// Test int64 Min with 3 inputs on CPU backend
+TEST_F(QnnCPUBackendTests, Min_3Inputs_Int64) {
+  std::vector<int64_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int64_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int64_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+  RunInt64MinOrMaxOpTest("Min",
+                         {TestInputDef<int64_t>({3, 4}, false, input0_data),
+                          TestInputDef<int64_t>({3, 4}, false, input1_data),
+                          TestInputDef<int64_t>({3, 4}, false, input2_data)},
+                         ExpectedEPNodeAssignment::All, "cpu", 13);
+}
+
+// Test int64 Max with 3 inputs on CPU backend
+TEST_F(QnnCPUBackendTests, Max_3Inputs_Int64) {
+  std::vector<int64_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int64_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int64_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+  RunInt64MinOrMaxOpTest("Max",
+                         {TestInputDef<int64_t>({3, 4}, false, input0_data),
+                          TestInputDef<int64_t>({3, 4}, false, input1_data),
+                          TestInputDef<int64_t>({3, 4}, false, input2_data)},
                          ExpectedEPNodeAssignment::All, "cpu", 13);
 }
 
@@ -194,6 +302,117 @@ TEST_F(QnnHTPBackendTests, Max_1Input_NotSupported_Int32) {
   RunInt32MinOrMaxOpTest("Max",
                          {TestInputDef<int32_t>({1, 3, 4, 4}, false, std::vector<int32_t>(48, 1))},
                          ExpectedEPNodeAssignment::None, "htp", 13);
+}
+
+// Variadic (>2 input) Min/Max on HTP: DQ -> float chain -> Q.
+
+// Test accuracy of 8-bit Q/DQ Min with 3 inputs on HTP backend.
+TEST_F(QnnHTPBackendTests, Min_3Inputs) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunQDQMinOrMaxOpTest<uint8_t>("Min",
+                                {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                 TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                 TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                                ExpectedEPNodeAssignment::All, 13);
+}
+
+// Variadic 8-bit Q/DQ Min with mixed-rank broadcasting on HTP: {2,3,4},{4},{3,1} -> {2,3,4}.
+TEST_F(QnnHTPBackendTests, Min_3Inputs_BroadcastMixedRank_U8) {
+  RunQDQMinOrMaxOpTest<uint8_t>("Min",
+                                {TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 24)),
+                                 TestInputDef<float>({4}, false, GetFloatDataInRange(-10.0f, 10.0f, 4)),
+                                 TestInputDef<float>({3, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 3))},
+                                ExpectedEPNodeAssignment::All, 13);
+}
+
+// Variadic 8-bit Q/DQ Max with mixed-rank broadcasting on HTP: {2,3,4},{4},{3,1} -> {2,3,4}.
+TEST_F(QnnHTPBackendTests, Max_3Inputs_BroadcastMixedRank_U8) {
+  RunQDQMinOrMaxOpTest<uint8_t>("Max",
+                                {TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 24)),
+                                 TestInputDef<float>({4}, false, GetFloatDataInRange(-10.0f, 10.0f, 4)),
+                                 TestInputDef<float>({3, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 3))},
+                                ExpectedEPNodeAssignment::All, 13);
+}
+
+// Test accuracy of 8-bit Q/DQ Max with 3 inputs on HTP backend.
+TEST_F(QnnHTPBackendTests, Max_3Inputs) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunQDQMinOrMaxOpTest<uint8_t>("Max",
+                                {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                 TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                 TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                                ExpectedEPNodeAssignment::All, 13);
+}
+
+// Test accuracy of 16-bit Q/DQ Min with 3 inputs on HTP backend (16-bit requant path).
+TEST_F(QnnHTPBackendTests, Min_3Inputs_U16) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunQDQMinOrMaxOpTest<uint16_t>("Min",
+                                 {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                  TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                  TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                                 ExpectedEPNodeAssignment::All, 13,
+                                 /*use_contrib_qdq=*/true);  // 16-bit zero-point needs com.microsoft Q/DQ
+}
+
+// Test accuracy of 16-bit Q/DQ Max with 3 inputs on HTP backend (16-bit requant path).
+TEST_F(QnnHTPBackendTests, Max_3Inputs_U16) {
+  std::vector<float> input_data = GetFloatDataInRange(-10.0f, 10.0f, 48);
+  RunQDQMinOrMaxOpTest<uint16_t>("Max",
+                                 {TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                  TestInputDef<float>({1, 3, 4, 4}, false, input_data),
+                                  TestInputDef<float>({1, 3, 4, 4}, false, input_data)},
+                                 ExpectedEPNodeAssignment::All, 13,
+                                 /*use_contrib_qdq=*/true);  // 16-bit zero-point needs com.microsoft Q/DQ
+}
+
+// Test int32 Min with 3 inputs on HTP backend (non-quantized integer fold branch).
+TEST_F(QnnHTPBackendTests, Min_3Inputs_Int32) {
+  std::vector<int32_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int32_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int32_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+
+  RunInt32MinOrMaxOpTest("Min",
+                         {TestInputDef<int32_t>({3, 4}, false, input0_data),
+                          TestInputDef<int32_t>({3, 4}, false, input1_data),
+                          TestInputDef<int32_t>({3, 4}, false, input2_data)},
+                         ExpectedEPNodeAssignment::All, "htp", 13);
+}
+
+// Test int32 Max with 3 inputs on HTP backend (non-quantized integer fold branch).
+TEST_F(QnnHTPBackendTests, Max_3Inputs_Int32) {
+  std::vector<int32_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int32_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int32_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+  RunInt32MinOrMaxOpTest("Max",
+                         {TestInputDef<int32_t>({3, 4}, false, input0_data),
+                          TestInputDef<int32_t>({3, 4}, false, input1_data),
+                          TestInputDef<int32_t>({3, 4}, false, input2_data)},
+                         ExpectedEPNodeAssignment::All, "htp", 13);
+}
+
+// Test int64 Min with 3 inputs on HTP backend (needs_int64_cast branch: int32 fold + Cast to int64).
+TEST_F(QnnHTPBackendTests, Min_3Inputs_Int64) {
+  std::vector<int64_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int64_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int64_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+  RunInt64MinOrMaxOpTest("Min",
+                         {TestInputDef<int64_t>({3, 4}, false, input0_data),
+                          TestInputDef<int64_t>({3, 4}, false, input1_data),
+                          TestInputDef<int64_t>({3, 4}, false, input2_data)},
+                         ExpectedEPNodeAssignment::All, "htp", 13);
+}
+
+// Test int64 Max with 3 inputs on HTP backend (needs_int64_cast branch: int32 fold + Cast to int64).
+TEST_F(QnnHTPBackendTests, Max_3Inputs_Int64) {
+  std::vector<int64_t> input0_data = {-10, -5, 0, 5, 10, -3, 7, -8, 2, -1, 9, -6};
+  std::vector<int64_t> input1_data = {3, -5, 1, -2, 6, -3, -7, 8, 2, 4, -9, 6};
+  std::vector<int64_t> input2_data = {0, 5, -1, 2, -6, 3, 7, -8, -2, 4, 9, -6};
+  RunInt64MinOrMaxOpTest("Max",
+                         {TestInputDef<int64_t>({3, 4}, false, input0_data),
+                          TestInputDef<int64_t>({3, 4}, false, input1_data),
+                          TestInputDef<int64_t>({3, 4}, false, input2_data)},
+                         ExpectedEPNodeAssignment::All, "htp", 13);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -148,6 +148,60 @@ TEST_F(QnnCPUBackendTests, UnaryOp_Softplus_Rank5) {
                  ExpectedEPNodeAssignment::All);
 }
 
+// Variadic (>2 input) float Sum on the QNN CPU backend (non-quantized fold branch).
+TEST_F(QnnCPUBackendTests, VariadicOp_Sum_3Inputs) {
+  RunOpTestOnCPU("Sum",
+                 {TestInputDef<float>({1, 2, 2, 2}, false, GetFloatDataInRange(-10.0f, 10.0f, 8)),
+                  TestInputDef<float>({1, 2, 2, 2}, false, GetFloatDataInRange(-10.0f, 10.0f, 8)),
+                  TestInputDef<float>({1, 2, 2, 2}, false, GetFloatDataInRange(-10.0f, 10.0f, 8))},
+                 {},
+                 13,
+                 ExpectedEPNodeAssignment::All);
+}
+
+// 2-input float Sum regression: n==2 shares the same variadic helper path as n>2.
+TEST_F(QnnCPUBackendTests, VariadicOp_Sum_2Inputs) {
+  RunOpTestOnCPU("Sum",
+                 {TestInputDef<float>({1, 2, 2, 2}, false, GetFloatDataInRange(-10.0f, 10.0f, 8)),
+                  TestInputDef<float>({1, 2, 2, 2}, false, GetFloatDataInRange(-10.0f, 10.0f, 8))},
+                 {},
+                 13,
+                 ExpectedEPNodeAssignment::All);
+}
+
+// Variadic float Sum with mixed-rank broadcasting: {2,3,4},{4},{3,1} -> {2,3,4}.
+TEST_F(QnnCPUBackendTests, VariadicOp_Sum_3Inputs_BroadcastMixedRank) {
+  RunOpTestOnCPU("Sum",
+                 {TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 24)),
+                  TestInputDef<float>({4}, false, GetFloatDataInRange(-10.0f, 10.0f, 4)),
+                  TestInputDef<float>({3, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 3))},
+                 {},
+                 13,
+                 ExpectedEPNodeAssignment::All);
+}
+
+// Variadic int64 Max with an int64 graph output on the QNN CPU backend.
+TEST_F(QnnCPUBackendTests, VariadicOp_Max_3Inputs_Int64Output) {
+  RunOpTestOnCPU<int64_t>("Max",
+                          {TestInputDef<int64_t>({1, 2, 2, 2}, false, {-4, 7, 0, 3, 9, -2, 5, 1}),
+                           TestInputDef<int64_t>({1, 2, 2, 2}, false, {6, -1, 2, 8, -5, 4, 0, 7}),
+                           TestInputDef<int64_t>({1, 2, 2, 2}, false, {1, 3, -8, 2, 0, 6, -3, 9})},
+                          {},
+                          13,
+                          ExpectedEPNodeAssignment::All);
+}
+
+// Variadic int64 Min with an int64 graph output on the QNN CPU backend.
+TEST_F(QnnCPUBackendTests, VariadicOp_Min_3Inputs_Int64Output) {
+  RunOpTestOnCPU<int64_t>("Min",
+                          {TestInputDef<int64_t>({1, 2, 2, 2}, false, {-4, 7, 0, 3, 9, -2, 5, 1}),
+                           TestInputDef<int64_t>({1, 2, 2, 2}, false, {6, -1, 2, 8, -5, 4, 0, 7}),
+                           TestInputDef<int64_t>({1, 2, 2, 2}, false, {1, 3, -8, 2, 0, 6, -3, 9})},
+                          {},
+                          13,
+                          ExpectedEPNodeAssignment::All);
+}
+
 // Verifies QNN_OP_HARD_SWISH computes x * clip((x+3)/6, 0, 1), not HardSigmoid.
 TEST_F(QnnCPUBackendTests, UnaryOp_HardSwish) {
   RunOpTestOnCPU("HardSwish",
@@ -340,6 +394,17 @@ TEST_F(QnnHTPBackendTests, Concat_EmptyInitializer) {
             {test::MakeAttribute("axis", static_cast<int64_t>(1))},
             13,
             ExpectedEPNodeAssignment::All);
+}
+
+// Variadic QDQ Sum with mixed-rank broadcasting on the QNN HTP backend: {2,3,4},{4},{3,1} -> {2,3,4}.
+TEST_F(QnnHTPBackendTests, VariadicOp_Sum_3Inputs_BroadcastMixedRank_U8) {
+  RunQDQOpTest<uint8_t>("Sum",
+                        {TestInputDef<float>({2, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 24)),
+                         TestInputDef<float>({4}, false, GetFloatDataInRange(-10.0f, 10.0f, 4)),
+                         TestInputDef<float>({3, 1}, false, GetFloatDataInRange(-10.0f, 10.0f, 3))},
+                        {},
+                        13,
+                        ExpectedEPNodeAssignment::All);
 }
 
 // Test the accuracy of QDQ Sigmoid.
@@ -1068,6 +1133,42 @@ TEST_F(QnnHTPBackendTests, BinaryOp_Add4D_FP64) {
                   provider_options,
                   17,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3)});
+}
+
+// Variadic (>2 input) Sum decomposed into a QNN binary-op chain.
+// QDQ path exercises DQ -> float Add chain -> Q (so partial sums do not clamp).
+
+TEST_F(QnnHTPBackendTests, VariadicOp_Sum_2Inputs) {
+  RunQDQOpTest<uint8_t>("Sum",
+                        {TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f),
+                         TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f)},
+                        {},
+                        17,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// 3-input 8-bit QDQ Sum.
+TEST_F(QnnHTPBackendTests, VariadicOp_Sum_3Inputs) {
+  RunQDQOpTest<uint8_t>("Sum",
+                        {TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f),
+                         TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f),
+                         TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f)},
+                        {},
+                        17,
+                        ExpectedEPNodeAssignment::All);
+}
+
+// 3-input 16-bit QDQ Sum (exercises the 16-bit requant path).
+TEST_F(QnnHTPBackendTests, VariadicOp_Sum_3Inputs_U16) {
+  RunQDQOpTest<uint16_t>("Sum",
+                         {TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f),
+                          TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f),
+                          TestInputDef<float>({1, 2, 2, 2}, false, -10.0f, 10.0f)},
+                         {},
+                         17,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,
+                         true);  // Use com.microsoft Q/DQ ops (16-bit zero-point needs contrib domain)
 }
 
 // Test 8-bit QDQ Sub

--- a/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
@@ -1401,6 +1401,49 @@ TEST(QnnUnit_UtilsTest, ConvertBlockQuantScalesToLpbq_UnsupportedBitwdithReturns
   EXPECT_FALSE(st.IsOK());
 }
 
+// =============================================================================
+// BroadcastShape — right-aligned broadcasting rules
+// =============================================================================
+
+TEST(QnnUnit_UtilsTest, BroadcastShape_SameShape) {
+  std::vector<uint32_t> a = {2, 3, 4};
+  std::vector<uint32_t> b = {2, 3, 4};
+  std::vector<uint32_t> out;
+  auto st = qnn::utils::BroadcastShape<uint32_t>(a, b, out);
+  EXPECT_TRUE(st.IsOK());
+  EXPECT_EQ(out, (std::vector<uint32_t>{2, 3, 4}));
+}
+
+TEST(QnnUnit_UtilsTest, BroadcastShape_DimOneBroadcasts) {
+  // {1, 3} vs {2, 1} → {2, 3}
+  std::vector<uint32_t> a = {1, 3};
+  std::vector<uint32_t> b = {2, 1};
+  std::vector<uint32_t> out;
+  auto st = qnn::utils::BroadcastShape<uint32_t>(a, b, out);
+  EXPECT_TRUE(st.IsOK());
+  EXPECT_EQ(out, (std::vector<uint32_t>{2, 3}));
+}
+
+TEST(QnnUnit_UtilsTest, BroadcastShape_DifferentRanksRightAligned) {
+  // {3} vs {2, 3} → {2, 3}
+  std::vector<uint32_t> a = {3};
+  std::vector<uint32_t> b = {2, 3};
+  std::vector<uint32_t> out;
+  auto st = qnn::utils::BroadcastShape<uint32_t>(a, b, out);
+  EXPECT_TRUE(st.IsOK());
+  EXPECT_EQ(out, (std::vector<uint32_t>{2, 3}));
+}
+
+TEST(QnnUnit_UtilsTest, BroadcastShape_HigherRankMixed) {
+  // {5, 1, 4} vs {3, 1} → {5, 3, 4}
+  std::vector<uint32_t> a = {5, 1, 4};
+  std::vector<uint32_t> b = {3, 1};
+  std::vector<uint32_t> out;
+  auto st = qnn::utils::BroadcastShape<uint32_t>(a, b, out);
+  EXPECT_TRUE(st.IsOK());
+  EXPECT_EQ(out, (std::vector<uint32_t>{5, 3, 4}));
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
 ### Description
 Add support for variadic (>2 input)  Sum, Max, and Min in the QNN EP. 

1.   A new helper ProcessVariadicToBinaryChain decomposes an N-input op into a left-folded chain of QNN binary ops:
-  Quantized (QDQ): DQ each input to float32, fold in float, then Q the output avoids clamping partial results.
-  Non-quantized (float / integer Min/Max): fold directly in the output dtype.

2. ExplicitOpCheck relaxed from "exactly 2" to "at least 2" inputs. Tests cover CPU float, HTP QDQ (uint8/uint16), int32, overflow, and broadcasting cases.

### Motivation and Context
 ONNX defines these as variadic  operators (≥1 input), but QNN's  QNN_OP_ELEMENT_WISE_BINARY (ADD /  MAXIMUM / MINIMUM) takes exactly 2  inputs. Previously the QNN EP rejected any Sum/Max/Min with more than 2 inputs, forcing a fallback to the ORT CPU EP.


