### PR TITLE
[CI] Minor CI improvements

### DIFF
--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -1169,7 +1169,9 @@ class ZipUpleveler(ArtifactUpleveler):
         files = [
             os.path.join(distribution_dir, f)
             for f in os.listdir(distribution_dir)
-            if os.path.isfile(os.path.join(distribution_dir, f)) and f.endswith(self.artifact_suffix) and not f.endswith(self._GITHUB_EXCLUDED_SUFFIXES)
+            if os.path.isfile(os.path.join(distribution_dir, f))
+            if f.endswith(self.artifact_suffix)
+            if not f.endswith(self._GITHUB_EXCLUDED_SUFFIXES)
         ]
         if not files:
             raise RuntimeError(f"No {self.artifact_format} files found in {distribution_dir}")

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -1161,7 +1161,7 @@ class ZipUpleveler(ArtifactUpleveler):
 
     # Never published to GitHub Releases, even though they're valid upload candidates
     # for the other destinations (Artifactory).
-    _GITHUB_EXCLUDED_SUFFIXES = ("win-arm64ec-pdb.zip", "win-arm64ec.zip")
+    _GITHUB_EXCLUDED_SUFFIXES = ("-pdb.zip", "win-arm64ec.zip")
 
     def _upload_to_github(self, distribution_dir: str) -> None:
         """Create a git tag + GitHub Release tagged v{version_to} and attach the artifacts."""

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -1129,7 +1129,9 @@ class ZipUpleveler(ArtifactUpleveler):
         """Return (title, body) from the first section of docs/release-notes.md.
 
         title — text of the first H1 line (without the leading '# ').
-        body  — all lines after that H1 up to (not including) the next H1.
+        body  — all lines after that H1 up to (not including) the next H1. release-notes.md
+                separates sections with a "---" / blank / "---" pair before the next H1;
+                the second one is dropped so the notes end with a single horizontal rule.
         Both are empty strings if the file is missing or has no H1.
         """
         notes_path = _REPO_ROOT / "docs" / "release-notes.md"
@@ -1153,7 +1155,13 @@ class ZipUpleveler(ArtifactUpleveler):
             elif in_section:
                 body_lines.append(stripped)
 
-        return title, "\n".join(body_lines).strip()
+        body = "\n".join(body_lines).strip()
+        body = body.removesuffix("---").rstrip()
+        return title, body
+
+    # Never published to GitHub Releases, even though they're valid upload candidates
+    # for the other destinations (Artifactory).
+    _GITHUB_EXCLUDED_SUFFIXES = ("win-arm64ec-pdb.zip", "win-arm64ec.zip")
 
     def _upload_to_github(self, distribution_dir: str) -> None:
         """Create a git tag + GitHub Release tagged v{version_to} and attach the artifacts."""
@@ -1161,7 +1169,7 @@ class ZipUpleveler(ArtifactUpleveler):
         files = [
             os.path.join(distribution_dir, f)
             for f in os.listdir(distribution_dir)
-            if os.path.isfile(os.path.join(distribution_dir, f)) and f.endswith(self.artifact_suffix)
+            if os.path.isfile(os.path.join(distribution_dir, f)) and f.endswith(self.artifact_suffix) and not f.endswith(self._GITHUB_EXCLUDED_SUFFIXES)
         ]
         if not files:
             raise RuntimeError(f"No {self.artifact_format} files found in {distribution_dir}")

--- a/qcom/scripts/upleveling/qnn_ep_uplevel.py
+++ b/qcom/scripts/upleveling/qnn_ep_uplevel.py
@@ -1159,9 +1159,11 @@ class ZipUpleveler(ArtifactUpleveler):
         body = body.removesuffix("---").rstrip()
         return title, body
 
-    # Never published to GitHub Releases, even though they're valid upload candidates
-    # for the other destinations (Artifactory).
-    _GITHUB_EXCLUDED_SUFFIXES = ("-pdb.zip", "win-arm64ec.zip")
+    @property
+    def _github_excluded_suffixes(self) -> tuple[str, ...]:
+        """Filename suffixes never published to GitHub Releases, even though they're
+        valid upload candidates for the other destinations (Artifactory)."""
+        return ("-pdb.zip", "win-arm64ec.zip")
 
     def _upload_to_github(self, distribution_dir: str) -> None:
         """Create a git tag + GitHub Release tagged v{version_to} and attach the artifacts."""
@@ -1171,7 +1173,7 @@ class ZipUpleveler(ArtifactUpleveler):
             for f in os.listdir(distribution_dir)
             if os.path.isfile(os.path.join(distribution_dir, f))
             if f.endswith(self.artifact_suffix)
-            if not f.endswith(self._GITHUB_EXCLUDED_SUFFIXES)
+            if not f.endswith(self._github_excluded_suffixes)
         ]
         if not files:
             raise RuntimeError(f"No {self.artifact_format} files found in {distribution_dir}")


### PR DESCRIPTION
### Description

This PR skips `win-arm64ec` zip and `pdb artifacts` from GitHub Releases and dedupe trailing release-notes rule

 `win-arm64ec.zip` and `*-pdb.zip` are now excluded when uploading artifacts to a GitHub Release. They're still uploaded normally to Artifactory destinations; the exclusion (`_GITHUB_EXCLUDED_SUFFIXES`) only applies to the `--index_server_to github` path. Skipped files are logged (`Skipping GitHub upload for excluded artifact: ...`).

**`ArtifactUpleveler._read_release_notes`** — `docs/release-notes.md` separates each release section from the next with a `---` / blank / `---` pair. The old `"\n".join(body_lines).strip()` only trimmed trailing whitespace, so both `---` rules ended up baked into the published GitHub release notes body. Now the trailing `---` is removed once (`body.removesuffix("---").rstrip()`), leaving exactly one horizontal rule at the end of the notes.