### PR TITLE
[QNN EP] Sign-extend sub-byte weights when pre-dequantizing a per-channel integer-op weight

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_conv_integer_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_conv_integer_fusion.cc
@@ -503,7 +503,7 @@ Ort::Status DQConvIntegerFusion::CreateOrValidateOnQnn(QnnModelWrapper& qmw, boo
   } else {
     std::vector<uint8_t> float_bytes;
     RETURN_IF_ERROR(PreDequantizePerChannelWeight(qmw, *b_scale_iodef_, b_zp_iodef,
-                                                  is_signed_weight,
+                                                  ci_inputs[1].type,
                                                   b_info.shape[0], hwcn_weight_bytes,
                                                   float_bytes));
     if (validate) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
 
 namespace onnxruntime {
@@ -195,10 +196,31 @@ Ort::Status BuildWeightQuantParams(const QnnModelWrapper& qmw,
 Ort::Status PreDequantizePerChannelWeight(const QnnModelWrapper& qmw,
                                           const OrtNodeUnitIODef& b_scale_iodef,
                                           const OrtNodeUnitIODef* b_zp_iodef,
-                                          bool is_signed_weight,
+                                          ONNXTensorElementDataType weight_onnx_type,
                                           uint32_t out_channels,
                                           const std::vector<uint8_t>& quant_bytes,
                                           std::vector<uint8_t>& out_float_bytes) {
+  // Classify the weight type, rejecting anything UnpackInitializerData() does not deliver one byte
+  // per element -- a wider type would make the `num_elems = quant_bytes.size()` below an overcount.
+  bool is_signed_weight = false;
+  bool needs_sign_extend = false;
+  switch (weight_onnx_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      is_signed_weight = true;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2:
+      is_signed_weight = true;
+      needs_sign_extend = true;
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT2:
+      break;  // unsigned: the masked byte already holds the value
+    default:
+      return MAKE_EP_FAIL("Unsupported weight element type for per-channel pre-dequantization");
+  }
+
   std::vector<float> scales;
   RETURN_IF_ERROR(ReadFloatInitializer(qmw, b_scale_iodef, scales));
   RETURN_IF_NOT(scales.size() == static_cast<size_t>(out_channels),
@@ -224,15 +246,25 @@ Ort::Status PreDequantizePerChannelWeight(const QnnModelWrapper& qmw,
   // then memcpy out to the byte buffer that QnnTensorWrapper expects. Per-channel scales / zps
   // are applied along the LAST axis of the byte buffer, which holds for both Conv's HWCN
   // weight and MatMul's [K,N] weight.
+  // Signed sub-byte data arrives with the unused high bits masked off; recover the true value in a
+  // copy, `quant_bytes` being the caller's buffer.
+  std::vector<uint8_t> sign_extended_bytes;
+  gsl::span<const uint8_t> plain_bytes(quant_bytes);
+  if (needs_sign_extend) {
+    sign_extended_bytes = quant_bytes;
+    utils::SignExtendUnpackedSubByteData(weight_onnx_type, gsl::make_span(sign_extended_bytes));
+    plain_bytes = sign_extended_bytes;
+  }
+
   std::vector<float> floats(num_elems);
   if (is_signed_weight) {
-    const int8_t* src = reinterpret_cast<const int8_t*>(quant_bytes.data());
+    const int8_t* src = reinterpret_cast<const int8_t*>(plain_bytes.data());
     for (size_t i = 0; i < num_elems; ++i) {
       const size_t c = i % n;
       floats[i] = scales[c] * static_cast<float>(static_cast<int32_t>(src[i]) - zps_onnx[c]);
     }
   } else {
-    const uint8_t* src = quant_bytes.data();
+    const uint8_t* src = plain_bytes.data();
     for (size_t i = 0; i < num_elems; ++i) {
       const size_t c = i % n;
       floats[i] = scales[c] * static_cast<float>(static_cast<int32_t>(src[i]) - zps_onnx[c]);

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.h
@@ -71,13 +71,19 @@ Ort::Status BuildWeightQuantParams(const QnnModelWrapper& qmw,
                                    int32_t per_channel_axis,
                                    QnnQuantParamsWrapper& out_params);
 
-// Pre-dequantizes per-channel int8 / uint8 weight bytes to float32 bytes. Per-channel scales /
-// zps are applied along the LAST axis of the byte buffer (used by both Conv's HWCN weight and
-// MatMul's [K,N] weight, where the output-channel dimension is last in both cases).
+// Pre-dequantizes per-channel weight bytes to float32 bytes. Per-channel scales / zps are applied
+// along the LAST axis of the byte buffer (used by both Conv's HWCN weight and MatMul's [K,N]
+// weight, where the output-channel dimension is last in both cases).
+//
+// `quant_bytes` must be what QnnModelWrapper::UnpackInitializerData() produced, so
+// `weight_onnx_type` has to be a type it delivers one byte per element: 8-bit or sub-byte. Wider
+// types are rejected. The QNN element type cannot stand in for the ONNX one, because
+// CreateMapQuantize collapses INT4 / INT2 into SFIXED_POINT_8 and so records neither the bit width
+// (needed to sign-extend the masked bytes) nor the bytes-per-element.
 Ort::Status PreDequantizePerChannelWeight(const QnnModelWrapper& qmw,
                                           const OrtNodeUnitIODef& b_scale_iodef,
                                           const OrtNodeUnitIODef* b_zp_iodef,
-                                          bool is_signed_weight,
+                                          ONNXTensorElementDataType weight_onnx_type,
                                           uint32_t out_channels,
                                           const std::vector<uint8_t>& quant_bytes,
                                           std::vector<uint8_t>& out_float_bytes);

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_matmul_integer_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/dq_matmul_integer_fusion.cc
@@ -398,7 +398,7 @@ Ort::Status DQMatMulIntegerFusion::CreateOrValidateOnQnn(QnnModelWrapper& qmw, b
   } else {
     std::vector<uint8_t> float_bytes;
     RETURN_IF_ERROR(PreDequantizePerChannelWeight(qmw, *b_scale_iodef_, b_zp_iodef,
-                                                  is_signed_weight,
+                                                  mm_inputs[1].type,
                                                   n, b_quant_bytes, float_bytes));
     if (validate) {
       per_channel_float_bytes = std::move(float_bytes);

--- a/onnxruntime/test/providers/qnn/unit/dq_integer_op_fusion_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/dq_integer_op_fusion_utils_test.cc
@@ -1,0 +1,238 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Function-level unit tests for PreDequantizePerChannelWeight() in dq_integer_op_fusion_utils.cc.
+//
+// It reads the bytes QnnModelWrapper::UnpackInitializerData() produced as int8_t / uint8_t. A
+// sub-byte initializer arrives one byte per element with the unused high bits masked off, so an
+// INT4 -1 would dequantize as 15 unless it is sign-extended first.
+//
+// Initializer access is mocked through mock_init_registry, so no real ORT graph is needed.
+
+#include "gtest/gtest.h"
+
+#if !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/dq_integer_op_fusion_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+#include "test/providers/qnn/unit/mock_init_registry.h"
+#include "test/providers/qnn/unit/qnn_unit_test_utils.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// An IODef naming a plain (non-quantized) initializer, e.g. a fusion's B_scale input.
+OrtNodeUnitIODef MakeInitIODef(const std::string& name,
+                               ONNXTensorElementDataType type,
+                               std::vector<int64_t> shape) {
+  OrtNodeUnitIODef io_def;
+  io_def.name = name;
+  io_def.type = type;
+  io_def.shape = std::optional<std::vector<int64_t>>(std::move(shape));
+  return io_def;
+}
+
+std::vector<float> AsFloat(const std::vector<uint8_t>& bytes) {
+  std::vector<float> out(bytes.size() / sizeof(float));
+  std::memcpy(out.data(), bytes.data(), out.size() * sizeof(float));
+  return out;
+}
+
+// Masks each value to `bits`, i.e. what UnpackInitializerData() hands over for a sub-byte type.
+std::vector<uint8_t> MaskedSubByteBytes(const std::vector<int8_t>& values, int bits) {
+  const uint8_t mask = static_cast<uint8_t>((1u << bits) - 1u);
+  std::vector<uint8_t> bytes;
+  bytes.reserve(values.size());
+  for (int8_t v : values) {
+    bytes.push_back(static_cast<uint8_t>(v) & mask);
+  }
+  return bytes;
+}
+
+}  // namespace
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeInt4_MatchesReferenceDequant) {
+  MockInitWrapperFixture fx;
+  // [K=4, N=4] weight holding every representable INT4 value; per-channel scales apply along the
+  // last axis. Symmetric (no zero point), as w4a16 checkpoints emit.
+  constexpr uint32_t kOutChannels = 4;
+  const std::vector<int8_t> values{-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7};
+  const std::vector<float> scales{0.5f, 0.25f, 0.125f, 1.0f};
+  const OrtValueInfo* w_vi = g_mock_init_reg.AddTensorInt4As8bit("w", {4, 4}, values);
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, scales);
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+
+  // Feed the helper exactly what the fusion feeds it: the masked bytes from the wrapper.
+  std::vector<uint8_t> quant_bytes;
+  ASSERT_TRUE(fx.wrapper->UnpackInitializerData(w_vi, quant_bytes).IsOK());
+  ASSERT_EQ(quant_bytes.size(), values.size());
+
+  std::vector<uint8_t> float_bytes;
+  ASSERT_TRUE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef, /*b_zp_iodef=*/nullptr,
+                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, kOutChannels,
+                                                 quant_bytes, float_bytes)
+                  .IsOK());
+
+  const std::vector<float> got = AsFloat(float_bytes);
+  ASSERT_EQ(got.size(), values.size());
+  for (size_t i = 0; i < got.size(); ++i) {
+    // Without the sign extension the negative half would come out as (q + 16) * scale.
+    EXPECT_FLOAT_EQ(got[i], scales[i % kOutChannels] * static_cast<float>(values[i]))
+        << "element " << i;
+  }
+}
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeInt2_MatchesReferenceDequant) {
+  MockInitWrapperFixture fx;
+  constexpr uint32_t kOutChannels = 2;
+  const std::vector<float> scales{0.5f, 0.25f};
+  const std::vector<int8_t> values{-2, -1, 0, 1};
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, scales);
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+
+  const std::vector<uint8_t> quant_bytes = MaskedSubByteBytes(values, /*bits=*/2);
+  std::vector<uint8_t> float_bytes;
+  ASSERT_TRUE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef, /*b_zp_iodef=*/nullptr,
+                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2, kOutChannels,
+                                                 quant_bytes, float_bytes)
+                  .IsOK());
+
+  const std::vector<float> got = AsFloat(float_bytes);
+  ASSERT_EQ(got.size(), values.size());
+  for (size_t i = 0; i < got.size(); ++i) {
+    EXPECT_FLOAT_EQ(got[i], scales[i % kOutChannels] * static_cast<float>(values[i]))
+        << "element " << i;
+  }
+}
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeUint4_IsNotSignExtended) {
+  // An unsigned sub-byte masked byte already holds the value, so 15 must stay 15, not become -1.
+  MockInitWrapperFixture fx;
+  constexpr uint32_t kOutChannels = 2;
+  const std::vector<float> scales{0.5f, 0.25f};
+  const std::vector<uint8_t> values{0, 1, 8, 15};
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, scales);
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+
+  std::vector<uint8_t> float_bytes;
+  ASSERT_TRUE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef, /*b_zp_iodef=*/nullptr,
+                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4, kOutChannels,
+                                                 values, float_bytes)
+                  .IsOK());
+
+  const std::vector<float> got = AsFloat(float_bytes);
+  ASSERT_EQ(got.size(), values.size());
+  for (size_t i = 0; i < got.size(); ++i) {
+    EXPECT_FLOAT_EQ(got[i], scales[i % kOutChannels] * static_cast<float>(values[i]))
+        << "element " << i;
+  }
+}
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeInt8_MatchesReferenceDequant) {
+  // The 8-bit path must stay exactly as it was; this is the control for the sub-byte cases above.
+  MockInitWrapperFixture fx;
+  constexpr uint32_t kOutChannels = 2;
+  const std::vector<float> scales{0.5f, 0.25f};
+  const std::vector<int8_t> values{-128, -1, 0, 127};
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, scales);
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+
+  std::vector<uint8_t> quant_bytes(values.size());
+  std::memcpy(quant_bytes.data(), values.data(), values.size());
+
+  std::vector<uint8_t> float_bytes;
+  ASSERT_TRUE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef, /*b_zp_iodef=*/nullptr,
+                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8, kOutChannels,
+                                                 quant_bytes, float_bytes)
+                  .IsOK());
+
+  const std::vector<float> got = AsFloat(float_bytes);
+  ASSERT_EQ(got.size(), values.size());
+  for (size_t i = 0; i < got.size(); ++i) {
+    EXPECT_FLOAT_EQ(got[i], scales[i % kOutChannels] * static_cast<float>(values[i]))
+        << "element " << i;
+  }
+}
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeUint8WithZeroPoint_SubtractsZeroPoint) {
+  // Pins the zero-point arithmetic the decoded value feeds into.
+  MockInitWrapperFixture fx;
+  constexpr uint32_t kOutChannels = 2;
+  const std::vector<float> scales{0.5f, 0.25f};
+  const std::vector<uint8_t> values{0, 100, 200, 255};
+  const std::vector<uint8_t> zps{128, 10};
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, scales);
+  g_mock_init_reg.AddTensorUint8("w_zp", {kOutChannels}, zps);
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+  auto zp_iodef = MakeInitIODef("w_zp", ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, {kOutChannels});
+
+  std::vector<uint8_t> float_bytes;
+  ASSERT_TRUE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef, &zp_iodef,
+                                                 ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8, kOutChannels,
+                                                 values, float_bytes)
+                  .IsOK());
+
+  const std::vector<float> got = AsFloat(float_bytes);
+  ASSERT_EQ(got.size(), values.size());
+  for (size_t i = 0; i < got.size(); ++i) {
+    const size_t c = i % kOutChannels;
+    EXPECT_FLOAT_EQ(got[i],
+                    scales[c] * (static_cast<float>(values[i]) - static_cast<float>(zps[c])))
+        << "element " << i;
+  }
+}
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeSubByteZeroPoint_FailsClosed) {
+  // ONNX requires the zero point to share the weight's type, but ReadZeroPointAsInt32() reads only
+  // INT8 / UINT8. An asymmetric sub-byte weight is therefore declined, not silently mis-decoded.
+  MockInitWrapperFixture fx;
+  constexpr uint32_t kOutChannels = 2;
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, {0.5f, 0.25f});
+  g_mock_init_reg.AddTensorInt4As8bit("w_zp", {kOutChannels}, {1, -1});
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+  auto zp_iodef = MakeInitIODef("w_zp", ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, {kOutChannels});
+
+  const std::vector<uint8_t> quant_bytes = MaskedSubByteBytes({-1, 2, -3, 4}, /*bits=*/4);
+  std::vector<uint8_t> float_bytes;
+  EXPECT_FALSE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef, &zp_iodef,
+                                                  ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4, kOutChannels,
+                                                  quant_bytes, float_bytes)
+                   .IsOK());
+}
+
+TEST(QnnUnit_DqIntegerOpFusionUtilsTest, PreDequantizeWiderThanEightBitWeight_FailsClosed) {
+  // quant_bytes.size() is taken as the element count, which only holds for types delivered one
+  // byte per element. Anything wider must be rejected rather than dequantized as garbage.
+  MockInitWrapperFixture fx;
+  constexpr uint32_t kOutChannels = 2;
+  g_mock_init_reg.AddTensorFloat("w_scale", {kOutChannels}, {0.5f, 0.25f});
+  auto scale_iodef = MakeInitIODef("w_scale", ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, {kOutChannels});
+
+  const std::vector<uint8_t> quant_bytes(8, 0);
+  for (ONNXTensorElementDataType type : {ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32,
+                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT}) {
+    std::vector<uint8_t> float_bytes;
+    EXPECT_FALSE(qnn::PreDequantizePerChannelWeight(*fx.wrapper, scale_iodef,
+                                                    /*b_zp_iodef=*/nullptr, type, kOutChannels,
+                                                    quant_bytes, float_bytes)
+                     .IsOK())
+        << "type " << static_cast<int>(type) << " must be rejected";
+  }
+}
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD) && QNN_EP_INTERNAL_SYMBOL_ACCESS

