### PR TITLE
Remove unused flags: allow_int8_, int8_allowed_, matmulintegertofloat_allowed_

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -864,10 +864,9 @@ bool OrtConvNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_ap
     return false;
   }
 
-  if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8) {
-    if (!int8_allowed_ || dt_weight.value() != dt_input.value()) {
-      return false;
-    }
+  if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 &&
+      dt_weight.value() != dt_input.value()) {
+    return false;
   }
 
   if (dq_nodes.size() == 3) {
@@ -894,11 +893,6 @@ bool OrtEinsumNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_
     auto dt_input = GetNodeInputDataType(dq_nodes[i], ort_api, 0);
 
     if (!dt_input.has_value()) {
-      return false;
-    }
-
-    // Check if INT8 is allowed
-    if (!allow_int8_ && dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8) {
       return false;
     }
   }
@@ -934,9 +928,6 @@ bool OrtReciprocalNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& 
     if (!dt_input.has_value()) {
       return false;
     }
-    if (!allow_int8_ && dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8) {
-      return false;
-    }
   }
   if (!q_nodes.empty()) {
     auto dt_input0 = GetNodeInputDataType(dq_nodes[0], ort_api, 0);
@@ -967,28 +958,22 @@ bool OrtMatMulNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_
     return false;
   }
 
-  // Check if INT8 is allowed
-  if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8) {
-    if (!int8_allowed_ || dt_weight.value() != dt_input.value()) {
-      return false;
-    }
+  if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 &&
+      dt_weight.value() != dt_input.value()) {
+    return false;
   }
 
-  // Potential match for QLinearMatMul or MatMulIntegerToFloat
-  bool qlinear = !q_nodes.empty();
-
-  if (qlinear) {
-    // QLinearMatMul
-    if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes)) {
-      return false;
-    }
-
-    auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
-    return dt_output.has_value() && dt_input.value() == dt_output.value();
-  } else {
-    // Can be converted to MatMulIntegerToFloat if EP supports that
-    return matmulintegertofloat_allowed_;
+  // Without a trailing Q this would be a MatMulIntegerToFloat, which QNN EP does not build.
+  if (q_nodes.empty()) {
+    return false;
   }
+
+  if (!CheckQDQNodes(graph, ort_api, node, redundant_clip_node, dq_nodes, q_nodes)) {
+    return false;
+  }
+
+  auto dt_output = GetNodeOutputDataType(q_nodes[0], ort_api, 0);
+  return dt_output.has_value() && dt_input.value() == dt_output.value();
 }
 
 bool OrtGemmNodeGroupSelector::Check(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* node,
@@ -1172,11 +1157,9 @@ bool OrtBatchNormalizationNodeGroupSelector::Check(const OrtGraph* graph, const 
     }
   }
 
