### PR TITLE
[QNN EP] Fix Linux x86_64 wheel packaging failure due to stale patchelf

### DIFF
--- a/qcom/scripts/linux/ubuntu_22_04/Dockerfile
+++ b/qcom/scripts/linux/ubuntu_22_04/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libc++1 \
     libc++abi1 \
-    patchelf \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install -y \

--- a/tools/ci_build/github/linux/python/requirements.txt
+++ b/tools/ci_build/github/linux/python/requirements.txt
@@ -5,6 +5,7 @@ pytest
 setuptools>=68.2.2
 wheel
 auditwheel
+patchelf
 protobuf==6.33.0
 sympy==1.14
 flatbuffers


### PR DESCRIPTION
### Motivation and Context:

The Linux `x86_64 Ubuntu 22.04` CI build was failing during the Python wheel packaging step with:

  `ValueError: patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5`

`auditwheel` (unpinned, resolved to 6.8.1) raised its minimum `patchelf` version floor, but the Docker image's system
`patchelf` (installed via apt from Ubuntu 22.04's package index) is fixed at `0.14.3` and cannot be updated without
rebuilding the image.

The fix moves ownership of patchelf from the Docker image (apt) to the Python virtual environment (pip). The patchelf pip package bundles a current patchelf binary that is installed into the venv's bin/ at build time, shadowing the stale system binary when auditwheel repair runs inside the activated venv. This also makes patchelf version management consistent with auditwheel both resolved by uv at build time from the same requirements.txt.