### PR TITLE
[QNN EP] Revert standalone constant Q/DQ folding (#339)

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/batchnormalization_op_builder.cc
@@ -447,14 +447,7 @@ class BatchNormalizationOpBuilder : public BaseOpBuilder {
 
 namespace {
 
-// Helper to check if a BatchNorm param is constant - either direct initializer or through a DQ node.
-//
-// node_unit.GetDQNodes() is only populated for a QDQGroup-type NodeUnit. When the surrounding QDQ
-// selector rejects the group (e.g. BatchNormalizationNodeGroupSelector requires the quantized input
-// and output element types to match; mixed-bitwidth BN like u8-in/u16-out does not), BatchNorm becomes
-// a SingleNode-type NodeUnit with an empty GetDQNodes(). In that case the param's standalone DQ node
-// is visited (and constant-folded via TryFoldConstantQDQ) as its own NodeUnit before BN, in topological
-// order, so IsEffectivelyConstantInput (which also checks IsFoldedConstant) still recognizes it.
+// Helper to check if a BatchNorm param is constant, either directly or through a DQ in its group.
 bool IsParamConstant(const QnnModelWrapper& qnn_model_wrapper,
                      const OrtNodeUnit& node_unit,
                      const std::string& name) {
@@ -500,9 +493,9 @@ void OverrideParamTypeForRequantize(Qnn_DataType_t x_dtype,
 // Single source of truth for float execution, shared by ProcessInputs (stores params) and
 // ProcessAttributesAndOutputs (emits the op).
 //   - has_float_output: quantized input, no output Q -> float island; BN emits float directly.
-//   - use_float_params: u8/u16 input where a BN param is per-channel quantized, or mean/var
-//     is raw float. QNN BN fuses them into per-tensor scale/bias, which drops per-channel
-//     range; the float path (Dequantize -> BN in F32 -> Quantize) keeps it.
+//   - use_float_params: mixed quantized input/output types, or a u8/u16 input where a BN
+//     param is per-channel quantized or mean/var is raw float. The float path
+//     (Dequantize -> BN in F32 -> Quantize) preserves those representations.
 struct BatchNormFloatExecution {
   bool has_float_output;
   bool use_float_params;
@@ -516,6 +509,9 @@ BatchNormFloatExecution GetBatchNormFloatExecution(const TensorInfo& input_info,
                                                    const TensorInfo& output_info) {
   const bool is_input_quantized = input_info.quant_param.IsQuantized();
   const bool has_float_output = is_input_quantized && !output_info.quant_param.IsQuantized();
+  const bool has_mixed_quant_types = is_input_quantized &&
+                                     output_info.quant_param.IsQuantized() &&
+                                     input_info.qnn_data_type != output_info.qnn_data_type;
   const bool any_param_per_channel = scale_info.quant_param.IsPerChannel() ||
                                      bias_info.quant_param.IsPerChannel() ||
                                      mean_info.quant_param.IsPerChannel() ||
@@ -525,7 +521,7 @@ BatchNormFloatExecution GetBatchNormFloatExecution(const TensorInfo& input_info,
                                       (!mean_info.quant_param.IsQuantized() ||
                                        !var_info.quant_param.IsQuantized());
   const bool use_float_params =
-      has_float_output ||
+      has_float_output || has_mixed_quant_types ||
       (is_input_quantized &&
        (input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_8 ||
         input_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) &&
@@ -650,9 +646,8 @@ Ort::Status BatchNormalizationOpBuilder::ProcessInputs(QnnModelWrapper& qnn_mode
                                (bias_info.qnn_data_type == QNN_DATATYPE_FLOAT_32 ||
                                 bias_info.qnn_data_type == QNN_DATATYPE_FLOAT_16);
 
-    // A param may be a real ONNX initializer (initializer_tensor set) or a standalone DQ-of-constant
-    // already folded to a STATIC tensor by TryFoldConstantQDQ (initializer_tensor is null in that
-    // case; see IsParamConstant above) -- read bytes from whichever the param actually is.
+    // Read through the effective-constant abstraction so initializer-backed and STATIC params use
+    // the same preprocessing path.
     std::vector<uint8_t> scale_unpacked_tensor;
     std::vector<uint8_t> bias_unpacked_tensor;
     std::vector<uint8_t> mean_unpacked_tensor;
@@ -894,6 +889,11 @@ Ort::Status BatchNormalizationOpBuilder::CheckHtpDataTypes(const std::vector<Qnn
   const bool x_is_quantized = (x_dtype == QNN_DATATYPE_UFIXED_POINT_8 || x_dtype == QNN_DATATYPE_SFIXED_POINT_8 ||
                                x_dtype == QNN_DATATYPE_UFIXED_POINT_16 || x_dtype == QNN_DATATYPE_SFIXED_POINT_16);
   if (x_is_quantized && (y_dtype == QNN_DATATYPE_FLOAT_32 || y_dtype == QNN_DATATYPE_FLOAT_16)) {
+    return Ort::Status();
+  }
+  const bool y_is_quantized = (y_dtype == QNN_DATATYPE_UFIXED_POINT_8 || y_dtype == QNN_DATATYPE_SFIXED_POINT_8 ||
+                               y_dtype == QNN_DATATYPE_UFIXED_POINT_16 || y_dtype == QNN_DATATYPE_SFIXED_POINT_16);
+  if (x_is_quantized && y_is_quantized && x_dtype != y_dtype) {
     return Ort::Status();
   }
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -39,19 +39,7 @@ static Ort::Status ProcessClipMinMax(QnnModelWrapper& qnn_model_wrapper,
   TensorInfo input_info = {};
   std::vector<uint8_t> val_bytes;
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input, input_info));
-
-  // ExplicitOpCheck() accepts either a real initializer or a DQ-of-constant folded to a STATIC
-  // fp32 tensor. A folded input is not an initializer; read its bytes from the registry instead.
-  if (!input_info.is_initializer) {
-    RETURN_IF_NOT(qnn_model_wrapper.IsFoldedConstant(input.name),
-                  "QNN EP: Clip min/max must be a constant initializer or a folded constant.");
-    RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input.name, val_bytes));
-    RETURN_IF(val_bytes.size() != sizeof(float), "Clip min/max must be a scalar.");
-    float_value = *reinterpret_cast<const float*>(val_bytes.data());
-    return Ort::Status();
-  }
-
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info.initializer_tensor, val_bytes));
+  RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input.name, val_bytes));
 
   // If the input is quantized, we need to dequantize it
   if (input.quant_param.has_value()) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -4,7 +4,6 @@
 #include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
 
 #include <cstring>
-#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -64,38 +63,32 @@ Ort::Status UnpackQuantParams(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-Ort::Status ResolvePerChannelAxis(QnnModelWrapper& qnn_model_wrapper,
-                                  const OrtNodeUnitIODef& io_def,
-                                  /*out*/ std::optional<int64_t>& axis) {
-  bool is_per_chan = false;
-  int64_t per_chan_axis = 0;
-  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(io_def, is_per_chan, per_chan_axis));
-  axis = is_per_chan ? std::optional<int64_t>(per_chan_axis) : std::nullopt;
-  return Ort::Status();
+}  // namespace
+
+bool CanFoldInitializerPerChannelDequantize(const QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit) {
+  // QDQGroup units are owned by the target op builder. This fallback is only for a
+  // standalone per-channel DQ that QNN cannot represent directly.
+  if (node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return false;
+  }
+  if (node_unit.OpType() != "DequantizeLinear" || node_unit.Inputs().empty()) {
+    return false;
+  }
+  const OrtNodeUnitIODef& input_def = node_unit.Inputs()[0];
+  if (!qnn_model_wrapper.IsConstantInput(input_def.name)) {
+    return false;
+  }
+  bool is_per_channel = false;
+  int64_t axis = 0;
+  if (!qnn_model_wrapper.IsPerChannelQuantized(input_def, is_per_channel, axis).IsOK()) {
+    return false;
+  }
+  return is_per_channel;
 }
 
-// Marks the tensor as folded so downstream Q/DQ hops keep folding through the chain.
-Ort::Status RegisterFoldedStaticTensor(QnnModelWrapper& qnn_model_wrapper,
-                                       const std::string& name,
-                                       Qnn_DataType_t data_type,
-                                       QnnQuantParamsWrapper quant_param,
-                                       std::vector<uint32_t> shape,
-                                       std::vector<uint8_t> data,
-                                       const char* failure_msg) {
-  QnnTensorWrapper out_wrapper(name,
-                               QNN_TENSOR_TYPE_STATIC,
-                               data_type,
-                               std::move(quant_param),
-                               std::move(shape),
-                               std::move(data));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)), failure_msg);
-  qnn_model_wrapper.MarkTensorAsFoldedConstant(name);
-  return Ort::Status();
-}
-
-// Only fp32 DQ output is supported; opset >= 21 fp16/bf16 outputs fall back to the normal op.
-Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
-                                         const OrtNodeUnit& node_unit) {
+Ort::Status FoldInitializerPerChannelDequantize(QnnModelWrapper& qnn_model_wrapper,
+                                                const OrtNodeUnit& node_unit) {
   const auto& input_def = node_unit.Inputs()[0];
   const auto& output_def = node_unit.Outputs()[0];
 
@@ -120,101 +113,30 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(input_info.shape), num_elems));
   std::vector<float> fp32_data(num_elems);
 
