### PR TITLE
[QNN EP] Apply fp16_clamp_overflow via graphSetConfig on EPContext binary-load path

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -9,9 +9,11 @@
 #include <thread>
 
 #include "HTP/QnnHtpContext.h"
+#include "HTP/QnnHtpGraph.h"
 #include "QnnOpDef.h"
 
 #include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_configs_helper.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/op_tracing/qnn_op_tracing.h"
 #include "core/providers/qnn/builder/qnn_profile_serializer.h"
@@ -440,6 +442,60 @@ Ort::Status QnnModel::SetupQnnInputOutput(const Ort::Logger& logger) {
   return Ort::Status();
 }
 
+Ort::Status QnnModel::ApplyRuntimeGraphConfigs(const HtpGraphConfigs_t& configs,
+                                               const Ort::Logger& logger) {
+  // Record for re-application after an SSR event re-retrieves the graph handle.
+  // Contract: intended to be called once per QnnModel at session creation; RecoverFromSSR
+  // relies on this cached value, so re-calling with different configs would silently change
+  // post-SSR behaviour.
+  runtime_graph_configs_ = configs;
+
+  if (qnn_backend_type_ != QnnBackendType::HTP || graph_info_ == nullptr) {
+    return Ort::Status();
+  }
+
+  // Build the runtime-settable subset of graph configs using the same builder pattern as
+  // QnnEp::InitQnnHtpGraphConfigs. Only add options confirmed settable on a finalized graph;
+  // a compile-time-only option here would come back as QNN_GRAPH_ERROR_GRAPH_FINALIZED.
+  QnnConfigsBuilder<QnnGraph_Config_t, QnnHtpGraph_CustomConfig_t> builder(
+      QNN_GRAPH_CONFIG_INIT, QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT);
+
+#ifdef QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+  if (configs.enable_htp_fp16_clamp_overflow) {
+    gsl::not_null<QnnHtpGraph_CustomConfig_t*> cc = builder.PushCustomConfig();
+    cc->option = QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW;
+    cc->fp16ClampOverflow = true;
+    gsl::not_null<QnnGraph_Config_t*> gc = builder.PushConfig();
+    gc->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+    gc->customConfig = cc;
+  }
+  // NOTE: future runtime-settable options append their own guarded block here.
+#endif
+
+  const QnnGraph_Config_t** graph_configs = builder.GetQnnConfigs();
+  if (graph_configs == nullptr) {
+    return Ort::Status();  // Nothing runtime-applicable was requested.
+  }
+
+  const auto& qnn_interface = qnn_backend_manager_->GetQnnInterface();
+  RETURN_IF(nullptr == qnn_interface.graphSetConfig,
+            "Invalid function pointer for graphSetConfig; cannot apply runtime graph configs.");
+  Qnn_ErrorHandle_t rt = qnn_interface.graphSetConfig(graph_info_->Graph(), graph_configs);
+  if (QNN_SUCCESS != rt) {
+    // QNN_GRAPH_ERROR_GRAPH_FINALIZED here means an option in the set is not runtime-settable
+    // on this SDK and must move back to compile-time wiring in InitQnnHtpGraphConfigs.
+    const std::string message = "Failed to apply runtime graph configs for graph: " +
+                                graph_info_->Name() + ". " +
+                                utils::FormatQnnError(qnn_interface, rt);
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_ERROR, message.c_str());
+    return MAKE_EP_FAIL(message.c_str());
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("Applied runtime graph configs for graph: " + graph_info_->Name()).c_str());
+  return Ort::Status();
+}
+
 static Ort::Status BindQnnTensorMemoryToOrtValueMemory(const OrtApi& ort_api,
                                                        const Ort::Logger& logger,
                                                        QnnBackendManager& qnn_backend_manager,
@@ -551,7 +607,10 @@ Ort::Status QnnModel::RecoverFromSSR(const Ort::Logger& logger) {
   graph_info_->ResetHandles(new_graph, new_context);
 
   // Re-build the tensor I/O metadata against the new graph handles.
-  return SetupQnnInputOutput(logger);
+  RETURN_IF_ERROR(SetupQnnInputOutput(logger));
+
+  // The freshly retrieved graph handle does not carry runtime graph configs, so re-apply them.
+  return ApplyRuntimeGraphConfigs(runtime_graph_configs_, logger);
 }
 
 Ort::Status QnnModel::BindAndExecuteGraph(OrtKernelContext* context,

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -444,10 +444,10 @@ Ort::Status QnnModel::SetupQnnInputOutput(const Ort::Logger& logger) {
 
 Ort::Status QnnModel::ApplyRuntimeGraphConfigs(const HtpGraphConfigs_t& configs,
                                                const Ort::Logger& logger) {
-  // Record for re-application after an SSR event re-retrieves the graph handle.
-  // Contract: intended to be called once per QnnModel at session creation; RecoverFromSSR
-  // relies on this cached value, so re-calling with different configs would silently change
-  // post-SSR behaviour.
+  // Caches configs for re-application after an SSR event re-retrieves the graph handle.
+  // Each call overwrites runtime_graph_configs_; RecoverFromSSR always re-applies the most
+  // recently cached value. Normal usage calls this once at session creation, but correctness
+  // does not depend on that.
   runtime_graph_configs_ = configs;
 
   if (qnn_backend_type_ != QnnBackendType::HTP || graph_info_ == nullptr) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -61,6 +61,12 @@ class QnnModel {
 
   Ort::Status SetupQnnInputOutput(const Ort::Logger& logger);
 
+  // Apply runtime-settable HTP graph configs (currently fp16 clamp overflow) on an already
+  // finalized graph loaded from a context binary, via QnnGraph_setConfig. Only options confirmed
+  // settable on a finalized graph belong here; compile-time-only options must stay in
+  // QnnEp::InitQnnHtpGraphConfigs. No-op when the backend is not HTP or nothing applies.
+  Ort::Status ApplyRuntimeGraphConfigs(const HtpGraphConfigs_t& configs, const Ort::Logger& logger);
+
   Ort::Status ExecuteGraph(OrtKernelContext* context, const Ort::Logger& logger);
 
   const OnnxTensorInfo* GetOutputInfo(const std::string& name) const {
@@ -206,6 +212,10 @@ class QnnModel {
   std::string context_bin_filepath_;
   int64_t max_spill_fill_size_ = 0;
   ContextPriority context_priority_ = ContextPriority::NORMAL;
+
+  // Runtime graph configs recorded by ApplyRuntimeGraphConfigs for re-application after an SSR
+  // re-retrieves the graph handle. See the single-call contract in the .cc.
+  HtpGraphConfigs_t runtime_graph_configs_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2560,6 +2560,8 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
             /*json_qnn_graph_path=*/{}};
         RETURN_IF_NOT_OK(qnn_model_shared->SetGraphInputOutputInfo(context));
         RETURN_IF_NOT_OK(qnn_model_shared->SetupQnnInputOutput(logger_));
+        RETURN_IF_NOT_OK(qnn_model_shared->ApplyRuntimeGraphConfigs(
+            htp_graph_configs_, logger_));
         qnn_models_.emplace(names[graph_idx].first, std::move(qnn_model_shared));
 
         auto node_compute_info = std::make_unique<QnnNodeComputeInfo>(*this);
@@ -2662,6 +2664,8 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
         /*json_qnn_graph_path=*/{}};
     RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(context));
     RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(logger_));
+    RETURN_IF_NOT_OK(qnn_model->ApplyRuntimeGraphConfigs(
+        htp_graph_configs_, logger_));
 
     // fused node name is QNNExecutionProvider_QNN_[hash_id]_[id]
     // the name here must be same with context->node_name in compute_info

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -2560,8 +2560,7 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
             /*json_qnn_graph_path=*/{}};
         RETURN_IF_NOT_OK(qnn_model_shared->SetGraphInputOutputInfo(context));
         RETURN_IF_NOT_OK(qnn_model_shared->SetupQnnInputOutput(logger_));
-        RETURN_IF_NOT_OK(qnn_model_shared->ApplyRuntimeGraphConfigs(
-            htp_graph_configs_, logger_));
+        RETURN_IF_NOT_OK(qnn_model_shared->ApplyRuntimeGraphConfigs(htp_graph_configs_, logger_));
         qnn_models_.emplace(names[graph_idx].first, std::move(qnn_model_shared));
 
         auto node_compute_info = std::make_unique<QnnNodeComputeInfo>(*this);
@@ -2664,8 +2663,7 @@ OrtStatus* QnnEp::CompileContextModel(const OrtGraph** graphs,
         /*json_qnn_graph_path=*/{}};
     RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(context));
     RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(logger_));
