### PR TITLE
[QNN EP] Fix flaky ScatterElementsSharedNegativeIndicesDifferentAxes test

### DIFF
--- a/onnxruntime/test/providers/qnn/scatterelements_test.cc
+++ b/onnxruntime/test/providers/qnn/scatterelements_test.cc
@@ -189,11 +189,12 @@ TEST_F(QnnHTPBackendTests, ScatterElementsSharedNegativeIndicesInitializer) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All});
 }
 
-// Different axis bounds -- indices `[-1]` resolves to `kRows-1` for scatterA
-// and `kCols-1` for scatterB. The `_qnn_idx` rename prevents the two
-// per-axis rewrites from aliasing.
-// Disabling this test as it is flaky with QAIRT 2.49.40
-TEST_F(QnnHTPBackendTests, DISABLED_ScatterElementsSharedNegativeIndicesDifferentAxes) {
+// Different axis bounds -- the shared indices initializer {-1,-2,-3} rewrites to
+// rows {2,1,0} for scatterA (axis=0, dim=kRows) and cols {6,5,4} for scatterB
+// (axis=1, dim=kCols). Distinct per-row destinations keep the result deterministic
+// (no duplicate-index collision); the `_qnn_idx` rename prevents the two per-axis
+// rewrites from aliasing.
+TEST_F(QnnHTPBackendTests, ScatterElementsSharedNegativeIndicesDifferentAxes) {
   constexpr int64_t kRows = 3;
   constexpr int64_t kCols = 7;  // != kRows so rewritten bytes differ.
 
@@ -203,7 +204,7 @@ TEST_F(QnnHTPBackendTests, DISABLED_ScatterElementsSharedNegativeIndicesDifferen
     builder.MakeInput<int32_t>("dataA", {kRows, kCols}, data_a);
     builder.MakeInput<int32_t>("dataB", {kRows, kCols}, data_b);
 
-    std::vector<int64_t> indices = {-1, -1, -1};
+    std::vector<int64_t> indices = {-1, -2, -3};  // distinct: no duplicate-index collision
     builder.MakeInitializer<int64_t>("indices", {kRows, 1}, indices);
 
     std::vector<int32_t> updates_a = {10, 20, 30};


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Fix by using distinct indices {-1,-2,-3} so each update lands on a unique cell for both axes, making expected outputs deterministic. The _qnn_idx per-axis non-aliasing path the test was designed to cover is still exercised since the two axes rewrite the shared initializer to different byte sequences.
- Remove DISABLED_ prefix and update comment accordingly.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The test used indices {-1,-1,-1} with axis=0, causing all three updates to collide at the same destination cell (row 2). ONNX ScatterElements with reduction='none' and duplicate indices is order-undefined; CPU reference EP picks last-write-wins (30) while HTP's write order varies, producing 10/20/30 intermittently.