-  std::optional<int64_t> axis;
-  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, input_def, axis));
+  // CanFoldInitializerPerChannelDequantize already established this is per-channel.
+  bool is_per_channel = false;
+  int64_t per_channel_axis = 0;
+  RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(input_def, is_per_channel, per_channel_axis));
 
   RETURN_IF_ERROR(utils::DequantizePerChannel(
       gsl::make_span(quant_bytes), gsl::make_span(input_info.shape),
       gsl::make_span(scales), gsl::make_span(offsets),
-      gsl::make_span(fp32_data), input_info.qnn_data_type, axis));
+      gsl::make_span(fp32_data), input_info.qnn_data_type, per_channel_axis));
 
   std::vector<uint8_t> output_bytes(fp32_data.size() * sizeof(float));
   std::memcpy(output_bytes.data(), fp32_data.data(), output_bytes.size());
 
-  return RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
-                                    QNN_DATATYPE_FLOAT_32, QnnQuantParamsWrapper(),
-                                    std::vector<uint32_t>(output_info.shape),
-                                    std::move(output_bytes),
-                                    "Failed to add folded DequantizeLinear output tensor.");
-}
-
-// Only fp32 Q input is supported; fp16/bf16 sources fall back to the normal op.
-Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
-                                       const OrtNodeUnit& node_unit) {
-  const auto& input_def = node_unit.Inputs()[0];
-  const auto& output_def = node_unit.Outputs()[0];
-
-  RETURN_IF(!output_def.quant_param.has_value(), "Q output has no quant param.");
-
-  std::vector<uint8_t> input_bytes;
-  RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input_def.name, input_bytes));
-
-  TensorInfo input_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(input_def, input_info));
-  RETURN_IF(input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
-            "Folded QuantizeLinear only supports float32 input.");
-
-  size_t num_elems = 0;
-  RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(input_info.shape), num_elems));
-  RETURN_IF(input_bytes.size() != SafeInt<size_t>(num_elems) * sizeof(float),
-            "QuantizeLinear input byte size mismatch with shape.");
-  gsl::span<const float> fp32_input(reinterpret_cast<const float*>(input_bytes.data()), num_elems);
-
-  std::vector<float> scales;
-  std::vector<int32_t> offsets;
-  RETURN_IF_ERROR(UnpackQuantParams(qnn_model_wrapper, *output_def.quant_param, scales, offsets));
-
-  TensorInfo output_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(output_def, output_info));
-
-  std::optional<int64_t> axis;
-  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, output_def, axis));
-
-  // Needed over GetElementSizeByType to correctly size sub-byte dtypes (e.g. int4).
-  const size_t total_bytes = utils::GetQnnTensorDataSizeInBytes(num_elems, output_info.qnn_data_type);
-  std::vector<uint8_t> quant_bytes(total_bytes);
-
-  RETURN_IF_ERROR(utils::QuantizeData(
-      fp32_input, gsl::make_span(input_info.shape),
-      gsl::make_span(scales), gsl::make_span(offsets),
-      gsl::make_span(quant_bytes), output_info.qnn_data_type, axis));
-
-  return RegisterFoldedStaticTensor(qnn_model_wrapper, output_def.name,
-                                    output_info.qnn_data_type,
-                                    std::move(output_info.quant_param),
-                                    std::vector<uint32_t>(output_info.shape),
-                                    std::move(quant_bytes),
-                                    "Failed to add folded QuantizeLinear output tensor.");
-}
-
-}  // namespace
-
-bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
-                        const OrtNodeUnit& node_unit) {
-  // QDQGroup units are owned by the target op builder; only standalone Q/DQ are foldable here.
-  if (node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
-    return false;
-  }
-  const std::string& op_type = node_unit.OpType();
-  if (op_type != "DequantizeLinear" && op_type != "QuantizeLinear") {
-    return false;
-  }
-  if (node_unit.Inputs().empty()) {
-    return false;
-  }
-  return qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
-}
-
-Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
-                               const OrtNodeUnit& node_unit) {
-  const std::string& op_type = node_unit.OpType();
-  if (op_type == "DequantizeLinear") {
-    return FoldConstantDequantizeLinear(qnn_model_wrapper, node_unit);
-  }
-  if (op_type == "QuantizeLinear") {
-    return FoldConstantQuantizeLinear(qnn_model_wrapper, node_unit);
-  }
-  return MAKE_EP_FAIL("TryFoldConstantQDQ called on a non-Q/DQ node.");
+  QnnTensorWrapper out_wrapper(output_def.name,
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_FLOAT_32,
+                               QnnQuantParamsWrapper(),
+                               std::vector<uint32_t>(output_info.shape),
+                               std::move(output_bytes));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(out_wrapper)),
+                "Failed to add folded DequantizeLinear output tensor.");
+  // Mark as folded so downstream consumers recognize it as compile-time data.
+  qnn_model_wrapper.MarkTensorAsFoldedConstant(output_def.name);
+  return Ort::Status();
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -10,15 +10,16 @@ namespace qnn {
 
 class QnnModelWrapper;
 
-// True if `node_unit` is a standalone Q/DQ with an effectively-constant input
-// (real initializer or previously-folded tensor) eligible for compile-time folding.
-bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
-                        const OrtNodeUnit& node_unit);
+// True only for an initializer-backed standalone per-channel DQ. QNN cannot represent that
+// node directly, so this narrow compatibility case remains foldable. All representable Q/DQ
+// nodes follow the pre-#339 path and stay as QNN operations.
+bool CanFoldInitializerPerChannelDequantize(const QnnModelWrapper& qnn_model_wrapper,
+                                            const OrtNodeUnit& node_unit);
 
