### PR TITLE
[QNN EP] Address PR #597 review comments (N-2 status leak, T-1 banner)

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -98,6 +98,7 @@ QnnEpFactory::QnnEpFactory(const char* ep_name,
                                              &mem_info);
   if (status != nullptr) {
     ort_api.ReleaseMemoryInfo(mem_info);
+    ort_api.ReleaseStatus(status);
   }
   host_accessible_memory_info_ = MemoryInfoUniquePtr(mem_info, ort_api.ReleaseMemoryInfo);
 }

--- a/onnxruntime/test/providers/qnn/unit/qnn_provider_factory_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_provider_factory_test.cc
@@ -713,6 +713,8 @@ TEST_F(QnnUnit_ProviderFactoryTest, GetSupportedDevices_CreateEpDeviceFails_Prop
   EXPECT_TRUE(ctx.created_ep_devices.empty());
   ctx.stub_ort_api.ReleaseStatus(status);
 }
+
+// ===========================================================================
 // Group 4: GetHardwareDeviceIncompatibilityDetailsImpl /
 //          ValidateCompiledModelCompatibilityInfoImpl — error paths that stop
 //          before std::make_unique<QnnEp>. The fixture leaves the default


### PR DESCRIPTION
## Summary

Follow-up to PR #597 review comments.

### [N-2] Release OrtStatus on CreateMemoryInfo_V2 failure (production fix)

`QnnEpFactory`'s ctor obtained an `OrtStatus*` from `CreateMemoryInfo_V2` but, on the failure path, only called `ReleaseMemoryInfo(mem_info)` and never `ReleaseStatus(status)` — leaking the status object.

- `onnxruntime/core/providers/qnn/qnn_provider_factory.cc:99-102`

```cpp
if (status != nullptr) {
  ort_api.ReleaseMemoryInfo(mem_info);
  ort_api.ReleaseStatus(status);   // <-- added
}
```

**Why it went unnoticed:** on the success path `status == nullptr`, so nothing leaks — the leak only exists on the `CreateMemoryInfo_V2` failure path, which effectively never triggers in practice. The unit test `Ctor_CreateMemoryInfoFails_ReleasesMemoryInfo` (added in #597) is the first thing to force that branch; the leak is only visible under ASan/LSan. This one-liner also makes that test's stubbed `StatusRecord` get released by the stub's `ReleaseStatus`, so the test no longer leaks — no test change needed.

### [T-1] Fix Group 4 section banner (test cosmetic)

Group 4's banner in `qnn_provider_factory_test.cc` was missing the preceding blank line and the opening rule line, unlike Groups 1/2/3/5/6. Cosmetic only.

## Test plan

- [x] `onnxruntime_provider_test --gtest_filter="QnnUnit_ProviderFactoryTest.*:QnnUnit_ProviderFactoryHtpTest.*"` — 40/40 pass
- [x] `lint_and_fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)