### PR TITLE
[QNN EP] Sign-extend sub-byte weights when folding a constant DequantizeLinear

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -24,8 +24,16 @@ Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper
   if (qnn_model_wrapper.IsConstantInput(tensor_name)) {
     const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(tensor_name);
     RETURN_IF(init == nullptr, "Constant initializer not found for tensor.");
-    return qnn_model_wrapper.UnpackInitializerData(init, bytes);
+    RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(init, bytes));
+
+    // Undo the sub-byte high-bit masking so callers can read these bytes as plain integers.
+    ONNXTensorElementDataType onnx_data_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    RETURN_IF_ERROR(utils::GetOnnxTensorElemDataType(init, onnx_data_type));
+    utils::SignExtendUnpackedSubByteData(onnx_data_type, gsl::make_span(bytes));
+    return Ort::Status();
   }
+  // A folded tensor holds fp32 bytes (DQ folding) or 8/16/32-bit quantized bytes (QuantizeData
+  // rejects sub-byte types), so both are already plain.
   if (qnn_model_wrapper.IsFoldedConstant(tensor_name) &&
       qnn_model_wrapper.IsQnnTensorWrapperExist(tensor_name)) {
     const QnnTensorWrapper& wrapper = qnn_model_wrapper.GetQnnTensorWrapper(tensor_name);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -20,7 +20,9 @@ bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
 Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
                                const OrtNodeUnit& node_unit) ORT_MUST_USE_RESULT;
 
-// Reads the raw bytes of a real initializer or a previously-folded STATIC tensor.
+// Reads the bytes of a real initializer or a previously-folded STATIC tensor as plain
+// two's-complement integers, one element per byte for sub-byte types. Unlike
+// QnnModelWrapper::UnpackInitializerData(), sub-byte elements are sign-extended, not left masked.
 Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper,
                                               const std::string& tensor_name,
                                               /*out*/ std::vector<uint8_t>& bytes) ORT_MUST_USE_RESULT;

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1235,6 +1235,27 @@ Ort::Status DequantizePerChannel(gsl::span<const uint8_t> quant_bytes, gsl::span
   return Ort::Status();
 }
 
+void SignExtendUnpackedSubByteData(ONNXTensorElementDataType onnx_data_type,
+                                   /*in,out*/ gsl::span<uint8_t> bytes) {
+  // The masks keep this well-defined for any input byte, and idempotent: SignExtendLower*Bits()
+  // left-shifts its argument, so it needs a byte holding nothing above the sub-byte element.
+  switch (onnx_data_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+      for (uint8_t& byte : bytes) {
+        byte = static_cast<uint8_t>(Int4x2::SignExtendLower4Bits(static_cast<std::byte>(byte & 0x0F)));
+      }
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
+      for (uint8_t& byte : bytes) {
+        byte = static_cast<uint8_t>(Int2x4::SignExtendLower2Bits(static_cast<std::byte>(byte & 0x03)));
+      }
+      break;
+    default:
+      // UINT4/UINT2 hold their value in the masked byte; nothing else was ever masked.
+      break;
+  }
+}
+
 Ort::Status ConvertBlockQuantScalesToLpbq(gsl::span<const float> bq_scales,
                                           gsl::span<const int32_t> bq_offsets,
                                           uint32_t num_blocks_per_channel,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -252,6 +252,15 @@ Ort::Status DequantizePerChannel(gsl::span<const uint8_t> quant_bytes, gsl::span
                                  /*out*/ gsl::span<float> data, Qnn_DataType_t data_type,
                                  std::optional<int64_t> axis = std::nullopt);
 
+// Recovers the true two's-complement value of sub-byte data that UnpackInitializerData() expanded
+// to one byte per element with the unused high bits masked off (UnpackInt4ToInt8 / UnpackInt2ToInt8
+// mask to work around a QNN INT4 accuracy bug; that mask must stay). Consumers that read those
+// bytes as plain integers need this: DequantizePerChannel is told SFIXED_POINT_8, since
+// CreateMapQuantize collapses INT4 into it on non-GPU backends, so a negative 4-bit value would
+// read back as q + 16. UINT4/UINT2 are never masked and are left alone.
+void SignExtendUnpackedSubByteData(ONNXTensorElementDataType onnx_data_type,
+                                   /*in,out*/ gsl::span<uint8_t> bytes);
+
 Ort::Status Quantize(const double double_value,
                      const float scale,
                      const int32_t zero_point,

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1016,6 +1016,53 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
 }
 
+// Builds: weight_q (int4 init) -> per-channel DQ -> Conv. QNN cannot represent a standalone
+// per-channel DQ, so it is folded to an fp32 static by decoding the initializer's bytes as int8.
+// Weights span the negative INT4 range, which a sign-handling regression would decode as q + 16.
+static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::vector<float>& scales) {
+  return [scales](ModelTestBuilder& builder) {
+    constexpr int64_t out_ch = 2;
+    constexpr int64_t in_ch = 3;
+    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
+    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
+    const std::vector<int8_t> weight_values{-8, -7, -1, 1, 5, 7};
+
+    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
+
+    std::vector<Int4x2> weight_data(Int4x2::CalcNumInt4Pairs(weight_values.size()));
+    for (size_t i = 0; i < weight_values.size(); ++i) {
+      weight_data[i >> 1].SetElem(i & 1, weight_values[i]);
+    }
+    builder.MakeInitializer<Int4x2>("weight_q", weight_shape, weight_data);
+    builder.MakeInitializer<float>("weight_scale", {out_ch}, scales);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
+    axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+    builder.AddNode("WeightDQ", "DequantizeLinear", {"weight_q", "weight_scale"}, {"weight_dq"},
+                    kOnnxDomain, axis_attrs);
+
+    builder.MakeOutput("output");
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+    builder.AddNode("Conv", "Conv", {"input", "weight_dq"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+}
+
+TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt4DQConstWeight_SignRegression) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildPerChannelInt4DQConstWeightConvTestCase(/*scales*/ {0.1f, 0.2f}),
+                  provider_options,
+                  /*opset*/ 21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
+}
+
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).
 // Conv2d: reuse_sparse_indices should be added to the QNN node parameters.
 TEST_F(QnnCPUBackendTests, Conv2D_ReuseSparseIndices) {
@@ -1219,6 +1266,17 @@ TEST_F(QnnHTPBackendTests, Conv_Fp16ClampOverflow_Smoke) {
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(0.01f)});
+}
+
+TEST_F(QnnHTPBackendTests, Convf32_PerChannelInt4DQConstWeight_SignRegression) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildPerChannelInt4DQConstWeightConvTestCase(/*scales*/ {0.1f, 0.2f}),
+                  provider_options,
+                  /*opset*/ 21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
 }
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.

