### PR TITLE
[QNN EP] Decompose Cast(fp32->bool) into Sign->Abs->Cast on HTP

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -43,11 +43,10 @@ class CastOpBuilder : public BaseOpBuilder {
   // True when the ONNX Cast/CastLike is (fp32|fp16) -> bool. Independent of backend.
   bool IsFpToBoolCast(const OrtNodeUnit& node_unit) const;
 
-  bool ShouldDecomposeFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
-                                   const OrtNodeUnit& node_unit) const;
-
-  bool ShouldUseNotEqualForFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
-                                        const OrtNodeUnit& node_unit) const;
+  // True when the fp -> bool Cast should be lowered as Sign -> Abs -> Cast on HTP.
+  // Assumes IsFpToBoolCast(node_unit) is already true; only checks backend + input dtype.
+  bool UseSignAbsCastForHtp(const QnnModelWrapper& qnn_model_wrapper,
+                            const OrtNodeUnit& node_unit) const;
 
   Ort::Status ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
                                            const OrtNodeUnit& node_unit,
@@ -81,27 +80,15 @@ bool CastOpBuilder::IsFpToBoolCast(const OrtNodeUnit& node_unit) const {
           output_qnn_dtype == QNN_DATATYPE_BOOL_8);
 }
 
-bool CastOpBuilder::ShouldDecomposeFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
-                                                const OrtNodeUnit& node_unit) const {
-  if (!IsFpToBoolCast(node_unit)) {
-    return false;
-  }
-  ONNXTensorElementDataType input_type = node_unit.Inputs()[0].type;
+bool CastOpBuilder::UseSignAbsCastForHtp(const QnnModelWrapper& qnn_model_wrapper,
+                                         const OrtNodeUnit& node_unit) const {
   Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
-  if (!utils::GetQnnDataType(false, input_type, input_qnn_dtype).IsOK() ||
+  if (!utils::GetQnnDataType(false, node_unit.Inputs()[0].type, input_qnn_dtype).IsOK() ||
       input_qnn_dtype != QNN_DATATYPE_FLOAT_32) {
     return false;
   }
   const QnnBackendType be = qnn_model_wrapper.GetQnnBackendType();
   return (be == QnnBackendType::HTP || be == QnnBackendType::SERIALIZER);
-}
-
-bool CastOpBuilder::ShouldUseNotEqualForFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
-                                                     const OrtNodeUnit& node_unit) const {
-  if (!IsFpToBoolCast(node_unit)) {
-    return false;
-  }
-  return !ShouldDecomposeFpToBoolCast(qnn_model_wrapper, node_unit);
 }
 
 Ort::Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
@@ -158,9 +145,10 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + input_name).c_str());
     input_names.push_back(input_name);
-    return ShouldUseNotEqualForFpToBoolCast(qnn_model_wrapper, node_unit)
-               ? ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger)
-               : Ort::Status();
+    if (IsFpToBoolCast(node_unit) && !UseSignAbsCastForHtp(qnn_model_wrapper, node_unit)) {
+      return ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger);
+    }
+    return Ort::Status();
   }
 
   // 4. Unpack initializer data if the input is a constant.
@@ -192,9 +180,11 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   input_names.push_back(input_name);
 
   // 7. Append the zero-tensor input for the NotEqual lowering when applicable.
-  return ShouldUseNotEqualForFpToBoolCast(qnn_model_wrapper, node_unit)
-             ? ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger)
-             : Ort::Status();
+  // FP -> bool on non-HTP backends needs the zero constant for the NotEqual lowering.
+  if (IsFpToBoolCast(node_unit) && !UseSignAbsCastForHtp(qnn_model_wrapper, node_unit)) {
+    return ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger);
+  }
+  return Ort::Status();
 }
 
 Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_model_wrapper,
@@ -303,43 +293,51 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
                 "Failed to add output tensor for QNN Cast node.");
 