-// Fold the Q/DQ statically and register its output as a STATIC tensor. Caller
-// MUST first verify with `CanFoldConstantQdq`.
-Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
-                               const OrtNodeUnit& node_unit) ORT_MUST_USE_RESULT;
+// Fold the initializer-backed per-channel DQ and register its output as a STATIC tensor.
+// Caller MUST first verify with `CanFoldInitializerPerChannelDequantize`.
+Ort::Status FoldInitializerPerChannelDequantize(QnnModelWrapper& qnn_model_wrapper,
+                                                const OrtNodeUnit& node_unit) ORT_MUST_USE_RESULT;
 
 // Reads the raw bytes of a real initializer or a previously-folded STATIC tensor.
 Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -85,9 +85,7 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     bool is_per_chan_quant = false;
     int64_t quant_axis = 0;
     RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Inputs()[0], is_per_chan_quant, quant_axis));
-    // Per-channel standalone DQ is allowed only if the input is a compile-time constant;
-    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
-    RETURN_IF(is_per_chan_quant && !is_input_const,
+    RETURN_IF(is_per_chan_quant && !CanFoldInitializerPerChannelDequantize(qnn_model_wrapper, node_unit),
               "QNN EP does not support a standalone DQ op with per-channel quantization");
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
@@ -111,10 +109,7 @@ Ort::Status SimpleOpBuilder::ExplicitOpCheck(QnnModelWrapper& qnn_model_wrapper,
     bool is_per_chan_quant = false;
     int64_t quant_axis = 0;
     RETURN_IF_ERROR(qnn_model_wrapper.IsPerChannelQuantized(node_unit.Outputs()[0], is_per_chan_quant, quant_axis));
-    // Per-channel standalone Q is allowed only if the input is a compile-time constant;
-    const bool is_input_const = qnn_model_wrapper.IsEffectivelyConstantInput(node_unit.Inputs()[0].name);
-    RETURN_IF(is_per_chan_quant && !is_input_const,
-              "QNN EP does not support a standalone Q op with per-channel quantization");
+    RETURN_IF(is_per_chan_quant, "QNN EP does not support a standalone Q op with per-channel quantization");
 
     if (qnn_model_wrapper.GetModelSettings().offload_graph_io_quantization &&
         qnn_model_wrapper.IsGraphInput(node_unit.Inputs()[0].name)) {
@@ -316,12 +311,10 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 #endif
   }
 
-  // Emit a STATIC tensor instead of an APP_WRITE input for standalone Q/DQ on constant inputs.
-  if (CanFoldConstantQdq(qnn_model_wrapper, node_unit)) {
-    Ort::Status fold_status = TryFoldConstantQDQ(qnn_model_wrapper, node_unit);
-    if (fold_status.IsOK()) {
-      return Ort::Status();
-    }
+  // Preserve the narrow fallback needed for standalone per-channel DQ. All representable
+  // Q/DQ nodes follow the pre-#339 path and are emitted as QNN operations.
+  if (CanFoldInitializerPerChannelDequantize(qnn_model_wrapper, node_unit)) {
+    return FoldInitializerPerChannelDequantize(qnn_model_wrapper, node_unit);
   }
 
   std::vector<std::string> param_tensor_names;

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -664,7 +664,8 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     return false;
   }
 
-  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes, static_cast<int>(num_dq_nodes))) {
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes,
+                     static_cast<int>(num_dq_nodes), /*is_empty_q_nodes_allowed=*/true)) {
     return false;
   }
 
