### PR TITLE
[QNN_EP] Support for Castlike op.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -15,6 +15,7 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreateArgMaxMinOpBuilder("ArgMin", *this);
   CreateBatchNormalizationOpBuilder("BatchNormalization", *this);
   CreateCastOpBuilder("Cast", *this);
+  CreateCastOpBuilder("CastLike", *this);
   CreateClipOpBuilder("Clip", *this);
   CreateConcatOpBuilder("Concat", *this);
   CreateConvOpBuilder("Conv", *this);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -140,6 +140,7 @@ class BaseOpBuilder : public IOpBuilder {
         {"AveragePool", QNN_OP_POOL_AVG_2D},
         {"BatchNormalization", QNN_OP_BATCHNORM},
         {"Cast", QNN_OP_CAST},
+        {"CastLike", QNN_OP_CAST},
         {"Ceil", QNN_OP_ELEMENT_WISE_UNARY},
         {"Clip", QNN_OP_ELEMENT_WISE_NEURON},
         {"Concat", QNN_OP_CONCAT},

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -14,6 +14,9 @@
 namespace onnxruntime {
 namespace qnn {
 
+// Handles both ONNX Cast and CastLike. CastLike's second input only conveys the target dtype
+// (already resolved into node_unit.Outputs()[0].type by ONNX type inference), so it is never
+// added to the QNN graph.
 class CastOpBuilder : public BaseOpBuilder {
  public:
   CastOpBuilder() : BaseOpBuilder("CastOpBuilder") {}
@@ -33,8 +36,8 @@ class CastOpBuilder : public BaseOpBuilder {
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
  private:
-  // QNN HTP currently does not support casting FP16/FP32 to Bool, and thus such Cast will be replaced by NotEqual with
-  // an additional static input 0.f to achieve the idential functional.
+  // QNN HTP currently does not support casting FP16/FP32 to Bool, and thus such Cast/CastLike will be replaced by
+  // NotEqual with an additional static input 0.f to achieve the idential functional.
   bool IsFpToBoolCast(const OrtNodeUnit& node_unit) const;
   Ort::Status ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
                                            const OrtNodeUnit& node_unit,
@@ -98,7 +101,8 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   ORT_UNUSED_PARAMETER(do_op_validation);
 
   const auto& inputs = node_unit.Inputs();
-  RETURN_IF_NOT(inputs.size() == 1, "QNN Cast node must have a single input.");
+  RETURN_IF_NOT(inputs.size() == 1 || inputs.size() == 2,
+                "QNN Cast node must have 1 input (Cast) or 2 inputs (CastLike).");
   const auto& input = inputs[0];
 
   const auto& input_name = input.name;

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -4,6 +4,7 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -69,6 +70,34 @@ static GetTestModelFn BuildCastFP64TestCase(const std::vector<int64_t>& shape) {
   };
 }
 
+/**
+ * Creates a graph with a single CastLike operator.
+ *
+ * \param shape The shape of the input and output. Input data is randomly generated with this shape.
+ * \param dst_type The destination type, conveyed via a same-typed scalar initializer fed as the second input.
+ *
+ * \return A function that builds the graph with the provided builder.
+ */
+template <typename InputType, typename DstType>
+static GetTestModelFn BuildCastLikeTestCase(const std::vector<int64_t>& shape) {
+  return [shape](ModelTestBuilder& builder) {
+    // Random input data
+    builder.MakeInput<InputType>("X", shape, static_cast<InputType>(0), static_cast<InputType>(20));
+    // The second input only conveys the target dtype; its value is irrelevant.
+    if constexpr (std::is_same_v<DstType, bool>) {
+      builder.MakeInitializerBool("target_type_like", {}, {false});
+    } else {
+      builder.MakeScalarInitializer<DstType>("target_type_like", static_cast<DstType>(0));
+    }
+    builder.AddNode(
+        "cast_like",
+        "CastLike",
+        {"X", "target_type_like"},
+        {"Y"});
+    builder.MakeOutput("Y");
+  };
+}
+
 ProviderOptions GetProviderOption(const std::string& backend_name, bool enable_fp16_precision) {
   ProviderOptions provider_options;
   provider_options["backend_type"] = backend_name;
@@ -126,6 +155,31 @@ static void RunCastFP64OpTest(const std::vector<int64_t>& shape,
   RunQnnModelTest(BuildCastFP64TestCase(shape),
                   GetProviderOption(backend_name, true),
                   13,  // opset
+                  EPVerificationParams{expected_ep_assignment});
+}
+
+/**
+ * Runs a CastLike model on the QNN CPU or HTP backend. Checks the graph node assignment, and that inference
+ * outputs for QNN and CPU match.
+ *
+ * \param shape The shape of the input and output. Input data is randomly generated with this shape.
+ * \param expected_ep_assignment How many nodes are expected to be assigned to QNN (All, Some, or None).
+ * \param backend_name True to run on HTP backend. Otherwise, runs on CPU.
+ */
+template <typename InputType, typename DstType>
+static void RunCastLikeOpTest(const std::vector<int64_t>& shape,
+                              ExpectedEPNodeAssignment expected_ep_assignment,
+                              const std::string& backend_name = "cpu",
+                              bool enable_fp16_precision = true) {
+  if (backend_name == "htp" && enable_fp16_precision) {
+#if defined(_WIN32)
+    SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#endif
+  }
+
+  RunQnnModelTest(BuildCastLikeTestCase<InputType, DstType>(shape),
+                  GetProviderOption(backend_name, enable_fp16_precision),
+                  15,  // opset (CastLike introduced at opset 15)
                   EPVerificationParams{expected_ep_assignment});
 }
 
@@ -189,6 +243,16 @@ TEST_F(QnnCPUBackendTests, TestCastFloatToDouble) {
   RunCastFP64OpTest({2, 3}, ExpectedEPNodeAssignment::All);
 }
 
+// CastLike int32_t to float on CPU
+TEST_F(QnnCPUBackendTests, TestCastLikeInt32ToFloat) {
+  RunCastLikeOpTest<int32_t, float>({2, 3}, ExpectedEPNodeAssignment::All);
+}
+
+// CastLike float to int32_t on CPU
+TEST_F(QnnCPUBackendTests, TestCastLikeFloatToInt32) {
+  RunCastLikeOpTest<float, int32_t>({2, 3}, ExpectedEPNodeAssignment::All);
+}
+
 #if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 //
 // HTP tests:
@@ -246,6 +310,27 @@ TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
 // Cast float to double on HTP.
 TEST_F(QnnHTPBackendTests, TestCastFloatToDoubleHTP) {
   RunCastFP64OpTest({3, 3}, ExpectedEPNodeAssignment::All, "htp");
+}
+
+// CastLike int32_t to float on HTP
+TEST_F(QnnHTPBackendTests, TestCastLikeInt32ToFloatHTP) {
+  RunCastLikeOpTest<int32_t, float>({3, 3}, ExpectedEPNodeAssignment::All, "htp", false);
+}
+
+// CastLike float to int32_t on HTP
+TEST_F(QnnHTPBackendTests, TestCastLikeFloatToInt32HTP) {
+  RunCastLikeOpTest<float, int32_t>({3, 3}, ExpectedEPNodeAssignment::All, "htp", false);
+}
+
+// CastLike int64_t to int32_t on HTP
+TEST_F(QnnHTPBackendTests, TestCastLikeInt64ToInt32HTP) {
+  RunCastLikeOpTest<int64_t, int32_t>({3, 3}, ExpectedEPNodeAssignment::All, "htp");
+}
+
+// CastLike float to bool on HTP. Exercises the FP-to-Bool -> NotEqual fallback path with a
+// second (target-type) input present.
+TEST_F(QnnHTPBackendTests, TestCastLikeFloatToBoolHTP) {
+  RunCastLikeOpTest<float, bool>({3, 3}, ExpectedEPNodeAssignment::All, "htp");
 }
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 


### PR DESCRIPTION

  Description

  Adds QNN execution provider support for the ONNX CastLike operator by reusing the
  existing CastOpBuilder.

  - onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc: relaxed
  ProcessInputs's input-count check to accept 1 input (Cast) or 2 inputs (CastLike). Only
  inputs[0] is ever processed — CastLike's second input (the type-reference tensor) is
  intentionally never added to the QNN graph, since its value is unused; ONNX type
  inference has already propagated its dtype onto the node's output type by the time the
  builder runs.
  - onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h: added a
  {"CastLike", QNN_OP_CAST} entry to the GetQnnOpType map so CastLike resolves to the same
  native QNN op as Cast.
  - onnxruntime/core/providers/qnn/builder/op_builder_factory.cc: registered
  CreateCastOpBuilder("CastLike", *this) alongside the existing Cast registration.
  - onnxruntime/test/providers/qnn/cast_test.cc: added
  BuildCastLikeTestCase/RunCastLikeOpTest helpers and CPU/HTP test coverage (int32↔float,
  int64→int32, and float→bool to exercise the existing FP-to-Bool NotEqual fallback path
  with the extra CastLike input present).

  No changes were needed to CastOpBuilder's FP→Bool NotEqual workaround, INT64/FP64
  output-narrowing logic, or the CastLoneQFusion node-group fusion — all already operate
  only on inputs[0]/outputs[0] and are unaffected by the extra input.

  Motivation and Context

  QNN EP had no op-builder registration for CastLike, so every CastLike node in a graph was
  rejected in GetCapabilityImpl and fell back to CPU EP — regardless of how trivial the
  cast. This showed up heavily in diffusion-style models (e.g. Stable Diffusion UNet),
  where ONNX export commonly inserts CastLike around GroupNormalization/MultiHeadAttention
  scale and bias tensors to keep them in sync with the surrounding activation dtype. In one
  repro model this produced 100+ unsupported CastLike nodes, fragmenting the graph into
  many small CPU/NPU partitions and hurting both accuracy-parity confidence and
  performance.

  Functionally, CastLike only differs from Cast in how the target dtype is expressed (a
  second input's dtype vs. a to attribute) — by builder time, ORT's type inference has
  already resolved both to a concrete Outputs()[0].type. So no new QNN op or casting
  behavior was needed; this just teaches QNN EP's op-builder factory to route CastLike to
  the same handler already used and validated for Cast.