### PR TITLE
Fix shared bias used when act scales are different

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -282,7 +282,7 @@ static Ort::Status ProcessRequantizeBias(QnnModelWrapper& qnn_model_wrapper,
   for (size_t i = 0; i < num_channels && !needs_requantization; ++i) {
     const float w = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
     if (current_offsets[i] != 0 ||
-        !utils::CheckBiasScaleMatch(current_scales[i], w, activation_scale, 1e-5f)) {
+        !utils::CheckBiasScaleMatch(current_scales[i], w, activation_scale)) {
       needs_requantization = true;
     }
   }

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1736,9 +1736,9 @@ uint64_t GetTimeStampInUs() {
   return std::chrono::duration_cast<std::chrono::microseconds>(timestamp).count();
 }
 
-bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale, float tolerance) {
-  float expected_scale = weights_scale * activation_scale;
-  return std::abs(bias_scale - expected_scale) <= tolerance;
+bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale) {
+  const float expected_scale = weights_scale * activation_scale;
+  return bias_scale == expected_scale;
 }
 
 Ort::Status GetWeightQuantScales(const QnnQuantParamsWrapper& weight_quant_param,

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -655,10 +655,12 @@ Ort::Status GetPermToLastAxis(uint32_t axis, uint32_t rank, std::vector<uint32_t
  */
 uint64_t GetTimeStampInUs();
 
-// Checks if bias scale matches the expected scale (weights_scale * activation_scale)
-// Returns true if they match within a tolerance, false otherwise
-bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale,
-                         float tolerance = 1e-5f);
+// Checks that a quantized bias scale is exactly the scale a (weights_scale * activation_scale).
+// Any other value has to be requantized before emission.
+// The comparison is exact because quantizers emit exactly float(weights_scale * activation_scale).
+// It must not use an absolute epsilon: bias scales are a product of two small scales and get as
+// small as 1e-10, so an epsilon like 1e-5 is far larger than the scales being compared
+bool CheckBiasScaleMatch(float bias_scale, float weights_scale, float activation_scale);
 
 // Extracts weight scales from a QnnQuantParamsWrapper.
 // Supports per-tensor (SCALE_OFFSET, BW_SCALE_OFFSET), per-channel (AXIS_SCALE_OFFSET,

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -3,9 +3,11 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
 #include <optional>
 #include <string>
 
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 
 #include "gtest/gtest.h"
@@ -301,6 +303,108 @@ static GetTestQDQModelFn<ActivationQType> BuildQDQConvPerChannelBiasRequantTestC
 
     AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(
         builder, "qdq_out", conv_out_name, output_qparams[0].scale, output_qparams[0].zero_point, use_contrib_qdq);
+  };
+}
+
+// Float32 reference for the QDQ shared-bias test below.
+static GetTestModelFn BuildF32SharedBiasTwoConvTestCase(const TestInputDef<float>& input_a_def,
+                                                        const TestInputDef<float>& input_b_def,
+                                                        const TestInputDef<float>& weights_def,
+                                                        const TestInputDef<float>& bias_def) {
+  return [input_a_def, input_b_def, weights_def, bias_def](ModelTestBuilder& builder) {
+    MakeTestInput<float>(builder, "input_a", input_a_def);
+    MakeTestInput<float>(builder, "input_b", input_b_def);
+    MakeTestInput<float>(builder, "weights", weights_def);
+    MakeTestInput<float>(builder, "bias", bias_def);
+
+    auto add_conv = [&](const char* node_name, const char* input_name, const char* output_name) {
+      std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+      conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+      conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+      conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+      conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+      builder.MakeOutput(output_name);
+      builder.AddNode(node_name, "Conv", {input_name, "weights", "bias"}, {output_name},
+                      kOnnxDomain, conv_attrs);
+    };
+    add_conv("ConvA", "input_a", "output_a");
+    add_conv("ConvB", "input_b", "output_b");
+  };
+}
+
+// Two Convs share one per-channel quantized int32 bias initializer, quantized at input_a's scale.
+// The declared bias scale therefore matches activation_scale * weight_scale for ConvA only, so
+// ConvB's bias must be requantized against its own activation scale.
+template <typename ActivationQType, typename WeightQType>
+static GetTestQDQModelFn<ActivationQType> BuildQDQSharedBiasTwoConvTestCase(
+    const TestInputDef<float>& input_a_def,
+    const TestInputDef<float>& input_b_def,
+    const TestInputDef<float>& weights_def,
+    const TestInputDef<float>& bias_def) {
+  return [input_a_def, input_b_def, weights_def, bias_def](
+             ModelTestBuilder& builder, std::vector<QuantParams<ActivationQType>>& output_qparams) {
+    MakeTestInput<float>(builder, "input_a", input_a_def);
+    MakeTestInput<float>(builder, "input_b", input_b_def);
+    const QuantParams<ActivationQType> qp_a = GetTestInputQuantParams<ActivationQType>(input_a_def);
+    const QuantParams<ActivationQType> qp_b = GetTestInputQuantParams<ActivationQType>(input_b_def);
+    const std::string input_a_dq = AddQDQNodePair<ActivationQType>(builder, "qdq_input_a", "input_a",
+                                                                   qp_a.scale, qp_a.zero_point);
+    const std::string input_b_dq = AddQDQNodePair<ActivationQType>(builder, "qdq_input_b", "input_b",
+                                                                   qp_b.scale, qp_b.zero_point);
+
+    QNN_ASSERT(weights_def.IsInitializer() && weights_def.IsRawData());
+    std::vector<float> weight_scales;
+    std::vector<WeightQType> weight_zero_points;
+    GetTestInputQuantParamsPerChannel<WeightQType>(weights_def, weight_scales, weight_zero_points,
+                                                   /*axis*/ 0, /*symmetric*/ true);
+    std::vector<WeightQType> quantized_weights(SizeOfShape(weights_def.GetShape()));
+    QuantizeValues<float, WeightQType>(weights_def.GetRawData(), quantized_weights, weights_def.GetShape(),
+                                       weight_scales, weight_zero_points, /*axis*/ 0);
+    builder.MakeInitializer<WeightQType>("weights_quant", weights_def.GetShape(), quantized_weights);
+
+    QNN_ASSERT(bias_def.IsInitializer() && bias_def.IsRawData());
+    const size_t num_channels = weight_scales.size();
+    std::vector<float> bias_scales(num_channels);
+    std::vector<int32_t> bias_zero_points(num_channels, 0);
+    for (size_t i = 0; i < num_channels; ++i) {
+      bias_scales[i] = qp_a.scale * weight_scales[i];
+    }
+    std::vector<int32_t> quantized_biases(SizeOfShape(bias_def.GetShape()));
+    QuantizeValues<float, int32_t>(bias_def.GetRawData(), quantized_biases, bias_def.GetShape(),
+                                   bias_scales, bias_zero_points, /*axis*/ 0);
+    builder.MakeInitializer<int32_t>("bias_quant", bias_def.GetShape(), quantized_biases);
+    builder.MakeInitializer<float>("bias_scale", {static_cast<int64_t>(num_channels)}, bias_scales);
+    builder.MakeInitializer<int32_t>("bias_zp", {static_cast<int64_t>(num_channels)}, bias_zero_points);
+
+    // Each Conv needs its own DQ over the shared initializers and its own Q on its output, or it
+    // forms no QDQ node unit and is built as a float Conv.
+    auto add_conv = [&](const std::string& tag, const std::string& input_dq, const char* output_name,
+                        size_t output_index) {
+      std::vector<ONNX_NAMESPACE::AttributeProto> weights_dq_attrs;
+      weights_dq_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+      const std::string weights_dq = "weights_dq_" + tag;
+      builder.AddDequantizeLinearNode("WeightDQ_" + tag, "weights_quant", weight_scales, weight_zero_points,
+                                      weights_dq, weights_dq_attrs, /*use_contrib_qdq*/ false);
+
+      std::vector<ONNX_NAMESPACE::AttributeProto> bias_dq_attrs;
+      bias_dq_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+      const std::string bias_dq = "bias_dq_" + tag;
+      builder.AddNode("BiasDQ_" + tag, "DequantizeLinear", {"bias_quant", "bias_scale", "bias_zp"},
+                      {bias_dq}, kOnnxDomain, bias_dq_attrs);
+
+      std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+      conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+      conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+      conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+      conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+      builder.AddNode("Conv" + tag, "Conv", {input_dq, weights_dq, bias_dq}, {output_name},
+                      kOnnxDomain, conv_attrs);
+      AddQDQNodePairWithOutputAsGraphOutput<ActivationQType>(builder, "qdq_out_" + tag, output_name,
+                                                             output_qparams[output_index].scale,
+                                                             output_qparams[output_index].zero_point);
+    };
+    add_conv("A", input_a_dq, "conv_a_out", 0);
+    add_conv("B", input_b_dq, "conv_b_out", 1);
   };
 }
 