--- a/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
@@ -1,0 +1,122 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Function-level unit tests for qdq_constant_folding.cc.
+//
+// GetEffectivelyConstantTensorBytes() hands initializer bytes to callers that read them as
+// int8_t / uint8_t. QnnModelWrapper::UnpackInitializerData() expands a sub-byte initializer to
+// one byte per element with the unused high bits masked off, which QNN needs (it reads only the
+// low bits via `bitwidth`) but which reads as a positive number in an int8_t decode -- so an INT4
+// -1 would come back as 15. These tests pin the sign extension that prevents that.
+//
+// Initializer access is mocked through mock_init_registry, so no real ORT graph is needed.
+
+#include "gtest/gtest.h"
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/builder/opbuilder/qdq_constant_folding.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/ort_api.h"
+
+#include "test/providers/qnn/unit/mock_init_registry.h"
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// QnnModelWrapper over a fake graph whose initializers come from g_mock_init_reg, which is what
+// makes IsConstantInput() / GetConstantTensor() / UnpackInitializerData() resolve by name.
+struct MockInitWrapperFixture {
+  OrtApiStubContext ctx;
+  // The Ort::ConstValueInfo / ConstTypeInfo wrappers that utils::GetOnnxTensorElemDataType() goes
+  // through dispatch on the GLOBAL Ort::GetApi(), not on api_ptrs_, so without this the mock
+  // OrtValueInfo* would be handed to the real ORT runtime and SIGSEGV.
+  OrtGlobalApiOverride global_api_override{&ctx.stub_ort_api};
+  QNN_INTERFACE_VER_TYPE qnn_interface = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t backend_handle = nullptr;
+  QNN_INTERFACE_VER_TYPE qnn_validator_interface = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t validator_backend_handle = nullptr;
+  Ort::Logger null_logger_{MakeNullLogger()};
+  int fake_graph_sentinel_{};
+  qnn::GraphInputOutputInfo input_info;
+  qnn::GraphInputOutputInfo output_info;
+  std::unique_ptr<qnn::QnnModelWrapper> wrapper;
+
+  MockInitWrapperFixture() {
+    g_mock_init_reg.clear();
+    // Seed from the real OrtApi so everything these paths touch beyond the mocked initializer
+    // queries still works -- notably CreateStatus / ReleaseStatus, which MAKE_EP_FAIL() needs on
+    // the not-found path and which a zero-initialised table would leave null.
+    ctx.stub_ort_api = *OrtGetApiBase()->GetApi(ORT_API_VERSION);
+    SetupMockInitRegistryStubs(ctx);
+    ApiPtrs api_ptrs = ctx.MakeApiPtrs();
+    const OrtGraph& fake_graph = *reinterpret_cast<const OrtGraph*>(&fake_graph_sentinel_);
+    wrapper = std::make_unique<qnn::QnnModelWrapper>(
+        fake_graph, api_ptrs, null_logger_,
+        qnn_interface, backend_handle,
+        qnn_validator_interface, validator_backend_handle,
+        input_info, output_info,
+        qnn::QnnBackendType::HTP, qnn::ModelSettings{});
+  }
+};
+
+std::vector<int8_t> AsInt8(const std::vector<uint8_t>& bytes) {
+  std::vector<int8_t> out(bytes.size());
+  std::memcpy(out.data(), bytes.data(), bytes.size());
+  return out;
+}
+
+}  // namespace
+
+TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_Int4_AreSignExtended) {
+  MockInitWrapperFixture fx;
+  // Every representable INT4 value, so both nibble positions and the whole negative half are hit.
+  const std::vector<int8_t> values{-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7};
+  g_mock_init_reg.AddTensorInt4As8bit("w_int4", {16}, values);
+
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(qnn::GetEffectivelyConstantTensorBytes(*fx.wrapper, "w_int4", bytes).IsOK());
+  ASSERT_EQ(bytes.size(), values.size());  // one byte per element, not packed nibbles
+  // Without the sign extension, -8..-1 would come back as 8..15.
+  EXPECT_EQ(AsInt8(bytes), values);
+}
+
+TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_Uint4_AreUnchanged) {
+  MockInitWrapperFixture fx;
+  const std::vector<uint8_t> values{0, 1, 7, 8, 14, 15};
+  g_mock_init_reg.AddTensorUint4As8bit("w_uint4", {6}, values);
+
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(qnn::GetEffectivelyConstantTensorBytes(*fx.wrapper, "w_uint4", bytes).IsOK());
+  EXPECT_EQ(bytes, values);
+}
+
+TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_Uint8_AreUnchanged) {
+  MockInitWrapperFixture fx;
+  const std::vector<uint8_t> values{0, 1, 127, 128, 255};
+  g_mock_init_reg.AddTensorUint8("w_uint8", {5}, values);
+
+  std::vector<uint8_t> bytes;
+  ASSERT_TRUE(qnn::GetEffectivelyConstantTensorBytes(*fx.wrapper, "w_uint8", bytes).IsOK());
+  EXPECT_EQ(bytes, values);
+}
+
+TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_UnknownTensor_Fails) {
+  MockInitWrapperFixture fx;
+  std::vector<uint8_t> bytes;
+  EXPECT_FALSE(qnn::GetEffectivelyConstantTensorBytes(*fx.wrapper, "missing", bytes).IsOK());
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
@@ -1444,6 +1444,63 @@ TEST(QnnUnit_UtilsTest, BroadcastShape_HigherRankMixed) {
   EXPECT_EQ(out, (std::vector<uint32_t>{5, 3, 4}));
 }
 
+// =============================================================================
+// SignExtendUnpackedSubByteData
+//
+// UnpackInitializerData() expands a sub-byte initializer to one byte per element with the unused
+// high bits masked off, which QNN needs but which reads as a positive number in any int8_t-based
+// decode. These tests pin the recovery of the original two's-complement value.
+// =============================================================================
+
+TEST(QnnUnit_UtilsTest, SignExtendUnpackedSubByteData_Int4_RecoversNegativeValues) {
+  // Every representable INT4 value, so both nibble positions and the whole negative half are hit.
+  const std::vector<int8_t> values{-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7};
+  std::vector<uint8_t> bytes, expected;
+  for (int8_t v : values) {
+    bytes.push_back(static_cast<uint8_t>(v) & 0x0F);  // as UnpackInitializerData() leaves it
+    expected.push_back(static_cast<uint8_t>(v));
+  }
+  qnn::utils::SignExtendUnpackedSubByteData(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4,
+                                            gsl::make_span(bytes));
+  EXPECT_EQ(bytes, expected);
+}
+
+TEST(QnnUnit_UtilsTest, SignExtendUnpackedSubByteData_Int2_RecoversNegativeValues) {
+  const std::vector<int8_t> values{-2, -1, 0, 1};
+  std::vector<uint8_t> bytes, expected;
+  for (int8_t v : values) {
+    bytes.push_back(static_cast<uint8_t>(v) & 0x03);
+    expected.push_back(static_cast<uint8_t>(v));
+  }
+  qnn::utils::SignExtendUnpackedSubByteData(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2,
+                                            gsl::make_span(bytes));
+  EXPECT_EQ(bytes, expected);
+}
+
+TEST(QnnUnit_UtilsTest, SignExtendUnpackedSubByteData_UnsignedAndByteWideTypesAreLeftAlone) {
+  // UINT4 / UINT2 masked bytes already hold the value, and types stored one element per their own
+  // width were never masked, so all of these must pass through untouched.
+  const std::vector<uint8_t> original{0x00, 0x03, 0x0F, 0x80, 0xFF};
+  for (ONNXTensorElementDataType type : {ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT}) {
+    std::vector<uint8_t> bytes = original;
+    qnn::utils::SignExtendUnpackedSubByteData(type, gsl::make_span(bytes));
+    EXPECT_EQ(bytes, original) << "type " << static_cast<int>(type) << " must not be modified";
+  }
+}
+
+TEST(QnnUnit_UtilsTest, SignExtendUnpackedSubByteData_EmptySpanIsSafe) {
+  std::vector<uint8_t> bytes;
+  qnn::utils::SignExtendUnpackedSubByteData(ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4,
+                                            gsl::make_span(bytes));
+  EXPECT_TRUE(bytes.empty());
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 


### PR DESCRIPTION
## Problem

`UnpackInitializerData()` expands a sub-byte initializer to one byte per element and masks off the unused high bits (`UnpackInt4ToInt8()`: `dst[i] &= 0x0F`). That mask works around a QNN INT4 accuracy bug, so it has to stay.

`GetEffectivelyConstantTensorBytes()` hands those bytes to callers that read them as `int8_t`. `FoldConstantDequantizeLinear()` → `DequantizePerChannel()` therefore decodes every negative 4-bit weight as `q + 16` (`-1` → `15`, `-7` → `9`), leaving the folded `FLOAT_32` result with no negative values at all. The bit width is unrecoverable there: `CreateMapQuantize` collapses INT4/INT2 into `SFIXED_POINT_8` on non-GPU backends.

## Fix

New `utils::SignExtendUnpackedSubByteData()` for INT4/INT2, over the existing `Int4x2::SignExtendLower4Bits` / `Int2x4::SignExtendLower2Bits`. It masks before extending, so it is well-defined for any input byte and idempotent. `GetEffectivelyConstantTensorBytes()` calls it on the initializer branch, which also covers the same defect in `BatchNormalization`'s folded-scale path.

UINT4/UINT2 need nothing — the masked byte is already the value. The folded-constant branch needs nothing either: those bytes are fp32 or 8/16/32-bit, since `QuantizeData` has no sub-byte case.

Deliberately *not* fixed by dropping the mask in `UnpackInt4ToInt8` (re-exposes the QNN bug across unaudited call sites), nor by teaching `DequantizePerChannel` about ONNX types (misses BatchNormalization).

## Where it shows up

A w4a16 Qwen3 0.6B QDQ model: 32 KV-producing ops take the float fallback — DQ input `uint16`, Q output `uint8`, so `CheckQDQNodes()` declines the node unit — and fold their weights through this path. The fallback is correct behaviour; only its int4 decode was wrong.

## Validation

| Check | Before | After |
|---|---|---|
| 16 SpinQuant R3 Hadamard weights (analytically ±1/√128 = ±0.0883883) | all positive; spurious `0.113642` = `0.0883883 × 9/7`, i.e. −7 read as 9 | exactly **±0.0883883** |
| PSNR vs AIMET QuantSim, min/mean | prompt **−7.66 dB** | prompt **14.48 / 26.59 dB**, token **16.73 / 34.30 dB** |
| Windowed wikitext perplexity, 2032 scored tokens | baseline 223.98 (unquantized ref 203.47) | **208.72**, ΔCE −0.0706 ± 0.0270 |

All 57 part2 outputs match; inputs byte-identical across arms. DLCs are otherwise structurally identical — same op and tensor counts, same dtype histograms — so the change is numeric only.

Perplexity caveats: SpinQuant R2+R3 only (no AdaScale/SeqMSE), so the absolute PPL is not recipe-faithful, and the sweep is windowed (disjoint 128-token windows, empty KV). All arms consume byte-identical windows, so the comparison holds.

## Tests

- **`Convf32_PerChannelInt4DQConstWeight_SignRegression`** (`conv_test.cc`, CPU **and** HTP): folds a per-channel INT4 DQ with weights spanning −8..7 against the CPU EP. Both variants fail without the fix, while the neighbouring int8 chain tests keep passing.
- `qnn_utils_test.cc`: every INT4 and INT2 value, the types the helper must leave alone, the empty span.
- `qdq_constant_folding_test.cc` (new): mocked INT4 / UINT4 / UINT8 initializers plus the not-found path.

627 tests pass. Negative control: neutering the sign extension fails exactly the 2 graph tests and 3 sign-sensitive unit tests, nothing else.

## Notes

- #729 is stacked on this and fixes the same class of defect in the DQ-IntegerOp fusion helper (a latent path). This PR stands alone.
- Possible follow-up: `UnpackZeroPoints()` hand-rolls the same unmasking inline, and #729 adds a third consumer. Converging them — or letting `UnpackInitializerData()` sign-extend on request, where the element type is already in hand — would remove the recurring trap for the ~80 call sites sharing the implicit "bytes are masked" convention.