--- a/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
+++ b/onnxruntime/test/providers/qnn/unit/mock_init_registry.h
@@ -8,14 +8,19 @@
 // made by QnnQuantParamsWrapper::Init (UnpackScales / UnpackZeroPoints) and
 // QnnModelWrapper::UnpackInitializerData.
 //
-// Usage:
-//   QnnModelWrapperTestContext ctx;
+// Usage, wiring the stubs by hand:
+//   OrtApiStubContext ctx;
 //   auto& reg = g_mock_init_reg;
 //   reg.clear();
 //   auto scale_vi = reg.AddScalarFloat("scale", 0.1f);
 //   auto zp_vi    = reg.AddScalarUint8("zp", 0);
 //   SetupMockInitRegistryStubs(ctx);
 //   // Pass scale_vi / zp_vi as OrtNodeUnitIODef::QuantParam fields.
+//
+// Usage, for code that needs a QnnModelWrapper -- see MockInitWrapperFixture below:
+//   MockInitWrapperFixture fx;
+//   g_mock_init_reg.AddTensorFloat("scale", {2}, {0.1f, 0.2f});
+//   // ... call EP code with *fx.wrapper
 //
 // The registry and stubs live in an anonymous namespace, so each TU including
 // this header gets its own private copy of `g_mock_init_reg`. Tests should