@@ -694,15 +695,13 @@ bool OrtClipNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     }
   }
 
-  auto dt_input = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
-  auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
-
-  if (!dt_input.has_value() || !dt_output.has_value()) {
-    return false;
-  }
-
-  if (dt_input.value() != dt_output.value()) {
-    return false;
+  if (!q_nodes.empty()) {
+    auto dt_input = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
+    auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
+    if (!dt_input.has_value() || !dt_output.has_value() ||
+        dt_input.value() != dt_output.value()) {
+      return false;
+    }
   }
 
   return true;
@@ -1149,12 +1148,10 @@ bool OrtBatchNormalizationNodeGroupSelector::Check(const OrtGraph* graph, const 
     return false;
   }
 
-  // The input/output dtype match only applies when the output is quantized.
-  if (!has_float_output) {
-    auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
-    if (!dt_output.has_value() || dt_input.value() != dt_output.value()) {
-      return false;
-    }
+  // A mismatch between the quantized input and output types is not disqualifying here:
+  // the BatchNorm builder runs those in float internally (see GetBatchNormFloatExecution).
+  if (!has_float_output && !GetNodeOutputDataType(q_nodes[0], ort_api, 0).has_value()) {
+    return false;
   }
 
   if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 &&

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -946,76 +946,6 @@ TEST_F(QnnCPUBackendTests, ConvTranspose1Df32_DynamicWeights_DefaultBias) {
                 ExpectedEPNodeAssignment::All);
 }
 
-// Builds: weight_q0 (int8 init) -> DQ -> Q -> DQ -> Conv.
-// Used to regression-test chained folding; differing scale0/scale1 exercises real requant
-// on the intermediate STATIC tensor rather than a byte round-trip.
-static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
-    const std::vector<float>& scale0,
-    const std::vector<int8_t>& zp0,
-    const std::vector<float>& scale1,
-    const std::vector<int8_t>& zp1) {
-  return [scale0, zp0, scale1, zp1](ModelTestBuilder& builder) {
-    constexpr int64_t out_ch = 2;
-    constexpr int64_t in_ch = 3;
-    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
-    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
-
-    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
-
-    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, std::vector<int8_t>{1, 2, 3, 4, 5, 6});
-    builder.MakeInitializer<float>("scale0", {out_ch}, scale0);
-    builder.MakeInitializer<int8_t>("zp0", {out_ch}, zp0);
-    builder.MakeInitializer<float>("scale1", {out_ch}, scale1);
-    builder.MakeInitializer<int8_t>("zp1", {out_ch}, zp1);
-
-    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
-    axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
-
-    builder.AddNode("WeightDQ0", "DequantizeLinear", {"weight_q0", "scale0", "zp0"}, {"weight_dq0"},
-                    kOnnxDomain, axis_attrs);
-    builder.AddNode("WeightQ1", "QuantizeLinear", {"weight_dq0", "scale1", "zp1"}, {"weight_q1"},
-                    kOnnxDomain, axis_attrs);
-    builder.AddNode("WeightDQ1", "DequantizeLinear", {"weight_q1", "scale1", "zp1"}, {"weight_dq1"},
-                    kOnnxDomain, axis_attrs);
-
-    builder.MakeOutput("output");
-    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
-    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
-    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
-    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
-
-    builder.AddNode("Conv", "Conv", {"input", "weight_dq1"}, {"output"}, kOnnxDomain, conv_attrs);
-  };
-}
-
-TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
-                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
-                      /*scale1*/ {0.1f, 0.2f}, /*zp1*/ {0, 0}),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
-}
-
-TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Regression) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
-                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
-                      /*scale1*/ {0.05f, 0.4f}, /*zp1*/ {-2, 3}),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
-}
-
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).
 // Conv2d: reuse_sparse_indices should be added to the QNN node parameters.
 TEST_F(QnnCPUBackendTests, Conv2D_ReuseSparseIndices) {
@@ -1164,32 +1094,6 @@ TEST_F(QnnHTPBackendTests, DISABLED_Test_QDQConvWithDynamicWeightsFromMul) {
                   provider_options,
                   13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All});