-  // 5. Sign -> Abs -> Cast lowering for HTP fp32 -> bool.
-  if (ShouldDecomposeFpToBoolCast(qnn_model_wrapper, node_unit)) {
-    RETURN_IF_NOT(input_names.size() == 1, "FP-to-Bool Cast decomposition expects exactly one input.");
+  // 5. FP -> bool: Sign -> Abs -> Cast on HTP, NotEqual(x, 0.f) elsewhere.
+  //    Non-fp -> bool: regular one-to-one Cast.
+  if (IsFpToBoolCast(node_unit)) {
+    if (UseSignAbsCastForHtp(qnn_model_wrapper, node_unit)) {
+      RETURN_IF_NOT(input_names.size() == 1, "FP-to-Bool Cast decomposition expects exactly one input.");
 
-    const auto& input = node_unit.Inputs()[0];
-    Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
-    RETURN_IF_ERROR(utils::GetQnnDataType(false, input.type, input_qnn_dtype));
+      const auto& input = node_unit.Inputs()[0];
+      Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
+      RETURN_IF_ERROR(utils::GetQnnDataType(false, input.type, input_qnn_dtype));
 
-    std::vector<uint32_t> input_shape;
-    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape),
-                  "Cannot get shape for FP-to-Bool Cast input.");
+      std::vector<uint32_t> input_shape;
+      RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape),
+                    "Cannot get shape for FP-to-Bool Cast input.");
 
-    return EmitSignAbsCastDecomposition(qnn_model_wrapper,
-                                        node_unit,
-                                        input_names[0],
-                                        input_shape,
-                                        input_qnn_dtype,
-                                        output_name,
-                                        do_op_validation);
+      return EmitSignAbsCastDecomposition(qnn_model_wrapper,
+                                          node_unit,
+                                          input_names[0],
+                                          input_shape,
+                                          input_qnn_dtype,
+                                          output_name,
+                                          do_op_validation);
+    }
+    // NotEqual(x, 0.f) — the zero constant was already appended in ProcessInputs.
+    const std::string notequal_node_name = utils::UniqueNameGenerator().New(node_unit);
+    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(notequal_node_name,
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                  QNN_OP_ELEMENT_WISE_NOT_EQUAL,
+                                                  std::move(input_names),
+                                                  {output_name},
+                                                  {},
+                                                  do_op_validation),
+                  "Failed to create NotEqual node.");
+    return Ort::Status();
   }
 
-  // 6. Otherwise emit a single node: NotEqual for non-HTP fp -> bool, plain Cast otherwise.
-  const bool use_notequal = ShouldUseNotEqualForFpToBoolCast(qnn_model_wrapper, node_unit);
-  const std::string qnn_op_type = use_notequal
-                                      ? QNN_OP_ELEMENT_WISE_NOT_EQUAL
-                                      : GetQnnOpType(node_unit.OpType());
-
-  std::vector<std::string> param_tensor_names;
+  // 6. Regular one-to-one Cast.
   const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                qnn_op_type,
+                                                GetQnnOpType(node_unit.OpType()),
                                                 std::move(input_names),
                                                 {output_name},
-                                                std::move(param_tensor_names),
+                                                {},
                                                 do_op_validation),
-                ("Failed to create " + qnn_op_type + " node.").c_str());
+                "Failed to create Cast node.");
 
   return Ort::Status();
 }

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -19,8 +19,7 @@ namespace qnn {
 // added to the QNN graph.
 //
 // FP -> Bool lowering:
-//   * HTP: emit Sign -> Abs -> Cast so the Cast input is normalised to {0.0, 1.0}. Applies to
-//     both fp32 and fp16 (fp16 exhibits the same defect on real HTP silicon — v79+).
+//   * HTP: emit Sign -> Abs -> Cast so the Cast input is normalised to {0.0, 1.0} to comply v79+.
 //   * Other backends: emit NotEqual(x, 0.f).
 class CastOpBuilder : public BaseOpBuilder {
  public:
@@ -53,13 +52,10 @@ class CastOpBuilder : public BaseOpBuilder {
                                            std::vector<std::string>& input_names,
                                            const Ort::Logger& logger) const;
 
-  // Emits Sign -> Abs -> Cast(BOOL). Caller must have already added the input and output
-  // tensor wrappers for `input_name` / `output_name`.
+  // Emits Sign -> Abs -> Cast(BOOL) for node_unit.Inputs()[0] -> output_name. Caller must
+  // have already added the input and output tensor wrappers.
   Ort::Status EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_model_wrapper,
                                            const OrtNodeUnit& node_unit,
-                                           const std::string& input_name,
-                                           const std::vector<uint32_t>& input_shape,
-                                           Qnn_DataType_t input_qnn_dtype,
                                            const std::string& output_name,
                                            bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
@@ -183,16 +179,24 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
 Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_model_wrapper,
                                                         const OrtNodeUnit& node_unit,
-                                                        const std::string& input_name,
-                                                        const std::vector<uint32_t>& input_shape,
-                                                        Qnn_DataType_t input_qnn_dtype,
                                                         const std::string& output_name,
                                                         bool do_op_validation) const {
-  // 1. Reserve deterministic intermediate names so DLC inspection and context cache lookups stay stable.
+  // 1. Derive input name, dtype, and shape from the Cast's ONNX input.
+  const auto& input = node_unit.Inputs()[0];
+  const std::string& input_name = input.name;
+
+  Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
+  RETURN_IF_ERROR(utils::GetQnnDataType(false, input.type, input_qnn_dtype));
+
+  std::vector<uint32_t> input_shape;
+  RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape),
+                "Cannot get shape for FP-to-Bool Cast input.");
+
+  // 2. Reserve deterministic intermediate names so DLC inspection and context cache lookups stay stable.
   const std::string sign_out_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_sign");
   const std::string abs_out_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_abs");
 