@@ -42,10 +47,12 @@
 
 #include <cstring>
 #include <deque>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/ort_api.h"
 
 #include "test/providers/qnn/unit/qnn_unit_test_utils.h"
@@ -325,6 +332,43 @@ inline void SetupMockInitRegistryStubs(T& ctx) {
   ctx.stub_ort_api.ValueInfo_GetInitializerValue = StubMockValueInfoGetInitializerValue;
   ctx.stub_ort_api.GetTensorData = StubMockGetTensorData;
 }
+
+// A QnnModelWrapper over a fake graph whose initializers resolve out of g_mock_init_reg, which is
+// what makes IsConstantInput() / GetConstantTensor() / UnpackInitializerData() work by name.
+// Clears the registry on construction; tests add their initializers afterwards.
+struct MockInitWrapperFixture {
+  OrtApiStubContext ctx;
+  // Ort::ConstValueInfo / ConstTypeInfo wrappers (e.g. inside
+  // utils::GetOnnxTensorElemDataType) dispatch on the GLOBAL Ort::GetApi(), not on api_ptrs_.
+  // Without this override a mock OrtValueInfo* would reach the real ORT runtime and SIGSEGV.
+  OrtGlobalApiOverride global_api_override{&ctx.stub_ort_api};
+  QNN_INTERFACE_VER_TYPE qnn_interface = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t backend_handle = nullptr;
+  QNN_INTERFACE_VER_TYPE qnn_validator_interface = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t validator_backend_handle = nullptr;
+  Ort::Logger null_logger_{MakeNullLogger()};
+  int fake_graph_sentinel_{};
+  qnn::GraphInputOutputInfo input_info;
+  qnn::GraphInputOutputInfo output_info;
+  std::unique_ptr<qnn::QnnModelWrapper> wrapper;
+
+  MockInitWrapperFixture() {
+    g_mock_init_reg.clear();
+    // Seed from the real OrtApi so everything these paths touch beyond the mocked initializer
+    // queries still works -- notably CreateStatus / ReleaseStatus, which MAKE_EP_FAIL() needs on
+    // an error path and which a zero-initialised table would leave null.
+    ctx.stub_ort_api = *OrtGetApiBase()->GetApi(ORT_API_VERSION);
+    SetupMockInitRegistryStubs(ctx);
+    ApiPtrs api_ptrs = ctx.MakeApiPtrs();
+    const OrtGraph& fake_graph = *reinterpret_cast<const OrtGraph*>(&fake_graph_sentinel_);
+    wrapper = std::make_unique<qnn::QnnModelWrapper>(
+        fake_graph, api_ptrs, null_logger_,
+        qnn_interface, backend_handle,
+        qnn_validator_interface, validator_backend_handle,
+        input_info, output_info,
+        qnn::QnnBackendType::HTP, qnn::ModelSettings{});
+  }
+};
 
 }  // namespace
 