-}
-
-TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_Regression) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "htp";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
-                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
-                      /*scale1*/ {0.1f, 0.2f}, /*zp1*/ {0, 0}),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
-}
-
-TEST_F(QnnHTPBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Regression) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "htp";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
-                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
-                      /*scale1*/ {0.05f, 0.4f}, /*zp1*/ {-2, 3}),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
 }
 
 // Smoke test for the enable_htp_fp16_clamp_overflow HTP option.

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -514,6 +514,37 @@ static bool HasQnnJsonGraph(const std::filesystem::path& dump_dir) {
   return false;
 }
 
+// A per-tensor DQ that produces ordinary data should remain a QNN op. Folding it would retain
+// an expanded fp32 copy of the initializer until graph composition completes.
+TEST_F(QnnCPUBackendTests, ConstantPerTensorDequantizeStaysOp) {
+  const std::filesystem::path dump_dir = "ConstantPerTensorDequantizeStaysOp";
+  std::filesystem::remove_all(dump_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(dump_dir));
+  auto cleanup = gsl::finally([&dump_dir]() { std::filesystem::remove_all(dump_dir); });
+
+  GetTestModelFn model_fn = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("X", {1, 8}, GetFloatDataInRange(-1.0f, 1.0f, 8));
+    builder.MakeInitializer<uint8_t>("weight_q", {1, 8}, {118, 120, 122, 124, 126, 128, 130, 132});
+    builder.AddDequantizeLinearNode<uint8_t>("weight_dq", "weight_q", 0.1f, 128, "weight");
+    builder.AddNode("add", "Add", {"X", "weight"}, {"Y"});
+    builder.MakeOutput("Y");
+  };
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = dump_dir.string();
+
+  RunQnnModelTest(model_fn, provider_options, 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+
+  if (!HasQnnJsonGraph(dump_dir)) {
+    return;
+  }
+
+  AssertOpInQnnGraph(dump_dir, "Dequantize", /*count=*/1);
+}
+
 // Builds a uint8 QDQ model (Q -> <op_type> -> DQ), dumps the composed QNN graph, and asserts the
 // op is emitted as the unified "ElementWiseNeuron" op (and that the op's old dedicated QNN op name
 // is absent). Uses QDQ rather than a float model so the test runs on the x86 HTP emulator, where

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -1558,9 +1558,8 @@ TEST(QnnUnit_EpUtilsTest, GetOrtQDQSelections_MaxPoolVersionCheck_CoversVersionP
 // not reached by existing tests.
 // =============================================================================
 
-// OrtClipNodeGroupSelector: CheckQDQNodes fails when q_nodes is empty and
-// is_empty_q_nodes_allowed=false (the Clip default) → returns false.
-TEST(QnnUnit_EpUtilsTest, Clip_CheckQDQNodesFails_ReturnsFalse) {
+// Clip may group its DQ-wrapped constant bounds even when its float output has no Q consumer.
+TEST(QnnUnit_EpUtilsTest, Clip_AcceptsEmptyOutputQ) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
   FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
@@ -1569,9 +1568,8 @@ TEST(QnnUnit_EpUtilsTest, Clip_CheckQDQNodesFails_ReturnsFalse) {
   FakeGraph graph{};
   OrtClipNodeGroupSelector sel;
   OrtNodeGroupSelector& base = sel;
-  // Empty q_nodes → CheckQDQNodes returns is_empty_q_nodes_allowed=false → L699.
-  EXPECT_FALSE(base.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
-                          {dq.AsNode()}, {}));
+  EXPECT_TRUE(base.Check(graph.AsGraph(), ctx.api, main_node.AsNode(), nullptr,
+                         {dq.AsNode()}, {}));
 }
 
 // OrtClipNodeGroupSelector: data_producer is nullptr (ValueInfo_GetValueProducer
@@ -1825,9 +1823,8 @@ TEST(QnnUnit_EpUtilsTest, BatchNorm_CheckQDQNodesFails_ReturnsFalse) {
                          {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
 }
 
-// OrtBatchNormalizationNodeGroupSelector: !has_float_output path,
-// dt_output.value() != dt_input.value() → returns false.
-TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInputOutputTypeMismatch) {
+// The builder bridges mixed quantized input/output types through a float BatchNorm.
+TEST(QnnUnit_EpUtilsTest, BatchNorm_AcceptsInputOutputTypeMismatch) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
   FakeValueInfo dq_data_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {}};
@@ -1840,8 +1837,8 @@ TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInputOutputTypeMismatch) {
   FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
 
   OrtBatchNormalizationNodeGroupSelector sel;
-  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
-                         {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq_data.AsNode(), dq_scale.AsNode()}, {q.AsNode()}));
 }
 
 // OrtTopKNodeGroupSelector: dt_input.value() != dt_output.value() → returns


