### PR TITLE
[QNNEP-LORA] Add support for Lora in ORT-QNNEP-LORA flow

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -273,7 +273,9 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
   }
   const auto output_count = GetOutputCountQnnRequired(node_unit);
   for (size_t output_i = 0; output_i < output_count; ++output_i) {
-    const auto& output_name = outputs[output_i].node_arg.Name();
+    // Use original ONNX tensor name — ORT may have stripped _output/_output_N suffix
+    const auto& output_name = qnn_model_wrapper.GetOriginalOnnxName(
+        outputs[output_i].node_arg.Name());
 
     TensorInfo output_info = {};
     ORT_RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(outputs[output_i], output_info));
@@ -329,7 +331,7 @@ Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
       output_info.qnn_data_type = supported_qnn_data_type;
       output_names.push_back(output_name);
     }
-    Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(output_name);
     QnnTensorWrapper output_tensorwrapper(output_name,
                                           tensor_type,
                                           output_info.qnn_data_type,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -1003,7 +1003,9 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_FLOAT_32;
   ORT_RETURN_IF_ERROR(utils::GetQnnDataType(is_quantized_tensor, type_proto, qnn_data_type));
 
-  const auto& output_name = outputs[0].node_arg.Name();
+  // Use original ONNX tensor name — ORT may have stripped _output/_output_N suffix
+  const std::string output_name = qnn_model_wrapper.GetOriginalOnnxName(
+      outputs[0].node_arg.Name());
   if (is_1d_conv) {
     const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
     std::vector<uint32_t> output_shape_2d = {
@@ -1036,8 +1038,7 @@ Status ConvOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wra
                                                          false,
                                                          is_graph_output));
   } else {
-    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
-    Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
+    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(output_name);
     QnnTensorWrapper output_tensorwrapper(output_name, tensor_type, qnn_data_type,
                                           std::move(output_quantize_param), std::move(output_shape));
     ORT_RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)), "Failed to add tensor.");

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -91,7 +91,7 @@ class QnnIrConfig : public QnnSerializerConfig {
     dlc_path_custom_config->option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
     dlc_path_custom_config->customConfig = dlc_path_config;
 
-    std::filesystem::create_directories(dlc_path);
+    std::filesystem::create_directories(dlc_path.parent_path());  // create output dir, not the file path
 
     // Keep the pointer to dlc_path_str's null-terminated string alive.
     std::swap(dlc_path_str, dlc_path_str_);

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -95,7 +95,10 @@ Status QnnModel::ComposeGraph(const GraphViewer& graph_viewer,
                               const qnn::ModelSettings& model_settings,
                               const logging::Logger& logger,
                               const QnnGraph_Config_t** graph_configs,
-                              const std::string& json_qnn_graph_path) {
+                              const std::string& json_qnn_graph_path,
+                              const std::unordered_set<std::string>& lora_updatable_tensors,
+                              const std::unordered_map<std::string, std::string>& onnx_tensor_name_map,
+                              bool skip_fusions) {
   LOGS(logger, VERBOSE) << "ComposeGraph Graph name: " << graph_viewer.Name();
 
   // Holder for the NodeUnits in the graph, this will guarantee the NodeUnits is
@@ -113,7 +116,10 @@ Status QnnModel::ComposeGraph(const GraphViewer& graph_viewer,
                                                       model_input_index_map_,
                                                       model_output_index_map_,
                                                       qnn_backend_manager_->GetQnnBackendType(),
-                                                      model_settings);
+                                                      model_settings,
+                                                      lora_updatable_tensors,
+                                                      onnx_tensor_name_map,
+                                                      skip_fusions);
   bool rt = true;
 
   qnn::profile::ProfilingInfo profiling_info;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <mutex>
+#include <unordered_set>
 #include <vector>
 
 #include "core/providers/qnn/ort_api.h"
@@ -36,7 +37,10 @@ class QnnModel {
                       const qnn::ModelSettings& model_settings,
                       const logging::Logger& logger,
                       const QnnGraph_Config_t** graph_configs = nullptr,
-                      const std::string& json_qnn_graph_path = "");
+                      const std::string& json_qnn_graph_path = "",
+                      const std::unordered_set<std::string>& lora_updatable_tensors = {},
+                      const std::unordered_map<std::string, std::string>& onnx_tensor_name_map = {},
+                      bool skip_fusions = false);
 
   Status FinalizeGraphs(const logging::Logger& logger);
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -51,7 +52,10 @@ class QnnModelWrapper {
                   const std::unordered_map<std::string, size_t>& input_index_map,
                   const std::unordered_map<std::string, size_t>& output_index_map,
                   QnnBackendType qnn_backend_type,
-                  const ModelSettings& model_settings)
+                  const ModelSettings& model_settings,
+                  const std::unordered_set<std::string>& lora_updatable_tensors = {},
+                  const std::unordered_map<std::string, std::string>& onnx_tensor_name_map = {},
+                  bool skip_fusions = false)
       : graph_viewer_(graph_viewer),
         logger_(logger),
         qnn_interface_(qnn_interface),