--- a/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
@@ -17,7 +17,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -32,42 +31,6 @@ namespace onnxruntime {
 namespace test {
 
 namespace {
-
-// QnnModelWrapper over a fake graph whose initializers come from g_mock_init_reg, which is what
-// makes IsConstantInput() / GetConstantTensor() / UnpackInitializerData() resolve by name.
-struct MockInitWrapperFixture {
-  OrtApiStubContext ctx;
-  // The Ort::ConstValueInfo / ConstTypeInfo wrappers that utils::GetOnnxTensorElemDataType() goes
-  // through dispatch on the GLOBAL Ort::GetApi(), not on api_ptrs_, so without this the mock
-  // OrtValueInfo* would be handed to the real ORT runtime and SIGSEGV.
-  OrtGlobalApiOverride global_api_override{&ctx.stub_ort_api};
-  QNN_INTERFACE_VER_TYPE qnn_interface = QNN_INTERFACE_VER_TYPE_INIT;
-  Qnn_BackendHandle_t backend_handle = nullptr;
-  QNN_INTERFACE_VER_TYPE qnn_validator_interface = QNN_INTERFACE_VER_TYPE_INIT;
-  Qnn_BackendHandle_t validator_backend_handle = nullptr;
-  Ort::Logger null_logger_{MakeNullLogger()};
-  int fake_graph_sentinel_{};
-  qnn::GraphInputOutputInfo input_info;
-  qnn::GraphInputOutputInfo output_info;
-  std::unique_ptr<qnn::QnnModelWrapper> wrapper;
-
-  MockInitWrapperFixture() {
-    g_mock_init_reg.clear();
-    // Seed from the real OrtApi so everything these paths touch beyond the mocked initializer
-    // queries still works -- notably CreateStatus / ReleaseStatus, which MAKE_EP_FAIL() needs on
-    // the not-found path and which a zero-initialised table would leave null.
-    ctx.stub_ort_api = *OrtGetApiBase()->GetApi(ORT_API_VERSION);
-    SetupMockInitRegistryStubs(ctx);
-    ApiPtrs api_ptrs = ctx.MakeApiPtrs();
-    const OrtGraph& fake_graph = *reinterpret_cast<const OrtGraph*>(&fake_graph_sentinel_);
-    wrapper = std::make_unique<qnn::QnnModelWrapper>(
-        fake_graph, api_ptrs, null_logger_,
-        qnn_interface, backend_handle,
-        qnn_validator_interface, validator_backend_handle,
-        input_info, output_info,
-        qnn::QnnBackendType::HTP, qnn::ModelSettings{});
-  }
-};
 
 std::vector<int8_t> AsInt8(const std::vector<uint8_t>& bytes) {
   std::vector<int8_t> out(bytes.size());


### PR DESCRIPTION
## Summary

Defensive hardening of `PreDequantizePerChannelWeight()`:

- Pass the ONNX weight type, sign-extend unpacked INT2/INT4 values, preserve 8-bit and unsigned behavior, and reject unsupported wider types.
- Add seven focused helper tests and share the existing mock-wrapper fixture.

## Review status

This is not needed for reachable production behavior. ONNX restricts `MatMulInteger` and `ConvInteger` inputs to INT8/UINT8, ORT rejects an INT4 graph as `INVALID_GRAPH`, and both QNN fusion gates reject non-8-bit weights before this helper. The Qwen W4A16 issue is already fixed by #728.

**Recommendation: close without merging.** The patch only hardens direct/helper invocation of an otherwise unreachable sub-byte path.

## Validation

- Coverage-symbol provider tests: 11/11 passed on `tetra18-linux` (7 new tests plus 4 fixture consumers).
- Qwen3-0.6B legacy converter vs EP: all jobs passed; fresh PSNR metrics exactly match the prior accepted run; EP PPL 208.7230 vs baseline 223.9822.
- Standard CI passed. The coverage job compiled the new test, then failed during wheel packaging with `No space left on device`.