@@ -1378,6 +1482,46 @@ TEST_F(QnnHTPBackendTests, ConvU8S8S32_PerChannel_BiasRequantization) {
                        13,  // opset
                        ExpectedEPNodeAssignment::All,
                        QDQTolerance(0.015f));
+}
+
+// Two Convs share one quantized int32 bias initializer but read activations whose scales differ by
+// 10x, so the bias scale can only match one of them and the other must be requantized
+TEST_F(QnnHTPBackendTests, ConvU8S8S32_SharedBiasInitializer_TinyScales) {
+  const std::filesystem::path json_dir = "ConvU8S8S32_SharedBiasInitializer_TinyScales";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  const std::vector<int64_t> input_shape = {1, 2, 4, 4};
+  const std::vector<int64_t> weight_shape = {3, 2, 2, 2};
+  const std::vector<int64_t> bias_shape = {3};
+
+  // The two input ranges differ by 10x, so the two activation scales do too.
+  TestInputDef<float> input_a_def(input_shape, false,
+                                  GetFloatDataInRange(-0.16f, 0.16f, SizeOfShape(input_shape)));
+  TestInputDef<float> input_b_def(input_shape, false,
+                                  GetFloatDataInRange(-0.016f, 0.016f, SizeOfShape(input_shape)));
+  TestInputDef<float> weight_def(weight_shape, true,
+                                 GetFloatDataInRange(-0.03f, 0.03f, SizeOfShape(weight_shape)));
+  TestInputDef<float> bias_def(bias_shape, true,
+                               GetFloatDataInRange(-0.03f, 0.03f, SizeOfShape(bias_shape)));
+
+  TestQDQModelAccuracy(BuildF32SharedBiasTwoConvTestCase(input_a_def, input_b_def, weight_def, bias_def),
+                       BuildQDQSharedBiasTwoConvTestCase<uint8_t, int8_t>(input_a_def, input_b_def,
+                                                                          weight_def, bias_def),
+                       provider_options,
+                       13,  // opset
+                       ExpectedEPNodeAssignment::All,
+                       QDQTolerance(0.015f));
+
+  AssertOpInQnnGraph(json_dir, "Conv2d", 2);
+  AssertNodeInputsDistinctInQnnGraph(json_dir, "Conv2d", /*input_index=*/2);
 }
 
 // Tests QDQ Conv where activation and weight are per-tensor quantized but bias is a plain float

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
@@ -4,6 +4,8 @@
 #include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 
 #include <fstream>