### PR DESCRIPTION
## Summary

- Behaviorally revert the generic standalone constant `QuantizeLinear`/`DequantizeLinear` folding introduced by #339.
- Keep representable per-tensor Q/DQ tensors compact and emit them as QNN operations instead of retaining materialized STATIC copies.
- Retain one narrow compatibility exception: an initializer-backed, single-hop per-channel DQ may fold because QNN cannot represent it standalone and existing Conv paths require it.
- Keep DQ-wrapped Clip bounds and mixed-quant-type BatchNormalization working by grouping and consuming their compact parameters at the owning operator.
- Remove the chained per-channel Conv tests that asserted #339's behavior.

Rebased onto `a0620c84c3` and squashed to a single commit. Net **+123 / -290** across 9 files.

## Why revert

The reported model has 255 direct initializer-to-DQ weights, **all per-tensor**. Their compact storage is 1.046 GiB, while folding them to FP32 materializes 4.184 GiB. The expanded buffers remain live during graph construction and raise peak working set substantially.

Note on scoping: only #339's `ExplicitOpCheck` relaxation was per-channel-gated. The fold itself (`CanFoldConstantQdq`) accepted any standalone constant Q/DQ, so per-tensor weights folded too — which is why this model, containing zero per-channel constant DQ, regressed as hard as it did.

