### PR TITLE
Ensure unique QNN graph node names

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -306,7 +306,9 @@ bool QnnModelWrapper::ProcessBF16InputConversion(const std::string& qnn_node_nam
                     ORT_LOGGING_LEVEL_VERBOSE,
                     ("BF16: Adding Cast op " + input_name + " -> " + cast_output_name).c_str());
 
-        QnnOpProperty cast_op(cast_output_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CAST,
+        QnnOpProperty cast_op(MakeUniqueQnnNodeName(cast_output_name),
+                              QNN_OP_PACKAGE_NAME_QTI_AISW,
+                              QNN_OP_CAST,
                               std::vector<std::string>{input_name},
                               std::vector<std::string>{cast_output_name},
                               std::vector<std::string>{});
@@ -328,7 +330,9 @@ bool QnnModelWrapper::ProcessBF16InputConversion(const std::string& qnn_node_nam
         ORT_CXX_LOG(logger_,
                     ORT_LOGGING_LEVEL_VERBOSE,
                     ("BF16: Adding Cast op for static tensor " + input_name + " -> " + cast_output_name).c_str());
-        QnnOpProperty cast_op(cast_output_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CAST,
+        QnnOpProperty cast_op(MakeUniqueQnnNodeName(cast_output_name),
+                              QNN_OP_PACKAGE_NAME_QTI_AISW,
+                              QNN_OP_CAST,
                               std::vector<std::string>{input_name},
                               std::vector<std::string>{cast_output_name},
                               std::vector<std::string>{});
@@ -513,12 +517,13 @@ bool QnnModelWrapper::CreateQnnNode(const std::string& qnn_node_name,
     return validation_status.IsOK();
   } else {
     // Standard execution - just add the node to the op list
-    QnnOpProperty qnn_op(qnn_node_name, package_name, qnn_node_type,
+    const std::string unique_node_name = MakeUniqueQnnNodeName(qnn_node_name);
+    QnnOpProperty qnn_op(unique_node_name, package_name, qnn_node_type,
                          std::move(input_names), std::move(output_names), std::move(param_tensor_names));
     qnn_op_property_list_.push_back(std::move(qnn_op));
 
     if (op_trace_collector_) {
-      op_trace_collector_->RecordOpMapping(qnn_node_name, qnn_node_type,
+      op_trace_collector_->RecordOpMapping(unique_node_name, qnn_node_type,
                                            qnn_op_property_list_.back().GetOutputNames());
     }
 
@@ -575,7 +580,7 @@ bool QnnModelWrapper::ProcessBF16Conversions(std::vector<QnnOpProperty>& final_o
                 ("[BF16] Adding " + std::to_string(graph_output_cast_ops.size()) + "output cast operations").c_str());
     for (size_t i = 0; i < graph_output_cast_ops.size(); ++i) {
       const auto& [bf16_name, fp32_name] = graph_output_cast_ops[i];
-      std::string cast_node_name = bf16_name;
+      std::string cast_node_name = MakeUniqueQnnNodeName(bf16_name);
       ORT_CXX_LOG(logger_,
                   ORT_LOGGING_LEVEL_VERBOSE,
                   ("[BF16] Adding output Cast op: " + cast_node_name + " (" + bf16_name + " -> " + fp32_name + ")")
@@ -600,6 +605,25 @@ bool QnnModelWrapper::ProcessBF16Conversions(std::vector<QnnOpProperty>& final_o
   }
 
   return true;
+}
+
+std::string QnnModelWrapper::MakeUniqueQnnNodeName(const std::string& requested_name) {
+  if (qnn_node_names_.insert(requested_name).second) {
+    return requested_name;
+  }
+
+  // requested_name already occupies one entry, so one suffix in this range is free.
+  const size_t max_suffix = qnn_node_names_.size() + 1;
+  for (size_t suffix = 2; suffix <= max_suffix; ++suffix) {
+    std::string unique_name = requested_name + "_" + std::to_string(suffix);
+    if (qnn_node_names_.insert(unique_name).second) {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Renamed duplicate QNN node " + requested_name + " to " + unique_name).c_str());
+      return unique_name;
+    }
+  }
+
+  ORT_CXX_API_THROW("Failed to allocate a unique QNN node name.", ORT_EP_FAIL);
 }
 
 // Register graph inputs/outputs in ONNX declaration order. This ensures DLC

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -553,6 +553,10 @@ class QnnModelWrapper {
 
   bool ProcessBF16Conversions(std::vector<QnnOpProperty>& final_ops);
 
+  // QNN requires node names to be unique within a graph. Reserve names here,
+  // where every composed QNN node is collected.
+  std::string MakeUniqueQnnNodeName(const std::string& requested_name);
+
   const std::string* GetTensorNameOverride(const std::string& internal) const;
 
   const OrtGraph& ort_graph_;
@@ -573,6 +577,7 @@ class QnnModelWrapper {
   // All QnnParamWrapper for the graph
   std::unordered_map<std::string, QnnParamWrapper> model_params_map_;
   std::vector<QnnOpProperty> qnn_op_property_list_;
+  std::unordered_set<std::string> qnn_node_names_;
   // <tensor_name, qnn_tensor_id> -- stores the QNN-assigned ID once the tensor is created
   // it includes normal qnn_tensors and qnn_tensors inside param_tensors
   std::unordered_map<std::string, uint32_t> qnn_tensor_id_map_;

--- a/onnxruntime/test/providers/qnn/qnn_node_group/transpose_reshape_transpose_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/transpose_reshape_transpose_fusion_test.cc
@@ -75,6 +75,27 @@ GetTestModelFn BuildTransposeReshapeTransposeWithContextTestCase(
   };
 }
 
+// Builds a fusable pattern followed by an ONNX node whose name matches the
+// legacy generated name for the fused Reshape.
+GetTestModelFn BuildTransposeReshapeTransposeNameCollisionTestCase() {
+  return [](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input", TestInputDef<float>({2, 3, 4}, false, -1.0f, 1.0f));
+
+    builder.AddNode("transpose1", "Transpose", {"input"}, {"transpose1_out"}, "",
+                    {test::MakeAttribute("perm", std::vector<int64_t>{1, 2, 0})});
+    builder.Make1DInitializer<int64_t>("reshape_shape", {12, 2});
+    builder.AddNode("reshape", "Reshape", {"transpose1_out", "reshape_shape"}, {"reshape_out"});
+    builder.AddNode("transpose2", "Transpose", {"reshape_out"}, {"transpose2_out"}, "",
+                    {test::MakeAttribute("perm", std::vector<int64_t>{1, 0})});
+
+    // Validation used to consume "transpose1", making the fused Reshape
+    // "transpose1_2", which collided with this source node during composition.
+    builder.MakeScalarInitializer<float>("bias", 0.25f);
+    builder.MakeOutput("output");
+    builder.AddNode("transpose1_2", "Add", {"transpose2_out", "bias"}, {"output"});
+  };
+}
+
 ProviderOptions GetProviderOptions() {
   ProviderOptions provider_options;
   provider_options["backend_type"] = "htp";
@@ -117,6 +138,25 @@ TEST_F(QnnHTPBackendTests, TransposeReshapeTransposeFusion_Basic) {
   // Verify fusion: should have Reshape, no Transpose
   AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
   AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 0);
+}
+
+TEST_F(QnnHTPBackendTests, TransposeReshapeTransposeFusion_NameCollision) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+  const std::filesystem::path json_qnn_graph_dir = "TransposeReshapeTransposeFusion_NameCollision";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options = GetProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildTransposeReshapeTransposeNameCollisionTestCase(), provider_options, 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Reshape", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Transpose", 0);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseAdd", 1);
 }
 
 // Test Case 2: Fusable pattern with surrounding ops

--- a/onnxruntime/test/providers/qnn/unit/qnn_model_wrapper_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_model_wrapper_test.cc
@@ -679,6 +679,13 @@ Qnn_ErrorHandle_t StubTensorCreateSuccess(Qnn_GraphHandle_t, Qnn_Tensor_t*) {
 Qnn_ErrorHandle_t StubGraphAddNode(Qnn_GraphHandle_t, Qnn_OpConfig_t) {
   return QNN_GRAPH_NO_ERROR;
 }
+
+std::vector<std::string> captured_qnn_node_names;
+
+Qnn_ErrorHandle_t StubGraphAddNodeCaptureNames(Qnn_GraphHandle_t, Qnn_OpConfig_t op_config) {
+  captured_qnn_node_names.emplace_back(op_config.v1.name);
+  return QNN_GRAPH_NO_ERROR;
+}
 }  // namespace
 
 // ComposeQnnGraph succeeds when tensors are registered and stubs are in place.
@@ -703,6 +710,40 @@ TEST(QnnUnit_ModelWrapperTest, ComposeQnnGraph_NativeTensors_Succeeds) {
                                      {"inp"}, {"out"}, {}, /*do_op_validation=*/false));
 
   EXPECT_TRUE(wrapper->ComposeQnnGraph());
+}
+
+TEST(QnnUnit_ModelWrapperTest, ComposeQnnGraph_DuplicateNodeNames_AreRenamed) {
+  QnnModelWrapperTestContext ctx;
+  ctx.qnn_interface.tensorCreateGraphTensor = StubTensorCreateSuccess;
+  ctx.qnn_interface.graphAddNode = StubGraphAddNodeCaptureNames;
+  qnn::ModelSettings settings{};
+  auto wrapper = ctx.CreateWrapper(settings);
+
+  qnn::QnnTensorWrapper input("input", QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
+                              qnn::QnnQuantParamsWrapper(), std::vector<uint32_t>{4});
+  qnn::QnnTensorWrapper intermediate("intermediate", QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
+                                     qnn::QnnQuantParamsWrapper(), std::vector<uint32_t>{4});
+  qnn::QnnTensorWrapper intermediate2("intermediate2", QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
+                                      qnn::QnnQuantParamsWrapper(), std::vector<uint32_t>{4});
+  qnn::QnnTensorWrapper output("output", QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_32,
+                               qnn::QnnQuantParamsWrapper(), std::vector<uint32_t>{4});
+  ASSERT_TRUE(wrapper->AddTensorWrapper(std::move(input)));
+  ASSERT_TRUE(wrapper->AddTensorWrapper(std::move(intermediate)));
+  ASSERT_TRUE(wrapper->AddTensorWrapper(std::move(intermediate2)));
+  ASSERT_TRUE(wrapper->AddTensorWrapper(std::move(output)));
+  ASSERT_TRUE(wrapper->CreateQnnNode("duplicate", QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CAST,
+                                     {"input"}, {"intermediate"}, {}, false));
+  ASSERT_TRUE(wrapper->CreateQnnNode("duplicate", QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CAST,
+                                     {"intermediate"}, {"intermediate2"}, {}, false));
+  ASSERT_TRUE(wrapper->CreateQnnNode("duplicate_2", QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CAST,
+                                     {"intermediate2"}, {"output"}, {}, false));
+
+  captured_qnn_node_names.clear();
+  ASSERT_TRUE(wrapper->ComposeQnnGraph());
+  ASSERT_EQ(captured_qnn_node_names.size(), 3u);
+  EXPECT_EQ(captured_qnn_node_names[0], "duplicate");
+  EXPECT_EQ(captured_qnn_node_names[1], "duplicate_2");
+  EXPECT_EQ(captured_qnn_node_names[2], "duplicate_2_2");
 }
 
 // With graph I/O names set, RegisterGraphInputOutputInOrder registers APP_WRITE / APP_READ


### PR DESCRIPTION
## Summary
- QNN graph node names must be unique across the fully composed graph. `UniqueNameGenerator` only counts repeated base-plus-suffix requests; it cannot reserve names requested later or raw ONNX names.
- Reserve each emitted QNN node name centrally in `QnnModelWrapper`; validation remains non-mutating. BF16-generated Cast operations use the same allocator.
- Use the established `_<N>` suffix convention and cover both the real collision shape and collisions with literal suffixed names.

Tracks https://github.com/qcom-ai-hub/tetracode/issues/20855.

## Validation
- Built the touched ARM64 QNN provider and provider-test translation units.
- Replayed the original ZeoDepth production ONNX: the unpatched provider fails with `EP_FAIL: Failed to compose Qnn graph` / QNN `6005` and emits no DLC; the patched provider emits one `1,907,062,452`-byte DLC.
- The focused wrapper test verifies `duplicate`, `duplicate_2`, and a later literal `duplicate_2` resolving to `duplicate_2_2`.
- `git diff --check` passed.

The full `onnxruntime_provider_test` target cannot complete in this local prebuilt-ORT configuration because the supplied headers omit `cpu_provider_factory.h`. The repository lint hook is also blocked while installing pinned `lintrunner==0.12.7` because the published package metadata is rejected by the current `uv` parser.