### PR TITLE
[QNN EP] Introduce QNN_ARCH_ARM64 arch-detection macro

### DIFF
--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -38,6 +38,16 @@
 
 namespace onnxruntime {
 
+// True for any ARM64 target: native ARM64 (Windows/Linux) AND the ARM64EC half of a
+// Windows arm64x fat binary. ARM64EC must be included because an amd64 process on an
+// arm64 device executes the ARM64EC half of an arm64x module, which defines _M_ARM64EC
+// (not _M_ARM64). Omitting it makes on-device code misdetect itself as an x86 host.
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#define QNN_ARCH_ARM64 1
+#else
+#define QNN_ARCH_ARM64 0
+#endif
+
 #define MAKE_FAIL(msg) Ort::Status(msg, ORT_FAIL)
 #define MAKE_EP_FAIL(msg) Ort::Status(msg, ORT_EP_FAIL)
 


### PR DESCRIPTION
### Description

Introduce a canonical `QNN_ARCH_ARM64` macro in `ort_api.h` that covers all ARM64 targets: native ARM64 (`__aarch64__`, `_M_ARM64`) **and** the ARM64EC half of a Windows arm64x fat binary (`_M_ARM64EC`).

This is a foundational change only — the macro is defined but not yet consumed. Each feature will be adopted in follow-up PRs.

### Motivation and Context

On a Windows-on-ARM device, an **amd64 (x64) Python process** loading an **arm64x** QNN EP artifact executes the module's **ARM64EC half**. MSVC compiles that half with `_M_ARM64EC` defined but **not** `_M_ARM64`. Throughout the QNN EP, on-device feature gates are keyed on `defined(__aarch64__) || defined(_M_ARM64)`, which causes the ARM64EC half to misidentify itself as an x86 host.

> **Note:** `GetPlatformInfo`, multi-SoC EP context guard, and `ValidateCompiledModelCompatibilityInfo` were already fixed by #701.