### PR TITLE
[QNN EP] Fix cmake build crashes in static_lib mode and ort_core prebuilt path

### DIFF
--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -83,6 +83,12 @@ else()
         --qnn_home "${onnxruntime_QNN_HOME}"
         --no_kleidiai
     )
+    # ort_core is fetched as a URL archive (zip), not a git clone, so there is no
+    # .git directory. Without this flag, build.py unconditionally runs
+    # "git submodule sync --recursive" and crashes with "fatal: not a git repository".
+    # NOTE: if ort_core is ever switched to GIT_REPOSITORY/GIT_TAG, remove this flag
+    # so that submodule sync runs correctly.
+    list(APPEND ORT_BUILD_COMMAND --skip_submodule_sync)
     if(onnxruntime_BUILD_CACHE)
         list(APPEND ORT_BUILD_COMMAND "--use_cache")
     endif()
@@ -224,7 +230,8 @@ ExternalProject_Add(
     SOURCE_DIR ${ORT_SOURCE_DIR}
     BINARY_DIR ${ORT_BUILD_DIR}
     DOWNLOAD_COMMAND ""
-    PATCH_COMMAND ""
+    PATCH_COMMAND ${Patch_EXECUTABLE} --ignore-whitespace -p1
+                  -i "${CMAKE_SOURCE_DIR}/cmake/patches/ort_core/0007-Guard-QNN_LIB_FILES-copy-in-onnxruntime-unittests.patch"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${ORT_BUILD_COMMAND}
     BUILD_ALWAYS ON

--- a/cmake/external/onnxruntime_prebuilt.cmake
+++ b/cmake/external/onnxruntime_prebuilt.cmake
@@ -231,7 +231,7 @@ ExternalProject_Add(
     BINARY_DIR ${ORT_BUILD_DIR}
     DOWNLOAD_COMMAND ""
     PATCH_COMMAND ${Patch_EXECUTABLE} --ignore-whitespace -p1
-                  -i "${CMAKE_SOURCE_DIR}/cmake/patches/ort_core/0007-Guard-QNN_LIB_FILES-copy-in-onnxruntime-unittests.patch"
+                  -i "${CMAKE_SOURCE_DIR}/patches/ort_core/0007-Guard-QNN_LIB_FILES-copy-in-onnxruntime-unittests.patch"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${ORT_BUILD_COMMAND}
     BUILD_ALWAYS ON

--- a/cmake/patches/ort_core/0007-Guard-QNN_LIB_FILES-copy-in-onnxruntime-unittests.patch
+++ b/cmake/patches/ort_core/0007-Guard-QNN_LIB_FILES-copy-in-onnxruntime-unittests.patch
@@ -1,0 +1,35 @@
+From: QNN EP team <noreply@qualcomm.com>
+Date: Mon, 18 Aug 2026 00:00:00 +0000
+Subject: [PATCH] cmake: guard QNN_LIB_FILES copy in onnxruntime_unittests.cmake
+
+In static_lib mode (e.g. Android builds) QNN_LIB_FILES is empty because
+the file(GLOB ...) block that populates it is inside an if(MSVC OR Linux)
+condition that is skipped.  The unguarded
+
+  add_custom_command(... cmake -E copy ${QNN_LIB_FILES} ${JAVA_NATIVE_TEST_DIR})
+
+emits a cmake -E copy invocation with zero source arguments, which causes
+CMake to print its usage banner and exit non-zero, crashing the build.
+
+Fix: add AND QNN_LIB_FILES to the if(onnxruntime_USE_QNN) guard so the
+copy command is only registered when there are actually files to copy.
+Shared-lib builds are unaffected; QNN_LIB_FILES is still non-empty there.
+
+TODO: re-check this patch on future ort_core upleveling since the target
+line number may drift.
+
+---
+ cmake/onnxruntime_unittests.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/cmake/onnxruntime_unittests.cmake
++++ b/cmake/onnxruntime_unittests.cmake
+@@ -2081,7 +2081,7 @@
+                 ${JAVA_NATIVE_TEST_DIR}/${CUSTOM_OP_LIBRARY_DST_FILE_NAME})
+
+         # also copy other library dependencies that may be required by tests to native-test
+-        if(onnxruntime_USE_QNN)
++        if(onnxruntime_USE_QNN AND QNN_LIB_FILES)
+           add_custom_command(TARGET onnxruntime_providers_qnn POST_BUILD
+               COMMAND ${CMAKE_COMMAND} -E copy ${QNN_LIB_FILES} ${JAVA_NATIVE_TEST_DIR})
+         endif()


### PR DESCRIPTION
## Description

Fixes two cmake defects that crash the build when using `--use_qnn static_lib` via the ort_core prebuilt path: an unguarded `cmake -E copy` on an empty `QNN_LIB_FILES` list, and a missing `--skip_submodule_sync` flag that causes `build.py` to run `git submodule sync` on a non-git source tree.

---

## Motivation & Context

Both issues manifest only in the `onnxruntime_prebuilt.cmake` ExternalProject build path and were worked around locally by commenting out code and manually patching the build command — fragile fixes invisible to CI.

**Issue 1 — empty `QNN_LIB_FILES` copy**

`QNN_LIB_FILES` is populated by a `file(GLOB ...)` inside an `if(MSVC OR Linux)` block in `microsoft/onnxruntime cmake/CMakeLists.txt`. On Android / static_lib builds that block is skipped, leaving the variable undefined (empty list).

In `cmake/onnxruntime_unittests.cmake` (upstream), the block that copies QNN libraries to the Java native-test directory is guarded only by `if(onnxruntime_USE_QNN)`. With `QNN_LIB_FILES` empty, CMake generates:

```
cmake -E copy <destination>
```

`cmake -E copy` requires at least one source argument before the destination. With zero sources it prints its usage banner and exits non-zero, crashing the build.

**Issue 2 — missing `--skip_submodule_sync`**

ort_core is fetched as a URL zip archive (`microsoft/onnxruntime v1.27.0`) — the extracted tree has no `.git` directory.
`build.py` unconditionally runs `git submodule sync --recursive` regardless, crashing with:

```
fatal: not a git repository (or any of the parent directories): .git
```

`build.py` exposes `--skip_submodule_sync` exactly for this scenario, but it was never appended to `ORT_BUILD_COMMAND` in this repo.

---