### PR TITLE
[QNN EP] Gate Num Prepare Threads for HTP Graph Splitting

### DIFF
--- a/cmake/onnxruntime_providers_qnn.cmake
+++ b/cmake/onnxruntime_providers_qnn.cmake
@@ -90,6 +90,21 @@
       QNN_SDK_VERSION_MINOR=${QNN_SDK_VERSION_MINOR})
   endif()
 
+  # Detect whether QnnHtpContext_GraphSplit_t contains numPrepareThreads.
+  include(CheckStructHasMember)
+  set(CMAKE_REQUIRED_INCLUDES "${onnxruntime_QNN_HOME}/include/QNN")
+  check_struct_has_member("QnnHtpContext_GraphSplit_t" "numPrepareThreads"
+                          "HTP/QnnHtpContext.h"
+                          QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
+                          LANGUAGE CXX)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  if(QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS)
+    target_compile_definitions(onnxruntime_providers_qnn PRIVATE QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS)
+    message(STATUS "QNN: QnnHtpContext_GraphSplit_t.numPrepareThreads detected — graph splitting thread count will be wired in.")
+  else()
+    message(STATUS "QNN: QnnHtpContext_GraphSplit_t.numPrepareThreads not found — graph splitting thread count will be ignored.")
+  endif()
+
   # Set linker flags for function(s) exported by EP DLL
   if(UNIX)
     if(ENABLE_COVERAGE AND NOT APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1590,7 +1590,7 @@ Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing,
     context_config_graph_splitting.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
     context_config_graph_splitting.customConfig = &graph_splitting_custom_config;
   }
-#else  // QNN_HTP_GRAPH_SPLITTING_AVAILABLE
+#else   // QNN_HTP_GRAPH_SPLITTING_AVAILABLE
   ORT_UNUSED_PARAMETER(enable_htp_graph_splitting);
   ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
   ORT_UNUSED_PARAMETER(graph_splitting_kway_partitions);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1305,22 +1305,18 @@ Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
 #ifdef QNN_HTP_GRAPH_SPLITTING_AVAILABLE
   QnnContext_Config_t context_config_graph_splitting_vtcm = QNN_CONTEXT_CONFIG_INIT;
   QnnHtpContext_CustomConfig_t graph_splitting_custom_config_vtcm;
-  ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
   if (enable_htp_graph_splitting) {
     graph_splitting_custom_config_vtcm.option = QNN_HTP_CONTEXT_CONFIG_OPTION_GRAPH_SPLITTING_CONFIGS;
     graph_splitting_custom_config_vtcm.graphSplittingConfigs.graphSplittingEnabled = true;
 #ifdef QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
     graph_splitting_custom_config_vtcm.graphSplittingConfigs.numPrepareThreads = graphsplitter_num_prepare_threads;
-#endif
+#else
+    ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
+#endif  // QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
     context_config_graph_splitting_vtcm.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
     context_config_graph_splitting_vtcm.customConfig = &graph_splitting_custom_config_vtcm;
   }
-#ifndef QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
-  else {
-    ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
-  }
-#endif
-#else
+#else  // QNN_HTP_GRAPH_SPLITTING_AVAILABLE
   ORT_UNUSED_PARAMETER(enable_htp_graph_splitting);
   ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
   ORT_UNUSED_PARAMETER(graph_splitting_kway_partitions);
@@ -1588,15 +1584,17 @@ Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing,
     graph_splitting_custom_config.graphSplittingConfigs.graphSplittingEnabled = true;
 #ifdef QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
     graph_splitting_custom_config.graphSplittingConfigs.numPrepareThreads = graphsplitter_num_prepare_threads;
-#endif
+#else
+    ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
+#endif  // QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
     context_config_graph_splitting.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
     context_config_graph_splitting.customConfig = &graph_splitting_custom_config;
   }
-#else
+#else  // QNN_HTP_GRAPH_SPLITTING_AVAILABLE
   ORT_UNUSED_PARAMETER(enable_htp_graph_splitting);
   ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
   ORT_UNUSED_PARAMETER(graph_splitting_kway_partitions);
