### PR TITLE
[QNN] Fix on-device macro guard to consider ARM64EC.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -3142,7 +3142,7 @@ Ort::Status QnnBackendManager::GetPlatformInfo() {
     return Ort::Status();
   }
 
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || (defined(_M_ARM64EC))
   RETURN_IF(qnn_interface_.deviceGetPlatformInfo == nullptr || qnn_interface_.deviceFreePlatformInfo == nullptr,
             "Failed to get valid QnnDevice function pointers.");
 
@@ -3187,7 +3187,7 @@ Ort::Status QnnBackendManager::GetPlatformInfo() {
   if (htp_arch_ != QNN_HTP_DEVICE_ARCH_NONE) {
     htp_arch_internal_ = htp_arch_;
   }
-#endif  // defined(__aarch64__) || defined(_M_ARM64)
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || (defined(_M_ARM64EC))
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -956,10 +956,10 @@ QnnEp::QnnEp(QnnEpFactory& factory,
   QnnHtpDevice_Arch_t htp_arch = QNN_HTP_DEVICE_ARCH_NONE;
   uint32_t soc_model = QNN_SOC_MODEL_UNKNOWN;
   if (enable_multi_soc_ep_context_) {
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || (defined(_M_ARM64EC))
     // Only enable on x86 platforms.
     LOG_AND_THROW_ERROR(logger_, "Multi-SoC EP context is only supported on x86 platforms and offline preparation.");
-#endif  // defined(__aarch64__) || defined(_M_ARM64)
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || (defined(_M_ARM64EC))
     if (!context_cache_enabled_) {
       LOG_AND_THROW_ERROR(logger_, "Per-SoC configurations are only supported for EP context enabled.");
     }
@@ -3206,11 +3206,11 @@ OrtStatus* QnnEp::ValidateCompiledModelCompatibilityInfo(const OrtHardwareDevice
     ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE, ("Validating compatibility info: " + info_string).c_str());
   }
 
-#if !defined(__aarch64__) && !defined(_M_ARM64)
+#if !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
   ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING, "Skip compatibility validation on x86 platforms.");
   *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
   return nullptr;
-#endif
+#endif  // !defined(__aarch64__) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
 
   qnn::QnnCompatibilityInfo info;
   Ort::Status status = qnn_cache_compatibility_manager_->DeserializeCompatibilityInfo(info_string, info);


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Fix on-device macro guard to correctly consider ARM64EC use case by adding `_M_ARM64EC`.
This change only targets on those guards introduced when enabling FCB feature, especially V2 model compatibility.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Currently, macros `__aarch64__` and `_M_ARM64` are used to check whether is on-device runtime. However, this combination lacks to consider ARM64EC use case (e.g., Python AMD64 on WoS), and causing unexpected behavior.
Considering a use case that EP context model is prepared on-device through Python AMD64 and then run with Python ARM64, the preparation is unable to acquire correct HTP arch and thus records default value 0 in compatibility info. During inference, when HTP arch is correctly acquired, model compatibility will report unsupported as cache HTP arch < 73 but runtime HTP arch >= 73. 

