### PR TITLE
[QNN EP] Handle broadcast Gemm C with FC and Add

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -41,6 +41,31 @@ bool IsBQGemmWeight(const QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnitI
   return bq::IsBQScale(scale_shape, weight_shape, block_axis);
 }
 
+// QNN FullyConnected accepts a vector bias, or a scalar bias for one output channel. Other valid
+// ONNX Gemm C broadcasts require a separate ElementWiseAdd.
+bool RequiresFcAddDecomposition(const OrtNodeUnit& node_unit, bool is_native_bias) {
+  OrtNodeAttrHelper node_helper(node_unit);
+  const float beta = node_helper.Get("beta", 1.0f);
+  if (node_unit.Inputs().size() != 3 || beta == 0.0f) {
+    return false;
+  }
+  if (is_native_bias) {
+    return true;
+  }
+
+  std::vector<uint32_t> weight_shape;
+  std::vector<uint32_t> bias_shape;
+  if (!QnnModelWrapper::GetOnnxShape(node_unit.Inputs()[1].shape, weight_shape) ||
+      !QnnModelWrapper::GetOnnxShape(node_unit.Inputs()[2].shape, bias_shape) ||
+      weight_shape.size() != 2) {
+    return false;
+  }
+
+  const int64_t trans_b = node_helper.Get("transB", static_cast<int64_t>(0));
+  const uint32_t output_channels = trans_b == 0 ? weight_shape[1] : weight_shape[0];
+  return !utils::IsCompatibleFcBiasShape(bias_shape, output_channels);
+}
+
 }  // namespace
 
 class GemmOpBuilder : public BaseOpBuilder {
@@ -62,7 +87,7 @@ class GemmOpBuilder : public BaseOpBuilder {
                                           bool do_op_validation) const override ORT_MUST_USE_RESULT;
 
  private:
-  Ort::Status ExplictOpCheck(const OrtNodeUnit& node_unit) const;
+  Ort::Status ExplictOpCheck(const OrtNodeUnit& node_unit, bool is_bq_gemm) const;
   // Block-quantized (BW_FLOAT_BLOCK) weight path for Gemm→QNN FullyConnected.
   Ort::Status ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wrapper,
                                      const OrtNodeUnit& node_unit,
@@ -73,31 +98,30 @@ class GemmOpBuilder : public BaseOpBuilder {
                                      bool do_op_validation) const ORT_MUST_USE_RESULT;
 };
 
