### PR TITLE
[QNN_EP] Rewrite QKV split to remove 5D Ops.

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qkv_split_attention_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qkv_split_attention_fusion.cc
@@ -1,0 +1,556 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_node_group/qkv_split_attention_fusion.h"
+
+#include <gsl/gsl>
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "QnnOpDef.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace {
+
+constexpr char kOpReshape[] = "Reshape";
+constexpr char kOpTranspose[] = "Transpose";
+constexpr char kOpGather[] = "Gather";
+constexpr char kOpMul[] = "Mul";
+constexpr char kOpMatMul[] = "MatMul";
+constexpr char kOpAdd[] = "Add";
+constexpr char kOpSoftmax[] = "Softmax";
+
+// ---------------------------------------------------------------------------
+// Matched sub-graph, resolved during MatchPattern. All pointers are non-owning
+// references into the graph's NodeUnits.
+// ---------------------------------------------------------------------------
+struct MatchedPattern {
+  const OrtNodeUnit* head_reshape = nullptr;    // Reshape([B,S,3,n,hs])
+  const OrtNodeUnit* head_transpose = nullptr;  // Transpose after the head reshape
+
+  const OrtNodeUnit* gather_q = nullptr;  // Gather(indices=0)
+  const OrtNodeUnit* gather_k = nullptr;  // Gather(indices=1)
+  const OrtNodeUnit* gather_v = nullptr;  // Gather(indices=2)
+
+  const OrtNodeUnit* q_scale_mul = nullptr;  // Mul(Q, 1/sqrt(hs))
+  const OrtNodeUnit* k_transpose = nullptr;  // Transpose on K before Q*K^T
+  const OrtNodeUnit* qk_matmul = nullptr;    // MatMul(Q, K^T)
+
+  // Interior mask-add / reshape chain between qk_matmul and softmax. Kept generic:
+  // the exact count of Add/Reshape nodes may vary (the reference graph has
+  // Add -> Reshape -> Add -> Reshape).
+  std::vector<const OrtNodeUnit*> interior;
+
+  const OrtNodeUnit* softmax = nullptr;    // Softmax
+  const OrtNodeUnit* av_matmul = nullptr;  // MatMul(softmax, V)
+
+  // Resolved emission parameters (packed-qkv input name + dims + gather output names).
+  QkvSplitAttentionFusion::SplitParams params;
+};
+
+// Return the single output value-info name of a node unit's target node.
+const std::string& FirstOutputName(const OrtNodeUnit& nu) {
+  return nu.Outputs()[0].name;
+}
+
+// Read the (int) 'indices' scalar of a Gather node unit whose indices input is a
+// constant scalar initializer. Returns nullopt if indices is not a constant scalar.
+std::optional<int64_t> GetGatherScalarIndex(const QnnModelWrapper& qmw, const OrtNodeUnit& gather) {
+  const auto& inputs = gather.Inputs();
+  if (inputs.size() < 2) {
+    return std::nullopt;
+  }
+  const std::string& idx_name = inputs[1].name;
+  if (!qmw.IsConstantInput(idx_name)) {
+    return std::nullopt;
+  }
+  const OrtValueInfo* vi = qmw.GetConstantTensor(idx_name);
+  if (vi == nullptr) {
+    return std::nullopt;
+  }
+  std::vector<uint8_t> bytes;
+  if (!qmw.UnpackInitializerData(vi, bytes).IsOK()) {
+    return std::nullopt;
+  }
+  // indices may be int64 or int32 scalar.
+  if (bytes.size() == sizeof(int64_t)) {
+    int64_t v = 0;
+    std::memcpy(&v, bytes.data(), sizeof(int64_t));
+    return v;
+  }
+  if (bytes.size() == sizeof(int32_t)) {
+    int32_t v = 0;
+    std::memcpy(&v, bytes.data(), sizeof(int32_t));
+    return static_cast<int64_t>(v);
+  }
+  return std::nullopt;
+}
+
+// Enumerate all distinct child NodeUnits that consume the single output of `parent`.
+// Unlike GetOnlyChildOfType this permits fan-out (the head Transpose feeds 3 Gathers).
+// Each returned child must be a standalone SingleNode NodeUnit that has not already been
+// claimed by another IQnnNodeGroup.
+std::vector<const OrtNodeUnit*> GetAllChildren(
+    const OrtNodeUnit& parent,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  std::vector<const OrtNodeUnit*> children;
+  const Ort::ConstNode parent_node(&parent.GetNode());
+  const std::vector<Ort::ConstValueInfo> outputs = parent_node.GetOutputs();
+  if (outputs.size() != 1) {
+    return children;
+  }
+  for (const Ort::ConstValueInfo& out : outputs) {
+    if (out.IsGraphOutput()) {
+      return {};  // feeding a graph output disqualifies fusion
+    }
+  }
+  for (const Ort::ValueInfoConsumerProducerInfo& consumer : outputs[0].GetConsumers()) {
+    if (consumer.node == nullptr) {
+      continue;
+    }
+    const auto it = node_to_node_unit.find(consumer.node);
+    if (it == node_to_node_unit.end()) {
+      return {};
+    }
+    const OrtNodeUnit* child = it->second;
+    if (node_unit_to_qnn_node_group.count(child) != 0) {
+      return {};
+    }
+    if (child->UnitType() != OrtNodeUnit::Type::SingleNode) {
+      return {};
+    }
+    // Deduplicate (a node could appear twice if it consumes the output on two inputs).
+    if (std::find(children.begin(), children.end(), child) == children.end()) {
+      children.push_back(child);
+    }
+  }
+  return children;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern matcher. Returns a populated MatchedPattern on success, else nullopt.
+// ---------------------------------------------------------------------------
+std::optional<MatchedPattern> MatchPattern(
+    const QnnModelWrapper& qmw,
+    const OrtNodeUnit& reshape_nu,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  if (reshape_nu.OpType() != kOpReshape ||
+      reshape_nu.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return std::nullopt;
+  }
+
+  MatchedPattern m;
+  m.head_reshape = &reshape_nu;
+
+  // Head Reshape must reshape the packed qkv into rank-5 [N, S, 3, n, hs]. The stacked-QKV
+  // axis (index 2) must equal 3; the trailing [n, hs] are heads/head_size.
+  std::vector<uint32_t> reshape_out_shape;
+  if (!qmw.GetOnnxShape(reshape_nu.Outputs()[0].shape, reshape_out_shape)) {
+    return std::nullopt;
+  }
+  if (reshape_out_shape.size() != 5 || reshape_out_shape[2] != 3) {
+    return std::nullopt;
+  }
+
+  // The packed-qkv producer must have a statically known rank-3 shape [N, S, 3*n*hs] whose
+  // last dim equals 3 * n * hs. This is the tensor we slice from.
+  const OrtNodeUnitIODef& qkv_in_def = reshape_nu.Inputs()[0];
+  std::vector<uint32_t> qkv_in_shape;
+  if (!qmw.GetOnnxShape(qkv_in_def.shape, qkv_in_shape) || qkv_in_shape.size() != 3) {
+    return std::nullopt;
+  }
+  const uint32_t n_rows = qkv_in_shape[0];
+  const uint32_t seq = qkv_in_shape[1];
+  const uint32_t packed = qkv_in_shape[2];
+  const uint32_t num_heads = reshape_out_shape[3];
+  const uint32_t head_size = reshape_out_shape[4];
+  if (num_heads == 0 || head_size == 0 || seq == 0 || n_rows == 0) {
+    return std::nullopt;
+  }
+  // Consistency: reshape leading dims collapse to N and S, and packed == 3 * n * hs.
+  // The product is computed in int64_t so an overflowing n*hs cannot alias a valid packed.
+  const int64_t hidden64 = static_cast<int64_t>(num_heads) * static_cast<int64_t>(head_size);
+  if (reshape_out_shape[0] != n_rows || reshape_out_shape[1] != seq ||
+      static_cast<int64_t>(packed) != 3 * hidden64) {
+    return std::nullopt;
+  }
+  // Slice bounds are emitted as int32_t ranges; reject geometry that cannot be represented.
+  if (3 * hidden64 > std::numeric_limits<int32_t>::max()) {
+    return std::nullopt;
+  }
+  // The rank-5 head Reshape output is absorbed by the rewrite and never re-emitted, so it
+  // must not be a graph output -- otherwise the tensor would vanish from the QNN graph.
+  // The head Transpose output is covered by the IsGraphOutput check in GetAllChildren.
+  if (qmw.IsGraphOutput(reshape_nu.Outputs()[0].name)) {
+    return std::nullopt;
+  }
+
+  m.params.qkv_input_name = qkv_in_def.name;
+  m.params.n_rows = n_rows;
+  m.params.seq = seq;
+  m.params.num_heads = num_heads;
+  m.params.head_size = head_size;
+
+  // Head Reshape -> single Transpose child.
+  const std::array<std::string_view, 1> transpose_type{kOpTranspose};
+  const OrtNodeUnit* transpose = GetOnlyChildOfType(qmw, reshape_nu, transpose_type,
+                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+  if (transpose == nullptr) {
+    return std::nullopt;
+  }
+  m.head_transpose = transpose;
+  // The head Transpose must move the stacked-3 axis to the front: perm == [2,0,3,1,4],
+  // producing [3, N, n, S, hs]. This is what makes each scalar Gather(axis=0) yield the
+  // per-role [N, n, S, hs] tensor.
+  {
+    OrtNodeAttrHelper transpose_helper(*transpose);
+    const std::vector<int64_t> perm =
+        transpose_helper.Get("perm", std::vector<int64_t>{});
+    const std::vector<int64_t> expected_perm{2, 0, 3, 1, 4};
+    if (perm != expected_perm) {
+      return std::nullopt;
+    }
+  }
+
+  // Transpose -> exactly 3 Gather children (the QKV split).
+  std::vector<const OrtNodeUnit*> children =
+      GetAllChildren(*transpose, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (children.size() != 3) {
+    return std::nullopt;
+  }
+  for (const OrtNodeUnit* child : children) {
+    if (child->OpType() != kOpGather) {
+      return std::nullopt;
+    }
+    OrtNodeAttrHelper gather_helper(*child);
+    if (gather_helper.Get("axis", static_cast<int64_t>(0)) != 0) {
+      return std::nullopt;  // must gather along the stacked-3 (front) axis
+    }
+    std::optional<int64_t> idx = GetGatherScalarIndex(qmw, *child);
+    if (!idx.has_value()) {
+      return std::nullopt;
+    }
+    // Each Gather output must be rank-4 [N, n, S, hs] (the scalar index removes axis 0).
+    std::vector<uint32_t> gather_out_shape;
+    if (!qmw.GetOnnxShape(child->Outputs()[0].shape, gather_out_shape) ||
+        gather_out_shape.size() != 4 ||
+        gather_out_shape[0] != n_rows || gather_out_shape[1] != num_heads ||
+        gather_out_shape[2] != seq || gather_out_shape[3] != head_size) {
+      return std::nullopt;
+    }
+    switch (idx.value()) {
+      case 0:
+        m.gather_q = child;
+        break;
+      case 1:
+        m.gather_k = child;
+        break;
+      case 2:
+        m.gather_v = child;
+        break;
+      default:
+        return std::nullopt;
+    }
+  }
+  if (m.gather_q == nullptr || m.gather_k == nullptr || m.gather_v == nullptr) {
+    return std::nullopt;
+  }
+  m.params.gather_out_names[0] = FirstOutputName(*m.gather_q);
+  m.params.gather_out_names[1] = FirstOutputName(*m.gather_k);
+  m.params.gather_out_names[2] = FirstOutputName(*m.gather_v);
+
+  // Q branch: Gather(0) -> Mul(scalar scale).
+  const std::array<std::string_view, 1> mul_type{kOpMul};
+  const OrtNodeUnit* q_mul = GetOnlyChildOfType(qmw, *m.gather_q, mul_type,
+                                                node_to_node_unit, node_unit_to_qnn_node_group);
+  if (q_mul == nullptr) {
+    return std::nullopt;
+  }
+  // Require a positive scalar constant on one of Mul's inputs (the 1/sqrt(head_size) scale).
+  {
+    bool has_scale = false;
+    for (const auto& in : q_mul->Inputs()) {
+      std::optional<float> val = GetScalarConstantValue(qmw, in.name);
+      if (val.has_value() && val.value() > 0.0f) {
+        has_scale = true;
+        break;
+      }
+    }
+    if (!has_scale) {
+      return std::nullopt;
+    }
+  }
+  m.q_scale_mul = q_mul;
+
+  // K branch: Gather(1) -> Transpose.
+  const OrtNodeUnit* k_transpose = GetOnlyChildOfType(qmw, *m.gather_k, transpose_type,
+                                                      node_to_node_unit, node_unit_to_qnn_node_group);
+  if (k_transpose == nullptr) {
+    return std::nullopt;
+  }
+  m.k_transpose = k_transpose;
+
+  // Q*K^T MatMul: the Mul output and the K Transpose output must converge on the same MatMul.
+  const std::array<std::string_view, 1> matmul_type{kOpMatMul};
+  const OrtNodeUnit* qk_matmul = GetOnlyChildOfType(qmw, *q_mul, matmul_type,
+                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+  if (qk_matmul == nullptr) {
+    return std::nullopt;
+  }
+  // Confirm k_transpose also feeds qk_matmul.
+  const OrtNodeUnit* k_child = GetOnlyChildOfType(qmw, *k_transpose, matmul_type,
+                                                  node_to_node_unit, node_unit_to_qnn_node_group);
+  if (k_child != qk_matmul) {
+    return std::nullopt;
+  }
+  m.qk_matmul = qk_matmul;
+
+  // Interior chain: walk single-child Add/Reshape nodes until reaching Softmax.
+  const OrtNodeUnit* cursor = qk_matmul;
+  constexpr int kMaxInterior = 8;  // guard against runaway loops
+  const std::array<std::string_view, 3> interior_types{kOpAdd, kOpReshape, kOpSoftmax};
+  const OrtNodeUnit* softmax = nullptr;
+  for (int i = 0; i < kMaxInterior; ++i) {
+    const OrtNodeUnit* next = GetOnlyChildOfType(qmw, *cursor, interior_types,
+                                                 node_to_node_unit, node_unit_to_qnn_node_group);
+    if (next == nullptr) {
+      return std::nullopt;
+    }
+    if (next->OpType() == kOpSoftmax) {
+      softmax = next;
+      break;
+    }
+    // Add or Reshape: record and continue.
+    m.interior.push_back(next);
+    cursor = next;
+  }
+  if (softmax == nullptr) {
+    return std::nullopt;
+  }
+  m.softmax = softmax;
+
+  // Softmax -> MatMul(., V). V branch (Gather(2)) must also feed this MatMul.
+  const OrtNodeUnit* av_matmul = GetOnlyChildOfType(qmw, *softmax, matmul_type,
+                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+  if (av_matmul == nullptr) {
+    return std::nullopt;
+  }
+  // Verify V (Gather(2)) feeds av_matmul as its other input.
+  {
+    const std::string& v_out = FirstOutputName(*m.gather_v);
+    const auto& av_inputs = av_matmul->Inputs();
+    const std::string& sm_out = FirstOutputName(*softmax);
+    bool v_feeds = false;
+    bool sm_feeds = false;
+    for (const auto& in : av_inputs) {
+      if (in.name == v_out) v_feeds = true;
+      if (in.name == sm_out) sm_feeds = true;
+    }
+    if (!v_feeds || !sm_feeds) {
+      return std::nullopt;
+    }
+  }
+  m.av_matmul = av_matmul;
+
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// Emission helpers
+// ---------------------------------------------------------------------------
+
+// Emit a QNN StridedSlice that selects [begin, end) along the last axis of a rank-3 tensor
+// [N, S, packed], producing [N, S, end-begin]. Mirrors MaxRoiPoolOpBuilder's ranges-only
+// StridedSlice (no begin/end/shrink masks needed).
+Ort::Status EmitLastAxisSlice(QnnModelWrapper& qmw,
+                              size_t node_index,
+                              const std::string& input_name,
+                              const std::string& output_name,
+                              const std::vector<uint32_t>& input_shape,
+                              int32_t begin,
+                              int32_t end,
+                              Qnn_DataType_t data_type,
+                              const QnnQuantParamsWrapper& quant_param,
+                              bool do_op_validation) {
+  const uint32_t n_rows = input_shape[0];
+  const uint32_t seq = input_shape[1];
+  const std::vector<uint32_t> output_shape{n_rows, seq, static_cast<uint32_t>(end - begin)};
+
+  const std::string node_name = utils::UniqueNameGenerator().New(output_name, QNN_OP_STRIDED_SLICE);
+
+  // ranges: [start, stop, step] per input dim (rank-3).
+  std::vector<uint32_t> ranges_data{
+      0u, n_rows, 1u,
+      0u, seq, 1u,
+      static_cast<uint32_t>(begin), static_cast<uint32_t>(end), 1u};
+  QnnParamWrapper ranges_param(node_index, node_name, QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                               {3u, 3u}, std::move(ranges_data), /*is_signed=*/true);
+  std::vector<std::string> param_names{ranges_param.GetParamTensorName()};
+  RETURN_IF_NOT(qmw.AddParamWrapper(std::move(ranges_param)), "Failed to add StridedSlice ranges param.");
+
+  QnnTensorWrapper output_tensor(output_name, QNN_TENSOR_TYPE_NATIVE, data_type,
+                                 quant_param.Copy(), std::vector<uint32_t>(output_shape));
+  RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(output_tensor)), "Failed to add StridedSlice output tensor.");
+
+  RETURN_IF_NOT(qmw.CreateQnnNode(node_name, QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_STRIDED_SLICE,
+                                  {input_name}, {output_name}, std::move(param_names), do_op_validation),
+                "Failed to create StridedSlice node.");
+  return Ort::Status();
+}
+
+// Emit one QKV branch: slice the packed qkv on the last axis, Reshape to [N,S,n,hs], then
+// Transpose(perm=[0,2,1,3]) to [N,n,S,hs] under the original Gather output name.
+Ort::Status EmitBranch(QnnModelWrapper& qmw,
+                       const OrtNodeUnit& head_reshape,
+                       const QkvSplitAttentionFusion::SplitParams& p,
+                       int role,  // 0=Q, 1=K, 2=V
+                       Qnn_DataType_t data_type,
+                       const QnnQuantParamsWrapper& quant_param,
+                       bool do_op_validation) {
+  const uint32_t hidden = p.num_heads * p.head_size;  // n*hs (== each slice width)
+  const std::vector<uint32_t> qkv_shape{p.n_rows, p.seq, 3u * hidden};
+  const int32_t begin = static_cast<int32_t>(role) * static_cast<int32_t>(hidden);
+  const int32_t end = begin + static_cast<int32_t>(hidden);
+
+  const std::string& gather_out = p.gather_out_names[role];
+  const std::string slice_out = utils::UniqueNameGenerator().New(gather_out, "_slice");
+  const std::string reshape_out = utils::UniqueNameGenerator().New(gather_out, "_reshape");
+
+  // 1) StridedSlice: [N,S,3*hidden] -> [N,S,hidden]
+  RETURN_IF_ERROR(EmitLastAxisSlice(qmw, head_reshape.Index(), p.qkv_input_name, slice_out,
+                                    qkv_shape, begin, end, data_type, quant_param, do_op_validation));
+
+  // 2) Reshape: [N,S,hidden] -> [N,S,n,hs]
+  RETURN_IF_ERROR(qmw.AddReshapeNode(slice_out, reshape_out,
+                                     {p.n_rows, p.seq, hidden},
+                                     {p.n_rows, p.seq, p.num_heads, p.head_size},
+                                     data_type, quant_param, do_op_validation,
+                                     /*is_for_input=*/false, /*is_for_output=*/false));
+
+  // 3) Transpose(perm=[0,2,1,3]): [N,S,n,hs] -> [N,n,S,hs] under the original Gather name.
+  RETURN_IF_ERROR(qmw.AddTransposeNode(head_reshape.Index(), reshape_out, gather_out,
+                                       {p.n_rows, p.seq, p.num_heads, p.head_size},
+                                       {0u, 2u, 1u, 3u},
+                                       {p.n_rows, p.num_heads, p.seq, p.head_size},
+                                       data_type, quant_param, do_op_validation,
+                                       /*is_for_input=*/false, /*is_for_output=*/false));
+  return Ort::Status();
+}
+
+// Shared implementation for IsSupported (validate=true) and AddToModelBuilder (validate=false).
+Ort::Status EmitOrValidate(QnnModelWrapper& qmw,
+                           const OrtNodeUnit& head_reshape,
+                           const QkvSplitAttentionFusion::SplitParams& p,
+                           bool do_op_validation) {
+  // Derive the QNN data type / quant params from the packed-qkv producer tensor so the
+  // emitted tensors preserve the original precision (e.g. fp16).
+  const OrtNodeUnitIODef& qkv_in_def = head_reshape.Inputs()[0];
+  TensorInfo qkv_info = {};
+  RETURN_IF_ERROR(qmw.GetTensorInfo(qkv_in_def, qkv_info));
+
+  // Ensure the packed-qkv input tensor exists in the QNN graph (it is produced by an
+  // upstream node, but may not have been registered yet during validation).
+  if (!qmw.IsQnnTensorWrapperExist(p.qkv_input_name)) {
+    QnnTensorWrapper qkv_tensor;
+    RETURN_IF_ERROR(qmw.MakeTensorWrapper(qkv_in_def, qkv_tensor));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(qkv_tensor)), "Failed to add packed-qkv input tensor.");
+  }
+
+  for (int role = 0; role < 3; ++role) {
+    RETURN_IF_ERROR(EmitBranch(qmw, head_reshape, p, role, qkv_info.qnn_data_type,
+                               qkv_info.quant_param, do_op_validation));
+  }
+  return Ort::Status();
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// QkvSplitAttentionFusion members
+// ---------------------------------------------------------------------------
+QkvSplitAttentionFusion::QkvSplitAttentionFusion(gsl::span<const OrtNodeUnit* const> claimed_node_units,
+                                                 SplitParams params)
+    : params_(std::move(params)) {
+  if (claimed_node_units.size() != node_units_.size()) {
+    ORT_CXX_API_THROW("QkvSplitAttentionFusion requires exactly 5 claimed NodeUnits.", ORT_EP_FAIL);
+  }
+  std::copy(claimed_node_units.begin(), claimed_node_units.end(), node_units_.begin());
+}
+
+std::unique_ptr<IQnnNodeGroup> QkvSplitAttentionFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& reshape_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  // NPU-only fusion. rank-5 tensors are supported on HTP but perform poorly; this fusion
+  // rewrites the rank-5 Reshape -> Transpose -> 3x Gather "QKV split" into rank-<=4 QNN
+  // ops, leaving the downstream SDPA math untouched. On non-NPU backends we defer to the
+  // existing per-op lowering.
+  if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return nullptr;
+  }
+
+  std::optional<MatchedPattern> matched =
+      MatchPattern(qnn_model_wrapper, reshape_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!matched.has_value()) {
+    return nullptr;
+  }
+
+  // Validate the rewrite on QNN before committing. If the emitted ops don't validate on the
+  // target backend, decline the fusion so the original nodes lower normally.
+  if (!EmitOrValidate(qnn_model_wrapper, *matched->head_reshape, matched->params,
+                      /*do_op_validation=*/true)
+           .IsOK()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("QkvSplitAttentionFusion: match at Reshape '" + reshape_node_unit.Name() +
+                 "' failed QNN validation; leaving unfused.")
+                    .c_str());
+    return nullptr;
+  }
+
+  // Claim only the 5 split nodes: [head Reshape, head Transpose, Gather_Q, Gather_K, Gather_V].
+  const std::array<const OrtNodeUnit*, 5> claimed{
+      matched->head_reshape, matched->head_transpose,
+      matched->gather_q, matched->gather_k, matched->gather_v};
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("QkvSplitAttentionFusion: rewriting rank-5 QKV split at Reshape '" +
+               reshape_node_unit.Name() + "' to rank-<=4 ops.")
+                  .c_str());
+  return std::make_unique<QkvSplitAttentionFusion>(
+      gsl::span<const OrtNodeUnit* const>{claimed.data(), claimed.size()}, matched->params);
+}
+
+gsl::span<const OrtNodeUnit* const> QkvSplitAttentionFusion::GetNodeUnits() const {
+  return gsl::span<const OrtNodeUnit* const>{node_units_.data(), node_units_.size()};
+}
+
+Ort::Status QkvSplitAttentionFusion::IsSupported(QnnModelWrapper& qnn_model_wrapper,
+                                                 const Ort::Logger& /*logger*/) const {
+  return EmitOrValidate(qnn_model_wrapper, *node_units_[0], params_, /*do_op_validation=*/true);
+}
+
+Ort::Status QkvSplitAttentionFusion::AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper,
+                                                       const Ort::Logger& /*logger*/) const {
+  return EmitOrValidate(qnn_model_wrapper, *node_units_[0], params_, /*do_op_validation=*/false);
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qkv_split_attention_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qkv_split_attention_fusion.h
@@ -1,0 +1,95 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <gsl/gsl>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// Rewrites the rank-5 "packed-QKV split" of a decomposed attention block into rank-<=4
+// QNN ops for the NPU (HTP/DSP) backend. rank-5 tensors are supported on HTP but perform
+// poorly; this fusion removes them from the hot attention path.
+//
+// Recognized ONNX pattern (Swin / GroundingDINO style), keyed on the head Reshape:
+//
+//   qkv[N,S,3*n*hs]
+//     - Reshape -> [N,S,3,n,hs]              (rank-5, slow on HTP)
+//     - Transpose(perm=[2,0,3,1,4]) -> [3,N,n,S,hs]   (rank-5, slow on HTP)
+//     - Gather(axis=0, idx=0) = Q -> [N,n,S,hs]
+//     - Gather(axis=0, idx=1) = K -> [N,n,S,hs]
+//     - Gather(axis=0, idx=2) = V -> [N,n,S,hs]
+//   ...downstream SDPA math (Mul/Transpose/MatMul/Add/Softmax/MatMul) is left untouched.
+//
+// This node group claims ONLY the 5 "split" nodes (head Reshape, head Transpose, and the
+// three Gathers). It re-emits them, per branch, as:
+//
+//   StridedSlice(qkv, last-axis block) -> [N,S,n*hs]   (rank-3)
+//     -> Reshape -> [N,S,n,hs]                          (rank-4)
+//     -> Transpose(perm=[0,2,1,3]) -> [N,n,S,hs]        (rank-4)  == original Gather output
+//
+// The three emitted branch outputs reuse the original Gather output tensor names, so every
+// downstream consumer keeps working with no further changes. The remaining attention nodes
+// are matched only to confirm the block really is packed-QKV attention; they are not
+// claimed and continue through their normal per-op lowering.
+//
+// On non-NPU backends, or when the pattern does not match, TryFusion returns nullptr and
+// the individual nodes fall back to their default per-op lowering.
+class QkvSplitAttentionFusion final : public IQnnNodeGroup {
+ public:
+  // Parameters resolved during matching and needed for emission.
+  struct SplitParams {
+    // Packed-QKV producer tensor (head Reshape's data input) and its shape [N, S, 3*n*hs].
+    std::string qkv_input_name;
+    uint32_t n_rows = 0;     // N   (product of leading/batch dims, i.e. num windows * batch)
+    uint32_t seq = 0;        // S   (tokens per row)
+    uint32_t num_heads = 0;  // n
+    uint32_t head_size = 0;  // hs
+    // Original Gather output tensor names, indexed by QKV role (0=Q, 1=K, 2=V). Emission
+    // reuses these names so downstream consumers are undisturbed.
+    std::array<std::string, 3> gather_out_names;
+  };
+
+  QkvSplitAttentionFusion(gsl::span<const OrtNodeUnit* const> claimed_node_units, SplitParams params);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(QkvSplitAttentionFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  // Target node is the head Reshape (first claimed node), the entry point of the split.
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return node_units_[0]; }
+  // Serialized as a JSON key in the framework op trace (summary.fusion_count[<Type()>]).
+  // Renaming is a breaking change for trace consumers.
+  static constexpr std::string_view kType = "QkvSplitAttentionFusion";
+  std::string_view Type() const override { return kType; }
+
+  // Traverses the graph starting from the head Reshape NodeUnit. Returns a
+  // QkvSplitAttentionFusion (claiming the 5 split nodes) if a valid packed-QKV attention
+  // block is found on an NPU backend and the rewrite validates on QNN, otherwise nullptr.
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& reshape_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  // The 5 claimed NodeUnits: [head Reshape, head Transpose, Gather_Q, Gather_K, Gather_V].
+  std::array<const OrtNodeUnit*, 5> node_units_;
+  SplitParams params_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -24,6 +24,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/layer_norm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/qkv_split_attention_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h"
@@ -34,6 +35,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/transpose_reshape_transpose_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/udo_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/window_partition_reverse_fusion.h"
 #include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/ort_api.h"
 
@@ -105,7 +107,14 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"ReduceMean", {LayerNormFusion::TryFusion}},
     {"ReduceL2", {L2NormFusion::TryFusion}},
     {"Einsum", {ReshapeEinsumReshapeNodeGroup::TryFusion}},
-    {"Reshape", {SpaceToDepthFusion::TryFusion, Rank6ToRank5Fusion::TryFusion, ReshapeTransposeFusion::TryFusion}},
+    // NOTE: order matters for the "Reshape" anchor. WindowPartitionReverseFusion must precede
+    // Rank6ToRank5Fusion: the generic rank-6 -> rank-5 fusion also matches the Swin window
+    // partition/reverse chains (they carry a unit batch dim that satisfies its conditions), so
+    // registering it first would let it claim those chains and prevent the rank-4 rewrite.
+    {"Reshape",
+     {SpaceToDepthFusion::TryFusion, WindowPartitionReverseFusion::TryFusion,
+      Rank6ToRank5Fusion::TryFusion, QkvSplitAttentionFusion::TryFusion,
+      ReshapeTransposeFusion::TryFusion}},
     {"Transpose", {ChannelShuffleFusion::TryFusion, TransposeReshapeTransposeFusion::TryFusion}}};
 
 void registerUDO(const std::string& node_type, const std::string& op_package) {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -30,6 +30,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/spacetodepth_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/swin_attention_projection_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_transpose_rank5.h"
 #include "core/providers/qnn/builder/qnn_node_group/scale_softmax_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/tanh_gelu_fusion.h"
@@ -98,7 +99,8 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"ConvInteger", {DQConvIntegerFusion::TryFusion}},
     {"Gather", {GatherTransposeReshapeFusion::TryFusion}},
     {"HardSigmoid", {HardSigmoidMulFusion::TryFusion}},
