### PR TITLE
Fix flaky archive-testdata CI: retry on IncompleteRead + persist ort_core zip cache

### DIFF
--- a/qcom/scripts/all/archive_testdata.py
+++ b/qcom/scripts/all/archive_testdata.py
@@ -18,17 +18,34 @@ expected by run_tests.{ps1,sh} and the test binaries.
 
 import argparse
 import hashlib
+import http.client
 import logging
+import os
 import re
 import shutil
 import tarfile
+import time
 import zipfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
 from urllib.request import urlretrieve
 
 QCOM_ROOT = Path(__file__).parent.parent.parent
 REPO_ROOT = QCOM_ROOT.parent
+
+# Persistent download cache root, matching package_manager.py's FileCache so we reuse the same
+# on-disk file (see ort_core_cache_path below). Kept outside build/ so `git clean -ffdx` can't wipe
+# it. Stdlib-only: this script runs on the bare interpreter (no venv), so it can't import FileCache
+# (certifi/tqdm/yaml).
+DEFAULT_CACHE_ROOT = Path(
+    os.environ.get("ORT_BUILD_PACKAGE_CACHE_PATH", str((Path("~") / ".ort-package-cache").expanduser()))
+)
+
+# GitHub's codeload endpoint drops large transfers mid-stream (http.client.IncompleteRead) under
+# throttling; retry with exponential backoff before giving up.
+DOWNLOAD_ATTEMPTS = int(os.environ.get("ORT_BUILD_DOWNLOAD_ATTEMPTS", "3"))
+DOWNLOAD_BACKOFF_BASE_SECONDS = float(os.environ.get("ORT_BUILD_DOWNLOAD_BACKOFF_SECONDS", "2"))
 
 __all__ = [
     "OrtCoreDep",
@@ -60,6 +77,13 @@ def parse_deps_txt(deps_file: Path) -> OrtCoreDep:
     raise ValueError(f"ort_core entry not found in {deps_file}")
 
 
+def ort_core_cache_path(cache_root: Path, url: str) -> Path:
+    """Location of the cached ort_core zip, matching package_manager.py's FileCache layout
+    (<root>/ort_core/<url-basename>, e.g. <root>/ort_core/v1.27.0.zip) so a zip already fetched by
+    fetch_cmake_deps.py on a persistent runner is reused instead of re-downloaded."""
+    return cache_root / "ort_core" / PurePosixPath(urlparse(url).path).name
+
+
 def _sha1_of(path: Path) -> str:
     h = hashlib.sha1()
     with open(path, "rb") as f:
@@ -87,12 +111,33 @@ def download_and_verify(url: str, sha1: str, cache_path: Path) -> Path:
             actual,
         )
         cache_path.unlink()
-    logging.info("Downloading %s -> %s", url, cache_path)
-    urlretrieve(url, cache_path)
-    actual = _sha1_of(cache_path)
-    if actual != sha1.lower():
-        raise ValueError(f"SHA1 mismatch on freshly downloaded {cache_path}: expected {sha1}, got {actual}")
-    return cache_path
+
+    last_error: Exception | None = None
+    for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+        try:
+            logging.info("Downloading %s -> %s (attempt %d/%d)", url, cache_path, attempt, DOWNLOAD_ATTEMPTS)
+            urlretrieve(url, cache_path)
+            actual = _sha1_of(cache_path)
+            if actual != sha1.lower():
+                raise ValueError(f"SHA1 mismatch on freshly downloaded {cache_path}: expected {sha1}, got {actual}")
+            return cache_path
+        except (OSError, http.client.HTTPException, ValueError) as e:
+            # OSError (urllib/socket), HTTPException (IncompleteRead — not an OSError), and our own
+            # SHA1 ValueError all mean a bad/partial body; drop it so the next attempt starts clean.
+            last_error = e
+            cache_path.unlink(missing_ok=True)
+            if attempt < DOWNLOAD_ATTEMPTS:
+                delay = DOWNLOAD_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+                logging.warning(
+                    "Download attempt %d/%d for %s failed: %s. Retrying in %.0fs.",
+                    attempt,
+                    DOWNLOAD_ATTEMPTS,
+                    url,
+                    e,
+                    delay,
+                )
+                time.sleep(delay)
+    raise RuntimeError(f"Failed to download {url} after {DOWNLOAD_ATTEMPTS} attempt(s).") from last_error
 
 
 # Maps each handle name to its source path. Handle names must match MAPPING in extract_testdata.py.