-  // INT8 is 3 in ONNX_NAMESPACE::TensorProto_DataType
-  if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8) {
-    if (!int8_allowed_ || dt_scale.value() != dt_input.value()) {
-      return false;
-    }
+  if (dt_input.value() == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 &&
+      dt_scale.value() != dt_input.value()) {
+    return false;
   }
 
   return true;

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.h
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.h
@@ -165,17 +165,12 @@ class OrtSplitNodeGroupSelector : public OrtNodeGroupSelector {
 // DQ nodes for X, W and optionally B -> node -> Q
 class OrtConvNodeGroupSelector : public OrtNodeGroupSelector {
  public:
-  // default to 'true'
-  explicit OrtConvNodeGroupSelector(bool int8_allowed = true)
-      : int8_allowed_(int8_allowed) {}
+  OrtConvNodeGroupSelector() = default;
 
   bool Check(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* node,
              const OrtNode* redundant_clip_node,
              const std::vector<const OrtNode*>& dq_nodes,
              const std::vector<const OrtNode*>& q_nodes) const override;
-
- private:
-  bool int8_allowed_;
 };
 
 class OrtWhereNodeGroupSelector : public OrtNodeGroupSelector {
@@ -201,50 +196,34 @@ class OrtPadNodeGroupSelector : public OrtNodeGroupSelector {
 // one ore more DQ nodes for each input -> node -> Q
 class OrtEinsumNodeGroupSelector : public OrtNodeGroupSelector {
  public:
-  explicit OrtEinsumNodeGroupSelector(bool allow_int8 = true)
-      : allow_int8_(allow_int8) {}
+  OrtEinsumNodeGroupSelector() = default;
 
   bool Check(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* node,
              const OrtNode* redundant_clip_node,
              const std::vector<const OrtNode*>& dq_nodes,
              const std::vector<const OrtNode*>& q_nodes) const override;
-
- private:
-  bool allow_int8_;
 };
 
 class OrtReciprocalNodeGroupSelector : public OrtNodeGroupSelector {
  public:
-  explicit OrtReciprocalNodeGroupSelector(bool allow_int8 = true)
-      : allow_int8_(allow_int8) {}
+  OrtReciprocalNodeGroupSelector() = default;
 
   bool Check(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* node,
              const OrtNode* redundant_clip_node,
              const std::vector<const OrtNode*>& dq_nodes,
              const std::vector<const OrtNode*>& q_nodes) const override;
-
- private:
-  bool allow_int8_;
 };
 
-// 2 DQ nodes for input -> node -> optional Q if QLinearMatMul, MatMulIntegerToFloat if not
-// The lack of a trailing Q isn't really a QDQ node group, so we default support for that to off.
+// 2 DQ nodes for input -> node -> Q.
+// A group without a trailing Q isn't really a QDQ node group, so it is not selected.
 class OrtMatMulNodeGroupSelector : public OrtNodeGroupSelector {
  public:
-  OrtMatMulNodeGroupSelector(bool int8_allowed = true,
-                             bool matmulintegertofloat_allowed = false)
-      : int8_allowed_(int8_allowed),
-        matmulintegertofloat_allowed_(matmulintegertofloat_allowed) {
-  }
+  OrtMatMulNodeGroupSelector() = default;
 
   bool Check(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* node,
              const OrtNode* redundant_clip_node,
              const std::vector<const OrtNode*>& dq_nodes,
              const std::vector<const OrtNode*>& q_nodes) const override;
-
- private:
-  bool int8_allowed_;
-  bool matmulintegertofloat_allowed_;
 };
 
 // Input: DQ nodes for A, B and optional C
@@ -271,16 +250,12 @@ class OrtInstanceAndLayerNormalizationNodeGroupSelector : public OrtNodeGroupSel
 // DQ nodes for X, W and optionally B, not used for mean, var -> node -> Q
 class OrtBatchNormalizationNodeGroupSelector : public OrtNodeGroupSelector {
  public:
-  // default to 'true'
-  OrtBatchNormalizationNodeGroupSelector(bool int8_allowed = true) : int8_allowed_(int8_allowed) {}
+  OrtBatchNormalizationNodeGroupSelector() = default;
 
   bool Check(const OrtGraph* graph, const OrtApi& ort_api, const OrtNode* node,
              const OrtNode* redundant_clip_node,
              const std::vector<const OrtNode*>& dq_nodes,
              const std::vector<const OrtNode*>& q_nodes) const override;
-
- private:
-  bool int8_allowed_;
 };
 
 // 2 DQ nodes providing input -> node with bool output tensor.

--- a/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_ep_utils_test.cc
@@ -520,7 +520,7 @@ struct ConvProducerGuard {
 // OrtConvNodeGroupSelector::Check
 //
 // dq[0]=input, dq[1]=weight, dq[2]=bias (optional INT32).
-// int8_allowed controls whether INT8 data is accepted.
+// An INT8 input requires an INT8 weight; other quant types are unconstrained.
 // main_node.inputs.size() must equal dq_nodes.size() for CheckQDQNodes.
 // =============================================================================
 
@@ -551,25 +551,7 @@ TEST(QnnUnit_EpUtilsTest, Conv_Accepts2DqUint8) {
                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
 }
 
-TEST(QnnUnit_EpUtilsTest, Conv_RejectsInt8WhenDisallowed) {
-  EpUtilsTestContext ctx;
-  FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
-  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
-  FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
-  FakeNode dq_wt{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
-
-  FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
-  FakeNode main_node{"conv", "Conv", "", 1, {&dummy, &dummy}, {&main_out}};
-
-  FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
-  FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
-
-  OrtConvNodeGroupSelector sel(/*int8_allowed=*/false);
-  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
-                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
-}
-
-TEST(QnnUnit_EpUtilsTest, Conv_AcceptsInt8WhenAllowed) {
+TEST(QnnUnit_EpUtilsTest, Conv_AcceptsInt8) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {1, 4}};
   FakeNode dq_data{"dq0", "DequantizeLinear", "", 13, {&dq_in}, {}};
@@ -591,7 +573,7 @@ TEST(QnnUnit_EpUtilsTest, Conv_AcceptsInt8WhenAllowed) {
   ctx.api.ValueInfo_GetValueProducer = &FakeConvProducerStub;
   OrtGlobalApiOverride global_guard(&ctx.api);
 
-  OrtConvNodeGroupSelector sel(/*int8_allowed=*/true);
+  OrtConvNodeGroupSelector sel;
   EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
                         {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
 }
@@ -686,7 +668,7 @@ TEST(QnnUnit_EpUtilsTest, Conv_RejectsFloatInputWithQuantWeight) {
 // =============================================================================
 // OrtMatMulNodeGroupSelector::Check
 //
-// 2 DQ inputs required.  Q node optional (matmulintegertofloat path).
+// 2 DQ inputs and a trailing Q required.
 // =============================================================================
 
 TEST(QnnUnit_EpUtilsTest, MatMul_Accepts2DqWithQ) {
@@ -707,25 +689,14 @@ TEST(QnnUnit_EpUtilsTest, MatMul_Accepts2DqWithQ) {
                         {dq1.AsNode(), dq2.AsNode()}, {q.AsNode()}));
 }
 
-TEST(QnnUnit_EpUtilsTest, MatMul_AcceptsNoQWhenMmIntToFloatAllowed) {
+TEST(QnnUnit_EpUtilsTest, MatMul_RejectsNoQ) {
   EpUtilsTestContext ctx;
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {4, 4}};
   FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
   FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
 
-  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true, /*matmulintegertofloat_allowed=*/true);
-  // qlinear=false → directly returns matmulintegertofloat_allowed_
-  EXPECT_TRUE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
-                        {dq1.AsNode(), dq2.AsNode()}, {}));
-}
-
-TEST(QnnUnit_EpUtilsTest, MatMul_RejectsNoQWhenMmIntToFloatDisallowed) {
-  EpUtilsTestContext ctx;
-  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {4, 4}};
-  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
-  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
-
-  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true, /*matmulintegertofloat_allowed=*/false);
+  // A MatMul with no trailing Q would be a MatMulIntegerToFloat, which is not selected.
+  OrtMatMulNodeGroupSelector sel;
   EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
                          {dq1.AsNode(), dq2.AsNode()}, {}));
 }