-    RETURN_IF_NOT_OK(qnn_model->ApplyRuntimeGraphConfigs(
-        htp_graph_configs_, logger_));
+    RETURN_IF_NOT_OK(qnn_model->ApplyRuntimeGraphConfigs(htp_graph_configs_, logger_));
 
     // fused node name is QNNExecutionProvider_QNN_[hash_id]_[id]
     // the name here must be same with context->node_name in compute_info

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 
+#include <cmath>
 #include <filesystem>
 #include <string>
 
@@ -3451,6 +3452,129 @@ TEST_F(QnnHTPBackendTests, QnnContextGenHtpBackendNoGpuConfig) {
   }
   ASSERT_EQ(std::remove(qnn_ctx_binary_file_name1.c_str()), 0);
 #endif
+}
+
+// Builds a simple fp16 Conv graph (float I/O; enable_htp_fp16_precision runs it in fp16 on HTP).
+static GetTestModelFn BuildFp16ConvModel() {
+  return [](ModelTestBuilder& builder) {
+    // Use large constant weights so the Conv accumulator reliably exceeds the fp16 maximum
+    // (~65504) when inputs are also large. Each output element = 8 * (300 * 300) = 720000,
+    // which overflows fp16: without fp16_clamp_overflow the output is NaN; with it, it
+    // saturates to fp16-max (finite), making the round-trip isfinite assertion a real fence.
+    auto input_def = TestInputDef<float>({1, 2, 4, 4}, false, std::vector<float>(32, 300.0f));
+    auto weights_def = TestInputDef<float>({2, 2, 2, 2}, true, std::vector<float>(16, 300.0f));
+    auto bias_def = TestInputDef<float>({2}, true, {0.0f, 0.0f});
+
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weights_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", {0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", {1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", {1, 1}));
+
+    builder.MakeOutput("output");
+    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+}
+
+// Verifies that enable_htp_fp16_clamp_overflow is applied on the EPContext (context-binary) path.
+// The option is a runtime graph config applied via graphSetConfig after the graph is restored
+// from the binary (QnnModel::ApplyRuntimeGraphConfigs). Input and weight values of 300.0f ensure
+// the Conv accumulator reliably overflows fp16 max (~65504): without the clamp the output is NaN;
+// with it the output saturates to fp16-max (finite), making the isfinite assertion a real fence.
+TEST_F(QnnHTPBackendTests, EPContext_Fp16ClampOverflow_RoundTrip) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["enable_htp_fp16_precision"] = "1";
+  provider_options["enable_htp_fp16_clamp_overflow"] = "1";
+#if defined(__linux__) && !defined(__aarch64__)
+  provider_options["soc_model"] = std::to_string(QNN_SOC_MODEL_SM8850);
+#endif
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+  provider_options["num_graph_prepare_threads"] = "1";
+#endif
+
+  ModelTestBuilder helper;
+  BuildFp16ConvModel()(helper);
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+  const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
+
+  const std::string context_model_file = "./testdata/qnn_ctx_fp16_clamp_overflow_test.onnx";
+  std::remove(context_model_file.c_str());
+
+  // Phase 1: generate the EPContext model + binary (compose/finalize path).
+  ONNX_NAMESPACE::ModelProto ctx_model_proto;
+  {
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, provider_options);
+
+    ScopedOrtSession scoped(std::move(registered_ep_device),
+                            Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
+
+    ASSERT_TRUE(std::filesystem::exists(context_model_file.c_str()));
+
+    std::ifstream ifs(context_model_file, std::ios::in | std::ios::binary);
+    ASSERT_TRUE(ifs.good()) << "Failed to open ONNX file: " << context_model_file;
+    ASSERT_TRUE(ctx_model_proto.ParseFromIstream(&ifs)) << "Failed to parse ONNX file: " << context_model_file;
+  }
+
+  // Phase 2: reload from the generated context model (binary-load path, where
+  // ApplyRuntimeGraphConfigs sets the fp16-clamp graph config), then run and check finite output.
+  {
+    Ort::SessionOptions so2;
+    so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    // Same provider_options as Phase 1: enable_htp_fp16_clamp_overflow must be set so
+    // ApplyRuntimeGraphConfigs fires on the binary-load path inside CompileContextModel.
+    RegisterQnnEpLibrary(registered_ep_device, so2, kQnnExecutionProvider, provider_options);
+
+    std::string ctx_model_data;
+    ctx_model_proto.SerializeToString(&ctx_model_data);
+    ScopedOrtSession scoped(std::move(registered_ep_device),
+                            Ort::Session(*ort_env, ctx_model_data.data(), ctx_model_data.size(), so2));
+
+    std::vector<float> input_value(32, 300.0f);
+    std::vector<int64_t> input_dim{1, 2, 4, 4};
+    Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+    std::vector<Ort::Value> ort_inputs;
+    ort_inputs.push_back(Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
+                                                  input_dim.data(), input_dim.size()));
+    const char* input_names_c[] = {"input"};
+    const char* output_names_c[] = {"output"};
+
+    auto ort_outputs = scoped.session().Run(Ort::RunOptions{}, input_names_c, ort_inputs.data(), ort_inputs.size(),
+                                            output_names_c, 1);
+
+    ASSERT_EQ(ort_outputs.size(), 1u);
+    const float* out_data = ort_outputs[0].GetTensorData<float>();
+    const size_t out_count = ort_outputs[0].GetTensorTypeAndShapeInfo().GetElementCount();
+    for (size_t i = 0; i < out_count; ++i) {
+      EXPECT_TRUE(std::isfinite(out_data[i])) << "Output element " << i << " is not finite: " << out_data[i];
+    }
+  }
+
+  CleanUpCtxFile(context_model_file);
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3455,32 +3455,6 @@ TEST_F(QnnHTPBackendTests, QnnContextGenHtpBackendNoGpuConfig) {
 }
 
 // Builds a simple fp16 Conv graph (float I/O; enable_htp_fp16_precision runs it in fp16 on HTP).
-static GetTestModelFn BuildFp16ConvModel() {
-  return [](ModelTestBuilder& builder) {
-    // Use large constant weights so the Conv accumulator reliably exceeds the fp16 maximum
-    // (~65504) when inputs are also large. Each output element = 8 * (300 * 300) = 720000,
-    // which overflows fp16: without fp16_clamp_overflow the output is NaN; with it, it
-    // saturates to fp16-max (finite), making the round-trip isfinite assertion a real fence.
-    auto input_def = TestInputDef<float>({1, 2, 4, 4}, false, std::vector<float>(32, 300.0f));
-    auto weights_def = TestInputDef<float>({2, 2, 2, 2}, true, std::vector<float>(16, 300.0f));
-    auto bias_def = TestInputDef<float>({2}, true, {0.0f, 0.0f});
-
-    MakeTestInput<float>(builder, "input", input_def);
-    MakeTestInput<float>(builder, "weights", weights_def);
-    MakeTestInput<float>(builder, "bias", bias_def);
-
-    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
-    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
-    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
-    conv_attrs.push_back(builder.MakeIntsAttribute("pads", {0, 0, 0, 0}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("strides", {1, 1}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", {1, 1}));
-
-    builder.MakeOutput("output");
-    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"output"}, kOnnxDomain, conv_attrs);
-  };
-}
-
 // Verifies that enable_htp_fp16_clamp_overflow is applied on the EPContext (context-binary) path.
 // The option is a runtime graph config applied via graphSetConfig after the graph is restored
 // from the binary (QnnModel::ApplyRuntimeGraphConfigs). Input and weight values of 300.0f ensure
@@ -3502,7 +3476,7 @@ TEST_F(QnnHTPBackendTests, EPContext_Fp16ClampOverflow_RoundTrip) {
 #endif
 
   ModelTestBuilder helper;
-  BuildFp16ConvModel()(helper);
+  BuildFp16ClampOverflowConvTestCase()(helper);
   const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
   for (const auto& [domain, version] : domain_to_version) {
     const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};

--- a/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_ep_context_test.cc
@@ -3460,6 +3460,9 @@ TEST_F(QnnHTPBackendTests, QnnContextGenHtpBackendNoGpuConfig) {
 // from the binary (QnnModel::ApplyRuntimeGraphConfigs). Input and weight values of 300.0f ensure
 // the Conv accumulator reliably overflows fp16 max (~65504): without the clamp the output is NaN;
 // with it the output saturates to fp16-max (finite), making the isfinite assertion a real fence.
+// Requires QAIRT >= 2.49 (QNN API >= 2.38) for the clamp option to be effective; the overflow
+// → NaN behavior only manifests on HTP arch v79+ (Glymur/SM8850 and later).
+#ifdef QNN_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 TEST_F(QnnHTPBackendTests, EPContext_Fp16ClampOverflow_RoundTrip) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
 
@@ -3550,6 +3553,7 @@ TEST_F(QnnHTPBackendTests, EPContext_Fp16ClampOverflow_RoundTrip) {
 
   CleanUpCtxFile(context_model_file);
 }
+#endif  // QNN_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1719,6 +1719,33 @@ inline GetTestModelFn BuildOpTestCase(const std::string& node_name,
   };
 }
 
+// Returns a function that builds a single fp16 Conv model with overflow-triggering
+// inputs and weights (300.0f). Each output element = 8 * (300 * 300) = 720000,
+// which overflows fp16 max (~65504): without fp16_clamp_overflow the output is NaN;
+// with it it saturates to fp16-max (finite), making an isfinite assertion a real fence.
+// Used by EPContext and SSR tests for enable_htp_fp16_clamp_overflow validation.
+inline GetTestModelFn BuildFp16ClampOverflowConvTestCase() {
+  return [](ModelTestBuilder& builder) {
+    auto input_def = TestInputDef<float>({1, 2, 4, 4}, false, std::vector<float>(32, 300.0f));
+    auto weights_def = TestInputDef<float>({2, 2, 2, 2}, true, std::vector<float>(16, 300.0f));
+    auto bias_def = TestInputDef<float>({2}, true, {0.0f, 0.0f});
+
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weights_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", {0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", {1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", {1, 1}));
+
+    builder.MakeOutput("output");
+    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+}
+
 /**
  * Returns a function that builds a model with a single QDQ operator with N float (quantizeable) inputs
  * and M inputs of a potentially different type.

--- a/onnxruntime/test/providers/qnn/qnn_test_utils.h
+++ b/onnxruntime/test/providers/qnn/qnn_test_utils.h
@@ -1719,6 +1719,14 @@ inline GetTestModelFn BuildOpTestCase(const std::string& node_name,
   };
 }
 
+// QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW is available from QNN API 2.38 (QAIRT 2.49).
+// Defined here (duplicated from core/providers/qnn/builder/qnn_def.h) so test files that must
+// not include EP-private headers can gate on it without breaking the public-API-only boundary.
+#if QNN_API_VERSION_MAJOR > 2 || \
+    (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 38)
+#define QNN_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+#endif
+
 // Returns a function that builds a single fp16 Conv model with overflow-triggering
 // inputs and weights (300.0f). Each output element = 8 * (300 * 300) = 720000,
 // which overflows fp16 max (~65504): without fp16_clamp_overflow the output is NaN;

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -10,8 +10,6 @@
 #include "onnxruntime_cxx_api.h"
 #include "onnxruntime_session_options_config_keys.h"
 
-#include "core/providers/qnn/builder/qnn_def.h"
-
 #include "test/providers/qnn/qnn_test_utils.h"
 
 #include "gtest/gtest.h"
@@ -672,48 +670,33 @@ TEST_F(QnnMockSSRBackendTests, DISABLED_SSRGraphExecuteEpContextWeightSharing) {
 
 #endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 
+// QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW is available from QNN API 2.38 (QAIRT 2.49).
+// Duplicated from core/providers/qnn/builder/qnn_def.h to avoid pulling that EP-private header
+// into this public-API-only test file.
+#if QNN_API_VERSION_MAJOR > 2 || \
+    (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 38)
+#define QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+#endif
+
 // Test that ApplyRuntimeGraphConfigs is re-applied after an SSR event on the
 // context-binary path. The mock SSR fires on the first graphExecute, triggering
 // RecoverFromSSR which calls ApplyRuntimeGraphConfigs(runtime_graph_configs_).
 // With inputs/weights of 300.0f the Conv accumulator overflows fp16 max (~65504):
 // if the clamp config is not re-applied after recovery the output would be NaN.
 //
-// Gated on QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE (QNN API >= 2.38 / QAIRT >= 2.49)
+// Gated on QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE (QNN API >= 2.38 / QAIRT >= 2.49)
 // and HTP arch > V75 since fp16 overflow→NaN only manifests on v79+.
 #if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && \
-    defined(QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE)
+    defined(QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE)
 TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContext_Fp16ClampOverflow_ReappliedAfterRecovery) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
 
   const std::string context_model_file = "./ssr_fp16_clamp_overflow_ctx.onnx";
   std::remove(context_model_file.c_str());
 
-  // Build an fp16 Conv model with overflow-triggering inputs/weights (300.0f).
-  // Each output element = 8 * (300 * 300) = 720000 >> fp16 max (~65504).
-  // Without fp16_clamp_overflow the output is NaN; with it it saturates to fp16-max (finite).
-  auto build_fp16_conv = [](ModelTestBuilder& builder) {
-    auto input_def = TestInputDef<float>({1, 2, 4, 4}, false, std::vector<float>(32, 300.0f));
-    auto weights_def = TestInputDef<float>({2, 2, 2, 2}, true, std::vector<float>(16, 300.0f));
-    auto bias_def = TestInputDef<float>({2}, true, {0.0f, 0.0f});
-
-    MakeTestInput<float>(builder, "input", input_def);
-    MakeTestInput<float>(builder, "weights", weights_def);
-    MakeTestInput<float>(builder, "bias", bias_def);
-
-    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
-    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
-    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
-    conv_attrs.push_back(builder.MakeIntsAttribute("pads", {0, 0, 0, 0}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("strides", {1, 1}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", {1, 1}));
-
-    builder.MakeOutput("output");
-    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"output"}, kOnnxDomain, conv_attrs);
-  };
-
   // Build and serialize the ONNX model.
   ModelTestBuilder helper;
-  build_fp16_conv(helper);
+  BuildFp16ClampOverflowConvTestCase()(helper);
   const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
   for (const auto& [domain, version] : domain_to_version) {
     const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
@@ -802,7 +785,7 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContext_Fp16ClampOverflow_Reappl
 
   CleanUpCtxFile(context_model_file);
 }
-#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -670,24 +670,16 @@ TEST_F(QnnMockSSRBackendTests, DISABLED_SSRGraphExecuteEpContextWeightSharing) {
 
 #endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 
-// QNN_HTP_GRAPH_CONFIG_OPTION_FP16_CLAMP_OVERFLOW is available from QNN API 2.38 (QAIRT 2.49).
-// Duplicated from core/providers/qnn/builder/qnn_def.h to avoid pulling that EP-private header
-// into this public-API-only test file.
-#if QNN_API_VERSION_MAJOR > 2 || \
-    (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 38)
-#define QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
-#endif
-
 // Test that ApplyRuntimeGraphConfigs is re-applied after an SSR event on the
 // context-binary path. The mock SSR fires on the first graphExecute, triggering
 // RecoverFromSSR which calls ApplyRuntimeGraphConfigs(runtime_graph_configs_).
 // With inputs/weights of 300.0f the Conv accumulator overflows fp16 max (~65504):
 // if the clamp config is not re-applied after recovery the output would be NaN.
 //
-// Gated on QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE (QNN API >= 2.38 / QAIRT >= 2.49)
+// Gated on QNN_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE (QNN API >= 2.38 / QAIRT >= 2.49)
 // and HTP arch > V75 since fp16 overflow→NaN only manifests on v79+.
 #if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && \
-    defined(QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE)
+    defined(QNN_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE)
 TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContext_Fp16ClampOverflow_ReappliedAfterRecovery) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
 
@@ -785,7 +777,7 @@ TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContext_Fp16ClampOverflow_Reappl
 
   CleanUpCtxFile(context_model_file);
 }
-#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && QNN_SSR_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && QNN_TEST_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -669,6 +669,139 @@ TEST_F(QnnMockSSRBackendTests, DISABLED_SSRGraphExecuteEpContextWeightSharing) {
 }
 
 #endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+
+// Test that ApplyRuntimeGraphConfigs is re-applied after an SSR event on the
+// context-binary path. The mock SSR fires on the first graphExecute, triggering
+// RecoverFromSSR which calls ApplyRuntimeGraphConfigs(runtime_graph_configs_).
+// With inputs/weights of 300.0f the Conv accumulator overflows fp16 max (~65504):
+// if the clamp config is not re-applied after recovery the output would be NaN.
+//
+// Gated on QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE (QNN API >= 2.38 / QAIRT >= 2.49)
+// and HTP arch > V75 since fp16 overflow→NaN only manifests on v79+.
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && \
+    defined(QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE)
+TEST_F(QnnMockSSRBackendTests, SSRGraphExecuteEpContext_Fp16ClampOverflow_ReappliedAfterRecovery) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
+
+  const std::string context_model_file = "./ssr_fp16_clamp_overflow_ctx.onnx";
+  std::remove(context_model_file.c_str());
+
+  // Build an fp16 Conv model with overflow-triggering inputs/weights (300.0f).
+  // Each output element = 8 * (300 * 300) = 720000 >> fp16 max (~65504).
+  // Without fp16_clamp_overflow the output is NaN; with it it saturates to fp16-max (finite).
+  auto build_fp16_conv = [](ModelTestBuilder& builder) {
+    auto input_def = TestInputDef<float>({1, 2, 4, 4}, false, std::vector<float>(32, 300.0f));
+    auto weights_def = TestInputDef<float>({2, 2, 2, 2}, true, std::vector<float>(16, 300.0f));
+    auto bias_def = TestInputDef<float>({2}, true, {0.0f, 0.0f});
+
+    MakeTestInput<float>(builder, "input", input_def);
+    MakeTestInput<float>(builder, "weights", weights_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", {0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", {1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", {1, 1}));
+
+    builder.MakeOutput("output");
+    builder.AddNode("Conv", "Conv", {"input", "weights", "bias"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+
+  // Build and serialize the ONNX model.
+  ModelTestBuilder helper;
+  build_fp16_conv(helper);
+  const std::unordered_map<std::string, int> domain_to_version = {{"", 13}, {kMSDomain, 1}};
+  for (const auto& [domain, version] : domain_to_version) {
+    const gsl::not_null<ONNX_NAMESPACE::OperatorSetIdProto*> opset_id_proto{helper.model_.add_opset_import()};
+    opset_id_proto->set_domain(domain);
+    opset_id_proto->set_version(version);
+  }
+  helper.model_.set_ir_version(ONNX_NAMESPACE::Version::IR_VERSION);
+  std::string model_data;
+  helper.model_.SerializeToString(&model_data);
+  const auto model_data_span = AsByteSpan(model_data.data(), model_data.size());
+
+  // -----------------------------------------------------------------------
+  // Step 1: Generate embed_mode=0 context binary with the real HTP backend.
+  // -----------------------------------------------------------------------
+  {
+    ProviderOptions htp_options;
+    htp_options["backend_type"] = "htp";
+    htp_options["offload_graph_io_quantization"] = "0";
+    htp_options["enable_htp_fp16_precision"] = "1";
+    htp_options["enable_htp_fp16_clamp_overflow"] = "1";
+    htp_options["num_graph_prepare_threads"] = "1";
+
+    Ort::SessionOptions so;
+    so.AddConfigEntry(kOrtSessionOptionEpContextEnable, "1");
+    so.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
+    so.AddConfigEntry(kOrtSessionOptionEpContextEmbedMode, "0");
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so, kQnnExecutionProvider, htp_options);
+    ScopedOrtSession scoped(std::move(registered_ep_device),
+                            Ort::Session(*ort_env, model_data_span.data(), model_data_span.size(), so));
+  }
+
+  ASSERT_TRUE(std::filesystem::exists(context_model_file.c_str()))
+      << "Context model not generated: " << context_model_file;
+
+  // -----------------------------------------------------------------------
+  // Step 2: Load via QnnMockSSR. SSR fires on the first graphExecute;
+  //         RecoverFromSSR reloads the .bin, re-applies fp16_clamp_overflow
+  //         via graphSetConfig, and retries. Output must be finite (not NaN).
+  // -----------------------------------------------------------------------
+  {
+    // provider_options from fixture SetUp() uses QnnMockSSR.dll.
+    ProviderOptions mock_options = provider_options;
+    mock_options["enable_htp_fp16_precision"] = "1";
+    // enable_htp_fp16_clamp_overflow must be set so ApplyRuntimeGraphConfigs fires on
+    // the binary-load path and is re-applied inside RecoverFromSSR after the mock SSR.
+    mock_options["enable_htp_fp16_clamp_overflow"] = "1";
+
+    Ort::SessionOptions so2;
+    so2.AddConfigEntry(kOrtSessionOptionEpContextFilePath, context_model_file.c_str());
+
+    onnx::ModelProto ctx_model_proto;
+    std::ifstream ifs(context_model_file, std::ios::in | std::ios::binary);
+    ASSERT_TRUE(ifs.good()) << "Failed to open context model: " << context_model_file;
+    ASSERT_TRUE(ctx_model_proto.ParseFromIstream(&ifs));
+    std::string ctx_model_data;
+    ctx_model_proto.SerializeToString(&ctx_model_data);
+
+    RegisteredEpDeviceUniquePtr registered_ep_device;
+    RegisterQnnEpLibrary(registered_ep_device, so2, kQnnExecutionProvider, mock_options);
+    ScopedOrtSession scoped(std::move(registered_ep_device),
+                            Ort::Session(*ort_env, ctx_model_data.data(), ctx_model_data.size(), so2));
+
+    std::vector<float> input_value(32, 300.0f);
+    std::vector<int64_t> input_dim{1, 2, 4, 4};
+    Ort::MemoryInfo info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+    std::vector<Ort::Value> ort_inputs;
+    ort_inputs.push_back(Ort::Value::CreateTensor(info, input_value.data(), input_value.size(),
+                                                  input_dim.data(), input_dim.size()));
+    const char* input_names_c[] = {"input"};
+    const char* output_names_c[] = {"output"};
+
+    // First Run: mock SSR fires → RecoverFromSSR → ApplyRuntimeGraphConfigs re-applied → retry.
+    auto ort_outputs = scoped.session().Run(Ort::RunOptions{}, input_names_c, ort_inputs.data(),
+                                            ort_inputs.size(), output_names_c, 1);
+
+    ASSERT_EQ(ort_outputs.size(), 1u);
+    const float* out_data = ort_outputs[0].GetTensorData<float>();
+    const size_t out_count = ort_outputs[0].GetTensorTypeAndShapeInfo().GetElementCount();
+    for (size_t i = 0; i < out_count; ++i) {
+      EXPECT_TRUE(std::isfinite(out_data[i]))
+          << "Output[" << i << "] is not finite after SSR recovery: " << out_data[i];
+    }
+  }
+
+  CleanUpCtxFile(context_model_file);
+}
+#endif  // defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC)) && QNN_HTP_FP16_CLAMP_OVERFLOW_AVAILABLE
+
 }  // namespace test
 }  // namespace onnxruntime
 

--- a/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
+++ b/onnxruntime/test/providers/qnn/ssr/qnn_ssr_test.cc
@@ -10,6 +10,8 @@
 #include "onnxruntime_cxx_api.h"
 #include "onnxruntime_session_options_config_keys.h"
 
+#include "core/providers/qnn/builder/qnn_def.h"
+
 #include "test/providers/qnn/qnn_test_utils.h"
 
 #include "gtest/gtest.h"

--- a/onnxruntime/test/providers/qnn/unit/qnn_model_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_model_test.cc
@@ -462,6 +462,65 @@ TEST(QnnUnit_ModelTest, Probe_HtpSetupBackend_WorksOnX86_64) {
   EXPECT_NE(ctx.model, nullptr);
 }
 
+// ---------------------------------------------------------------------------
+// ApplyRuntimeGraphConfigs tests
+//
+// These tests exercise the code-logic paths of ApplyRuntimeGraphConfigs that
+// are reachable without hardware. The hardware-dependent path (graphSetConfig
+// on a real finalized graph) is covered by the EPContext and SSR integration
+// tests.
+// ---------------------------------------------------------------------------
+
+// A freshly-constructed QnnModel has no graph_info_ yet. ApplyRuntimeGraphConfigs
+// must return OK without calling graphSetConfig (graph_info_ == nullptr guard).
+TEST(QnnUnit_ModelTest, ApplyRuntimeGraphConfigs_NoGraphInfo_ReturnsOk) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) {
+    GTEST_SKIP() << "HTP backend not available on this host";
+  }
+
+  qnn::HtpGraphConfigs_t configs;
+  configs.enable_htp_fp16_clamp_overflow = true;
+
+  auto status = ctx.model->ApplyRuntimeGraphConfigs(configs, ctx.logger);
+  EXPECT_TRUE(status.IsOK()) << status.GetErrorMessage();
+}
+
+// When no runtime-applicable flags are set, the builder produces nothing and
+// ApplyRuntimeGraphConfigs returns OK without issuing a graphSetConfig call.
+TEST(QnnUnit_ModelTest, ApplyRuntimeGraphConfigs_NoFlagsSet_ReturnsOk) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) {
+    GTEST_SKIP() << "HTP backend not available on this host";
+  }
+
+  qnn::HtpGraphConfigs_t configs;  // all flags default false
+  auto status = ctx.model->ApplyRuntimeGraphConfigs(configs, ctx.logger);
+  EXPECT_TRUE(status.IsOK()) << status.GetErrorMessage();
+}
+
+// ApplyRuntimeGraphConfigs stores the configs struct for SSR re-apply. Verify
+// the cached value reflects the last call (used by RecoverFromSSR).
+TEST(QnnUnit_ModelTest, ApplyRuntimeGraphConfigs_CachesConfigsForSsr) {
+  QnnModelHtpTestContext ctx;
+  if (!ctx.IsValid()) {
+    GTEST_SKIP() << "HTP backend not available on this host";
+  }
+
+  // First call: enable the flag.
+  qnn::HtpGraphConfigs_t configs_on;
+  configs_on.enable_htp_fp16_clamp_overflow = true;
+  EXPECT_TRUE(ctx.model->ApplyRuntimeGraphConfigs(configs_on, ctx.logger).IsOK());
+
+  // Second call with flag off — SSR would now skip re-applying the config.
+  qnn::HtpGraphConfigs_t configs_off;
+  configs_off.enable_htp_fp16_clamp_overflow = false;
+  EXPECT_TRUE(ctx.model->ApplyRuntimeGraphConfigs(configs_off, ctx.logger).IsOK());
+
+  // Third call restores the flag — SSR re-apply would include it again.
+  EXPECT_TRUE(ctx.model->ApplyRuntimeGraphConfigs(configs_on, ctx.logger).IsOK());
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
### Description

- FP16_CLAMP_OVERFLOW is a runtime graph config settable via graphSetConfig on a finalized graph. Add QnnModel::ApplyRuntimeGraphConfigs taking HtpGraphConfigs_t& (extensible for future runtime options) and call it
from both branches of CompileContextModel and after SSR recovery.
- Add EPContext_Fp16ClampOverflow_RoundTrip unit test.

### Motivation and Context
- On the context-binary path, enable_htp_fp16_clamp_overflow was silently ignored because QnnModelContext.graph_configs is always nullptr there, causing NaN output on HTP v79+.