-  // 2. Register the two NATIVE intermediates with the same shape/dtype as the Cast input.
+  // 3. Register the two NATIVE intermediates with the same shape/dtype as the Cast input.
   QnnTensorWrapper sign_out_wrapper(sign_out_name,
                                     QNN_TENSOR_TYPE_NATIVE,
                                     input_qnn_dtype,
@@ -209,7 +213,7 @@ Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_mod
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(abs_out_wrapper)),
                 "Failed to add Abs intermediate tensor.");
 
-  // 3. Sign(x) -> sign_out. Sign(x) is {-1, 0, +1}.
+  // 4. Sign(x) -> sign_out. Sign(x) is {-1, 0, +1}.
   const std::string sign_node_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_sign_node");
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(sign_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
@@ -220,7 +224,7 @@ Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_mod
                                                 do_op_validation),
                 "Failed to create Sign node.");
 
-  // 4. Abs(sign_out) -> abs_out. Collapses {-1, 0, +1} to {0, 1}.
+  // 5. Abs(sign_out) -> abs_out. Collapses {-1, 0, +1} to {0, 1}.
   const std::string abs_node_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_abs_node");
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(abs_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
@@ -231,7 +235,7 @@ Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_mod
                                                 do_op_validation),
                 "Failed to create Abs node.");
 
-  // 5. Cast(abs_out, to=BOOL) -> original ONNX Cast output.
+  // 6. Cast(abs_out, to=BOOL) -> original ONNX Cast output.
   const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,
@@ -292,22 +296,7 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   if (IsFpToBoolCast(node_unit)) {
     if (UseSignAbsCastForHtp(qnn_model_wrapper)) {
       RETURN_IF_NOT(input_names.size() == 1, "FP-to-Bool Cast decomposition expects exactly one input.");
-
-      const auto& input = node_unit.Inputs()[0];
-      Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
-      RETURN_IF_ERROR(utils::GetQnnDataType(false, input.type, input_qnn_dtype));
-
-      std::vector<uint32_t> input_shape;
-      RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape),
-                    "Cannot get shape for FP-to-Bool Cast input.");
-
-      return EmitSignAbsCastDecomposition(qnn_model_wrapper,
-                                          node_unit,
-                                          input_names[0],
-                                          input_shape,
-                                          input_qnn_dtype,
-                                          output_name,
-                                          do_op_validation);
+      return EmitSignAbsCastDecomposition(qnn_model_wrapper, node_unit, output_name, do_op_validation);
     }
     // NotEqual(x, 0.f) — the zero constant was already appended in ProcessInputs.
     const std::string notequal_node_name = utils::UniqueNameGenerator().New(node_unit);
@@ -322,7 +311,7 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     return Ort::Status();
   }
 
-  // 6. Regular one-to-one Cast.
+  // 6. Non-fp -> bool: regular one-to-one Cast.
   const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
                                                 QNN_OP_PACKAGE_NAME_QTI_AISW,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -17,6 +17,10 @@ namespace qnn {
 // Handles both ONNX Cast and CastLike. CastLike's second input only conveys the target dtype
 // (already resolved into node_unit.Outputs()[0].type by ONNX type inference), so it is never
 // added to the QNN graph.
+//
+// FP -> Bool lowering:
+//   * HTP: emit Sign -> Abs -> Cast so the Cast input is normalised to {0.0, 1.0} to comply v79+
+//   * Other backends: emit NotEqual(x, 0.f).
 class CastOpBuilder : public BaseOpBuilder {
  public:
   CastOpBuilder() : BaseOpBuilder("CastOpBuilder") {}
@@ -36,13 +40,29 @@ class CastOpBuilder : public BaseOpBuilder {
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
  private:
-  // QNN HTP currently does not support casting FP16/FP32 to Bool, and thus such Cast/CastLike will be replaced by
-  // NotEqual with an additional static input 0.f to achieve the idential functional.
+  // True when the ONNX Cast/CastLike is (fp32|fp16) -> bool. Independent of backend.
   bool IsFpToBoolCast(const OrtNodeUnit& node_unit) const;
+
+  bool ShouldDecomposeFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
+                                   const OrtNodeUnit& node_unit) const;
+
+  bool ShouldUseNotEqualForFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
+                                        const OrtNodeUnit& node_unit) const;
+
   Ort::Status ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
                                            const OrtNodeUnit& node_unit,
                                            std::vector<std::string>& input_names,
                                            const Ort::Logger& logger) const;
