### PR TITLE
[QNN EP] Reject FP16/FP32 Tensors on HTP runtime for v68

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -80,6 +80,14 @@ Ort::Status BaseOpBuilder::ProcessDataTypes(QnnModelWrapper& qnn_model_wrapper,
   if (IsCpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
     return CheckCpuDataTypes(input_qnn_dtypes, output_qnn_dtypes);
   } else if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    // HTP v68 has no FP32/FP16 execution path. Reject early so nodes fall back
+    // to the CPU EP cleanly rather than failing deep inside the QNN SDK.
+    if (qnn_model_wrapper.GetModelSettings().htp_arch == QNN_HTP_DEVICE_ARCH_V68) {
+      for (const auto& qnn_dt : input_qnn_dtypes) {
+        RETURN_IF(qnn_dt == QNN_DATATYPE_FLOAT_32 || qnn_dt == QNN_DATATYPE_FLOAT_16,
+                  "QNN EP does not support FP32 or FP16 tensors on HTP v68.");
+      }
+    }
     return CheckHtpDataTypes(input_qnn_dtypes, output_qnn_dtypes);
   } else if (IsGpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
     return CheckGpuDataTypes(input_qnn_dtypes, output_qnn_dtypes);
@@ -432,6 +440,14 @@ Ort::Status DataTypeCheckForCpuBackend(QnnModelWrapper& qnn_model_wrapper,
   const auto float_elem_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
   bool is_cpu_backend = IsCpuBackend(qnn_model_wrapper.GetQnnBackendType());
   RETURN_IF(is_cpu_backend && onnx_tensor_data_type != float_elem_type, error_msg.c_str());
+
+  // HTP v68 has no FP32/FP16 execution path. Reject here so layout-sensitive ops
+  // that call this function on the pre-layout-transform (NCHW) path fall back to
+  // the CPU EP cleanly on pass 1, without waiting for the validator on pass 2.
+  RETURN_IF(IsHtpV68Arch(qnn_model_wrapper) &&
+                (onnx_tensor_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
+                 onnx_tensor_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16),
+            "QNN EP does not support FP32 or FP16 tensors on HTP v68.");
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.h
@@ -459,5 +459,12 @@ Ort::Status DataTypeCheckForCpuBackend(QnnModelWrapper& qnn_model_wrapper,
                                        ONNXTensorElementDataType onnx_tensor_data_type,
                                        std::string error_msg);
 
+// Returns true when the backend is NPU/HTP and the silicon is HTP v68.
+// HTP v68 does not support FP32 or FP16 tensors; callers should reject such ops.
+inline bool IsHtpV68Arch(const QnnModelWrapper& qnn_model_wrapper) {
+  return IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+         qnn_model_wrapper.GetModelSettings().htp_arch == QNN_HTP_DEVICE_ARCH_V68;
+}
+
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -3055,14 +3055,30 @@ Ort::Status QnnBackendManager::GetPlatformInfo() {
   if (platform_info_ptr->version == QNN_DEVICE_PLATFORM_INFO_VERSION_1) {
     const QnnDevice_PlatformInfoV1_t& plt_info = platform_info_ptr->v1;
 
+    ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE,
+                    ("GetPlatformInfo: numHwDevices=" + std::to_string(plt_info.numHwDevices)).c_str());
+
     for (uint32_t idx = 0; idx < plt_info.numHwDevices; ++idx) {
       const QnnDevice_HardwareDeviceInfo_t& hw_info = plt_info.hwDevices[idx];
+      ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE,
+                      ("GetPlatformInfo: device[" + std::to_string(idx) +
+                       "] hw_version=" + std::to_string(hw_info.version) +
+                       " extensionPtr=" + (hw_info.v1.deviceInfoExtension ? "non-null" : "null"))
+                          .c_str());
       if (hw_info.version != QNN_DEVICE_HARDWARE_DEVICE_INFO_VERSION_1) {
         continue;
       }
 
       const auto* htp_ext = reinterpret_cast<const QnnHtpDevice_DeviceInfoExtension_t*>(hw_info.v1.deviceInfoExtension);
-      if (htp_ext && htp_ext->devType == QNN_HTP_DEVICE_TYPE_ON_CHIP) {
+      if (htp_ext) {
+        ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE,
+                        ("GetPlatformInfo: device[" + std::to_string(idx) +
+                         "] devType=" + std::to_string(static_cast<int>(htp_ext->devType)) +
+                         " arch=" + std::to_string(static_cast<int>(htp_ext->onChipDevice.arch)))
+                            .c_str());
+      }
+      if (htp_ext && (htp_ext->devType == QNN_HTP_DEVICE_TYPE_ON_CHIP ||
+                      htp_ext->devType == QNN_HTP_DEVICE_TYPE_OFF_CHIP)) {
         htp_arch_internal_ = htp_ext->onChipDevice.arch;
         vtcm_size_internal_ = static_cast<uint32_t>(htp_ext->onChipDevice.vtcmSize);
         break;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -11,6 +11,7 @@
 
 #include "nlohmann/json.hpp"
 #include "QnnInterface.h"
+#include "HTP/QnnHtpDevice.h"
 
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_quant_params_wrapper.h"
@@ -40,6 +41,7 @@ struct ModelSettings {
   bool htp_bf16_enable = false;
   bool enable_block_quant_weight_optimization = false;
   bool enable_htp_monolithic_lstm = false;
+  QnnHtpDevice_Arch_t htp_arch = QNN_HTP_DEVICE_ARCH_NONE;
 };
 
 class QnnModelWrapper {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2063,6 +2063,12 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
     return ep->ort_api.CreateStatus(ORT_EP_FAIL, message.c_str());
   }
 
+  // Populate HTP arch now that SetupBackend has resolved htp_arch_internal_.
+  // Not set for multi-SoC path; that path uses per-SoC htp_arch_per_soc_ arrays instead.
+  if (!ep->enable_multi_soc_ep_context_) {
+    ep->model_settings_.htp_arch = ep->qnn_backend_manager_->GetHtpArch();
+  }
+
   if (qnn::IsNpuBackend(ep->qnn_backend_manager_->GetQnnBackendType())) {
     // Create the HTP power config id (and its release timer) for the main thread.
     // The perf mode itself is not voted here: it is applied around graph compile


### PR DESCRIPTION
### Description

HTP v68 does not have a hardware FP32 or FP16 execution path. Running a float model on a v68 device causes ops to fail inside the QNN SDK with opaque error code or silently fail at compile/runtime.

This PR fixes the problem at two levels:

**1. Fix HTP arch detection on multi-SOC devices (`qnn_backend_manager.cc`)**

`GetPlatformInfo` enumerates HTP devices to determine the silicon architecture. On multi-SOC devices like, the SDK reports devices as `QNN_HTP_DEVICE_TYPE_OFF_CHIP` from the primary chip's perspective. The old code only accepted `ON_CHIP` devices, so the loop found nothing, `htp_arch_internal_` stayed `NONE`, and the EP had no knowledge it was running on v68. The fix: also accept `OFF_CHIP` in the enumeration loop. The union has only one member (`onChipDevice`) regardless of device type, so the arch value is valid either way.

**2. Centralized FP32/FP16 rejection for v68 (`base_op_builder.cc`, `base_op_builder.h`)**

Rather than per-op manual guards, the rejection is placed in two existing chokepoints that together cover all op paths:

- **`ProcessDataTypes`** (NPU branch) — covers all simple ops (Relu, Add, Mul, etc.) and any op using `BaseOpBuilder::IsOpSupported`
- **`DataTypeCheckForCpuBackend`** — already called by all layout-sensitive ops (Conv, Pool, LRN, Resize, InstanceNorm, GroupNorm, LpPool) on the pre-layout-transform NCHW path (pass 1)

The `IsHtpV68Arch()` predicate in `base_op_builder.h` is available as a shared utility for any future op builder that needs it.

**Supporting changes**

- `qnn_model_wrapper.h` — adds `QnnHtpDevice_Arch_t htp_arch` to `ModelSettings` so the silicon architecture is visible inside op builders without threading the backend manager through
- `qnn_execution_provider.cc` — populates `model_settings_.htp_arch` immediately after `SetupBackend` resolves `htp_arch_internal_`