### PR TITLE
[QNN EP] Fix FP16 Reciprocal divisor serialization

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/reciprocal_op_builder.cc
@@ -71,10 +71,17 @@ Ort::Status ReciprocalOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qn
     size_t element_size = qnn::utils::GetElementSizeByType(divisor_qnn_data_type);
     divisor_data.resize(element_size);
     std::memcpy(divisor_data.data(), &quantized_divisor_value, element_size);
+  } else if (divisor_qnn_data_type == QNN_DATATYPE_FLOAT_16) {
+    Ort::Float16_t one(1.0f);
+    divisor_data.resize(sizeof(Ort::Float16_t));
+    std::memcpy(divisor_data.data(), &one.val, sizeof(Ort::Float16_t));
+  } else if (divisor_qnn_data_type == QNN_DATATYPE_BFLOAT_16) {
+    Ort::BFloat16_t one(1.0f);
+    divisor_data.resize(sizeof(Ort::BFloat16_t));
+    std::memcpy(divisor_data.data(), &one.val, sizeof(Ort::BFloat16_t));
   } else {
-    // Create a float divisor tensor
-    divisor_data.resize(sizeof(float));
     float one = 1.0f;
+    divisor_data.resize(sizeof(float));
     std::memcpy(divisor_data.data(), &one, sizeof(float));
   }
 

--- a/onnxruntime/test/providers/qnn/bf16_test.cc
+++ b/onnxruntime/test/providers/qnn/bf16_test.cc
@@ -252,6 +252,26 @@ TEST_F(QnnHTPBackendTests, DISABLED_BF16_Sigmoid) {
       shape);
 }
 
+// Test BF16 handling with Reciprocal, which is lowered to ElementWiseDivide against a
+// builder-created constant divisor tensor. Covers that divisor under BF16 mode.
+static GetTestModelFn BuildBF16ReciprocalTestCase(const TestInputDef<float>& input_def) {
+  return [input_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", input_def);
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    builder.AddNode("reciprocal_node", "Reciprocal", {"input"}, {"output"}, "", attributes);
+    builder.MakeOutput("output");
+  };
+}
+
+TEST_F(QnnHTPBackendTests, DISABLED_BF16_Reciprocal) {
+  std::vector<int64_t> shape = {2, 3, 4};
+  RunBF16ModelTest(
+      BuildBF16ReciprocalTestCase(
+          TestInputDef<float>(shape, false, GetSequentialFloatData(shape, 1.0f, 0.1f))),
+      shape);
+}
+
 // Test BF16 handling with Softmax
 static GetTestModelFn BuildBF16SoftmaxTestCase(const TestInputDef<float>& input_def, int64_t axis) {
   return [input_def, axis](ModelTestBuilder& builder) {

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -1274,6 +1274,14 @@ TEST_F(QnnHTPBackendTests, Reciprocal_Basic_FLOAT) {
                    ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnHTPBackendTests, Reciprocal_Basic_FP16) {
+  RunFP16OpTest("Reciprocal",
+                {TestInputDef<float>({2, 2}, false, {1.0f, 2.0f, 0.5f, 4.0f})},
+                {},  // No attributes
+                13,
+                ExpectedEPNodeAssignment::All);
+}
+
 TEST_F(QnnHTPBackendTests, Reciprocal_QU8) {
   RunQDQOpTest<uint8_t>("Reciprocal",
                         {TestInputDef<float>({2, 2}, false, GetFloatDataInRange(1.0f, 5.0f, 4))},


### PR DESCRIPTION
## Summary
- Serialize the static `1.0` divisor emitted for `Reciprocal` using the matching QNN tensor element type.
- Add QNN HTP FP16 `Reciprocal` coverage.

## Root Cause
For FP16 input, the divisor is declared as `QNN_DATATYPE_FLOAT_16`, so QNN expects a one-element static buffer of 2 bytes. The builder always allocated and copied an FP32 `float`, producing a 4-byte client buffer and the reported static-tensor data-length mismatch.

The fix serializes `Ort::Float16_t(1.0f)` for FP16 and the equivalent BF16 scalar for the analogous two-byte type. The FP32 and quantized paths are unchanged.