+
+  // Emits Sign -> Abs -> Cast(BOOL). Caller must have already added the input and output
+  // tensor wrappers for `input_name` / `output_name`.
+  Ort::Status EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_model_wrapper,
+                                           const OrtNodeUnit& node_unit,
+                                           const std::string& input_name,
+                                           const std::vector<uint32_t>& input_shape,
+                                           Qnn_DataType_t input_qnn_dtype,
+                                           const std::string& output_name,
+                                           bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
 
 bool CastOpBuilder::IsFpToBoolCast(const OrtNodeUnit& node_unit) const {
@@ -59,6 +79,29 @@ bool CastOpBuilder::IsFpToBoolCast(const OrtNodeUnit& node_unit) const {
 
   return ((input_qnn_dtype == QNN_DATATYPE_FLOAT_16 || input_qnn_dtype == QNN_DATATYPE_FLOAT_32) &&
           output_qnn_dtype == QNN_DATATYPE_BOOL_8);
+}
+
+bool CastOpBuilder::ShouldDecomposeFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
+                                                const OrtNodeUnit& node_unit) const {
+  if (!IsFpToBoolCast(node_unit)) {
+    return false;
+  }
+  ONNXTensorElementDataType input_type = node_unit.Inputs()[0].type;
+  Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
+  if (!utils::GetQnnDataType(false, input_type, input_qnn_dtype).IsOK() ||
+      input_qnn_dtype != QNN_DATATYPE_FLOAT_32) {
+    return false;
+  }
+  const QnnBackendType be = qnn_model_wrapper.GetQnnBackendType();
+  return (be == QnnBackendType::HTP || be == QnnBackendType::SERIALIZER);
+}
+
+bool CastOpBuilder::ShouldUseNotEqualForFpToBoolCast(const QnnModelWrapper& qnn_model_wrapper,
+                                                     const OrtNodeUnit& node_unit) const {
+  if (!IsFpToBoolCast(node_unit)) {
+    return false;
+  }
+  return !ShouldDecomposeFpToBoolCast(qnn_model_wrapper, node_unit);
 }
 
 Ort::Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
@@ -100,23 +143,27 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                          bool do_op_validation) const {
   ORT_UNUSED_PARAMETER(do_op_validation);
 
+  // 1. Validate input count. Cast has 1 input; CastLike has 2 (second only conveys dtype).
   const auto& inputs = node_unit.Inputs();
   RETURN_IF_NOT(inputs.size() == 1 || inputs.size() == 2,
                 "QNN Cast node must have 1 input (Cast) or 2 inputs (CastLike).");
   const auto& input = inputs[0];
 
+  // 2. FP64 is unsupported in QNN graph IO.
   const auto& input_name = input.name;
   RETURN_IF(qnn_model_wrapper.IsGraphInput(input_name) && input.type == ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE,
             "Unsupported FP64 data type in graph IO.");
 
+  // 3. Reuse existing tensor wrapper if this input was already added by an upstream op.
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + input_name).c_str());
     input_names.push_back(input_name);
-    return IsFpToBoolCast(node_unit)
+    return ShouldUseNotEqualForFpToBoolCast(qnn_model_wrapper, node_unit)
                ? ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger)
                : Ort::Status();
   }
 
+  // 4. Unpack initializer data if the input is a constant.
   std::vector<uint8_t> unpacked_tensor;
   bool is_constant_input = qnn_model_wrapper.IsConstantInput(input_name);
   if (is_constant_input) {
@@ -124,6 +171,7 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_tensor, unpacked_tensor));
   }
 
+  // 5. Resolve tensor metadata (type, shape, dtype).
   Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(input_name);
   std::vector<uint32_t> input_shape;
   RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape),
@@ -136,15 +184,80 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                         input_type,
                                         qnn_data_type));
 
