### PR TITLE
Extend the expiration period of QA artifacts from 30 days to 60 days

### DIFF
--- a/qcom/scripts/artifactory/aql/expired_qa_artifacts.json
+++ b/qcom/scripts/artifactory/aql/expired_qa_artifacts.json
@@ -6,7 +6,7 @@
                     "repo": "${repo}",
                     "$and": [
                         {
-                            "created": { "$before": "30d" },
+                            "created": { "$before": "60d" },
                             "path": { "$match": "qa/*" }
                         }
                     ]


### PR DESCRIPTION
### Description
Extend the expiration period of QA artifacts from 30 days to 60 days.



### Motivation and Context
QAIRT CI would pull the prebuilt artifacts, and we may update the tag to them once a month. However, the artifacts stored in the artifactory are kept for only 30 days, so if they have been deleted, the fetch will fail.