@@ -160,11 +205,21 @@ def main() -> int:
         default=REPO_ROOT / "build",
         help="Directory to write onnxruntime-testdata.{zip,tar.bz2} into.",
     )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=DEFAULT_CACHE_ROOT,
+        help=(
+            "Persistent cache root for the ort_core zip. Defaults to ORT_BUILD_PACKAGE_CACHE_PATH "
+            "(the same root as package_manager.py), so the ~278 MiB zip is shared with the build's "
+            "fetch_cmake_deps download and survives `git clean` across CI runs."
+        ),
+    )
     args = parser.parse_args()
 
     dep = parse_deps_txt(REPO_ROOT / "cmake" / "deps.txt")
 
-    cache_zip = args.build_dir / "ort_core.zip"
+    cache_zip = ort_core_cache_path(args.cache_dir, dep.url)
     download_and_verify(dep.url, dep.sha1, cache_zip)
 
     extract_root = args.build_dir / "ort_core-src"

--- a/qcom/scripts/all/tests/test_archive_testdata.py
+++ b/qcom/scripts/all/tests/test_archive_testdata.py
@@ -2,15 +2,27 @@
 # SPDX-License-Identifier: MIT
 
 import hashlib
+import http.client
 import shutil
 import tarfile
 import zipfile
 from pathlib import Path
 
 import pytest