+#include <map>
+#include <utility>
 
 #include "nlohmann/json.hpp"
 #include "gtest/gtest.h"
@@ -68,6 +70,47 @@ void AssertNodeNotInQnnGraph(const std::filesystem::path& dump_dir,
 
   EXPECT_FALSE(root["graph"]["nodes"].contains(node_name))
       << "Unexpected QNN node found: '" << node_name << "' in " << json_path;
+}
+
+void AssertNodeInputsDistinctInQnnGraph(const std::filesystem::path& dump_dir,
+                                        const std::string& op,
+                                        size_t input_index) {
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
+    }
+  }
+  ASSERT_FALSE(json_path.empty()) << "No QNN JSON graph file found in " << dump_dir;
+
+  std::ifstream json_file(json_path);
+  ASSERT_TRUE(json_file.is_open()) << "Failed to open QNN JSON graph: " << json_path;
+
+  nlohmann::json root;
+  json_file >> root;
+
+  ASSERT_TRUE(root.contains("graph") && root["graph"].contains("nodes"))
+      << "JSON missing 'graph.nodes' field in: " << json_path;
+
+  std::map<std::string, std::string> input_to_node;
+  for (const auto& [node_name, node_json] : root["graph"]["nodes"].items()) {
+    if (node_json.value("type", "") != op) {
+      continue;
+    }
+
+    const auto& input_names = node_json["input_names"];
+    ASSERT_GT(input_names.size(), input_index)
+        << "QNN node '" << node_name << "' of type '" << op << "' has only " << input_names.size()
+        << " input(s) in " << json_path;
+
+    const std::string input_name = input_names[input_index].get<std::string>();
+    const auto [it, inserted] = input_to_node.emplace(input_name, node_name);
+    EXPECT_TRUE(inserted)
+        << "QNN nodes '" << it->second << "' and '" << node_name << "' (type '" << op
+        << "') both read tensor '" << input_name << "' at input " << input_index << " in " << json_path;
+  }
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
@@ -21,5 +21,12 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
 void AssertNodeNotInQnnGraph(const std::filesystem::path& dump_dir,
                              const std::string& node_name);
 
