### PR TITLE
Fix unreachable code warnings from GTEST_SKIP

### DIFF
--- a/onnxruntime/test/providers/qnn/batchnormalization_test.cc
+++ b/onnxruntime/test/providers/qnn/batchnormalization_test.cc
@@ -789,7 +789,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_U8S8F32) {
 TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U16) {
 #if defined(__linux__) && !defined(__aarch64__)
   GTEST_SKIP() << "Skipped on x86_64 simulator due to flaky behavior";
-#endif
+#else
   constexpr int64_t batch = 1;
   constexpr int64_t channels = 4;
   constexpr int64_t H = 2;
@@ -812,6 +812,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U16) {
   RunBatchNormQDQTest<uint16_t, uint8_t>(input_def, scale_def, bias_def,
                                          ExpectedEPNodeAssignment::All,
                                          QDQTolerance(0.008f));
+#endif
 }
 
 // Test BatchNorm with near-zero variance channels (U8 input). When gamma/sqrt(var+eps) produces
@@ -890,7 +891,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_NearZeroVariance_U8) {
 TEST_F(QnnHTPBackendTests, BatchNorm2D_PerTensorGamma_PerChannelVar_U16) {
 #if defined(__linux__) && !defined(__aarch64__)
   GTEST_SKIP() << "Skipped on x86_64 simulator due to flaky behavior";
-#endif
+#else
   constexpr int64_t batch = 1;
   constexpr int64_t channels = 4;
   constexpr int64_t H = 2;
@@ -970,6 +971,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_PerTensorGamma_PerChannelVar_U16) {
   TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
                        qdq_model_fn, provider_options, 21, ExpectedEPNodeAssignment::All,
                        QDQTolerance(0.008f));
+#endif
 }
 
 // Negative test: scale is per-channel, var is per-tensor. Verifies float-promotion triggers
@@ -977,7 +979,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_PerTensorGamma_PerChannelVar_U16) {
 TEST_F(QnnHTPBackendTests, BatchNorm2D_PerChannelGamma_PerTensorVar_U16) {
 #if defined(__linux__) && !defined(__aarch64__)
   GTEST_SKIP() << "Skipped on x86_64 simulator due to flaky behavior";
-#endif
+#else
   constexpr int64_t batch = 1;
   constexpr int64_t channels = 4;
   constexpr int64_t H = 2;
@@ -1056,6 +1058,7 @@ TEST_F(QnnHTPBackendTests, BatchNorm2D_PerChannelGamma_PerTensorVar_U16) {
   TestQDQModelAccuracy(BuildBatchNormTestCase(input_def, scale_def, bias_def),
                        qdq_model_fn, provider_options, 21, ExpectedEPNodeAssignment::All,
                        QDQTolerance(0.008f));
+#endif
 }
 
 // Builds the float (reference) form of the NASNet reduction-cell pattern:

--- a/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
+++ b/onnxruntime/test/providers/qnn/framework_op_trace_test.cc
@@ -993,7 +993,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_QDQFusion_ManyToOne) {
 TEST_F(QnnHTPBackendTests, FrameworkOpTrace_GeluFusion) {
 #if defined(_WIN32) && !defined(_M_ARM64)
   GTEST_SKIP() << "GeluFusion not supported on Windows x86 HTP simulation";
-#endif
+#else
   ScopedTempDir tmp;
   // Use the ONNX Gelu decomposition pattern (Mul/Div/Erf/Add) so the
   // GeluFusion node group fires. kMSDomain Gelu fails to finalize on HTP.
@@ -1035,6 +1035,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_GeluFusion) {
   auto j = ReadTraceJson(trace_file);
   ASSERT_GE(j["subgraph_traces"].size(), 1u);
   EXPECT_GT(j["subgraph_traces"][0]["op_mappings"].size(), 0u);
+#endif
 }
 
 // Test 1:N mapping on HTP.
@@ -1720,7 +1721,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_MixedEPContext_HTP_Phase2InferenceSu
 TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_GeluFusion) {
 #if defined(_WIN32) && !defined(_M_ARM64)
   GTEST_SKIP() << "GeluFusion not supported on Windows x86 HTP simulation";
-#endif
+#else
   ScopedTempDir tmp;
   // ONNX Gelu decomposition pattern: GeluFusion maps 5 ONNX ops → 1 QNN Gelu op.
   auto build_gelu = [](ModelTestBuilder& builder) {
@@ -1784,6 +1785,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_GeluFusion) {
   if (!found_fusion) {
     EXPECT_GT(op_mappings.size(), 0u) << "Should have at least one op mapping";
   }
+#endif
 }
 
 // Test N:M trace for ReshapeEinsumReshape fusion (3 ONNX ops → 3 QNN ops).
@@ -1793,7 +1795,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_GeluFusion) {
 TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_ReshapeEinsumReshape) {
 #if defined(_WIN32) && !defined(_M_ARM64)
   GTEST_SKIP() << "ReshapeEinsumReshape fusion not supported on Windows x86 HTP simulation";
-#endif
+#else
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
   ScopedTempDir tmp;
 
@@ -1860,6 +1862,7 @@ TEST_F(QnnHTPBackendTests, FrameworkOpTrace_NtoM_ReshapeEinsumReshape) {
         << "Each N:M fusion entry should reference all 3 ONNX source ops "
            "(reshape1, einsum, reshape2)";
   }
+#endif
 }
 
 // ========================= Profiling + Tracing Combination Tests =========================

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -2157,7 +2157,7 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
   GTEST_SKIP() << "HTP weight sharing on ARM64 requires QNN API version >= 2.34.";
 #elif defined(__ANDROID__)
   GTEST_SKIP() << "Weight sharing on Android devices is disabled";
-#endif
+#else
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -2265,6 +2265,7 @@ TEST_F(QnnHTPBackendTests, QnnContextShareAcrossSessions) {
     std::remove(ctx_model_path.c_str());
   }
   std::remove(qnn_ctx_binary_file_name1.c_str());
+#endif
 }
 
 TEST_F(QnnHTPBackendTests, DISABLED_VTCMBackupBufferSharing) {
@@ -2273,7 +2274,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_VTCMBackupBufferSharing) {
   GTEST_SKIP() << "HTP weight sharing on ARM64 requires QNN API version >= 2.34.";
 #elif defined(__ANDROID__)
   GTEST_SKIP() << "Weight sharing on Android devices is disabled";
-#endif
+#else
 
   // Disable the test on test-android job in Qualcomm CI here while we investigate
   // but do not upstream this change.
@@ -2381,6 +2382,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_VTCMBackupBufferSharing) {
     std::remove(ctx_model_path.c_str());
   }
   std::remove(qnn_ctx_binary_file_name1.c_str());