-Ort::Status GemmOpBuilder::ExplictOpCheck(const OrtNodeUnit& node_unit) const {
+Ort::Status GemmOpBuilder::ExplictOpCheck(const OrtNodeUnit& node_unit, bool is_bq_gemm) const {
   OrtNodeAttrHelper node_helper(node_unit);
   auto alpha = node_helper.Get("alpha", (float)1.0);
   RETURN_IF(alpha != 1.0, "QNN FullyConnected Op only support alpha=1.0.");
   auto beta = node_helper.Get("beta", (float)1.0);
   RETURN_IF(beta != 1.0 && beta != 0.0, "QNN FullyConnected Op only support beta=1.0 or beta=0.0.");
 
-  // input C shape need to be [M] or [1, M] (skip validation when beta=0.0 — C is ignored)
-  if (node_unit.Inputs().size() == 3 && beta != 0.0f) {
+  // Split non-FC-compatible C broadcasts into FullyConnected + ElementWiseAdd. BQ Gemm only
+  // supports FullyConnected, so it still requires a compatible bias shape.
+  if (node_unit.Inputs().size() == 3 && beta != 0.0f &&
+      (is_bq_gemm || !RequiresFcAddDecomposition(node_unit, /*is_native_bias=*/false))) {
     auto& inputB = node_unit.Inputs()[1];
     std::vector<uint32_t> inputB_shape;
-    QnnModelWrapper::GetOnnxShape(inputB.shape, inputB_shape);
+    RETURN_IF_NOT(QnnModelWrapper::GetOnnxShape(inputB.shape, inputB_shape) && inputB_shape.size() == 2,
+                  "QNN FullyConnected Op requires a rank-2 B input.");
 
     auto& inputC = node_unit.Inputs()[2];
     std::vector<uint32_t> inputC_shape;
-    QnnModelWrapper::GetOnnxShape(inputC.shape, inputC_shape);
+    RETURN_IF_NOT(QnnModelWrapper::GetOnnxShape(inputC.shape, inputC_shape), "Cannot get C shape.");
 
     auto transB = node_helper.Get("transB", static_cast<int64_t>(0));
-    auto M = (transB == 0) ? inputB_shape.at(1) : inputB_shape.at(0);
-    RETURN_IF(inputC_shape.size() == 0 || (inputC_shape.size() == 1 && inputC_shape.at(0) != M) ||
-                  (inputC_shape.size() == 2 && inputC_shape.at(1) != M),
-              "QNN FullyConnected Op only support C with shape [N, M].");
-
-    RETURN_IF(inputC_shape.size() == 2 && node_unit.Inputs()[2].quant_param.has_value() && inputC_shape.at(0) != 1,
-              "QNN FullyConnected Op only support quantized C with shape [1, M].");
+    auto output_channels = (transB == 0) ? inputB_shape.at(1) : inputB_shape.at(0);
+    RETURN_IF(!utils::IsCompatibleFcBiasShape(inputC_shape, output_channels),
+              "QNN FullyConnected Op requires scalar C for N=1, or C with shape [N] or [1, N].");
   }
 
   return Ort::Status();
@@ -108,17 +132,18 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
                                          const Ort::Logger& logger,
                                          std::vector<std::string>& input_names,
                                          bool do_op_validation) const {
-  if (do_op_validation) {
-    RETURN_IF_ERROR(ExplictOpCheck(node_unit));
-  }
-
   OrtNodeAttrHelper node_helper(node_unit);
   const int64_t trans_b = node_helper.Get("transB", static_cast<int64_t>(0));
   const float beta = node_helper.Get("beta", 1.0f);
   const auto& inputs = node_unit.Inputs();
+  const bool is_bq_gemm = IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b);
+
+  if (do_op_validation) {
+    RETURN_IF_ERROR(ExplictOpCheck(node_unit, is_bq_gemm));
+  }
 
   // Block-quantized weight: translate to QNN FullyConnected with BW_FLOAT_BLOCK weight.
-  if (IsBQGemmWeight(qnn_model_wrapper, inputs[1], trans_b)) {
+  if (is_bq_gemm) {
     return ProcessInputsForBQGemm(qnn_model_wrapper, node_unit, trans_b, beta, logger, input_names,
                                   do_op_validation);
   }
@@ -424,7 +449,6 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
                                                        const Ort::Logger& logger,
                                                        bool do_op_validation) const {
   OrtNodeAttrHelper node_helper(node_unit);
-  auto beta = node_helper.Get("beta", (float)1.0);
   const int64_t trans_b_out = node_helper.Get("transB", static_cast<int64_t>(0));
 
   // Detect BQ (BW_FLOAT_BLOCK) Gemm using IsBQGemmWeight, consistent with ProcessInputs detection.
@@ -524,25 +548,13 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     return Ort::Status();
   }
 
-  // Non-BQ path: decompose Gemm into FullyConnected + Add when needed.
-  bool split_gemm = false;
-  if (node_unit.Inputs().size() == 3 && beta != 0.0f) {
-    auto& input_c = node_unit.Inputs()[2];
-    std::vector<uint32_t> input_c_shape;
-    QnnModelWrapper::GetOnnxShape(input_c.shape, input_c_shape);
+  // Non-BQ path: decompose Gemm into FullyConnected + Add when C cannot be an FC bias.
+  const bool is_native_bias = node_unit.Inputs().size() == 3 &&
+                              qnn_model_wrapper.GetTensorType(node_unit.Inputs()[2].name) == QNN_TENSOR_TYPE_NATIVE;
+  const bool requires_fc_add_decomposition = RequiresFcAddDecomposition(node_unit, is_native_bias);
 
-    // Split when input_c has 2d shape and not [1, M]
-    split_gemm = (input_c_shape.size() == 2 && input_c_shape.at(0) != 1);
-
-    // Split when bias is an intermediate (NATIVE) tensor produced by another op.
-    // ORT's MatMulAddFusion can fuse MatMul+Add->Gemm where the Add's other input
-    // is an intermediate tensor (e.g., output of another MatMul). QNN FC requires
-    // bias to be either STATIC (constant) or APP_WRITE (graph input), not NATIVE.
-    split_gemm = split_gemm || qnn_model_wrapper.GetTensorType(input_c.name) == QNN_TENSOR_TYPE_NATIVE;
-  }
-
-  if (split_gemm) {
-    // If split_gemm, input and output of Gemm must at least 2d.
+  if (requires_fc_add_decomposition) {
+    // Gemm input and output must be at least rank 2 for the FC + Add decomposition.
     const std::string& org_output_name = node_unit.Outputs()[0].name;
     TensorInfo input_info = {};
     RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -36,6 +36,14 @@ class QnnModelWrapper;
 class QnnQuantParamsWrapper;
 
 namespace utils {
+
+template <typename T>
+inline bool IsCompatibleFcBiasShape(const std::vector<T>& bias_shape, T output_channels) {
+  return (bias_shape.empty() && output_channels == 1) ||
+         (bias_shape.size() == 1 && bias_shape[0] == output_channels) ||
+         (bias_shape.size() == 2 && bias_shape[0] == 1 && bias_shape[1] == output_channels);
+}
+
 /**
  * Returns a lowercase version of the input string.
  * /param str The string to lowercase.

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -69,21 +69,16 @@ std::optional<ONNXTensorElementDataType> GetNodeOutputDataType(const OrtNode* no
   return GetDataTypeFromValueInfo(ort_api, outputs[index]);
 }
 
-// 1.4 (rank, dim[0]) for a ValueInfo. Returns false on API failure.
-bool GetValueInfoRankAndFirstDim(const OrtApi& ort_api, const OrtValueInfo* value_info,
-                                 size_t& rank, int64_t& first_dim) {
+// 1.4 Shape for a ValueInfo. Returns false on API failure.
+bool GetValueInfoShape(const OrtApi& ort_api, const OrtValueInfo* value_info, std::vector<int64_t>& shape) {
   const OrtTypeInfo* type_info = nullptr;
   if (ort_api.GetValueInfoTypeInfo(value_info, &type_info) != nullptr) return false;
   const OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
   if (ort_api.CastTypeInfoToTensorInfo(type_info, &tensor_info) != nullptr || tensor_info == nullptr) return false;
+  size_t rank = 0;
   if (ort_api.GetDimensionsCount(tensor_info, &rank) != nullptr) return false;
-  first_dim = 0;
-  if (rank >= 1) {
-    std::vector<int64_t> dims(rank);
-    if (ort_api.GetDimensions(tensor_info, dims.data(), rank) != nullptr) return false;
-    first_dim = dims[0];
-  }
-  return true;
+  shape.resize(rank);
+  return rank == 0 || ort_api.GetDimensions(tensor_info, shape.data(), rank) == nullptr;
 }
 
 // =============================================================================
@@ -311,18 +306,12 @@ bool IsGemmWeightBlockQuantized(const OrtApi& ort_api, const OrtValueInfo* weigh
   if (ort_api.Node_GetNumInputs(dq, &dq_num_inputs) != nullptr || dq_num_inputs < 2) return false;
   std::vector<const OrtValueInfo*> dq_inputs(dq_num_inputs);
   if (ort_api.Node_GetInputs(dq, dq_inputs.data(), dq_inputs.size()) != nullptr) return false;
-  size_t scale_rank = 0;
-  int64_t scale_dim0 = 0;
-  if (!GetValueInfoRankAndFirstDim(ort_api, dq_inputs[1], scale_rank, scale_dim0)) return false;
-  return scale_rank == 2;
+  std::vector<int64_t> scale_shape;
+  return GetValueInfoShape(ort_api, dq_inputs[1], scale_shape) && scale_shape.size() == 2;
 }
 
-// 3b.0 Split_gemm guard for the absorb-Reshape path.
-//   Reject when the vanilla Gemm builder would have split into FC + Add:
-//     - transB != 0                         (builder hard-asserts transB=0)
-//     - bias is 2-D with shape[0] != 1      (broadcast-bias split)
-//     - bias is produced by another op      (NATIVE bias split)
-//   Also reject block-quantized weight — handled by the BQ builder path.
+// 3b.0 Guard for the absorb-Reshape path. Reject configurations that require another builder path:
+// transposed B, non-FC bias shapes, NATIVE bias, and BQ weight.
 bool IsGemmSafeForAbsorbedReshape(const OrtApi& ort_api, const OrtNode* gemm_node) {
   OrtNodeAttrHelper attrs(*gemm_node);
   if (attrs.Get("transB", static_cast<int64_t>(0)) != 0) return false;
@@ -332,22 +321,35 @@ bool IsGemmSafeForAbsorbedReshape(const OrtApi& ort_api, const OrtNode* gemm_nod
 
   std::vector<const OrtValueInfo*> inputs(num_inputs);
   if (ort_api.Node_GetInputs(gemm_node, inputs.data(), inputs.size()) != nullptr) return false;
-  if (num_inputs >= 2 && IsGemmWeightBlockQuantized(ort_api, inputs[1])) return false;
+  if (num_inputs < 2 || inputs[1] == nullptr || IsGemmWeightBlockQuantized(ort_api, inputs[1])) return false;
 
-  if (num_inputs < 3) return true;  // No bias → split_gemm never triggers.
+  if (num_inputs < 3) return true;  // No bias requires no separate Add.
 
   const OrtValueInfo* bias_vi = inputs[2];
   if (bias_vi == nullptr) return true;
 
-  // 3b.0.1 Shape gate: reject 2-D bias with shape[0] != 1.
-  size_t bias_rank = 0;
-  int64_t bias_dim0 = 0;
-  if (!GetValueInfoRankAndFirstDim(ort_api, bias_vi, bias_rank, bias_dim0)) return false;
-  if (bias_rank == 2 && bias_dim0 != 1) return false;
+  const float beta = attrs.Get("beta", 1.0f);
+  if (beta == 0.0f) return true;
+
+  // 3b.0.1 Shape gate: scalar C for N=1, C=[N], or C=[1,N] can be passed to FullyConnected.
+  std::vector<int64_t> weight_shape;
+  std::vector<int64_t> bias_shape;
+  if (!GetValueInfoShape(ort_api, inputs[1], weight_shape) ||
+      !GetValueInfoShape(ort_api, bias_vi, bias_shape) ||
+      weight_shape.size() != 2) {
+    return false;
+  }
+  for (int64_t dim : weight_shape) {
+    if (dim < 0) return false;
+  }
+  for (int64_t dim : bias_shape) {
+    if (dim < 0) return false;
+  }
+  if (!qnn::utils::IsCompatibleFcBiasShape(bias_shape, weight_shape[1])) return false;
 
   // 3b.0.2 NATIVE-bias gate: walk through a DQ (if any) to the true producer. If that
   //         producer is another op, the bias is NATIVE (intermediate) and the builder
-  //         would have split_gemm'd.
+  //         would require a separate Add.
   const OrtNode* bias_producer = nullptr;
   if (ort_api.ValueInfo_GetValueProducer(bias_vi, &bias_producer, nullptr) != nullptr) return false;
   if (bias_producer == nullptr) return true;  // graph input / initializer

--- a/onnxruntime/test/providers/qnn/gemm_test.cc
+++ b/onnxruntime/test/providers/qnn/gemm_test.cc
@@ -181,6 +181,18 @@ TEST_F(QnnCPUBackendTests, Gemm_Broadcast_Bias_DynamicA_StaticB_StaticC) {
                      ExpectedEPNodeAssignment::All);
 }
 
+// FullyConnected cannot consume C=[M,1] as a bias, but ElementWiseAdd can broadcast it over N.
+TEST_F(QnnCPUBackendTests, Gemm_ColumnBroadcast_DynamicC) {
+  constexpr int64_t M = 2;
+  constexpr int64_t K = 4;
+  constexpr int64_t N = 3;
+  RunGemmTest<float>({TestInputDef<float>({M, K}, false, -1.0f, 1.0f),
+                      TestInputDef<float>({K, N}, true, -1.0f, 1.0f),
+                      TestInputDef<float>({M, 1}, false, -1.0f, 1.0f)},
+                     {},
+                     ExpectedEPNodeAssignment::All);
+}
+
 namespace {
 GetTestModelFn BuildReshapeGemmTestCase(const TestInputDef<float>& input, const TestInputDef<int64_t>& shape,
                                         const TestInputDef<float>& weight, const TestInputDef<float>& bias) {
@@ -570,6 +582,31 @@ GetTestModelFn BuildGemmFromMatMulAddTestCase(int64_t K, int64_t N) {
     builder.MakeOutput("add3");
   };
 }
+
+GetTestModelFn BuildGemmFromMatMulAddColumnBroadcastTestCase(int64_t M, int64_t K, int64_t N) {
+  return [M, K, N](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("A", {M, K}, -1.0f, 1.0f);
+    builder.MakeInput<float>("C_A", {M, K}, -1.0f, 1.0f);
+    builder.MakeInitializer<float>("W", {K, N}, -1.0f, 1.0f);
+    builder.MakeInitializer<float>("C_W", {K, 1}, -1.0f, 1.0f);
+
+    builder.AddNode("column_matmul", "MatMul", {"C_A", "C_W"}, {"C"});
+    builder.AddNode("matmul", "MatMul", {"A", "W"}, {"matmul_out"});
+    builder.AddNode("add", "Add", {"matmul_out", "C"}, {"Y"});
+    builder.MakeOutput("Y");
+  };
+}
+
+void RunGemmFromMatMulAddColumnBroadcastTest(const std::string& backend_name, float fp32_abs_err = 1e-5f) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend_name;
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  RunQnnModelTest(BuildGemmFromMatMulAddColumnBroadcastTestCase(/*M=*/2, /*K=*/4, /*N=*/3),
+                  provider_options,
+                  /*opset=*/18,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(fp32_abs_err)});
+}
 }  // namespace
 
 TEST_F(QnnHTPBackendTests, GemmFromMatMulAddNonStaticBias) {
@@ -592,6 +629,14 @@ TEST_F(QnnCPUBackendTests, GemmFromMatMulAddNonStaticBias) {
                   provider_options,
                   /*opset=*/18,
                   EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
+
+TEST_F(QnnHTPBackendTests, GemmFromMatMulAddColumnBroadcastBias) {
+  RunGemmFromMatMulAddColumnBroadcastTest("htp", 2e-3f);
+}
+
+TEST_F(QnnCPUBackendTests, GemmFromMatMulAddColumnBroadcastBias) {
+  RunGemmFromMatMulAddColumnBroadcastTest("cpu");
 }
 
 namespace {
@@ -876,7 +921,7 @@ TEST_F(QnnHTPBackendTests, GemmMatMulAddFusion_U16Act_S16Weight_WithRelu) {
 namespace {
 // activation: rank-2 [M, K] float -> Q(u16) -> DQ
 // weight:    rank-2 [K, N] (or [N, K] when trans_b=1) static -> DQ
-// bias (opt): rank-1 [N] INT32 static -> DQ
+// bias (opt): static INT32 -> DQ; rank-1 [N] by default
 // -> Gemm -> Reshape (rank-3 [1, M, N]) -> Q -> DQ -> output
 struct DirectGemmReshapeQConfig {
   int64_t M = 4;
@@ -885,6 +930,7 @@ struct DirectGemmReshapeQConfig {
   int64_t trans_b = 0;                  // 0 → weight [K,N]; 1 → weight [N,K]
   bool include_bias = true;             // rank-1 bias by default
   bool bias_from_intermediate = false;  // if true, bias is produced by an intermediate MatMul (NATIVE bias)
+  std::optional<std::vector<int64_t>> bias_shape;
 };
 
 GetTestModelFn BuildDirectGemmReshapeQTestCase(const DirectGemmReshapeQConfig& cfg) {
@@ -927,9 +973,9 @@ GetTestModelFn BuildDirectGemmReshapeQTestCase(const DirectGemmReshapeQConfig& c
         builder.AddNode("bias_mm", "MatMul", {bias_mm_dq_a, "bias_mm_w"}, {"bias_native"}, kOnnxDomain);
         gemm_inputs.push_back("bias_native");
       } else {
-        const std::vector<int64_t> bias_shape{cfg.N};
+        const std::vector<int64_t> bias_shape = cfg.bias_shape.value_or(std::vector<int64_t>{cfg.N});
         TestInputDef<float> bias_def(bias_shape, /*is_initializer=*/true,
-                                     GetFloatDataInRange(-0.2f, 0.2f, static_cast<size_t>(cfg.N)));
+                                     GetFloatDataInRange(-0.2f, 0.2f, SizeOfShape(bias_shape)));
         const std::string bias_dq = MakeTestQDQBiasInput(builder, "bias", bias_def,
                                                          act_qp.scale * wt_qp.scale, /*use_contrib_qdq=*/true);
         gemm_inputs.push_back(bias_dq);
@@ -970,7 +1016,7 @@ TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_TransB0_1DBias) {
 
 // Negative gate (M-1): direct Gemm(transB=1) -> Reshape -> Q must NOT be absorbed by the
 // absorb-Reshape selector — the builder's absorbed path hard-asserts transB=0. The graph
-// still runs on QNN EP via the split_gemm / regular Gemm path (Reshape is a separate node).
+// still runs on QNN EP via the regular Gemm path with a standalone Reshape.
 TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_TransB1_NotAbsorbed) {
   DirectGemmReshapeQConfig cfg;
   cfg.trans_b = 1;
@@ -982,12 +1028,26 @@ TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_TransB1_NotAbsorbed) {
 
 // Negative gate (M-2): direct Gemm with a NATIVE bias (produced by an intermediate MatMul)
 // -> Reshape -> Q. The absorb-Reshape path must reject it (unsafe: NATIVE bias would have
-// forced split_gemm). The graph still runs via split_gemm.
+// required a separate Add). The graph still runs through the regular Gemm path.
 TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_NativeBias_NotAbsorbed) {
   DirectGemmReshapeQConfig cfg;
   cfg.bias_from_intermediate = true;
   RunQnnModelTest(BuildDirectGemmReshapeQTestCase(cfg), GetHtpProviderOptions(), /*opset=*/21,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(2e-2f)});
+}
+
+// C=[M,1] and C=[1,1] broadcast in ONNX but are not FullyConnected bias vectors. Keep the
+// standalone Reshape so the builder emits FC + Add.
+TEST_F(QnnHTPBackendTests, GemmReshapeQ_Direct_IncompatibleBiasBroadcast_NotAbsorbed) {
+  DirectGemmReshapeQConfig column_bias;
+  column_bias.bias_shape = std::vector<int64_t>{column_bias.M, 1};
+  RunQnnModelTest(BuildDirectGemmReshapeQTestCase(column_bias), GetHtpProviderOptions(), /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(2e-2f)});
+
+  DirectGemmReshapeQConfig unit_bias;
+  unit_bias.bias_shape = std::vector<int64_t>{1, 1};
+  RunQnnModelTest(BuildDirectGemmReshapeQTestCase(unit_bias), GetHtpProviderOptions(), /*opset=*/21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::Some, ElementwiseAbsoluteVerifier(2e-2f)});
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)


### PR DESCRIPTION
## Summary
- Lower valid Gemm C broadcasts that cannot be represented as a QNN FullyConnected bias to FullyConnected + ElementWiseAdd.
- Share the FC-compatible bias-shape rule and keep the absorbed-Reshape selector aligned with the builder.
- Add direct, MatMulAddFusion, and selector regression coverage.

## Root cause
ORT MatMulAddFusion can produce Gemm with C=[M,1] from MatMul followed by a column-broadcast Add. ONNX permits C to broadcast to [M,N], but QNN FullyConnected can consume only one bias value per output channel. Validation rejected C before the existing FC + Add lowering could run.

The fix keeps scalar C for N=1, [N], and [1,N] on the direct FC path. Other valid broadcasts use a separate Add; block-quantized Gemm remains strict.