-    {"MatMul", {LowPowerBlockQuantizedMatMulFusion::TryFusion}},
+    {"MatMul", {SwinAttentionProjectionFusion::TryFusion,
+                LowPowerBlockQuantizedMatMulFusion::TryFusion}},
     {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmFusionGroup::TryFusion4, ReshapeGemmFusionGroup::TryFusion3, ReshapeGemmFusionGroup::TryFusion2}},
     {"Mul", {ScaleSoftmaxFusion::TryFusion}},
     {"Cast", {CastLoneQFusion::TryFusion}},

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/swin_attention_projection_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/swin_attention_projection_fusion.cc
@@ -1,0 +1,412 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_node_group/swin_attention_projection_fusion.h"
+
+#include <gsl/gsl>
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "QnnOpDef.h"
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace {
+
+using Params = SwinAttentionProjectionFusion::Params;
+using NodeMap = std::unordered_map<const OrtNode*, const OrtNodeUnit*>;
+using GroupMap = std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>;
+
+constexpr std::array<int64_t, 6> kWindowPerm{0, 1, 3, 2, 4, 5};
+
+struct Match {
+  Params params;
+  std::vector<const OrtNodeUnit*> claimed;
+  const OrtNodeUnit* reverse_reshape = nullptr;
+};
+
+std::vector<const OrtNodeUnit*> Children(const OrtNodeUnit& parent,
+                                         const NodeMap& node_map,
+                                         const GroupMap& group_map) {
+  std::vector<const OrtNodeUnit*> result;
+  const auto outputs = Ort::ConstNode(&parent.GetNode()).GetOutputs();
+  if (outputs.size() != 1 || outputs[0].IsGraphOutput()) return {};
+  for (const auto& consumer : outputs[0].GetConsumers()) {
+    if (consumer.node == nullptr) continue;
+    const auto it = node_map.find(consumer.node);
+    if (it == node_map.end() || group_map.count(it->second) != 0 ||
+        it->second->UnitType() != OrtNodeUnit::Type::SingleNode) {
+      return {};
+    }
+    if (std::find(result.begin(), result.end(), it->second) == result.end()) {
+      result.push_back(it->second);
+    }
+  }
+  return result;
+}
+
+const OrtNodeUnit* OnlyChild(const OrtNodeUnit& parent, std::string_view type,
+                             const NodeMap& node_map, const GroupMap& group_map) {
+  const auto children = Children(parent, node_map, group_map);
+  return children.size() == 1 && children[0]->OpType() == type ? children[0] : nullptr;
+}
+
+bool Shape(const QnnModelWrapper& qmw, const OrtNodeUnitIODef& def,
+           std::vector<uint32_t>& shape) {
+  return qmw.GetOnnxShape(def.shape, shape);
+}
+
+bool IsTokenShape(const std::vector<uint32_t>& shape, uint32_t channels) {
+  return !shape.empty() && shape.back() == channels &&
+         std::all_of(shape.begin(), shape.end(), [](uint32_t d) { return d != 0; });
+}
+
+std::optional<Match> MatchPattern(const QnnModelWrapper& qmw,
+                                  const OrtNodeUnit& mm,
+                                  const NodeMap& node_map,
+                                  const GroupMap& group_map) {
+  if (mm.OpType() != "MatMul" || mm.UnitType() != OrtNodeUnit::Type::SingleNode ||
+      mm.Inputs().size() != 2 || !qmw.IsConstantInput(mm.Inputs()[1].name)) {
+    return std::nullopt;
+  }
+
+  Match m;
+  m.claimed.push_back(&mm);
+
+  const OrtNodeUnit* post_cast = OnlyChild(mm, "Cast", node_map, group_map);
+  if (post_cast == nullptr) return std::nullopt;
+  const OrtNodeUnit* add = OnlyChild(*post_cast, "Add", node_map, group_map);
+  if (add == nullptr || add->Inputs().size() != 2) return std::nullopt;
+  m.claimed.push_back(post_cast);
+  m.claimed.push_back(add);
+
+  const OrtNodeUnitIODef* bias = nullptr;
+  for (const auto& input : add->Inputs()) {
+    if (qmw.IsConstantInput(input.name)) {
+      if (bias != nullptr) return std::nullopt;
+      bias = &input;
+    }
+  }
+  if (bias == nullptr) return std::nullopt;
+
+  const OrtNodeUnit* r1 = OnlyChild(*add, "Reshape", node_map, group_map);
+  const OrtNodeUnit* transpose = r1 == nullptr ? nullptr : OnlyChild(*r1, "Transpose", node_map, group_map);
+  const OrtNodeUnit* r2 = transpose == nullptr ? nullptr : OnlyChild(*transpose, "Reshape", node_map, group_map);
+  if (r1 == nullptr || transpose == nullptr || r2 == nullptr) return std::nullopt;
+
+  OrtNodeAttrHelper transpose_attrs(*transpose);
+  if (transpose_attrs.Get("perm", std::vector<int64_t>{}) !=
+      std::vector<int64_t>(kWindowPerm.begin(), kWindowPerm.end())) {
+    return std::nullopt;
+  }
+
+  std::vector<uint32_t> chain_in, rank6, reverse_out;
+  if (!Shape(qmw, r1->Inputs()[0], chain_in) || !Shape(qmw, r1->Outputs()[0], rank6) ||
+      !Shape(qmw, r2->Outputs()[0], reverse_out) || rank6.size() != 6 ||
+      chain_in.size() != 3 || reverse_out.size() != 4) {
+    return std::nullopt;
+  }
+
+  Params& p = m.params;
+  p.batch = rank6[0];
+  p.gh = rank6[1];
+  p.gw = rank6[2];
+  p.window_size = rank6[3];
+  p.channels = rank6[5];
+  if (p.window_size == 0 || rank6[4] != p.window_size || p.channels == 0 ||
+      chain_in != std::vector<uint32_t>{p.batch * p.gh * p.gw,
+                                        p.window_size * p.window_size, p.channels} ||
+      reverse_out != std::vector<uint32_t>{p.batch, p.gh * p.window_size,
+                                           p.gw * p.window_size, p.channels}) {
+    return std::nullopt;
+  }
+
+  std::vector<uint32_t> weight_shape, bias_shape, mm_input_shape;
+  if (!Shape(qmw, mm.Inputs()[1], weight_shape) ||
+      weight_shape != std::vector<uint32_t>{p.channels, p.channels} ||
+      !Shape(qmw, *bias, bias_shape) || bias_shape.empty() || bias_shape.back() != p.channels ||
+      !Shape(qmw, mm.Inputs()[0], mm_input_shape) || !IsTokenShape(mm_input_shape, p.channels)) {
+    return std::nullopt;
+  }
+  for (size_t i = 0; i + 1 < bias_shape.size(); ++i) {
+    if (bias_shape[i] != 1) return std::nullopt;
+  }
+
+  const OrtNodeUnit* pre_cast = GetParentOfType(qmw, mm, std::array<std::string_view, 1>{"Cast"},
+                                                node_map, group_map);
+  if (pre_cast == nullptr || OnlyChild(*pre_cast, "MatMul", node_map, group_map) != &mm) {
+    return std::nullopt;
+  }
+  p.chain_input_name = pre_cast->Inputs()[0].name;
+  p.chain_input_def = &pre_cast->Inputs()[0];
+  m.claimed.insert(m.claimed.begin(), pre_cast);
+
+  TensorInfo chain_input_info{}, mm_input_info{}, weight_info{}, mm_info{};
+  TensorInfo post_cast_info{}, bias_info{}, out_info{};
+  if (!qmw.GetTensorInfo(pre_cast->Inputs()[0], chain_input_info).IsOK() ||
+      !qmw.GetTensorInfo(mm.Inputs()[0], mm_input_info).IsOK() ||
+      !qmw.GetTensorInfo(mm.Inputs()[1], weight_info).IsOK() ||
+      !qmw.GetTensorInfo(mm.Outputs()[0], mm_info).IsOK() ||
+      !qmw.GetTensorInfo(post_cast->Outputs()[0], post_cast_info).IsOK() ||
+      !qmw.GetTensorInfo(*bias, bias_info).IsOK() ||
+      !qmw.GetTensorInfo(add->Outputs()[0], out_info).IsOK()) {
+    return std::nullopt;
+  }
+
+  // Match the mixed-precision island used by the Swin projection exactly. This also
+  // guarantees that the emitted FC and bias Add have homogeneous operand dtypes.
+  if (chain_input_info.qnn_data_type != QNN_DATATYPE_FLOAT_16 ||
+      mm_input_info.qnn_data_type != QNN_DATATYPE_FLOAT_32 ||
+      weight_info.qnn_data_type != QNN_DATATYPE_FLOAT_32 ||
+      mm_info.qnn_data_type != QNN_DATATYPE_FLOAT_32 ||
+      post_cast_info.qnn_data_type != QNN_DATATYPE_FLOAT_16 ||
+      bias_info.qnn_data_type != QNN_DATATYPE_FLOAT_16 ||
+      out_info.qnn_data_type != QNN_DATATYPE_FLOAT_16 ||
+      chain_input_info.quant_param.IsQuantized() || mm_info.quant_param.IsQuantized() ||
+      out_info.quant_param.IsQuantized()) {
+    return std::nullopt;
+  }
+  p.matmul_dtype = QNN_DATATYPE_FLOAT_32;
+  p.output_dtype = QNN_DATATYPE_FLOAT_16;
+  p.weight_def = &mm.Inputs()[1];
+  p.bias_def = bias;
+  p.reverse_anchor = r1;
+  p.reverse_output_name = r2->Outputs()[0].name;
+  m.reverse_reshape = r1;
+  m.claimed.insert(m.claimed.end(), {r1, transpose, r2});
+
+  // Walk the Slice/Concat DAG after window reverse. The unique terminal must be a depad
+  // Slice followed by the final token Reshape. Branching is allowed only inside this DAG.
+  std::vector<const OrtNodeUnit*> work = Children(*r2, node_map, group_map);
+  std::unordered_set<const OrtNodeUnit*> seen;
+  const OrtNodeUnit* final_reshape = nullptr;
+  const OrtNodeUnit* depad = nullptr;
+  while (!work.empty()) {
+    const OrtNodeUnit* node = work.back();
+    work.pop_back();
+    if (!seen.insert(node).second) continue;
+    if (node->OpType() != "Slice" && node->OpType() != "Concat") return std::nullopt;
+
+    std::vector<uint32_t> out_shape;
+    if (!Shape(qmw, node->Outputs()[0], out_shape) || !IsTokenShape(out_shape, p.channels) ||
+        qmw.IsGraphOutput(node->Outputs()[0].name)) {
+      return std::nullopt;
+    }
+
+    const auto children = Children(*node, node_map, group_map);
+    if (children.size() == 1 && children[0]->OpType() == "Reshape") {
+      if (node->OpType() != "Slice" || final_reshape != nullptr) return std::nullopt;
+      depad = node;
+      final_reshape = children[0];
+      p.depad_shape = out_shape;
+      continue;
+    }
+    if (children.empty()) return std::nullopt;
+    work.insert(work.end(), children.begin(), children.end());
+  }
+  if (depad == nullptr || final_reshape == nullptr ||
+      !Shape(qmw, final_reshape->Outputs()[0], p.final_shape) ||
+      !IsTokenShape(p.final_shape, p.channels)) {
+    return std::nullopt;
+  }
+
+  p.depad_output_name = depad->Outputs()[0].name;
+  p.final_output_name = final_reshape->Outputs()[0].name;
+  p.post_reverse_nodes.assign(seen.begin(), seen.end());
+  std::sort(p.post_reverse_nodes.begin(), p.post_reverse_nodes.end(),
+            [](const OrtNodeUnit* a, const OrtNodeUnit* b) { return a->Index() < b->Index(); });
+  m.claimed.insert(m.claimed.end(), p.post_reverse_nodes.begin(), p.post_reverse_nodes.end());
+  m.claimed.push_back(final_reshape);
+
+  // Every crossed node must preserve complete tokens. The depad must actually reduce the
+  // spatial/token count; otherwise there is no reason to perform this more invasive fusion.
+  uint64_t before = 1, after = 1;
+  for (size_t i = 0; i + 1 < reverse_out.size(); ++i) before *= reverse_out[i];
+  for (size_t i = 0; i + 1 < p.depad_shape.size(); ++i) after *= p.depad_shape[i];
+  if (after >= before) return std::nullopt;
+
+  return m;
+}
+
+Ort::Status EmitReverse(QnnModelWrapper& qmw, const OrtNodeUnit& anchor,
+                        const Params& p, bool validate) {
+  RETURN_IF_NOT(p.chain_input_def != nullptr, "Swin fusion has no chain input definition.");
+  if (!qmw.IsQnnTensorWrapperExist(p.chain_input_name)) {
+    QnnTensorWrapper wrapper;
+    RETURN_IF_ERROR(qmw.MakeTensorWrapper(*p.chain_input_def, wrapper));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(wrapper)), "Failed to add Swin fusion input.");
+  }
+
+  const uint32_t B = p.batch, Gh = p.gh, Gw = p.gw, ws = p.window_size, C = p.channels;
+  const uint32_t H = Gh * ws, W = Gw * ws;
+  const size_t index = anchor.Index();
+  auto name = [&p](std::string_view suffix) {
+    return utils::UniqueNameGenerator().New(p.final_output_name, std::string(suffix));
+  };
+  const std::vector<uint32_t> perm{0, 2, 1, 3};
+  const QnnQuantParamsWrapper qp;
+
+  const std::string r1 = name("_swin_wr_r1");
+  RETURN_IF_ERROR(qmw.AddReshapeNode(p.chain_input_name, r1,
+                                     {B * Gh * Gw, ws * ws, C}, {B, Gh, Gw, ws * ws * C},
+                                     p.output_dtype, qp, validate, false, false));
+  const std::string t1 = name("_swin_wr_t1");
+  RETURN_IF_ERROR(qmw.AddTransposeNode(index, r1, t1, {B, Gh, Gw, ws * ws * C}, perm,
+                                       {B, Gw, Gh, ws * ws * C}, p.output_dtype, qp,
+                                       validate, false, false));
+  const std::string r2 = name("_swin_wr_r2");
+  RETURN_IF_ERROR(qmw.AddReshapeNode(t1, r2, {B, Gw, Gh, ws * ws * C},
+                                     {B, Gw, H, ws * C}, p.output_dtype, qp,
+                                     validate, false, false));
+  const std::string t2 = name("_swin_wr_t2");
+  RETURN_IF_ERROR(qmw.AddTransposeNode(index, r2, t2, {B, Gw, H, ws * C}, perm,
+                                       {B, H, Gw, ws * C}, p.output_dtype, qp,
+                                       validate, false, false));
+  return qmw.AddReshapeNode(t2, p.reverse_output_name, {B, H, Gw, ws * C},
+                            {B, H, W, C}, p.output_dtype, qp, validate, false, false);
+}
+
+Ort::Status EmitProjection(QnnModelWrapper& qmw, const Params& p,
+                           const Ort::Logger& logger, bool validate) {
+  auto name = [&p](std::string_view suffix) {
+    return utils::UniqueNameGenerator().New(p.final_output_name, std::string(suffix));
+  };
+  uint32_t tokens = 1;
+  for (size_t i = 0; i + 1 < p.depad_shape.size(); ++i) tokens *= p.depad_shape[i];
+  const std::vector<uint32_t> flat_shape{tokens, p.channels};
+  const QnnQuantParamsWrapper qp;
+
+  const std::string flat = name("_swin_proj_flat");
+  RETURN_IF_ERROR(qmw.AddReshapeNode(p.depad_output_name, flat, p.depad_shape, flat_shape,
+                                     p.output_dtype, qp, validate, false, false));
+
+  std::vector<uint32_t> weight_shape;
+  RETURN_IF_NOT(qmw.GetOnnxShape(p.weight_def->shape, weight_shape), "Missing projection weight shape.");
+  const OrtValueInfo* weight = qmw.GetConstantTensor(p.weight_def->name);
+  RETURN_IF_NOT(weight != nullptr, "Projection weight is not constant.");
+  std::vector<uint8_t> weight_data;
+  RETURN_IF_ERROR(utils::TwoDimensionTranspose(qmw, weight_shape, weight, weight_data, logger, validate));
+  std::reverse(weight_shape.begin(), weight_shape.end());
+  const std::string weight_name = name("_swin_proj_weight");
+  if (!qmw.IsQnnTensorWrapperExist(weight_name)) {
+    QnnTensorWrapper wrapper(weight_name, QNN_TENSOR_TYPE_STATIC, p.matmul_dtype,
+                             QnnQuantParamsWrapper(), std::move(weight_shape),
+                             std::move(weight_data));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(wrapper)), "Failed to add projection weight.");
+  }
+
+  const std::string fc_input = name("_swin_proj_input");
+  RETURN_IF_ERROR(qmw.AddCastNode(name("_swin_proj_precast"), flat, fc_input,
+                                  QNN_TENSOR_TYPE_NATIVE, p.matmul_dtype,
+                                  QnnQuantParamsWrapper(), std::vector<uint32_t>(flat_shape),
+                                  validate));
+
+  const std::string zero_bias = name("_swin_proj_zero_bias");
+  if (!qmw.IsQnnTensorWrapperExist(zero_bias)) {
+    const size_t element_size = p.matmul_dtype == QNN_DATATYPE_FLOAT_32 ? 4u : 2u;
+    QnnTensorWrapper wrapper(zero_bias, QNN_TENSOR_TYPE_STATIC, p.matmul_dtype,
+                             QnnQuantParamsWrapper(), std::vector<uint32_t>{p.channels},
+                             std::vector<uint8_t>(p.channels * element_size, 0));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(wrapper)), "Failed to add zero FC bias.");
+  }
+
+  const std::string fc_output = name("_swin_proj_fc");
+  QnnTensorWrapper fc_wrapper(fc_output, QNN_TENSOR_TYPE_NATIVE, p.matmul_dtype,
+                              QnnQuantParamsWrapper(), std::vector<uint32_t>(flat_shape),
+                              std::vector<uint8_t>());
+  RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(fc_wrapper)), "Failed to add FC output.");
+  RETURN_IF_NOT(qmw.CreateQnnNode(name("_swin_proj_fc_node"), QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                  QNN_OP_FULLY_CONNECTED, {fc_input, weight_name, zero_bias},
+                                  {fc_output}, {}, validate), "Failed to create projection FC.");
+
+  const std::string cast_output = name("_swin_proj_postcast");
+  RETURN_IF_ERROR(qmw.AddCastNode(name("_swin_proj_postcast_node"), fc_output, cast_output,
+                                  QNN_TENSOR_TYPE_NATIVE, p.output_dtype,
+                                  QnnQuantParamsWrapper(), std::vector<uint32_t>(flat_shape),
+                                  validate));
+
+  if (!qmw.IsQnnTensorWrapperExist(p.bias_def->name)) {
+    QnnTensorWrapper bias_wrapper;
+    RETURN_IF_ERROR(qmw.MakeTensorWrapper(*p.bias_def, bias_wrapper));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(bias_wrapper)), "Failed to add projection bias.");
+  }
+  const std::string add_output = name("_swin_proj_add");
+  QnnTensorWrapper add_wrapper(add_output, QNN_TENSOR_TYPE_NATIVE, p.output_dtype,
+                               QnnQuantParamsWrapper(), std::vector<uint32_t>(flat_shape),
+                               std::vector<uint8_t>());
+  RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(add_wrapper)), "Failed to add projection Add output.");
+  RETURN_IF_NOT(qmw.CreateQnnNode(name("_swin_proj_add_node"), QNN_OP_PACKAGE_NAME_QTI_AISW,
+                                  QNN_OP_ELEMENT_WISE_ADD, {cast_output, p.bias_def->name},
+                                  {add_output}, {}, validate), "Failed to create projection bias Add.");
+
+  return qmw.AddReshapeNode(add_output, p.final_output_name, flat_shape, p.final_shape,
+                            p.output_dtype, qp, validate, false,
+                            qmw.IsGraphOutput(p.final_output_name));
+}
+
+Ort::Status Emit(QnnModelWrapper& qmw, const OrtNodeUnit& reverse_anchor,
+                 const Params& p, const Ort::Logger& logger, bool validate) {
+  RETURN_IF_ERROR(EmitReverse(qmw, reverse_anchor, p, validate));
+  for (const OrtNodeUnit* node : p.post_reverse_nodes) {
+    const IOpBuilder* builder = GetOpBuilder(node->OpType());
+    RETURN_IF_NOT(builder != nullptr, "Missing Slice/Concat builder for Swin fusion.");
+    RETURN_IF_ERROR(builder->AddToModelBuilder(qmw, *node, logger, validate));
+  }
+  return EmitProjection(qmw, p, logger, validate);
+}
+
+}  // namespace
+
+SwinAttentionProjectionFusion::SwinAttentionProjectionFusion(
+    gsl::span<const OrtNodeUnit* const> node_units, Params params)
+    : node_units_(node_units.begin(), node_units.end()), params_(std::move(params)) {}
+
+std::unique_ptr<IQnnNodeGroup> SwinAttentionProjectionFusion::TryFusion(
+    QnnModelWrapper& qmw, const OrtNodeUnit& matmul, const NodeMap& node_map,
+    const GroupMap& group_map, const Ort::Logger& logger) {
+  if (!IsNpuBackend(qmw.GetQnnBackendType())) return nullptr;
+  auto match = MatchPattern(qmw, matmul, node_map, group_map);
+  if (!match.has_value()) return nullptr;
+  if (!Emit(qmw, *match->reverse_reshape, match->params, logger, true).IsOK()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("SwinAttentionProjectionFusion: QNN validation failed at '" + matmul.Name() + "'.").c_str());
+    return nullptr;
+  }
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("SwinAttentionProjectionFusion: moved projection after depad at '" + matmul.Name() + "'.").c_str());
+  return std::make_unique<SwinAttentionProjectionFusion>(
+      gsl::span<const OrtNodeUnit* const>{match->claimed.data(), match->claimed.size()},
+      std::move(match->params));
+}
+
+gsl::span<const OrtNodeUnit* const> SwinAttentionProjectionFusion::GetNodeUnits() const {
+  return {node_units_.data(), node_units_.size()};
+}
+
+Ort::Status SwinAttentionProjectionFusion::IsSupported(QnnModelWrapper& qmw,
+                                                        const Ort::Logger& logger) const {
+  RETURN_IF_NOT(params_.reverse_anchor != nullptr, "Swin fusion has no reverse anchor.");
+  return Emit(qmw, *params_.reverse_anchor, params_, logger, true);
+}
+
+Ort::Status SwinAttentionProjectionFusion::AddToModelBuilder(QnnModelWrapper& qmw,
+                                                              const Ort::Logger& logger) const {
+  RETURN_IF_NOT(params_.reverse_anchor != nullptr, "Swin fusion has no reverse anchor.");
+  return Emit(qmw, *params_.reverse_anchor, params_, logger, false);
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/swin_attention_projection_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/swin_attention_projection_fusion.h
@@ -1,0 +1,80 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <gsl/gsl>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_def.h"
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// Moves a Swin attention output projection after window reverse, optional cyclic unshift,
+// and depadding. The group also emits the window reverse as rank-4 operations.
+//
+//   Cast -> MatMul -> Cast -> Add(bias) -> window_reverse -> [roll] -> depad -> Reshape
+// becomes
+//   rank4_window_reverse -> [roll] -> depad -> Cast -> FC -> Cast -> Add(bias) -> Reshape
+//
+// This is valid because all operations crossed by the projection only permute or discard
+// complete tokens and leave the channel axis unchanged. Running after depadding avoids
+// projecting padded tokens and removes the format-conversion island before window reverse.
+class SwinAttentionProjectionFusion final : public IQnnNodeGroup {
+ public:
+  struct Params {
+    std::string chain_input_name;
+    std::string reverse_output_name;
+    std::string depad_output_name;
+    std::string final_output_name;
+    const OrtNodeUnitIODef* chain_input_def = nullptr;
+    const OrtNodeUnitIODef* weight_def = nullptr;
+    const OrtNodeUnitIODef* bias_def = nullptr;
+    const OrtNodeUnit* reverse_anchor = nullptr;
+    Qnn_DataType_t matmul_dtype{};
+    Qnn_DataType_t output_dtype{};
+    uint32_t batch = 0;
+    uint32_t gh = 0;
+    uint32_t gw = 0;
+    uint32_t window_size = 0;
+    uint32_t channels = 0;
+    std::vector<uint32_t> depad_shape;
+    std::vector<uint32_t> final_shape;
+    // Original Slice/Concat nodes after window reverse, in topological order. Re-emitted
+    // through their normal op builders after the rank-4 reverse writes reverse_output_name.
+    std::vector<const OrtNodeUnit*> post_reverse_nodes;
+  };
+
+  SwinAttentionProjectionFusion(gsl::span<const OrtNodeUnit* const> node_units, Params params);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(SwinAttentionProjectionFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return node_units_[0]; }
+  static constexpr std::string_view kType = "SwinAttentionProjectionFusion";
+  std::string_view Type() const override { return kType; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& matmul_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::vector<const OrtNodeUnit*> node_units_;
+  Params params_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/window_partition_reverse_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/window_partition_reverse_fusion.cc
@@ -1,0 +1,299 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#include "core/providers/qnn/builder/qnn_node_group/window_partition_reverse_fusion.h"
+
+#include <gsl/gsl>
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+namespace {
+
+constexpr char kOpReshape[] = "Reshape";
+constexpr char kOpTranspose[] = "Transpose";
+constexpr size_t kRank6 = 6;
+
+// The window partition/reverse Transpose only swaps axes 2 and 3 of a rank-6 tensor.
+const std::array<int64_t, 6> kWindowPerm{0, 1, 3, 2, 4, 5};
+
+using Params = WindowPartitionReverseFusion::Params;
+using Direction = WindowPartitionReverseFusion::Direction;
+
+// Match Reshape -> Transpose(perm=[0,1,3,2,4,5]) -> Reshape with rank-6 intermediates and
+// resolve the window geometry (B, Gh, Gw, ws, C). Returns nullopt if not a window chain.
+std::optional<std::pair<std::array<const OrtNodeUnit*, 3>, Params>> MatchWindowChain(
+    const QnnModelWrapper& qmw,
+    const OrtNodeUnit& reshape1,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group) {
+  if (reshape1.OpType() != kOpReshape || reshape1.UnitType() != OrtNodeUnit::Type::SingleNode) {
+    return std::nullopt;
+  }
+
+  const std::array<std::string_view, 1> transpose_type{kOpTranspose};
+  const OrtNodeUnit* transpose = GetOnlyChildOfType(qmw, reshape1, transpose_type,
+                                                    node_to_node_unit, node_unit_to_qnn_node_group);
+  if (transpose == nullptr) {
+    return std::nullopt;
+  }
+  const std::array<std::string_view, 1> reshape_type{kOpReshape};
+  const OrtNodeUnit* reshape2 = GetOnlyChildOfType(qmw, *transpose, reshape_type,
+                                                   node_to_node_unit, node_unit_to_qnn_node_group);
+  if (reshape2 == nullptr) {
+    return std::nullopt;
+  }
+
+  // Perm must be exactly the window axis-swap.
+  {
+    OrtNodeAttrHelper helper(*transpose);
+    const std::vector<int64_t> perm = helper.Get("perm", std::vector<int64_t>{});
+    if (perm.size() != kRank6 ||
+        !std::equal(perm.begin(), perm.end(), kWindowPerm.begin())) {
+      return std::nullopt;
+    }
+  }
+
+  std::vector<uint32_t> in_shape, t1_shape, t2_shape, out_shape;
+  if (!qmw.GetOnnxShape(reshape1.Inputs()[0].shape, in_shape) ||
+      !qmw.GetOnnxShape(reshape1.Outputs()[0].shape, t1_shape) ||
+      !qmw.GetOnnxShape(transpose->Outputs()[0].shape, t2_shape) ||
+      !qmw.GetOnnxShape(reshape2->Outputs()[0].shape, out_shape)) {
+    return std::nullopt;
+  }
+  if (t1_shape.size() != kRank6 || t2_shape.size() != kRank6) {
+    return std::nullopt;
+  }
+
+  Params p;
+  // Partition: t1 = [B, Gh, ws, Gw, ws, C]  (in_rank=4 [B,H,W,C], out_rank=3).
+  // Reverse:   t1 = [B, Gh, Gw, ws, ws, C]  (in_rank=3, out_rank=4 [B,H,W,C]).
+  if (in_shape.size() == 4 && out_shape.size() == 3) {
+    p.direction = Direction::kPartition;
+    p.batch = t1_shape[0];
+    p.gh = t1_shape[1];
+    p.ws = t1_shape[2];
+    p.gw = t1_shape[3];
+    const uint32_t ws2 = t1_shape[4];
+    p.channels = t1_shape[5];
+    // Consistency: square window, and dims match the [B,H,W,C] input / [nW,ws*ws,C] output.
+    if (p.ws != ws2 || p.ws == 0 || p.gh == 0 || p.gw == 0 || p.channels == 0) {
+      return std::nullopt;
+    }
+    if (in_shape[0] != p.batch || in_shape[1] != p.gh * p.ws || in_shape[2] != p.gw * p.ws ||
+        in_shape[3] != p.channels) {
+      return std::nullopt;
+    }
+    if (out_shape[0] != p.batch * p.gh * p.gw || out_shape[1] != p.ws * p.ws ||
+        out_shape[2] != p.channels) {
+      return std::nullopt;
+    }
+  } else if (in_shape.size() == 3 && out_shape.size() == 4) {
+    p.direction = Direction::kReverse;
+    p.batch = t1_shape[0];
+    p.gh = t1_shape[1];
+    p.gw = t1_shape[2];
+    p.ws = t1_shape[3];
+    const uint32_t ws2 = t1_shape[4];
+    p.channels = t1_shape[5];
+    if (p.ws != ws2 || p.ws == 0 || p.gh == 0 || p.gw == 0 || p.channels == 0) {
+      return std::nullopt;
+    }
+    if (in_shape[0] != p.batch * p.gh * p.gw || in_shape[1] != p.ws * p.ws ||
+        in_shape[2] != p.channels) {
+      return std::nullopt;
+    }
+    if (out_shape[0] != p.batch || out_shape[1] != p.gh * p.ws || out_shape[2] != p.gw * p.ws ||
+        out_shape[3] != p.channels) {
+      return std::nullopt;
+    }
+  } else {
+    return std::nullopt;
+  }
+
+  // The rewrite folds window/channel axes together (ws*C and ws*ws*C) and merges the leading
+  // block axes (B*Gh*Gw). Compute those products in int64_t and reject geometry whose folded
+  // dims cannot be represented as the uint32_t QNN shapes require.
+  {
+    const int64_t ws64 = static_cast<int64_t>(p.ws);
+    const int64_t c64 = static_cast<int64_t>(p.channels);
+    const int64_t blocks64 =
+        static_cast<int64_t>(p.batch) * static_cast<int64_t>(p.gh) * static_cast<int64_t>(p.gw);
+    const int64_t max_u32 = static_cast<int64_t>(std::numeric_limits<uint32_t>::max());
+    if (ws64 * c64 > max_u32 || ws64 * ws64 * c64 > max_u32 || blocks64 > max_u32) {
+      return std::nullopt;
+    }
+  }
+
+  // The two rank-6 intermediates are absorbed by the rewrite and never re-emitted, so
+  // neither may be a graph output -- otherwise the tensor would vanish from the QNN graph.
+  if (qmw.IsGraphOutput(reshape1.Outputs()[0].name) ||
+      qmw.IsGraphOutput(transpose->Outputs()[0].name)) {
+    return std::nullopt;
+  }
+
+  p.input_name = reshape1.Inputs()[0].name;
+  p.output_name = reshape2->Outputs()[0].name;
+  return std::make_pair(std::array<const OrtNodeUnit*, 3>{&reshape1, transpose, reshape2}, p);
+}
+
+// Build the rank-<=4 op sequence. On do_op_validation the ops are validated on QNN; otherwise
+// they are appended to the model. The final Reshape writes p.output_name (the original name).
+Ort::Status EmitChain(QnnModelWrapper& qmw,
+                      const OrtNodeUnit& reshape1,
+                      const Params& p,
+                      bool do_op_validation) {
+  const OrtNodeUnitIODef& in_def = reshape1.Inputs()[0];
+  TensorInfo in_info = {};
+  RETURN_IF_ERROR(qmw.GetTensorInfo(in_def, in_info));
+  const Qnn_DataType_t dt = in_info.qnn_data_type;
+  const QnnQuantParamsWrapper& qp = in_info.quant_param;
+
+  const uint32_t B = p.batch, Gh = p.gh, Gw = p.gw, ws = p.ws, C = p.channels;
+  const uint32_t H = Gh * ws, W = Gw * ws;
+  const size_t idx = reshape1.Index();
+  const bool out_is_graph_output = qmw.IsGraphOutput(p.output_name);
+
+  // Ensure the chain input tensor exists in the QNN graph.
+  if (!qmw.IsQnnTensorWrapperExist(p.input_name)) {
+    QnnTensorWrapper in_wrap;
+    RETURN_IF_ERROR(qmw.MakeTensorWrapper(in_def, in_wrap));
+    RETURN_IF_NOT(qmw.AddTensorWrapper(std::move(in_wrap)), "Failed to add window-chain input tensor.");
+  }
+
+  const std::string& base = p.output_name;
+  auto name = [&base](std::string_view suffix) {
+    return utils::UniqueNameGenerator().New(base, std::string(suffix));
+  };
+
+  const std::vector<uint32_t> perm4{0u, 2u, 1u, 3u};
+
+  if (p.direction == Direction::kPartition) {
+    // x[B,H,W,C] -> [B,H,Gw,ws*C]
+    const std::string r1 = name("_wp_r1");
+    RETURN_IF_ERROR(qmw.AddReshapeNode(p.input_name, r1,
+                                       {B, H, W, C}, {B, H, Gw, ws * C},
+                                       dt, qp, do_op_validation, false, false));
+    // -> transpose [B,Gw,H,ws*C]
+    const std::string t1 = name("_wp_t1");
+    RETURN_IF_ERROR(qmw.AddTransposeNode(idx, r1, t1,
+                                         {B, H, Gw, ws * C}, perm4, {B, Gw, H, ws * C},
+                                         dt, qp, do_op_validation, false, false));
+    // -> [B,Gw,Gh,ws*ws*C]
+    const std::string r2 = name("_wp_r2");
+    RETURN_IF_ERROR(qmw.AddReshapeNode(t1, r2,
+                                       {B, Gw, H, ws * C}, {B, Gw, Gh, ws * ws * C},
+                                       dt, qp, do_op_validation, false, false));
+    // -> transpose [B,Gh,Gw,ws*ws*C]
+    const std::string t2 = name("_wp_t2");
+    RETURN_IF_ERROR(qmw.AddTransposeNode(idx, r2, t2,
+                                         {B, Gw, Gh, ws * ws * C}, perm4, {B, Gh, Gw, ws * ws * C},
+                                         dt, qp, do_op_validation, false, false));
+    // -> [B*Gh*Gw, ws*ws, C]  (final, original output name)
+    RETURN_IF_ERROR(qmw.AddReshapeNode(t2, p.output_name,
+                                       {B, Gh, Gw, ws * ws * C}, {B * Gh * Gw, ws * ws, C},
+                                       dt, qp, do_op_validation, false, out_is_graph_output));
+  } else {
+    // x[B*Gh*Gw, ws*ws, C] -> [B,Gh,Gw,ws*ws*C]
+    const std::string r1 = name("_wr_r1");
+    RETURN_IF_ERROR(qmw.AddReshapeNode(p.input_name, r1,
+                                       {B * Gh * Gw, ws * ws, C}, {B, Gh, Gw, ws * ws * C},
+                                       dt, qp, do_op_validation, false, false));
+    // -> transpose [B,Gw,Gh,ws*ws*C]
+    const std::string t1 = name("_wr_t1");
+    RETURN_IF_ERROR(qmw.AddTransposeNode(idx, r1, t1,
+                                         {B, Gh, Gw, ws * ws * C}, perm4, {B, Gw, Gh, ws * ws * C},
+                                         dt, qp, do_op_validation, false, false));
+    // -> [B,Gw,H,ws*C]
+    const std::string r2 = name("_wr_r2");
+    RETURN_IF_ERROR(qmw.AddReshapeNode(t1, r2,
+                                       {B, Gw, Gh, ws * ws * C}, {B, Gw, H, ws * C},
+                                       dt, qp, do_op_validation, false, false));
+    // -> transpose [B,H,Gw,ws*C]
+    const std::string t2 = name("_wr_t2");
+    RETURN_IF_ERROR(qmw.AddTransposeNode(idx, r2, t2,
+                                         {B, Gw, H, ws * C}, perm4, {B, H, Gw, ws * C},
+                                         dt, qp, do_op_validation, false, false));
+    // -> [B,H,W,C]  (final, original output name)
+    RETURN_IF_ERROR(qmw.AddReshapeNode(t2, p.output_name,
+                                       {B, H, Gw, ws * C}, {B, H, W, C},
+                                       dt, qp, do_op_validation, false, out_is_graph_output));
+  }
+  return Ort::Status();
+}
+
+}  // namespace
+
+WindowPartitionReverseFusion::WindowPartitionReverseFusion(
+    gsl::span<const OrtNodeUnit* const> node_units, Params params)
+    : params_(std::move(params)) {
+  if (node_units.size() != node_units_.size()) {
+    ORT_CXX_API_THROW("WindowPartitionReverseFusion expects exactly 3 NodeUnits.", ORT_EP_FAIL);
+  }
+  std::copy(node_units.begin(), node_units.end(), node_units_.begin());
+}
+
+std::unique_ptr<IQnnNodeGroup> WindowPartitionReverseFusion::TryFusion(
+    QnnModelWrapper& qnn_model_wrapper,
+    const OrtNodeUnit& reshape_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    const Ort::Logger& logger) {
+  // NPU-only: the win is replacing the rank-5/6 window Transpose with rank-4 ops on HTP.
+  if (!IsNpuBackend(qnn_model_wrapper.GetQnnBackendType())) {
+    return nullptr;
+  }
+
+  std::optional<std::pair<std::array<const OrtNodeUnit*, 3>, Params>> matched =
+      MatchWindowChain(qnn_model_wrapper, reshape_node_unit, node_to_node_unit, node_unit_to_qnn_node_group);
+  if (!matched.has_value()) {
+    return nullptr;
+  }
+
+  if (!EmitChain(qnn_model_wrapper, reshape_node_unit, matched->second, /*do_op_validation=*/true).IsOK()) {
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("WindowPartitionReverseFusion: match at Reshape '" + reshape_node_unit.Name() +
+                 "' failed QNN validation; leaving unfused.")
+                    .c_str());
+    return nullptr;
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              (std::string("WindowPartitionReverseFusion: rewriting window ") +
+               (matched->second.direction == Direction::kPartition ? "partition" : "reverse") +
+               " at Reshape '" + reshape_node_unit.Name() + "' to rank-<=4 ops.")
+                  .c_str());
+  return std::make_unique<WindowPartitionReverseFusion>(
+      gsl::span<const OrtNodeUnit* const>{matched->first.data(), matched->first.size()}, matched->second);
+}
+
+gsl::span<const OrtNodeUnit* const> WindowPartitionReverseFusion::GetNodeUnits() const {
+  return gsl::span<const OrtNodeUnit* const>{node_units_.data(), node_units_.size()};
+}
+
+Ort::Status WindowPartitionReverseFusion::IsSupported(QnnModelWrapper& qnn_model_wrapper,
+                                                      const Ort::Logger& /*logger*/) const {
+  return EmitChain(qnn_model_wrapper, *node_units_[0], params_, /*do_op_validation=*/true);
+}
+
+Ort::Status WindowPartitionReverseFusion::AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper,
+                                                            const Ort::Logger& /*logger*/) const {
+  return EmitChain(qnn_model_wrapper, *node_units_[0], params_, /*do_op_validation=*/false);
+}
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/window_partition_reverse_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/window_partition_reverse_fusion.h
@@ -1,0 +1,98 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <gsl/gsl>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/ort_api.h"
+
+namespace onnxruntime {
+namespace qnn {
+
+class QnnModelWrapper;
+
+// The generic Rank6ToRank5Fusion already reduces these chains rank-6 -> rank-5 (the batch
+// unit dim is dropped), but leaves a rank-5 Transpose over a large (~ws*ws*grid*C) tensor,
+// which is a slow path on HTP. This fusion instead restructures the whole chain into rank-4
+// ops (two rank-4 Transposes plus Reshapes), so it must be registered BEFORE
+// Rank6ToRank5Fusion to claim these chains first.
+//
+// Partition (in_rank=4 -> mid rank-6 -> out_rank=3), keyed on the first Reshape:
+//   x[B,H,W,C]
+//     Reshape   -> [B, Gh, ws, Gw, ws, C]                    (rank-6)
+//     Transpose -> [B, Gh, Gw, ws, ws, C]  perm=[0,1,3,2,4,5](rank-6)
+//     Reshape   -> [B*Gh*Gw, ws*ws, C]                       (rank-3)
+//   rewritten (H=Gh*ws, W=Gw*ws) as:
+//     Reshape   -> [B, H, Gw, ws*C]
+//     Transpose -> [B, Gw, H, ws*C]        perm=[0,2,1,3]
+//     Reshape   -> [B, Gw, Gh, ws*ws*C]
+//     Transpose -> [B, Gh, Gw, ws*ws*C]    perm=[0,2,1,3]
+//     Reshape   -> [B*Gh*Gw, ws*ws, C]
+//
+// Reverse (in_rank=3 -> mid rank-6 -> out_rank=4), the exact inverse, keyed on the first
+// Reshape:
+//   x[B*Gh*Gw, ws*ws, C]
+//     Reshape   -> [B, Gh, Gw, ws, ws, C]                    (rank-6)
+//     Transpose -> [B, Gh, ws, Gw, ws, C]  perm=[0,1,3,2,4,5](rank-6)
+//     Reshape   -> [B, H, W, C]                              (rank-4)
+//   rewritten as:
+//     Reshape   -> [B, Gh, Gw, ws*ws*C]
+//     Transpose -> [B, Gw, Gh, ws*ws*C]    perm=[0,2,1,3]
+//     Reshape   -> [B, Gw, H, ws*C]
+//     Transpose -> [B, H, Gw, ws*C]        perm=[0,2,1,3]
+//     Reshape   -> [B, H, W, C]
+//
+// The rewrite reuses the final output tensor name, so downstream consumers are undisturbed.
+// It claims exactly the 3 chain nodes (Reshape, Transpose, Reshape). On non-NPU backends, or
+// when the pattern does not match / fails QNN validation, TryFusion returns nullptr.
+class WindowPartitionReverseFusion final : public IQnnNodeGroup {
+ public:
+  enum class Direction { kPartition,
+                         kReverse };
+
+  // Geometry resolved during matching and needed for emission.
+  struct Params {
+    Direction direction = Direction::kPartition;
+    std::string input_name;   // first Reshape data input
+    std::string output_name;  // final Reshape output (reused so downstream is undisturbed)
+    uint32_t batch = 0;       // B
+    uint32_t gh = 0;          // H / ws
+    uint32_t gw = 0;          // W / ws
+    uint32_t ws = 0;          // window size (assumed square)
+    uint32_t channels = 0;    // C
+  };
+
+  WindowPartitionReverseFusion(gsl::span<const OrtNodeUnit* const> node_units, Params params);
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(WindowPartitionReverseFusion);
+
+  Ort::Status IsSupported(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qnn_model_wrapper, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override { return node_units_[0]; }
+  // Serialized as a JSON key in the framework op trace (summary.fusion_count[<Type()>]).
+  // Renaming is a breaking change for trace consumers.
+  static constexpr std::string_view kType = "WindowPartitionReverseFusion";
+  std::string_view Type() const override { return kType; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& reshape_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::array<const OrtNodeUnit*, 3> node_units_;  // Reshape, Transpose, Reshape
+  Params params_;
+};
+
+}  // namespace qnn
+}  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qkv_split_attention_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qkv_split_attention_fusion_test.cc
@@ -1,0 +1,242 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <gsl/gsl>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Geometry for the decomposed packed-QKV window-attention block that
+// QkvSplitAttentionFusion targets. Kept tiny: N=2 rows/windows, S=4 tokens,
+// n=2 heads, hs=3 head size => packed = 3 * n * hs = 18.
+constexpr int64_t kN = 2;
+constexpr int64_t kS = 4;
+constexpr int64_t kHeads = 2;
+constexpr int64_t kHeadSize = 3;
+constexpr int64_t kPacked = 3 * kHeads * kHeadSize;
+
+// Builds the decomposed packed-QKV attention block:
+//
+//   qkv[N,S,3*n*hs]
+//     Reshape -> [N,S,3,n,hs]
+//     Transpose(perm=[2,0,3,1,4]) -> [3,N,n,S,hs]
+//     Gather(axis=0, idx=0/1/2) = Q/K/V -> [N,n,S,hs]
+//   Q * scale ; K^T(perm=[0,1,3,2]) ; MatMul(Q,K^T) -> [N,n,S,S]
+//   + mask ; Softmax ; MatMul(., V) -> [N,n,S,hs]
+//
+// `single_mask == true`  emits MatMul -> Add(mask) -> Softmax (non-shifted block).
+// `single_mask == false` emits MatMul -> Add -> Reshape -> Add -> Reshape -> Softmax
+//                        (the shifted-window double-mask variant).
+//
+// All downstream shapes are derived from `head_perm` so the graph stays ONNX-valid for any
+// permutation (the negative test passes a non-window perm, which changes the score shape).
+GetTestModelFn BuildQkvSplitAttentionTestCase(bool single_mask,
+                                              const std::vector<int64_t>& head_perm = {2, 0, 3, 1, 4},
+                                              int64_t packed_override = kPacked) {
+  return [single_mask, head_perm, packed_override](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("qkv_split_attention_graph");
+
+    // Shapes implied by head_perm: transpose_out = permute([N,S,3,n,hs]); each Gather(axis=0)
+    // drops the leading axis, so Q/K/V share g = permuted[1:]. The QK product (and hence the
+    // mask) is [g0, g1, g2, g2].
+    const std::vector<int64_t> base5{kN, kS, 3, kHeads, kHeadSize};
+    std::vector<int64_t> permuted(base5.size());
+    for (size_t i = 0; i < head_perm.size(); ++i) {
+      permuted[i] = base5[static_cast<size_t>(head_perm[i])];
+    }
+    const std::vector<int64_t> g(permuted.begin() + 1, permuted.end());
+    const std::vector<int64_t> score_shape{g[0], g[1], g[2], g[2]};
+    const std::vector<int64_t> score_shape5{1, g[0], g[1], g[2], g[2]};
+
+    const auto qkv_def = TestInputDef<float>({kN, kS, packed_override}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "qkv", qkv_def);
+
+    // Reshape qkv -> [N,S,3,n,hs]
+    builder.Make1DInitializer<int64_t>("reshape_shape", {kN, kS, 3, kHeads, kHeadSize});
+    builder.AddNode("Reshape", "Reshape", {"qkv", "reshape_shape"}, {"reshape_out"}, kOnnxDomain);
+
+    builder.AddNode("Transpose", "Transpose", {"reshape_out"}, {"transpose_out"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("perm", head_perm)});
+
+    // Three scalar Gathers along axis 0 (indices 0/1/2) -> Q/K/V each [N,n,S,hs].
+    builder.MakeScalarInitializer<int64_t>("idx0", 0);
+    builder.MakeScalarInitializer<int64_t>("idx1", 1);
+    builder.MakeScalarInitializer<int64_t>("idx2", 2);
+    builder.AddNode("GatherQ", "Gather", {"transpose_out", "idx0"}, {"q"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))});
+    builder.AddNode("GatherK", "Gather", {"transpose_out", "idx1"}, {"k"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))});
+    builder.AddNode("GatherV", "Gather", {"transpose_out", "idx2"}, {"v"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(0))});
+
+    // Q * scale (1/sqrt(hs)).
+    builder.MakeScalarInitializer<float>("scale", 1.0f / std::sqrt(static_cast<float>(kHeadSize)));
+    builder.AddNode("MulScale", "Mul", {"q", "scale"}, {"q_scaled"}, kOnnxDomain);
+
+    // K^T: transpose last two dims -> [N,n,hs,S].
+    builder.AddNode("TransposeK", "Transpose", {"k"}, {"k_t"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("perm", {0, 1, 3, 2})});
+
+    builder.AddNode("QK", "MatMul", {"q_scaled", "k_t"}, {"qk"}, kOnnxDomain);
+
+    std::string softmax_in;
+    if (single_mask) {
+      const auto mask_def = TestInputDef<float>(score_shape, false, -0.5f, 0.5f);
+      MakeTestInput<float>(builder, "mask", mask_def);
+      builder.AddNode("AddMask", "Add", {"qk", "mask"}, {"qk_masked"}, kOnnxDomain);
+      softmax_in = "qk_masked";
+    } else {
+      const auto mask1_def = TestInputDef<float>(score_shape, false, -0.5f, 0.5f);
+      MakeTestInput<float>(builder, "mask1", mask1_def);
+      builder.AddNode("AddMask1", "Add", {"qk", "mask1"}, {"qk_m1"}, kOnnxDomain);
+
+      builder.Make1DInitializer<int64_t>("rshape5", score_shape5);
+      builder.AddNode("Reshape5", "Reshape", {"qk_m1", "rshape5"}, {"qk_r5"}, kOnnxDomain);
+
+      const auto mask2_def = TestInputDef<float>(score_shape5, false, -0.5f, 0.5f);
+      MakeTestInput<float>(builder, "mask2", mask2_def);
+      builder.AddNode("AddMask2", "Add", {"qk_r5", "mask2"}, {"qk_m2"}, kOnnxDomain);
+
+      builder.Make1DInitializer<int64_t>("rshape4", score_shape);
+      builder.AddNode("Reshape4", "Reshape", {"qk_m2", "rshape4"}, {"qk_r4"}, kOnnxDomain);
+      softmax_in = "qk_r4";
+    }
+
+    builder.AddNode("Softmax", "Softmax", {softmax_in}, {"attn"}, kOnnxDomain,
+                    {test::MakeAttribute("axis", static_cast<int64_t>(-1))});
+
+    builder.AddNode("AV", "MatMul", {"attn", "v"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetHtpProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  return provider_options;
+}
+
+ProviderOptions GetCpuProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  return provider_options;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// CPU backend: the fusion is NPU-only, so the pattern must lower per-op and
+// still produce correct numerics. Not inside an ARM64 guard: the CPU backend
+// is exercised on x86 hosts too.
+// ---------------------------------------------------------------------------
+TEST_F(QnnCPUBackendTests, QkvSplitAttentionFusion_Cpu_NotFusedStillCorrect) {
+  const std::filesystem::path json_dir = "QkvSplitAttentionFusion_Cpu_NotFused";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetCpuProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildQkvSplitAttentionTestCase(/*single_mask=*/true),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
+
+  // NPU-only fusion => the three Gathers must survive on the CPU backend.
+  AssertOpInQnnGraph(json_dir, "Gather", 3);
+  AssertOpInQnnGraph(json_dir, "StridedSlice", 0);
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// Single-mask (non-shifted) window attention block.
+TEST_F(QnnHTPBackendTests, QkvSplitAttentionFusion_SingleMask) {
+  const std::filesystem::path json_dir = "QkvSplitAttentionFusion_SingleMask";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetHtpProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildQkvSplitAttentionTestCase(/*single_mask=*/true),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+
+  // Structural proof the fusion fired: the three Gathers are replaced by three
+  // StridedSlices. Asserting node assignment alone would pass even if the
+  // fusion declined, because the per-op path also runs entirely on QNN.
+  AssertOpInQnnGraph(json_dir, "StridedSlice", 3);
+  AssertOpInQnnGraph(json_dir, "Gather", 0);
+}
+
+// Shifted-window variant with the Add -> Reshape -> Add -> Reshape mask chain
+// between the QK MatMul and Softmax.
+TEST_F(QnnHTPBackendTests, QkvSplitAttentionFusion_DoubleMask) {
+  const std::filesystem::path json_dir = "QkvSplitAttentionFusion_DoubleMask";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetHtpProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildQkvSplitAttentionTestCase(/*single_mask=*/false),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+
+  AssertOpInQnnGraph(json_dir, "StridedSlice", 3);
+  AssertOpInQnnGraph(json_dir, "Gather", 0);
+}
+
+// NEGATIVE: a head Transpose perm that is not the packed-QKV split perm must
+// not fuse. [2,0,1,3,4] keeps the 3-way axis leading (so the Gathers still
+// index it) but permutes the remaining axes differently, which would corrupt
+// the Q/K/V layout if the fusion claimed it.
+TEST_F(QnnHTPBackendTests, QkvSplitAttentionFusion_WrongPerm_DoesNotFuse) {
+  const std::filesystem::path json_dir = "QkvSplitAttentionFusion_WrongPerm";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetHtpProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildQkvSplitAttentionTestCase(/*single_mask=*/true,
+                                                 /*head_perm=*/{2, 0, 1, 3, 4}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-2f)});
+
+  // Fusion must decline: Gathers survive, no StridedSlice emitted.
+  AssertOpInQnnGraph(json_dir, "Gather", 3);
+  AssertOpInQnnGraph(json_dir, "StridedSlice", 0);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/window_partition_reverse_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/window_partition_reverse_fusion_test.cc
@@ -1,0 +1,192 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <gsl/gsl>
+
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
+#include "test/providers/qnn/qnn_test_utils.h"
+#include "test/unittest_util/qdq_test_utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime {
+namespace test {
+
+namespace {
+
+// Small window geometry: B=1, H=W=24, ws=12 => Gh=Gw=2, nW=4, ws*ws=144, C=8.
+constexpr int64_t kB = 1;
+constexpr int64_t kH = 24;
+constexpr int64_t kW = 24;
+constexpr int64_t kC = 8;
+constexpr int64_t kWs = 12;
+constexpr int64_t kGh = kH / kWs;
+constexpr int64_t kGw = kW / kWs;
+
+// Window PARTITION: [B,H,W,C] -> rank-6 Reshape/Transpose -> [B*nW, ws*ws, C].
+// A trailing Add consumes the rank-3 result, mirroring how the real graph feeds
+// the partitioned tensor into attention.
+GetTestModelFn BuildWindowPartitionTestCase(const std::vector<int64_t>& perm = {0, 1, 3, 2, 4, 5}) {
+  return [perm](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("window_partition_graph");
+
+    const auto x_def = TestInputDef<float>({kB, kH, kW, kC}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "x", x_def);
+
+    builder.Make1DInitializer<int64_t>("rs1", {kB, kGh, kWs, kGw, kWs, kC});
+    builder.AddNode("R1", "Reshape", {"x", "rs1"}, {"r1"}, kOnnxDomain);
+    builder.AddNode("T1", "Transpose", {"r1"}, {"t1"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("perm", perm)});
+    builder.Make1DInitializer<int64_t>("rs2", {kB * kGh * kGw, kWs * kWs, kC});
+    builder.AddNode("R2", "Reshape", {"t1", "rs2"}, {"windows"}, kOnnxDomain);
+
+    const auto bias_def = TestInputDef<float>({kC}, false, -0.5f, 0.5f);
+    MakeTestInput<float>(builder, "bias", bias_def);
+    builder.AddNode("Add", "Add", {"windows", "bias"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+}
+
+// Window REVERSE: [B*nW, ws*ws, C] -> rank-6 Reshape/Transpose -> [B,H,W,C].
+GetTestModelFn BuildWindowReverseTestCase(const std::vector<int64_t>& perm = {0, 1, 3, 2, 4, 5}) {
+  return [perm](ModelTestBuilder& builder) -> void {
+    builder.graph_->set_name("window_reverse_graph");
+
+    const auto x_def = TestInputDef<float>({kB * kGh * kGw, kWs * kWs, kC}, false, -1.0f, 1.0f);
+    MakeTestInput<float>(builder, "x", x_def);
+
+    builder.Make1DInitializer<int64_t>("rs1", {kB, kGh, kGw, kWs, kWs, kC});
+    builder.AddNode("R1", "Reshape", {"x", "rs1"}, {"r1"}, kOnnxDomain);
+    builder.AddNode("T1", "Transpose", {"r1"}, {"t1"}, kOnnxDomain,
+                    {builder.MakeIntsAttribute("perm", perm)});
+    builder.Make1DInitializer<int64_t>("rs2", {kB, kH, kW, kC});
+    builder.AddNode("R2", "Reshape", {"t1", "rs2"}, {"img"}, kOnnxDomain);
+
+    const auto bias_def = TestInputDef<float>({kC}, false, -0.5f, 0.5f);
+    MakeTestInput<float>(builder, "bias", bias_def);
+    builder.AddNode("Add", "Add", {"img", "bias"}, {"output"}, kOnnxDomain);
+    builder.MakeOutput("output");
+  };
+}
+
+ProviderOptions GetHtpProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  return provider_options;
+}
+
+ProviderOptions GetCpuProviderOptions() {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  return provider_options;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// CPU backend: the fusion is NPU-only. Not inside an ARM64 guard so it runs on
+// x86 hosts as well.
+// ---------------------------------------------------------------------------
+TEST_F(QnnCPUBackendTests, WindowPartitionFusion_Cpu_NotFusedStillCorrect) {
+  const std::filesystem::path json_dir = "WindowPartitionFusion_Cpu_NotFused";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetCpuProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildWindowPartitionTestCase(),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
+
+  // NPU-only fusion => the original 2 Reshapes + 1 Transpose survive.
+  AssertOpInQnnGraph(json_dir, "Transpose", 1);
+  AssertOpInQnnGraph(json_dir, "Reshape", 2);
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+// The rewrite emits 3 Reshapes + 2 rank-4 Transposes, replacing the rank-6
+// Reshape/Transpose/Reshape chain.
+TEST_F(QnnHTPBackendTests, WindowPartitionFusion_Partition) {
+  const std::filesystem::path json_dir = "WindowPartitionFusion_Partition";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetHtpProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildWindowPartitionTestCase(),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
+
+  // Structural proof the fusion fired (2 Transposes instead of 1, 3 Reshapes
+  // instead of 2). Node assignment alone cannot distinguish this from the
+  // unfused path, nor from the generic Rank6ToRank5Fusion rewrite.
+  AssertOpInQnnGraph(json_dir, "Transpose", 2);
+  AssertOpInQnnGraph(json_dir, "Reshape", 3);
+}
+
+TEST_F(QnnHTPBackendTests, WindowPartitionFusion_Reverse) {
+  const std::filesystem::path json_dir = "WindowPartitionFusion_Reverse";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetHtpProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  RunQnnModelTest(BuildWindowReverseTestCase(),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
+
+  AssertOpInQnnGraph(json_dir, "Transpose", 2);
+  AssertOpInQnnGraph(json_dir, "Reshape", 3);
+}
+
+// NEGATIVE (guards the layout-correctness condition): perm [0,1,2,3,4,5] is the
+// identity, and [0,2,1,3,4,5] / [0,1,3,2,5,4] are genuine permutations that are
+// NOT the window axis-swap. None may be rewritten as a window partition -- doing
+// so would silently produce a different element ordering. The fusion must
+// decline and leave the chain to the generic rank-6 handling.
+TEST_F(QnnHTPBackendTests, WindowPartitionFusion_GenuinePerm_DoesNotFuse) {
+  const std::filesystem::path json_dir = "WindowPartitionFusion_GenuinePerm";
+  std::filesystem::remove_all(json_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_dir));
+  auto cleanup = gsl::finally([&json_dir]() { std::filesystem::remove_all(json_dir); });
+
+  ProviderOptions provider_options = GetHtpProviderOptions();
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_dir.string();
+
+  // Swaps axes 4 and 5 in addition to 2/3 -- not a window partition.
+  RunQnnModelTest(BuildWindowPartitionTestCase(/*perm=*/{0, 1, 3, 2, 5, 4}),
+                  provider_options,
+                  /*opset_version=*/13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
+
+  // Must NOT be the 3-Reshape/2-Transpose window rewrite. Rank6ToRank5Fusion
+  // still reduces the chain, so exactly 1 Transpose and 2 Reshapes remain.
+  AssertOpInQnnGraph(json_dir, "Transpose", 1);
+  AssertOpInQnnGraph(json_dir, "Reshape", 2);
+}
+
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
+
+}  // namespace test
+}  // namespace onnxruntime
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
### Description
Rewrite high-rank tensor patterns in Swin-Transformer-style attention into rank-≤4 QNN ops on the HTP backend.



### Motivation and Context
Rank-5 tensors are supported on HTP but perform poorly; these fusions eliminate them from the hot path and achieve ~2x perf gain.
**Before**: 1005 ms
**After**: 502 ms 