+#endif
 }
 
 TEST_F(QnnHTPBackendTests, FileMapping_Off) {
@@ -2389,7 +2391,7 @@ TEST_F(QnnHTPBackendTests, FileMapping_Off) {
   GTEST_SKIP() << "HTP weight sharing on ARM64 requires QNN API version >= 2.34.";
 #elif defined(__ANDROID__)
   GTEST_SKIP() << "Weight sharing on Android devices is disabled";
-#endif
+#else
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -2504,6 +2506,7 @@ TEST_F(QnnHTPBackendTests, FileMapping_Off) {
     std::remove(ctx_model_path.c_str());
   }
   std::remove(qnn_ctx_binary_file_name1.c_str());
+#endif
 }
 
 // For Ort sessions to generate the context binary, with session option ep.share_ep_contexts enabled
@@ -2514,7 +2517,7 @@ TEST_F(QnnHTPBackendTests, QnnContextGenWeightSharingSessionAPI) {
   GTEST_SKIP() << "HTP weight sharing on ARM64 requires QNN API version >= 2.34.";
 #elif defined(__ANDROID__)
   GTEST_SKIP() << "Weight sharing on Android devices is disabled";
-#endif
+#else
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -2573,6 +2576,7 @@ TEST_F(QnnHTPBackendTests, QnnContextGenWeightSharingSessionAPI) {
     ASSERT_EQ(std::remove(ctx_model_path.c_str()), 0);
   }
   ASSERT_EQ(std::remove(qnn_ctx_binary_file_name1.c_str()), 0);
+#endif
 }
 
 // Session created from array wth ep.context_enable enabled without ep.context_file_path
@@ -3286,9 +3290,9 @@ TEST_F(QnnHTPBackendTests, PrepareOnly_RunReturnsError) {
 // ============================================================
 
 // Helper: build session options with Graph Splittling enabled.
-static void SetGraphSplittingOptions(Ort::SessionOptions& so,
-                                     const std::string& ctx_path,
-                                     const std::string& num_threads = "") {
+[[maybe_unused]] static void SetGraphSplittingOptions(Ort::SessionOptions& so,
+                                                      const std::string& ctx_path,
+                                                      const std::string& num_threads = "") {
   so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
   so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, ctx_path.c_str());
   so.AddConfigEntry("ep.qnnexecutionprovider.enable_htp_graph_splitting", "1");
@@ -3304,7 +3308,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_DefaultThreads_CompileSucceeds)
 #if !(defined(QNN_SDK_VERSION_MAJOR) && QNN_SDK_VERSION_MAJOR == 2 && \
       defined(QNN_SDK_VERSION_MINOR) && QNN_SDK_VERSION_MINOR >= 49)
   GTEST_SKIP() << "Graph splitting requires QAIRT SDK 2.49+. Skipping on this SDK build.";
-#endif
+#else
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -3339,6 +3343,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_DefaultThreads_CompileSucceeds)
   EXPECT_TRUE(std::filesystem::exists(ctx_path));
 
   CleanUpCtxFile(ctx_path);