+  // 6. Register the input tensor wrapper.
   QnnTensorWrapper input_tensorwrapper(input_name, tensor_type, qnn_data_type, QnnQuantParamsWrapper(),
                                        std::move(input_shape), std::move(unpacked_tensor));
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(input_tensorwrapper)),
                 "Failed to add input tensor for QNN Cast node.");
   input_names.push_back(input_name);
 
-  return IsFpToBoolCast(node_unit)
+  // 7. Append the zero-tensor input for the NotEqual lowering when applicable.
+  return ShouldUseNotEqualForFpToBoolCast(qnn_model_wrapper, node_unit)
              ? ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger)
              : Ort::Status();
+}
+
+Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_model_wrapper,
+                                                        const OrtNodeUnit& node_unit,
+                                                        const std::string& input_name,
+                                                        const std::vector<uint32_t>& input_shape,
+                                                        Qnn_DataType_t input_qnn_dtype,
+                                                        const std::string& output_name,
+                                                        bool do_op_validation) const {
+  // 1. Reserve deterministic intermediate names so DLC inspection and context cache lookups stay stable.
+  const std::string sign_out_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_sign");
+  const std::string abs_out_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_abs");
+
+  // 2. Register the two NATIVE intermediates with the same shape/dtype as the Cast input.
+  QnnTensorWrapper sign_out_wrapper(sign_out_name,
+                                    QNN_TENSOR_TYPE_NATIVE,
+                                    input_qnn_dtype,
+                                    QnnQuantParamsWrapper(),
+                                    std::vector<uint32_t>(input_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(sign_out_wrapper)),
+                "Failed to add Sign intermediate tensor.");
+
+  QnnTensorWrapper abs_out_wrapper(abs_out_name,
+                                   QNN_TENSOR_TYPE_NATIVE,
+                                   input_qnn_dtype,
+                                   QnnQuantParamsWrapper(),
+                                   std::vector<uint32_t>(input_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(abs_out_wrapper)),
+                "Failed to add Abs intermediate tensor.");
+
+  // 3. Sign(x) -> sign_out. Sign(x) is {-1, 0, +1}.
+  const std::string sign_node_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_sign_node");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(sign_node_name,
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_ELEMENT_WISE_SIGN,
+                                                {input_name},
+                                                {sign_out_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create Sign node.");
+
+  // 4. Abs(sign_out) -> abs_out. Collapses {-1, 0, +1} to {0, 1}.
+  const std::string abs_node_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_abs_node");
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(abs_node_name,
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_ELEMENT_WISE_ABS,
+                                                {sign_out_name},
+                                                {abs_out_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create Abs node.");
+
+  // 5. Cast(abs_out, to=BOOL) -> original ONNX Cast output.
+  const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                                QNN_OP_CAST,
+                                                {abs_out_name},
+                                                {output_name},
+                                                {},
+                                                do_op_validation),
+                "Failed to create Cast node.");
+  return Ort::Status();
 }
 
 Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_model_wrapper,
@@ -154,11 +267,13 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                        bool do_op_validation) const {
   ORT_UNUSED_PARAMETER(logger);
 
+  // 1. Validate output arity.
   const auto& outputs = node_unit.Outputs();
   RETURN_IF_NOT(outputs.size() == 1, "QNN Cast node must have a single output.");
   const auto& output = outputs[0];
   const auto& output_name = output.name;
 
+  // 2. Resolve output dtype and shape.
   ONNXTensorElementDataType output_type = output.type;
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_UNDEFINED;
   RETURN_IF_ERROR(utils::GetQnnDataType(false,  // Do not try to get the quantized type. HTP cast supports normal types.
@@ -170,6 +285,7 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                 "Cannot get shape for QNN Cast node's output.");
   const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
 
+  // 3. Narrow int64 -> int32 for internal tensors; substitute fp32 for internal fp64.
   const Qnn_TensorType_t tensor_type = is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE;
   if (qnn_data_type == QNN_DATATYPE_INT_64 && tensor_type == QNN_TENSOR_TYPE_NATIVE) {
     qnn_data_type = QNN_DATATYPE_INT_32;
@@ -177,6 +293,8 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     RETURN_IF(is_graph_output, "Unsupported FP64 data type in graph IO.");
     qnn_data_type = QNN_DATATYPE_FLOAT_32;
   }
+
+  // 4. Register the output tensor wrapper.
   QnnTensorWrapper output_tensorwrapper(output_name,
                                         tensor_type,
                                         qnn_data_type,
@@ -185,12 +303,33 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(output_tensorwrapper)),
                 "Failed to add output tensor for QNN Cast node.");
 
-  const bool is_fp_to_bool_cast = IsFpToBoolCast(node_unit);
-  const std::string qnn_op_type = is_fp_to_bool_cast
+  // 5. Sign -> Abs -> Cast lowering for HTP fp32 -> bool.
+  if (ShouldDecomposeFpToBoolCast(qnn_model_wrapper, node_unit)) {
+    RETURN_IF_NOT(input_names.size() == 1, "FP-to-Bool Cast decomposition expects exactly one input.");
+
+    const auto& input = node_unit.Inputs()[0];
+    Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
+    RETURN_IF_ERROR(utils::GetQnnDataType(false, input.type, input_qnn_dtype));
+
+    std::vector<uint32_t> input_shape;
+    RETURN_IF_NOT(qnn_model_wrapper.GetOnnxShape(input.shape, input_shape),
+                  "Cannot get shape for FP-to-Bool Cast input.");
+
+    return EmitSignAbsCastDecomposition(qnn_model_wrapper,
+                                        node_unit,
+                                        input_names[0],
+                                        input_shape,
+                                        input_qnn_dtype,
+                                        output_name,
+                                        do_op_validation);
+  }
+
+  // 6. Otherwise emit a single node: NotEqual for non-HTP fp -> bool, plain Cast otherwise.
+  const bool use_notequal = ShouldUseNotEqualForFpToBoolCast(qnn_model_wrapper, node_unit);
+  const std::string qnn_op_type = use_notequal
                                       ? QNN_OP_ELEMENT_WISE_NOT_EQUAL
                                       : GetQnnOpType(node_unit.OpType());
 
-  // FP->bool cast is implemented as ElementWiseNotEqual against a zero tensor. Plain Cast takes no params.
   std::vector<std::string> param_tensor_names;
   const std::string cast_node_name = utils::UniqueNameGenerator().New(node_unit);
   RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(cast_node_name,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -19,7 +19,8 @@ namespace qnn {
 // added to the QNN graph.
 //
 // FP -> Bool lowering:
-//   * HTP: emit Sign -> Abs -> Cast so the Cast input is normalised to {0.0, 1.0} to comply v79+
+//   * HTP: emit Sign -> Abs -> Cast so the Cast input is normalised to {0.0, 1.0}. Applies to
+//     both fp32 and fp16 (fp16 exhibits the same defect on real HTP silicon — v79+).
 //   * Other backends: emit NotEqual(x, 0.f).
 class CastOpBuilder : public BaseOpBuilder {
  public:
@@ -44,9 +45,8 @@ class CastOpBuilder : public BaseOpBuilder {
   bool IsFpToBoolCast(const OrtNodeUnit& node_unit) const;
 
   // True when the fp -> bool Cast should be lowered as Sign -> Abs -> Cast on HTP.
-  // Assumes IsFpToBoolCast(node_unit) is already true; only checks backend + input dtype.
-  bool UseSignAbsCastForHtp(const QnnModelWrapper& qnn_model_wrapper,
-                            const OrtNodeUnit& node_unit) const;
+  // Assumes IsFpToBoolCast(node_unit) is already true; only checks the backend.
+  bool UseSignAbsCastForHtp(const QnnModelWrapper& qnn_model_wrapper) const;
 
   Ort::Status ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_model_wrapper,
                                            const OrtNodeUnit& node_unit,
@@ -80,13 +80,7 @@ bool CastOpBuilder::IsFpToBoolCast(const OrtNodeUnit& node_unit) const {
           output_qnn_dtype == QNN_DATATYPE_BOOL_8);
 }
 
-bool CastOpBuilder::UseSignAbsCastForHtp(const QnnModelWrapper& qnn_model_wrapper,
-                                         const OrtNodeUnit& node_unit) const {
-  Qnn_DataType_t input_qnn_dtype = QNN_DATATYPE_UNDEFINED;
-  if (!utils::GetQnnDataType(false, node_unit.Inputs()[0].type, input_qnn_dtype).IsOK() ||
-      input_qnn_dtype != QNN_DATATYPE_FLOAT_32) {
-    return false;
-  }
+bool CastOpBuilder::UseSignAbsCastForHtp(const QnnModelWrapper& qnn_model_wrapper) const {
   const QnnBackendType be = qnn_model_wrapper.GetQnnBackendType();
   return (be == QnnBackendType::HTP || be == QnnBackendType::SERIALIZER);
 }
@@ -145,7 +139,7 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_name)) {
     ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Tensor already added, skip it: " + input_name).c_str());
     input_names.push_back(input_name);
-    if (IsFpToBoolCast(node_unit) && !UseSignAbsCastForHtp(qnn_model_wrapper, node_unit)) {
+    if (IsFpToBoolCast(node_unit) && !UseSignAbsCastForHtp(qnn_model_wrapper)) {
       return ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger);
     }
     return Ort::Status();
@@ -181,7 +175,7 @@ Ort::Status CastOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
 
   // 7. Append the zero-tensor input for the NotEqual lowering when applicable.
   // FP -> bool on non-HTP backends needs the zero constant for the NotEqual lowering.
-  if (IsFpToBoolCast(node_unit) && !UseSignAbsCastForHtp(qnn_model_wrapper, node_unit)) {
+  if (IsFpToBoolCast(node_unit) && !UseSignAbsCastForHtp(qnn_model_wrapper)) {
     return ProcessExtraInputForNotEqual(qnn_model_wrapper, node_unit, input_names, logger);
   }
   return Ort::Status();
@@ -296,7 +290,7 @@ Ort::Status CastOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   // 5. FP -> bool: Sign -> Abs -> Cast on HTP, NotEqual(x, 0.f) elsewhere.
   //    Non-fp -> bool: regular one-to-one Cast.
   if (IsFpToBoolCast(node_unit)) {
-    if (UseSignAbsCastForHtp(qnn_model_wrapper, node_unit)) {
+    if (UseSignAbsCastForHtp(qnn_model_wrapper)) {
       RETURN_IF_NOT(input_names.size() == 1, "FP-to-Bool Cast decomposition expects exactly one input.");
 
       const auto& input = node_unit.Inputs()[0];

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -323,10 +323,48 @@ TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP_GenericFpValues) {
 }
 
 // Cast float16 to bool on HTP.
+// The Sign -> Abs -> Cast lowering emits a final Cast(fp16 -> BOOL) which the x86 HTP
+// prepare-lib validator rejects even at soc_model=SM8850. On real HTP silicon (v79+)
+// this passes and is required to work around the fp16 zero-comparison defect — see
+// UseSignAbsCastForHtp in cast_op_builder.cc.
 TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
+#if defined(__linux__) && !defined(__aarch64__)
+  GTEST_SKIP() << "x86 HTP sim validator rejects Cast(fp16 -> BOOL); requires real device.";
+#endif
   RunCastFP16HTPTest({3, 3},
                      ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                      ExpectedEPNodeAssignment::All);
+}
+
+// Cast(fp16 -> bool) on HTP over a mix of signs, magnitudes, and sub-1 values.
+// Guards the Sign -> Abs -> Cast lowering for fp16 in cast_op_builder.cc.
+TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP_GenericFpValues) {
+#if defined(_WIN32)
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+#endif
+#if defined(__linux__) && !defined(__aarch64__)
+  GTEST_SKIP() << "x86 HTP sim validator rejects Cast(fp16 -> BOOL); requires real device.";
+#endif
+  const std::vector<float> fp32_data = {-5.0f, -0.5f, 0.0f, 0.5f, 0.9f, 1.0f, 5.0f, 100.0f};
+  std::vector<Ort::Float16_t> fp16_data;
+  fp16_data.reserve(fp32_data.size());
+  for (float v : fp32_data) {
+    fp16_data.push_back(Ort::Float16_t(v));
+  }
+
+  auto testcase = [fp16_data](ModelTestBuilder& builder) {
+    builder.MakeInput<Ort::Float16_t>("X", {8}, fp16_data);
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute(
+        "to", static_cast<int64_t>(ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL)));
+    builder.AddNode("cast", "Cast", {"X"}, {"Y"}, "", attributes);
+    builder.MakeOutput("Y");
+  };
+
+  RunQnnModelTest(testcase,
+                  GetProviderOption("htp", /* enable_fp16_precision */ true),
+                  13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 
 // Cast float to double on HTP.

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -203,12 +203,9 @@ static void RunCastFP16HTPTest(const std::vector<int64_t>& shape,
 #if defined(_WIN32)
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 #endif
-  ProviderOptions provider_options;
-#if defined(_WIN32)
-  provider_options["backend_path"] = "QnnHtp.dll";
-#else
-  provider_options["backend_path"] = "libQnnHtp.so";
-#endif
+  // enable_fp16_precision=true pins to SM8850 on the x86 sim so fp16 ops aren't rejected
+  // by the v68-default validator, and sets enable_htp_fp16_precision on all platforms.
+  ProviderOptions provider_options = GetProviderOption("htp", /* enable_fp16_precision */ true);
 
   auto testcase = [shape, dst_type](ModelTestBuilder& builder) {
     auto input_def_fp = TestInputDef(shape, false, static_cast<float>(0), static_cast<float>(20));

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -25,6 +25,19 @@ namespace test {
  * \return A function that builds the graph with the provided builder.
  */
 template <typename InputType>
+static GetTestModelFn BuildCastTestCaseWithData(const std::vector<int64_t>& shape,
+                                                ONNX_NAMESPACE::TensorProto_DataType dst_type,
+                                                const std::vector<InputType>& input_data) {
+  return [shape, dst_type, input_data](ModelTestBuilder& builder) {
+    builder.MakeInput<InputType>("X", shape, input_data);
+    std::vector<ONNX_NAMESPACE::AttributeProto> attributes;
+    attributes.push_back(builder.MakeScalarAttribute("to", static_cast<int64_t>(dst_type)));
+    builder.AddNode("cast", "Cast", {"X"}, {"Y"}, "", attributes);
+    builder.MakeOutput("Y");
+  };
+}
+
+template <typename InputType>
 static GetTestModelFn BuildCastTestCase(const std::vector<int64_t>& shape,
                                         ONNX_NAMESPACE::TensorProto_DataType dst_type) {
   return [shape, dst_type](ModelTestBuilder& builder) {
@@ -298,6 +311,18 @@ TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP) {
                        ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                        ExpectedEPNodeAssignment::All,
                        "htp");
+}
+
+// Cast(fp32 -> bool) on HTP over a mix of signs, magnitudes, and sub-1 values.
+// Guards the Sign -> Abs -> Cast lowering in cast_op_builder.cc.
+TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP_GenericFpValues) {
+  RunQnnModelTest(BuildCastTestCaseWithData<float>(
+                      {8},
+                      ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
+                      {-5.0f, -0.5f, 0.0f, 0.5f, 0.9f, 1.0f, 5.0f, 100.0f}),
+                  GetProviderOption("htp", false),
+                  13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 
 // Cast float16 to bool on HTP.

--- a/onnxruntime/test/providers/qnn/cast_test.cc
+++ b/onnxruntime/test/providers/qnn/cast_test.cc
@@ -322,15 +322,12 @@ TEST_F(QnnHTPBackendTests, TestCastFloatToBoolHTP_GenericFpValues) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 
-// Cast float16 to bool on HTP.
-// The Sign -> Abs -> Cast lowering emits a final Cast(fp16 -> BOOL) which the x86 HTP
-// prepare-lib validator rejects even at soc_model=SM8850. On real HTP silicon (v79+)
-// this passes and is required to work around the fp16 zero-comparison defect — see
-// UseSignAbsCastForHtp in cast_op_builder.cc.
+// Cast float16 to bool on HTP. (Windows ARM64 CI v73 rejects).
 TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
 #if defined(__linux__) && !defined(__aarch64__)
   GTEST_SKIP() << "x86 HTP sim validator rejects Cast(fp16 -> BOOL); requires real device.";
 #endif
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
   RunCastFP16HTPTest({3, 3},
                      ONNX_NAMESPACE::TensorProto_DataType::TensorProto_DataType_BOOL,
                      ExpectedEPNodeAssignment::All);
@@ -339,12 +336,10 @@ TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP) {
 // Cast(fp16 -> bool) on HTP over a mix of signs, magnitudes, and sub-1 values.
 // Guards the Sign -> Abs -> Cast lowering for fp16 in cast_op_builder.cc.
 TEST_F(QnnHTPBackendTests, TestCastFloat16ToBoolHTP_GenericFpValues) {
-#if defined(_WIN32)
-  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
-#endif
 #if defined(__linux__) && !defined(__aarch64__)
   GTEST_SKIP() << "x86 HTP sim validator rejects Cast(fp16 -> BOOL); requires real device.";
 #endif
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V75);
   const std::vector<float> fp32_data = {-5.0f, -0.5f, 0.0f, 0.5f, 0.9f, 1.0f, 5.0f, 100.0f};
   std::vector<Ort::Float16_t> fp16_data;
   fp16_data.reserve(fp32_data.size());


### PR DESCRIPTION
### Description
On HTP (and SERIALIZER), rewrite ONNX Cast(fp32 → bool) into Sign → Abs → Cast(BOOL). Sign(x) ∈ {-1, 0, +1} and Abs collapses it to {0, 1}, so the final HTP Cast only ever sees values it handles correctly. 



### Motivation and Context
on v79 and above , the NotEqual(x, 0.f) returns TRUE when x is 0.f