@@ -59,7 +63,10 @@ class QnnModelWrapper {
         input_index_map_(input_index_map),
         output_index_map_(output_index_map),
         qnn_backend_type_(qnn_backend_type),
-        model_settings_(model_settings) {
+        model_settings_(model_settings),
+        lora_updatable_tensors_(lora_updatable_tensors),
+        onnx_tensor_name_map_(onnx_tensor_name_map),
+        skip_fusions_(skip_fusions) {
   }
   ORT_DISALLOW_COPY_ASSIGNMENT_AND_MOVE(QnnModelWrapper);
 
@@ -151,15 +158,24 @@ class QnnModelWrapper {
   }
 
   Qnn_TensorType_t GetTensorType(const std::string& tensor_name) const {
+    bool is_lora = lora_updatable_tensors_.count(tensor_name) > 0;
     if (IsConstantInput(tensor_name)) {
-      return QNN_TENSOR_TYPE_STATIC;
+      return is_lora ? QNN_TENSOR_TYPE_UPDATEABLE_STATIC : QNN_TENSOR_TYPE_STATIC;
     } else if (IsGraphInput(tensor_name)) {
       return QNN_TENSOR_TYPE_APP_WRITE;
     } else if (IsGraphOutput(tensor_name)) {
       return QNN_TENSOR_TYPE_APP_READ;
     } else {
-      return QNN_TENSOR_TYPE_NATIVE;
+      return is_lora ? QNN_TENSOR_TYPE_UPDATEABLE_NATIVE : QNN_TENSOR_TYPE_NATIVE;
     }
+  }
+
+  bool IsSkipFusions() const { return skip_fusions_; }
+
+  // Restore original ONNX tensor name if ORT renamed it (e.g. stripped _output suffix)
+  const std::string& GetOriginalOnnxName(const std::string& ort_name) const {
+    auto it = onnx_tensor_name_map_.find(ort_name);
+    return (it != onnx_tensor_name_map_.end()) ? it->second : ort_name;
   }
 
   Status GetTensorInfo(const NodeUnitIODef& input, TensorInfo& input_info) const;
@@ -389,6 +405,9 @@ class QnnModelWrapper {
   const std::unordered_map<std::string, size_t>& output_index_map_;
   QnnBackendType qnn_backend_type_ = QnnBackendType::CPU;
   ModelSettings model_settings_ = {};
+  std::unordered_set<std::string> lora_updatable_tensors_;
+  std::unordered_map<std::string, std::string> onnx_tensor_name_map_;  // ORT name → original ONNX name
+  bool skip_fusions_ = false;  // skip all QnnNodeGroup fusions for pure ONNX→QNN translation
   utils::QnnJSONGraph json_qnn_graph_;
 };  // QnnModelWrapper
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -184,9 +184,12 @@ static Status GetQnnNodeGroupsImpl(/*out*/ std::vector<std::unique_ptr<IQnnNodeG
       continue;  // Already handled this node unit
     }
 
-    std::unique_ptr<IQnnNodeGroup> fused_node_group = TryQnnFusions(qnn_model_wrapper, *node_unit,
-                                                                    node_to_node_unit, node_unit_to_qnn_node_group,
-                                                                    logger);
+    std::unique_ptr<IQnnNodeGroup> fused_node_group = nullptr;
+    if (!qnn_model_wrapper.IsSkipFusions()) {
+      fused_node_group = TryQnnFusions(qnn_model_wrapper, *node_unit,
+                                       node_to_node_unit, node_unit_to_qnn_node_group,
+                                       logger);
+    }
 
     if (fused_node_group) {
       const size_t index = qnn_node_groups.size();

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -4,9 +4,11 @@
 #include "qnn_execution_provider.h"
 
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string_view>
 #include <thread>
+#include "onnx/onnx_pb.h"
 #include <unordered_set>
 
 #include "IR/QnnIrGraph.h"
@@ -380,6 +382,26 @@ QNNExecutionProvider::QNNExecutionProvider(const ProviderOptions& provider_optio
   }
 
   std::unique_ptr<qnn::QnnSerializerConfig> qnn_serializer_config = ParseSerializerBackendOptions(provider_options_map);
+
+  // Parse lora_tensor_names_path — used to mark tensors as UPDATEABLE in the QNN graph
+  static const std::string LORA_TENSOR_NAMES_PATH = "lora_tensor_names_path";
+  auto lora_names_path_pos = provider_options_map.find(LORA_TENSOR_NAMES_PATH);
+  if (lora_names_path_pos != provider_options_map.end()) {
+    std::ifstream lora_file(lora_names_path_pos->second);
+    std::string line;
+    while (std::getline(lora_file, line)) {
+      if (!line.empty()) lora_updatable_tensors_.insert(line);
+    }
+    LOGS_DEFAULT(INFO) << "Loaded " << lora_updatable_tensors_.size()
+                       << " lora updatable tensor names from " << lora_names_path_pos->second;
+  }
+
+  // Parse qnn_direct_dlc_mode — serialize DLC directly via IrGraphBuilder, skip EPContext
+  static const std::string QNN_DIRECT_DLC_MODE = "qnn_direct_dlc_mode";
+  direct_dlc_mode_ = ParseBoolOption(QNN_DIRECT_DLC_MODE, false, provider_options_map);
+  if (direct_dlc_mode_) {
+    LOGS_DEFAULT(INFO) << "direct_dlc_mode enabled: DLC will be written directly via IrGraphBuilder";
+  }
 
   std::string profiling_file_path;
   static const std::string PROFILING_LEVEL = "profiling_level";
@@ -960,6 +982,33 @@ QNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer
 
   const auto& logger = *GetLogger();
 
+  // Build ONNX tensor name map once (direct_dlc_mode only).
+  // ORT internally strips _output/_output_N from single-output node tensor names.
+  // We restore originals so QNN tensors match the ONNX tensor names exactly.
+  if (direct_dlc_mode_ && onnx_tensor_name_map_.empty()) {
+    const auto& model_path = graph_viewer.ModelPath();
+    if (!model_path.empty()) {
+      std::ifstream model_file(model_path, std::ios::binary);
+      if (model_file) {
+        ONNX_NAMESPACE::ModelProto model_proto;
+        if (model_proto.ParseFromIstream(&model_file)) {
+          for (const auto& node : model_proto.graph().node()) {
+            if (node.name().empty()) continue;
+            for (int i = 0; i < node.output_size(); i++) {
+              const std::string& onnx_out = node.output(i);
+              if (!onnx_out.empty() && onnx_out != node.name()) {
+                // node.name() is what ORT uses; onnx_out is the original
+                onnx_tensor_name_map_[node.name()] = onnx_out;
+              }
+            }
+          }
+          LOGS(logger, INFO) << "Built ONNX tensor name map with "
+                             << onnx_tensor_name_map_.size() << " entries";
+        }
+      }
+    }
+  }
+
   // Check BF16 compatibility early
   if (model_settings_.htp_bf16_enable) {
     // Check SoC model
@@ -1166,6 +1215,11 @@ QNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_viewer
 }
 
 DataLayout QNNExecutionProvider::GetPreferredLayout() const {
+  // In direct_dlc_mode, skip layout transforms to preserve original ONNX tensor names.
+  // This ensures QNN graph tensor names match lora_tensor_names.txt exactly.
+  if (direct_dlc_mode_) {
+    return DataLayout::NCHW;
+  }
   return DataLayout::NHWC;
 }
 
@@ -1275,12 +1329,14 @@ Status QNNExecutionProvider::CompileFromOrtGraph(const std::vector<FusedNodeAndG
 
     qnn::QnnSerializerConfig* qnn_serializer_config = qnn_backend_manager_->GetQnnSerializerConfig();
     if (qnn_serializer_config) {
-      if (context_cache_enabled_) {
+      if (context_cache_enabled_ && !direct_dlc_mode_) {
+        // Original convergence flow: keep IrGraph in memory, extract via contextGetBinary pointer
         skip_config.option = QNN_IR_GRAPH_CONFIG_OPTION_SKIP_SERIALIZATION;
         skip_graph_config.option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
         skip_graph_config.customConfig = &skip_config;
         all_graph_configs.push_back(&skip_graph_config);
       } else {
+        // direct_dlc_mode: write DLC directly via IrGraphBuilder + DnnWriter in finalize()
         qnn_serializer_config->SetGraphName(fused_node.Name());
         const QnnGraph_Config_t** serializer_configs = qnn_serializer_config->Configure();
         if (serializer_configs) {
@@ -1306,7 +1362,10 @@ Status QNNExecutionProvider::CompileFromOrtGraph(const std::vector<FusedNodeAndG
     }
 
     ORT_RETURN_IF_ERROR(qnn_model->ComposeGraph(graph_viewer, fused_node, model_settings_, logger,
-                                                all_graph_configs_ptr, json_graph_filepath));
+                                                all_graph_configs_ptr, json_graph_filepath,
+                                                lora_updatable_tensors_,
+                                                onnx_tensor_name_map_,
+                                                direct_dlc_mode_));
     ORT_RETURN_IF_ERROR(qnn_model->FinalizeGraphs(logger));
     ORT_RETURN_IF_ERROR(qnn_model->SetupQnnInputOutput(logger));
 
@@ -1416,8 +1475,8 @@ Status QNNExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused
   }
 
   ORT_RETURN_IF_ERROR(CompileFromOrtGraph(fused_nodes_and_graphs, node_compute_funcs, logger));
-  // Generate QNN context model if it's QDQ model + context_cache_enabled=true + not exist already
-  if (!is_qnn_ctx_model && context_cache_enabled_ && !is_ctx_file_exist) {
+  // Generate QNN context model if: QDQ model + context_cache_enabled + not direct_dlc_mode + not cached
+  if (!is_qnn_ctx_model && context_cache_enabled_ && !direct_dlc_mode_ && !is_ctx_file_exist) {
     // All partitioned graph share single QNN context, included in the same context binary
     uint64_t buffer_size(0);
     auto context_buffer = qnn_backend_manager_->GetContextBinaryBuffer(buffer_size);

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "core/providers/qnn/ort_api.h"
@@ -105,8 +106,13 @@ class QNNExecutionProvider : public IExecutionProvider {
   bool context_cache_enabled_ = false;
   std::string context_cache_path_cfg_ = "";
   std::string context_node_name_prefix_ = "";
-  bool disable_cpu_ep_fallback_ = false;  // True if CPU EP fallback has been disabled for this session.
+  bool disable_cpu_ep_fallback_ = false;
   bool qnn_context_embed_mode_ = true;
+  bool direct_dlc_mode_ = false;   // write DLC directly via IrGraphBuilder, skip EPContext
+  std::unordered_set<std::string> lora_updatable_tensors_;
+  // Map: ORT-internal tensor name → original ONNX tensor name
+  // ORT strips _output/_output_N suffix for single-output nodes; this restores them.
+  mutable std::unordered_map<std::string, std::string> onnx_tensor_name_map_;
   int32_t vtcm_size_in_mb_ = 0;
   bool enable_vtcm_backup_buffer_sharing_ = false;
   std::unique_ptr<onnxruntime::Model> qnn_ep_context_model_;


### PR DESCRIPTION
- Use the tensor names specified in lora_tensor_names.txt
  to mark the corresponding tensors as updatable in the
  QNN graph created after the ORT-QNN EP flow
- Modified the QNN EP workflow to use the original ONNX
  output names instead of ORT's internally modified names,
  eliminating tensor name mismatch issues
- Modified the QNN EP workflow to skip the QnnNodeGroup fusions
  like HardSigmoid+Mul, Scale+Softmax, Gelu
- Disabled all ORT level optimization/transformation