+#endif
 }
 
 // Test 2: Graph Splittling enabled with a custom thread count (4 threads) — context binary is written.
@@ -3346,7 +3351,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_CustomThreads_CompileSucceeds) 
 #if !(defined(QNN_SDK_VERSION_MAJOR) && QNN_SDK_VERSION_MAJOR == 2 && \
       defined(QNN_SDK_VERSION_MINOR) && QNN_SDK_VERSION_MINOR >= 49)
   GTEST_SKIP() << "Graph splitting requires QAIRT SDK 2.49+. Skipping on this SDK build.";
-#endif
+#else
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -3381,6 +3386,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_CustomThreads_CompileSucceeds) 
   EXPECT_TRUE(std::filesystem::exists(ctx_path));
 
   CleanUpCtxFile(ctx_path);
+#endif
 }
 
 // Test 3: Graph Splittling disabled (key unset) — existing path is unchanged, no regression.
@@ -3428,7 +3434,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_KwayPartitions_CompileSucceeds)
 #if !(defined(QNN_SDK_VERSION_MAJOR) && QNN_SDK_VERSION_MAJOR == 2 && \
       defined(QNN_SDK_VERSION_MINOR) && QNN_SDK_VERSION_MINOR >= 49)
   GTEST_SKIP() << "Graph splitting requires QAIRT SDK 2.49+. Skipping on this SDK build.";
-#endif
+#else
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -3450,6 +3456,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_KwayPartitions_CompileSucceeds)
   EXPECT_TRUE(std::filesystem::exists(ctx_path));
 
   CleanUpCtxFile(ctx_path);
+#endif
 }
 
 // Test: GPE_KWAY_PARTITIONS stale value — session 1 sets kway=4, session 2 sets kway=0.
@@ -3459,7 +3466,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_KwayPartitions_StaleEnvVarClear
 #if !(defined(QNN_SDK_VERSION_MAJOR) && QNN_SDK_VERSION_MAJOR == 2 && \
       defined(QNN_SDK_VERSION_MINOR) && QNN_SDK_VERSION_MINOR >= 49)
   GTEST_SKIP() << "Graph splitting requires QAIRT SDK 2.49+. Skipping on this SDK build.";
-#endif
+#else
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -3512,6 +3519,7 @@ TEST_F(QnnHTPBackendTests, GraphSplittingEnabled_KwayPartitions_StaleEnvVarClear
     EXPECT_EQ(0u, GetEnvironmentVariableA("GPE_KWAY_PARTITIONS", buf, sizeof(buf)));
 #endif
   }
+#endif
 }
 
 // ==============================================================================
@@ -3526,7 +3534,7 @@ TEST_F(QnnHTPBackendTests, QnnContextGenHtpBackendNoGpuConfig) {
   GTEST_SKIP() << "HTP weight sharing on ARM64 requires QNN API version >= 2.34.";
 #elif defined(__ANDROID__)
   GTEST_SKIP() << "Weight sharing on Android devices is disabled";
-#endif
+#else
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
   provider_options["offload_graph_io_quantization"] = "0";
@@ -3582,6 +3590,7 @@ TEST_F(QnnHTPBackendTests, QnnContextGenHtpBackendNoGpuConfig) {
     ASSERT_EQ(std::remove(ctx_model_path.c_str()), 0);
   }
   ASSERT_EQ(std::remove(qnn_ctx_binary_file_name1.c_str()), 0);
+#endif
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -491,7 +491,7 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextWeightSharing) {
 #if (defined(__aarch64__) || defined(_M_ARM64)) && \
     !(QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 34))
   GTEST_SKIP() << "HTP weight sharing on ARM64 requires QNN API version >= 2.34.";
-#endif
+#else
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 
   // Create 2 identical QDQ models.
@@ -665,6 +665,7 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContextWeightSharing) {
   std::remove(ctx_path1.c_str());
   std::remove(ctx_path2.c_str());
   std::remove(bin_name1.c_str());
+#endif
 }
 
 #endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))


### PR DESCRIPTION
### Description
* When GTEST_SKIP is used under a preprocessor `#if`, guard the rest of the test body behind an `#else` so that it is never unreachable.

### Motivation and Context
* MSVC Debug builds were failing on tip because of unreachable code warnings (treated as errors) in qnn_ep_context_test.cc.