This version restores the pre-#339 path for every representable standalone Q/DQ node and removes constant `QuantizeLinear` folding as well.

## Memory A/B

Windows ARM64 / HTP V73 (Snapdragon X Elite), `onnxruntime_perf_test` on the reported 1.1 GB model, two runs per arm (spread < 30 MB):

| Build | Peak working set | Session creation |
|---|---:|---:|
| `main` @ `a0620c84c3` (#339 folding) | 7,712,866,304 B / 7.183 GiB | 156.3 s |
| This revert @ `482fbcb016` | 6,068,539,392 B / 5.652 GiB | 165.4 s |

**Recovers 1.53 GiB (-20.9%).** For reference, the pre-#339 control measured earlier on base `b5826e06` was 5.872 GiB, so this is at or below the pre-regression level.

Session creation grows ~6% because the 255 DQ ops are now compiled by the backend instead of folded away. That is the pre-#339 cost profile being restored.

## Why this is not a literal `git revert`

The fold call site in `simple_op_builder.cc` was the **only** producer of folded constants, so a bare revert makes `IsFoldedConstant()` permanently false and silently regresses two downstream consumers. Both now obtain their compact parameters via QDQ grouping instead:

- **Clip with DQ-wrapped constant min/max** (`bf5ef01036`): the Clip selector accepts an empty output Q so the group forms, and the builder reads the bounds directly.
- **BatchNormalization with mixed input/output quant types** (`513f6c127a`, tetracode #20348): the selector no longer rejects the type mismatch, and the builder runs those in float internally (`Dequantize -> BN in F32 -> Quantize`).

Gating the retained per-channel fold on a *real initializer* rather than an effectively-constant input is what stops it from chaining hop by hop.

## Intentional tradeoff

This PR does not preserve #339's original Qwen input-signature fix. The original `initializer -> DQ -> Q -> DQ -> Conv` topology assigns only 4 of 6 nodes on both CPU and HTP, and the final constant-derived weight can become a QNN `APP_WRITE` input. That is the expected old behavior for this revert.

A future fix should collapse that chain while retaining compact quantized storage; it should not restore hop-by-hop FP32 materialization.

## Validation

- Windows ARM64 QNN provider test build clean (`-WX`).
- Affected CPU/HTP matrix: **154 passed, 1 architecture-gated skip** (`Conv_Fp16ClampOverflow_Smoke`), including all four regression guards the revert has to keep alive (BatchNorm mixed-dtype x2, Clip QDQ const min/max x2) and the new `ConstantPerTensorDequantizeStaysOp`.
- 8 `ConvLPBQ_U16Int4_*` HTP failures are **pre-existing**: they reproduce identically on untouched `main` with the same `CreateQnnInputOutputTensors` / `weight_quant error code: 1000`.
- `unit/qnn_ep_utils_test.cc` changes are behind `QNN_EP_INTERNAL_SYMBOL_ACCESS` and do not compile locally — CI-only, unverified on the dev box.