-from archive_testdata import OrtCoreDep, download_and_verify, parse_deps_txt, stage_sources, write_archives
+from archive_testdata import (
+    OrtCoreDep,
+    download_and_verify,
+    ort_core_cache_path,
+    parse_deps_txt,
+    stage_sources,
+    write_archives,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _sha1_of_file(path: Path) -> str:
+    return hashlib.sha1(path.read_bytes()).hexdigest()
 
 
 def test_parse_deps_txt_returns_url_and_sha1(tmp_path):
@@ -32,6 +44,13 @@ def test_parse_deps_txt_raises_when_ort_core_missing(tmp_path):
     deps_file.write_text("abseil_cpp;https://example.com/abseil.zip;deadbeef\n")
     with pytest.raises(ValueError, match="ort_core"):
         parse_deps_txt(deps_file)
+
+
+def test_ort_core_cache_path_matches_filecache_layout(tmp_path):
+    """The cache path must match package_manager.py's FileCache (<root>/ort_core/<url-basename>) so a
+    zip already fetched by fetch_cmake_deps.py is reused rather than re-downloaded."""
+    url = "https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.27.0.zip"
+    assert ort_core_cache_path(tmp_path, url) == tmp_path / "ort_core" / "v1.27.0.zip"
 
 
 def _make_fake_zip(path: Path) -> str:
@@ -89,22 +108,67 @@ def test_download_and_verify_removes_stale_cache_and_redownloads(tmp_path, monke
 
 
 def test_download_and_verify_raises_on_fresh_download_sha_mismatch(tmp_path, monkeypatch):
-    """When the freshly downloaded file doesn't match the expected SHA, raise ValueError."""
+    """A persistent SHA mismatch is retried, then raises RuntimeError once attempts are exhausted."""
     cache = tmp_path / "ort_core.zip"
     downloaded = tmp_path / "downloaded.zip"
     _make_fake_zip(downloaded)  # has a real SHA1 ≠ "0"*40
 
+    calls: list[str] = []
+
     def fake_urlretrieve(url: str, path: str) -> None:
+        calls.append(path)
         shutil.copy(str(downloaded), path)
 
     monkeypatch.setattr("archive_testdata.urlretrieve", fake_urlretrieve)
+    monkeypatch.setattr("archive_testdata.time.sleep", lambda _s: None)  # keep the retry loop fast
 
-    with pytest.raises(ValueError, match="SHA1 mismatch"):
+    with pytest.raises(RuntimeError, match="after 3 attempt"):
         download_and_verify(
             url="https://example.invalid/",
             sha1="0" * 40,
             cache_path=cache,
         )
+    assert len(calls) == 3, "a persistent SHA mismatch should exhaust all download attempts"
+    assert not cache.exists(), "the bad partial file must not be left in the cache"
+
+
+def test_download_and_verify_retries_incomplete_read_then_succeeds(tmp_path, monkeypatch):
+    """The observed CI failure (transient http.client.IncompleteRead) is retried and then succeeds."""
+    cache = tmp_path / "ort_core.zip"
+    good_zip = tmp_path / "good.zip"
+    good_sha1 = _make_fake_zip(good_zip)
+
+    attempts: list[str] = []
+
+    def flaky_urlretrieve(url: str, path: str) -> None:
+        attempts.append(path)
+        if len(attempts) == 1:
+            # Simulate a truncated transfer: write a partial file, then raise like urllib would.
+            Path(path).write_bytes(b"partial")
+            raise http.client.IncompleteRead(b"partial", 3451)
+        shutil.copy(str(good_zip), path)
+
+    monkeypatch.setattr("archive_testdata.urlretrieve", flaky_urlretrieve)
+    monkeypatch.setattr("archive_testdata.time.sleep", lambda _s: None)
+
+    result = download_and_verify(url="https://example.invalid/", sha1=good_sha1, cache_path=cache)
+    assert len(attempts) == 2, "must retry after the first IncompleteRead"
+    assert result == cache
+    assert _sha1_of_file(cache) == good_sha1
+
+
+def test_download_and_verify_content_addressed_cache_hit_skips_download(tmp_path, monkeypatch):
+    """A cache file already matching the expected SHA1 is returned without any network call."""
+    persistent = tmp_path / "ort_core-cachekey.zip"
+    sha1 = _make_fake_zip(persistent)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("urlretrieve must not run on a persistent-cache hit")
+
+    monkeypatch.setattr("archive_testdata.urlretrieve", fail_if_called)
+
+    result = download_and_verify(url="https://example.invalid/", sha1=sha1, cache_path=persistent)
+    assert result == persistent
 
 
 def _make_tree(root: Path, files: dict[str, str]) -> None:


### PR DESCRIPTION
## Motivation and Context

The `archive-testdata` CI job fails intermittently when downloading the ~278 MiB `ort_core` source zip from GitHub's codeload endpoint: `http.client.IncompleteRead: IncompleteRead(0 bytes read)`

The download takes ~7 minutes on the self-hosted runners and codeload drops large transfers mid-stream under throttling. The previous code called `urlretrieve()` once with no retry, so a single dropped connection failed the whole job. It also cached the zip under `build/testdata-stage/`, which `git clean -ffdx` wipes on every checkout — so every run re-downloaded from scratch even though the build's `fetch_cmake_deps.py` already downloads the identical file into the persistent package cache.

The artifact itself is fine — URL, file, and SHA1 verified end-to-end (292 MB, hash matches `cmake/deps.txt`). This is purely a delivery-path problem.

## Changes

**`qcom/scripts/all/archive_testdata.py`**

- **Retry with backoff**: `download_and_verify` retries up to 3× with exponential backoff, deleting the partial file between attempts. The `except` catches `http.client.HTTPException` — the actual class of `IncompleteRead`, which is **not** an `OSError` and would slip past a naive `except OSError`.

- **Reuse the package cache**: new `ort_core_cache_path()` helper computes the cache location using the *same layout* as `package_manager.py`'s `FileCache` — `<root>/ort_core/<url-basename>` (e.g. `<root>/ort_core/v1.27.0.zip`) under `ORT_BUILD_PACKAGE_CACHE_PATH`. On a persistent runner where `fetch_cmake_deps.py` already downloaded that exact file, `archive_testdata` now sees a cache hit (SHA1 matches) and **skips the download entirely**. This root lives outside `build/`, so it also survives `git clean`. New `--cache-dir` arg overrides the root.

The script stays **stdlib-only** — the `archive_testdata` task has no `@depends(["create_venv"])` and runs on the bare interpreter, so it can't `import FileCache` directly (which pulls in `certifi`/`tqdm`/`yaml`); the helper replicates just the path computation.

**`qcom/scripts/all/tests/test_archive_testdata.py`**

- Added `test_ort_core_cache_path_matches_filecache_layout` locking the `<root>/ort_core/<url-basename>` path (the reuse guarantee).
- Updated the SHA-mismatch test (now retries then raises `RuntimeError` instead of fast-failing with `ValueError`).
- Added: `IncompleteRead` → retry → success (the exact CI failure), and a persistent-cache-hit-skips-download test.