+// Asserts that no two nodes of type `op` in the compiled QNN graph read the same tensor at
+// `input_index`. Use this where the EP derives a static input per consuming node: each consumer must
+// end up with its own tensor instead of all of them collapsing onto one shared name.
+void AssertNodeInputsDistinctInQnnGraph(const std::filesystem::path& dump_dir,
+                                        const std::string& op,
+                                        size_t input_index);
+
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
@@ -1038,21 +1038,45 @@ TEST(QnnUnit_UtilsTest, GetPermToLastAxis_AxisOutOfRangeFails) {
 }
 
 // =============================================================================
-// CheckBiasScaleMatch — tolerance logic
+// CheckBiasScaleMatch
 // =============================================================================
 
 TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_ExactMatchReturnsTrue) {
-  EXPECT_TRUE(qnn::utils::CheckBiasScaleMatch(0.006f, 0.02f, 0.3f));
+  EXPECT_TRUE(qnn::utils::CheckBiasScaleMatch(0.02f * 0.3f, 0.02f, 0.3f));
 }
 
-TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_WithinToleranceReturnsTrue) {
-  // expected = 0.02f * 0.3f = 0.006f; diff = 1e-6f < default 1e-5f
-  EXPECT_TRUE(qnn::utils::CheckBiasScaleMatch(0.006001f, 0.02f, 0.3f));
+TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_OffByTwoStepsReturnsFalse) {
+  // The comparison is exact, so even a two-step difference means the bias was not quantized at this
+  // Conv's accumulator scale and gets requantized
+  constexpr float expected = 0.02f * 0.3f;
+  const float off_by_two_steps = std::nextafter(std::nextafter(expected, 1.0f), 1.0f);
+  EXPECT_NE(off_by_two_steps, expected);
+  EXPECT_FALSE(qnn::utils::CheckBiasScaleMatch(off_by_two_steps, 0.02f, 0.3f));
 }
 
-TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_OutsideToleranceReturnsFalse) {
-  // expected = 0.006f; diff = 0.001f >> 1e-5f
-  EXPECT_FALSE(qnn::utils::CheckBiasScaleMatch(0.007f, 0.02f, 0.3f));
+TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_GrosslyWrongScaleReturnsFalse) {
+  EXPECT_FALSE(qnn::utils::CheckBiasScaleMatch(0.01f, 0.02f, 0.3f));
+}
+
+// A real encoding mismatch can be small. OSNet has such a Conv, 0.043% off, and its bias is still
+// folded in at the wrong scale on device
+TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_SmallButRealMismatchReturnsFalse) {
+  EXPECT_FALSE(qnn::utils::CheckBiasScaleMatch(0.02f * 0.3f * 0.99957f, 0.02f, 0.3f));
+}
+
+TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_DoubledTinyScaleReturnsFalse) {
+  constexpr float weights_scale = 6.2e-08f / 0.001f;
+  constexpr float activation_scale = 0.001f;  // expected bias scale = 6.2e-08f
+  EXPECT_FALSE(qnn::utils::CheckBiasScaleMatch(2.019f * 6.2e-08f, weights_scale, activation_scale));
+}
+
+// Falls out of the exact comparison, no special case needed: 0 == 0 * activation_scale.
+TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_BothScalesZeroReturnsTrue) {
+  EXPECT_TRUE(qnn::utils::CheckBiasScaleMatch(0.0f, 0.0f, 0.3f));
+}
+
+TEST(QnnUnit_UtilsTest, CheckBiasScaleMatch_ZeroBiasScaleWithNonZeroExpectedReturnsFalse) {
+  EXPECT_FALSE(qnn::utils::CheckBiasScaleMatch(0.0f, 0.02f, 0.3f));
 }
 
 // =============================================================================


### PR DESCRIPTION
### Description
In OSNet, groups of four Conv nodes share a single weight initializer and a single int32 bias initializer. AIMET computed one bias encoding, taken from the first consumer's input activation scale. HTP folds an int32 conv bias into the accumulator at activation_scale × weight_scale and ignores the declared bias encoding, so with the four consumers' activation scales differing (3.08e-3 / 2.45e-3 / 1.35e-3 / 2.83e-4 in conv2.1.gate.fc1), the required bias scale is different for each and the shared encoding is correct for only one — the other three see an effective bias inflated by the activation-scale ratio, up to 12.4x.


EP already handles this in ProcessRequantizeBias, which requantizes the bias per node and emits it under a unique _rq name. But the gate on that path, CheckBiasScaleMatch, compared scales with an absolute 1e-5 epsilon. Expected bias scales in this model span 7.2e-11 to 3.0e-4, so a fixed epsilon would not work; it flagged only 13 of the 36 mismatched Convs.  Switching to a absolute comparison flags all 36 with no issues

### Motivation and Context
OSNet w8a8 scores **56.6% mAP** through QNN EP against **81.5%** expected.  This PR restores the accuracy