@@ -897,7 +868,7 @@ TEST(QnnUnit_EpUtilsTest, Conv_RejectsInt8DataWithUint8Weight) {
   FakeValueInfo q_out{"z", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
   FakeNode q{"q", "QuantizeLinear", "", 13, {}, {&q_out}};
 
-  OrtConvNodeGroupSelector sel(/*int8_allowed=*/true);
+  OrtConvNodeGroupSelector sel;
   EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
                          {dq_data.AsNode(), dq_wt.AsNode()}, {q.AsNode()}));
 }
@@ -913,20 +884,9 @@ TEST(QnnUnit_EpUtilsTest, MatMul_RejectsInt8DataWithUint8Weight) {
   FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_data_in}, {}};
   FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_wt_in}, {}};
 
-  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true);
+  OrtMatMulNodeGroupSelector sel;
   EXPECT_FALSE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
                          {dq1.AsNode(), dq2.AsNode()}, {}));
-}
-
-TEST(QnnUnit_EpUtilsTest, MatMul_AcceptsInt16WithMatMulIntegerToFloat) {
-  EpUtilsTestContext ctx;
-  FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16, {}};
-  FakeNode dq1{"dq1", "DequantizeLinear", "", 13, {&dq_in}, {}};
-  FakeNode dq2{"dq2", "DequantizeLinear", "", 13, {&dq_in}, {}};
-
-  OrtMatMulNodeGroupSelector sel(/*int8_allowed=*/true, /*mmtof=*/true);
-  EXPECT_TRUE(sel.Check(nullptr, ctx.api, nullptr, nullptr,
-                        {dq1.AsNode(), dq2.AsNode()}, {}));
 }
 
 // =============================================================================