-#endif
+#endif  // QNN_HTP_GRAPH_SPLITTING_AVAILABLE
 
   std::vector<const QnnContext_Config_t*> npu_context_configs_vec;
   npu_context_configs_vec.push_back(&context_priority_config);

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1305,13 +1305,21 @@ Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
 #ifdef QNN_HTP_GRAPH_SPLITTING_AVAILABLE
   QnnContext_Config_t context_config_graph_splitting_vtcm = QNN_CONTEXT_CONFIG_INIT;
   QnnHtpContext_CustomConfig_t graph_splitting_custom_config_vtcm;
+  ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
   if (enable_htp_graph_splitting) {
     graph_splitting_custom_config_vtcm.option = QNN_HTP_CONTEXT_CONFIG_OPTION_GRAPH_SPLITTING_CONFIGS;
     graph_splitting_custom_config_vtcm.graphSplittingConfigs.graphSplittingEnabled = true;
+#ifdef QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
     graph_splitting_custom_config_vtcm.graphSplittingConfigs.numPrepareThreads = graphsplitter_num_prepare_threads;
+#endif
     context_config_graph_splitting_vtcm.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
     context_config_graph_splitting_vtcm.customConfig = &graph_splitting_custom_config_vtcm;
   }
+#ifndef QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
+  else {
+    ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
+  }
+#endif
 #else
   ORT_UNUSED_PARAMETER(enable_htp_graph_splitting);
   ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
@@ -1574,10 +1582,13 @@ Ort::Status QnnBackendManager::CreateContext(bool enable_htp_weight_sharing,
 #ifdef QNN_HTP_GRAPH_SPLITTING_AVAILABLE
   QnnContext_Config_t context_config_graph_splitting = QNN_CONTEXT_CONFIG_INIT;
   QnnHtpContext_CustomConfig_t graph_splitting_custom_config;
+  ORT_UNUSED_PARAMETER(graphsplitter_num_prepare_threads);
   if (enable_htp_graph_splitting) {
     graph_splitting_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_GRAPH_SPLITTING_CONFIGS;
     graph_splitting_custom_config.graphSplittingConfigs.graphSplittingEnabled = true;
+#ifdef QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS
     graph_splitting_custom_config.graphSplittingConfigs.numPrepareThreads = graphsplitter_num_prepare_threads;
+#endif
     context_config_graph_splitting.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
     context_config_graph_splitting.customConfig = &graph_splitting_custom_config;
   }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1302,6 +1302,13 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                   "htp_graph_splitting_kway_partitions is set but enable_htp_graph_splitting=0. Value will be ignored.");
     }
   }
+#if defined(QNN_HTP_GRAPH_SPLITTING_AVAILABLE) && !defined(QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS)
+  if (enable_htp_graph_splitting_ && user_set_graph_splitting_threads) {
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                "htp_graphsplitter_num_prepare_threads is set but numPrepareThreads is not supported "
+                "by this SDK build. Value will be ignored; SDK will use its default thread count.");
+  }
+#endif
 
   // Option to skip QNN API interface version check to use other QNN library other than default.
   static const std::string SKIP_QNN_VERSION_CHECK = "skip_qnn_version_check";


### PR DESCRIPTION
PR #645 added support for Graph Splitting for HTP backend. It introduced a provider option `num_prepare_threads` to specify the number of thread used to prepare the sub graphs. This option will be available from `QAIRT 2.50`. Without this change, the build will fail when we uplevel QAIRT to `2.49`.

This PR adds `CMake check_struct_has_member` detection for `QnnHtpContext_GraphSplit_t.numPrepareThreads` in `onnxruntime_providers_qnn.cmake`. When the field is detected, defines `QNN_HTP_GRAPH_SPLIT_HAS_NUM_PREPARE_THREADS` as a compile definition, which gates the `numPrepareThreads` assignment in `qnn_backend_manager.cc`. A parse-time warning is emitted when the user sets `htp_graphsplitter_num_prepare_threads` but the SDK build does not expose the field.