@@ -985,16 +945,16 @@ TEST(QnnUnit_EpUtilsTest, Einsum_AcceptsUint8NoQ) {
                         {dq.AsNode()}, {}));
 }
 
-TEST(QnnUnit_EpUtilsTest, Einsum_RejectsInt8WhenDisallowed) {
+TEST(QnnUnit_EpUtilsTest, Einsum_AcceptsInt8) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
   FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
   FakeNode main_node{"einsum", "Einsum", "", 12, {&dummy}, {}};
 
-  OrtEinsumNodeGroupSelector sel(/*allow_int8=*/false);
-  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
-                         {dq.AsNode()}, {}));
+  OrtEinsumNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {}));
 }
 
 TEST(QnnUnit_EpUtilsTest, Einsum_AcceptsInt16) {
@@ -1040,16 +1000,16 @@ TEST(QnnUnit_EpUtilsTest, Reciprocal_AcceptsUint8NoQ) {
                         {dq.AsNode()}, {}));
 }
 
-TEST(QnnUnit_EpUtilsTest, Reciprocal_RejectsInt8WhenDisallowed) {
+TEST(QnnUnit_EpUtilsTest, Reciprocal_AcceptsInt8) {
   EpUtilsTestContext ctx;
   FakeValueInfo dummy{"d", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
   FakeValueInfo dq_in{"x", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, {}};
   FakeNode dq{"dq", "DequantizeLinear", "", 13, {&dq_in}, {}};
   FakeNode main_node{"recip", "Reciprocal", "", 13, {&dummy}, {}};
 
-  OrtReciprocalNodeGroupSelector sel(/*allow_int8=*/false);
-  EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
-                         {dq.AsNode()}, {}));
+  OrtReciprocalNodeGroupSelector sel;
+  EXPECT_TRUE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
+                        {dq.AsNode()}, {}));
 }
 
 // =============================================================================
@@ -1133,7 +1093,7 @@ TEST(QnnUnit_EpUtilsTest, BatchNorm_RejectsInt8WithMixedScale) {
   FakeValueInfo main_out{"y", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {}};
   FakeNode main_node{"bn", "BatchNormalization", "", 15, {&dummy, &dummy}, {&main_out}};
 
-  OrtBatchNormalizationNodeGroupSelector sel(/*int8_allowed=*/true);
+  OrtBatchNormalizationNodeGroupSelector sel;
   EXPECT_FALSE(sel.Check(nullptr, ctx.api, main_node.AsNode(), nullptr,
                          {dq_data.AsNode(), dq_scale.AsNode()}, {}));
 }


### PR DESCRIPTION
### Description
Remove unused flags: allow_int8_, int8_allowed_, matmulintegertofloat_allowed_
No functionality change. 

Continuation of my previous PR - https://github.com/onnxruntime/onnxruntime-qnn/pull/689 


