### PR TITLE
[QNN EP] Refactor LPBQ lowering helpers across op builders

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -230,8 +230,8 @@ Warning: Enabling HTP Monolithic LSTM may improve session creation time, but thi
 
 |`"enable_block_quant_weight_optimization"`|Description|
 |---|---|
-|`"0"`|Default. Disabled. Block-quantized models use the standard compatibility path.|
-|`"1"`|Enabled. Uses an optimized path for block-quantized weights when supported. If the optimized path is not available, QNN EP falls back to the standard compatibility path.|
+|'0'|Default. Disabled. Block-quantized models use the standard compatibility path.|
+|'1'|Enabled. Uses an optimized path for block-quantized weights when supported. If the optimized path is not available, QNN EP falls back to the standard compatibility path.|
 
 |`"enable_htp_shared_memory_allocator"`|Description|
 |---|---|

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -13,47 +13,6 @@
 namespace onnxruntime {
 namespace qnn {
 
-namespace {
-// Extracts the per-tensor activation scale from a QNN quant params wrapper.
-inline float GetActivationScale(const QnnQuantParamsWrapper& quant_params) {
-  const auto& qp = quant_params.Get();
-  if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
-    return qp.scaleOffsetEncoding.scale;
-  } else if (qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
-    return qp.bwScaleOffsetEncoding.scale;
-  }
-  return 1.0f;
-}
-
-// Builds a QnnQuantParamsWrapper for a bias tensor from computed scales and offsets.
-// Uses per-tensor encoding when there is exactly one scale, per-channel otherwise.
-inline QnnQuantParamsWrapper BuildBiasQuantParams(const std::vector<float>& new_scales,
-                                                  const std::vector<int32_t>& new_offsets,
-                                                  int32_t bias_quant_axis) {
-  if (new_scales.size() == 1) {
-    return QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0]);
-  }
-  return QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
-}
-
-// Creates a static bias tensor wrapper and registers it with the model.
-inline Ort::Status AddStaticBiasTensor(QnnModelWrapper& qnn_model_wrapper,
-                                       const std::string& bias_name,
-                                       const std::vector<uint32_t>& bias_shape,
-                                       Qnn_DataType_t data_type,
-                                       QnnQuantParamsWrapper quant_params,
-                                       std::vector<uint8_t> bias_data,
-                                       std::vector<std::string>& input_names) {
-  QnnTensorWrapper bias_wrapper(bias_name, QNN_TENSOR_TYPE_STATIC, data_type,
-                                std::move(quant_params), std::vector<uint32_t>(bias_shape),
-                                std::move(bias_data));
-  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
-                "Failed to add bias tensor.");
-  input_names.push_back(bias_name);
-  return Ort::Status();
-}
-}  // namespace
-
 // ONNX convolution types supported by this builder.
 // We translate node_unit.OpType() into this enum to avoid repeated string comparisons.
 enum class OnnxConvType {
@@ -255,92 +214,12 @@ static Ort::Status ProcessBqFp16Bias(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF_ERROR(utils::DequantizeInt32BiasToFp16(raw_bias_bytes, bias_scale_vals, fp16_bias_bytes));
 
   const std::string fp16_bias_name = utils::UniqueNameGenerator().New(bias_def.name, "_fp16");
-  return AddStaticBiasTensor(qnn_model_wrapper, fp16_bias_name, bias_info.shape,
-                             QNN_DATATYPE_FLOAT_16, QnnQuantParamsWrapper(),
-                             std::move(fp16_bias_bytes), input_names);
-}
-
-// Requantize a quantized bias whose scales don't match activation_scale * weight_scale.
-// Sets was_requantized=true and adds the tensor if requantization was needed; false if scales match.
-static Ort::Status ProcessRequantizeBias(QnnModelWrapper& qnn_model_wrapper,
-                                         const Ort::Logger& logger,
-                                         const OrtNodeUnitIODef& bias_def,
-                                         const TensorInfo& bias_info,
-                                         gsl::span<const float> weights_scales,
-                                         float activation_scale,
-                                         std::vector<std::string>& input_names,
-                                         bool& was_requantized) {
-  was_requantized = false;
-  int32_t bias_quant_axis = 0;
-  std::vector<float> current_scales;
-  std::vector<int32_t> current_offsets;
-  RETURN_IF_ERROR(utils::GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales,
-                                                      current_offsets, bias_quant_axis));
-
-  const size_t num_channels = current_scales.size();
-  bool needs_requantization = false;
-  for (size_t i = 0; i < num_channels && !needs_requantization; ++i) {
-    const float w = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
-    if (current_offsets[i] != 0 ||
-        !utils::CheckBiasScaleMatch(current_scales[i], w, activation_scale, 1e-5f)) {
-      needs_requantization = true;
-    }
-  }
-
-  if (!needs_requantization) {
-    return Ort::Status();  // Scales already match; process bias normally.
-  }
-
-  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing bias " + bias_def.name).c_str());
-
-  std::vector<uint8_t> original_bias_data;
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
-
-  std::vector<uint8_t> new_bias_data;
-  std::vector<float> new_scales;
-  std::vector<int32_t> new_offsets;
-  const auto axis_opt = (num_channels > 1) ? std::optional<int64_t>(bias_quant_axis) : std::nullopt;
-  RETURN_IF_ERROR(utils::RequantizeBiasTensor(
-      original_bias_data, bias_info.shape, current_scales, current_offsets,
-      weights_scales, activation_scale, bias_info.qnn_data_type,
-      new_bias_data, new_scales, new_offsets, axis_opt));
-
-  const std::string rq_bias_name = utils::UniqueNameGenerator().New(bias_def.name, "_rq");
-  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, rq_bias_name, bias_info.shape,
-                                      bias_info.qnn_data_type,
-                                      BuildBiasQuantParams(new_scales, new_offsets, bias_quant_axis),
-                                      std::move(new_bias_data), input_names));
-  was_requantized = true;
-  return Ort::Status();
-}
-
-// Quantize a float bias using bias_scale = activation_scale * weight_scale.
-static Ort::Status ProcessFloatBias(QnnModelWrapper& qnn_model_wrapper,
-                                    const Ort::Logger& logger,
-                                    const OrtNodeUnitIODef& bias_def,
-                                    const TensorInfo& bias_info,
-                                    gsl::span<const float> weights_scales,
-                                    float activation_scale,
-                                    std::vector<std::string>& input_names) {
-  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
-              ("Quantizing float bias " + bias_def.name + " using activation_scale * weight_scale[c]").c_str());
-  std::vector<uint8_t> original_bias_data;
-  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
-  const size_t num_channels = bias_info.shape[0];
-  RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
-                "Unexpected bias data size for float bias quantization");
-  std::vector<uint8_t> new_bias_data;
-  std::vector<float> new_scales;
-  std::vector<int32_t> new_offsets;
-  int32_t bias_quant_axis = 0;
-  RETURN_IF_ERROR(utils::QuantizeFloatBiasTensor(
-      gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
-      weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
-  const std::string q_bias_name = utils::UniqueNameGenerator().New(bias_def.name, "_q");
-  RETURN_IF_ERROR(AddStaticBiasTensor(qnn_model_wrapper, q_bias_name, bias_info.shape,
-                                      QNN_DATATYPE_SFIXED_POINT_32,
-                                      BuildBiasQuantParams(new_scales, new_offsets, bias_quant_axis),
-                                      std::move(new_bias_data), input_names));
+  QnnTensorWrapper fp16_bias_wrapper(fp16_bias_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_FLOAT_16,
+                                     QnnQuantParamsWrapper(), std::vector<uint32_t>(bias_info.shape),
+                                     std::move(fp16_bias_bytes));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fp16_bias_wrapper)),
+                "Failed to add FP16 bias tensor.");
+  input_names.push_back(fp16_bias_name);
   return Ort::Status();
 }
 
@@ -355,44 +234,23 @@ Ort::Status ConvOpBuilder::ProcessConvBias(QnnModelWrapper& qnn_model_wrapper,
     return ProcessBqFp16Bias(qnn_model_wrapper, inputs[2], input_names);
   }
 
-  const auto& bias_def = inputs[2];
-  TensorInfo bias_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_def, bias_info));
+  // LPBQ and per-tensor/per-channel path: use shared quantized op bias processing.
+  // This handles: INT32 quantized (check/requantize if mismatch), float (quantize).
+  // non-initializer or unquantized (pass through normally).
+  TensorInfo input0_info = {}, input1_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
 
-  if (bias_info.is_initializer) {
-    TensorInfo input0_info = {}, input1_info = {};
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[0], input0_info));
-    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(inputs[1], input1_info));
-
-    if (input0_info.quant_param.IsQuantized() && input1_info.quant_param.IsQuantized()) {
-      // Get activation scale (must be per-tensor for Conv)
-      RETURN_IF_NOT(input0_info.quant_param.IsPerTensor(/*include_bw*/ true),
-                    "Activation must be per-tensor quantized for Conv 2D");
-      const float activation_scale = GetActivationScale(input0_info.quant_param);
-      std::vector<float> weights_scales;
-      RETURN_IF_ERROR(utils::GetWeightQuantScales(input1_info.quant_param, weights_scales));
-      RETURN_IF(weights_scales.empty(), "No weight scales found for bias quantization");
-
-      if (bias_info.quant_param.IsQuantized()) {
-        // Requantize if bias scales don't match activation_scale * weight_scale.
-        bool was_requantized = false;
-        RETURN_IF_ERROR(ProcessRequantizeBias(qnn_model_wrapper, logger, bias_def, bias_info,
-                                              weights_scales, activation_scale, input_names,
-                                              was_requantized));
-        if (was_requantized) {
-          return Ort::Status();
-        }
-        // Else scales already match, process bias normally.
-      } else {
-        // Bias is float, quantize using activation_scale * weight_scale
-        return ProcessFloatBias(qnn_model_wrapper, logger, bias_def, bias_info,
-                                weights_scales, activation_scale, input_names);
-      }
-    }
+  bool was_handled = false;
+  RETURN_IF_ERROR(utils::ProcessBiasForQuantizedOp(qnn_model_wrapper, logger, inputs[2],
+                                                   input0_info.quant_param, input1_info.quant_param,
+                                                   input_names, was_handled));
+  if (was_handled) {
+    return Ort::Status();
   }
 
   // Process bias normally: non-initializer, or activation/weight not quantized, or scales already match.
-  return ProcessInput(qnn_model_wrapper, bias_def, logger, input_names);
+  return ProcessInput(qnn_model_wrapper, inputs[2], logger, input_names);
 }
 
 Ort::Status ConvOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -136,7 +136,7 @@ Ort::Status ProcessInput0(QnnModelWrapper& qnn_model_wrapper,
                           bool use_fully_connected,
                           const std::vector<uint32_t>* target_shape = nullptr) {
   // use_fully_connected and target_shape (conv2d path) are mutually exclusive
-  assert(!(use_fully_connected && target_shape != nullptr));
+  RETURN_IF(use_fully_connected && target_shape != nullptr, "use_fully_connected and target_shape (conv2d path) are mutually exclusive");
   const bool is_rank1 = input_0_info.shape.size() == 1;
   const bool shape_mismatch = (target_shape != nullptr && input_0_info.shape != *target_shape);
   const bool reshape_input_0 = is_rank1 || shape_mismatch || (use_fully_connected && input_0_info.shape.size() > 2);
@@ -559,32 +559,14 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnConv2D(QnnModelWrapper& qnn_mode
                                   logger, do_op_validation, /*use_fully_connected=*/false, &conv_input_shape));
   }
 
-  // Unsqueeze input[1] [K, N] -> [1, 1, K, N] (HWCN)
-  // The LPBQ encoding axis is on the N (output-channel) dimension:
-  // Axis 1 in [K, N]  ->  axis 3 in [1, 1, K, N]
+  // Register LPBQ weight as [1, 1, K, N] (HWCN 1×1 filter) via shared helper.
+  // The helper unsqueezes [K, N] → [1, 1, K, N] and updates the LPBQ quant axis (1 → 3).
   {
-    // CheckInputs already checks the rank for input[1] for Conv2D. This check is just for any future refactoring guard.
-    RETURN_IF_NOT(input_info_1.shape.size() == 2, "LPBQ Conv2D lowering requires weight to be rank-2 [K, N]");
-    const uint32_t K = input_info_1.shape[0];
-    const uint32_t N = input_info_1.shape[1];
-
-    std::vector<uint32_t> conv_weight_shape = {1, 1, K, N};
-    QnnQuantParamsWrapper conv_weight_quant = input_info_1.quant_param.Copy();
-    RETURN_IF_ERROR(conv_weight_quant.HandleUnsqueeze<uint32_t>(input_info_1.shape, conv_weight_shape));
-
-    const std::string conv_weight_name = utils::UniqueNameGenerator().New(org_input_1_name, "_reshape");
-
     RETURN_IF_NOT(input_info_1.is_initializer, "LPBQ Conv2D lowering requires weight to be static initializer");
     std::vector<uint8_t> unpacked_tensor;
     RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info_1.initializer_tensor, unpacked_tensor));
-
-    Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(org_input_1_name);
-    QnnTensorWrapper weight_tensorwrapper(conv_weight_name, tensor_type, input_info_1.qnn_data_type,
-                                          std::move(conv_weight_quant), std::move(conv_weight_shape),
-                                          std::move(unpacked_tensor));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensorwrapper)),
-                  "Failed to add Conv2D weight tensor.");
-    input_names.emplace_back(conv_weight_name);
+    RETURN_IF_ERROR(bq::RegisterWeightAsConv1x1Filter(qnn_model_wrapper, org_input_1_name, input_info_1,
+                                                      std::move(unpacked_tensor), input_names));
   }
 
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 16 && QNN_API_VERSION_MINOR <= 18)
@@ -594,7 +576,7 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnConv2D(QnnModelWrapper& qnn_mode
 
     if (input_info_0.quant_param.IsPerTensor(/*include_bw*/ true) && input_info_1.quant_param.IsQuantized()) {
       const std::string bias_name = qnn::utils::UniqueNameGenerator().New(node_unit, "_implicit_bias");
-      std::vector<uint32_t> bias_shape = {input_info_1.shape[0]};
+      std::vector<uint32_t> bias_shape = {input_info_1.shape[1]};
       RETURN_IF_ERROR(AddZeroBiasInput(qnn_model_wrapper, input_info_0.quant_param, input_info_1.quant_param,
                                        std::move(bias_shape), bias_name, logger, input_names));
     }
@@ -741,7 +723,6 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   TensorInfo input_info_1{};
   bool use_fully_connected = false;
   bool use_conv2d = false;
-  std::string qnn_op_type;
   RETURN_IF_ERROR(
       CheckInputs(qnn_model_wrapper, inputs[0], inputs[1], input_info_0, input_info_1,
                   use_fully_connected, use_conv2d));
@@ -755,36 +736,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
 
   bool reshape_input_0 = input_info_0.shape.size() == 1;
   bool reshape_input_1 = input_info_1.shape.size() == 1;
-  bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2) ||
-                        (use_conv2d && input_info_0.shape.size() < 4);
-
-  std::vector<std::string> param_tensor_names;
-  if (use_conv2d) {
-    qnn_op_type = QNN_OP_CONV_2D;
-    // Conv2D params: stride=[1,1], pad_amount=[[0,0],[0,0]], dilation=[1,1], group=1
-    QnnParamWrapper stride_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_STRIDE, {2}, {1, 1});
-    param_tensor_names.push_back(stride_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(stride_param));
-
-    QnnParamWrapper pad_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, {2, 2}, {0, 0, 0, 0});
-    param_tensor_names.push_back(pad_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(pad_param));
-
-    QnnParamWrapper dilation_param(node_unit.Index(), node_unit.Name(), QNN_OP_CONV_2D_PARAM_DILATION, {2}, {1, 1});
-    param_tensor_names.push_back(dilation_param.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(dilation_param));
-
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), 1,
-                                           QNN_OP_CONV_2D_PARAM_GROUP, param_tensor_names));
-  } else if (use_fully_connected) {
-    qnn_op_type = QNN_OP_FULLY_CONNECTED;
-  } else {
-    qnn_op_type = QNN_OP_MAT_MUL;
-    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
-                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, param_tensor_names));
-    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
-                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, param_tensor_names));
-  }
+  bool reshape_output = reshape_input_0 || reshape_input_1 || (use_fully_connected && input_info_0.shape.size() > 2) || (use_conv2d && input_info_0.shape.size() < 4);
 
   const std::string& org_output_name = node_unit.Outputs()[0].name;
   std::string op_output_name = org_output_name;
@@ -795,9 +747,12 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
   if (reshape_output) {
     op_output_name = utils::UniqueNameGenerator().New(org_output_name, "_reshape");
     if (use_conv2d) {
-      op_output_shape.insert(op_output_shape.end() - 2, 1);
+      // Insert height=1 dim before [M, N] to produce the 4D Conv2D output shape.
+      // 2D [M, N]    → [1, 1, M, N]
+      // 3D [B, M, N] → [B, 1, M, N]
+      op_output_shape.insert(op_output_shape.end() - 2, 1u);
       if (op_output_shape.size() < 4)
-        op_output_shape.insert(op_output_shape.begin(), 1);
+        op_output_shape.insert(op_output_shape.begin(), 1u);
       RETURN_IF_ERROR(op_output_quant_param.HandleUnsqueeze<uint32_t>(output_info.shape, op_output_shape));
     } else if (use_fully_connected && input_info_0.shape.size() > 2) {
       uint32_t batch = 0;
@@ -830,7 +785,28 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     is_bq_matmul = qnn_model_wrapper.GetQnnTensorWrapper(input_names[1]).GetQnnQuantParams().IsBlockQuantized();
   }
 
-  if (is_bq_matmul) {
+  std::string qnn_op_type = QNN_OP_FULLY_CONNECTED;
+  std::vector<std::string> param_tensor_names;
+  if (!use_conv2d && !use_fully_connected) {
+    qnn_op_type = QNN_OP_MAT_MUL;
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
+                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, param_tensor_names));
+    RETURN_IF_ERROR(AddQnnScalar<bool>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), false,
+                                       QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, param_tensor_names));
+  }
+
+  if (use_conv2d) {
+    // LPBQ path: Conv2D with 1×1 filters.
+    // AddConv2DNodeforBQLowering builds Conv2D params, registers the output tensor, and creates the node.
+    RETURN_IF_ERROR(bq::AddConv2DNodeforBQLowering(qnn_model_wrapper, node_unit,
+                                                   std::move(input_names),
+                                                   op_output_name,
+                                                   op_output_shape,
+                                                   output_info.qnn_data_type,
+                                                   op_output_quant_param,
+                                                   is_op_output_graph_output,
+                                                   do_op_validation));
+  } else if (is_bq_matmul) {
     // The QNN HTP BQ MatMul runs on 4-D tensors and outputs FP16.
     // Pipeline: MatMul (4-D FP16 [batch,1,M,N]) → Reshape (to ONNX [...,M,N] FP16)
     //           → Quantize (FP16 → INT16)
@@ -849,7 +825,7 @@ Ort::Status MatMulOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(matmul_4d_wrapper)),
                   "Failed to add 4-D FP16 BQ MatMul output tensor.");
     RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_MAT_MUL,
+                                                  QNN_OP_PACKAGE_NAME_QTI_AISW, qnn_op_type,
                                                   std::move(input_names), {matmul_4d_out},
                                                   std::move(param_tensor_names), do_op_validation),
                   "Failed to add BQ MatMul node.");

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -641,43 +641,6 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                      false,
                                                      is_graph_output));
   } else {
-    // 1. Add MatMul as Conv2d with default stride/pad amount.
-    std::vector<std::string> param_tensor_names;
-
-    std::vector<uint32_t> stride = {1, 1};
-    QnnParamWrapper stride_param_wrapper(node_unit.Index(),
-                                         node_unit.Name(),
-                                         QNN_OP_CONV_2D_PARAM_STRIDE,
-                                         {2},
-                                         std::move(stride));
-    param_tensor_names.push_back(stride_param_wrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(stride_param_wrapper));
-
-    std::vector<uint32_t> pad_amount = {0, 0, 0, 0};
-    QnnParamWrapper pad_amount_param_wrapper(node_unit.Index(),
-                                             node_unit.Name(),
-                                             QNN_OP_CONV_2D_PARAM_PAD_AMOUNT,
-                                             {2, 2},
-                                             std::move(pad_amount));
-    param_tensor_names.push_back(pad_amount_param_wrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(pad_amount_param_wrapper));
-
-    std::vector<uint32_t> dilation = {1, 1};
-    QnnParamWrapper dilation_param_wrapper(node_unit.Index(),
-                                           node_unit.Name(),
-                                           QNN_OP_CONV_2D_PARAM_DILATION,
-                                           {2},
-                                           std::move(dilation));
-    param_tensor_names.push_back(dilation_param_wrapper.GetParamTensorName());
-    qnn_model_wrapper.AddParamWrapper(std::move(dilation_param_wrapper));
-
-    RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper,
-                                           node_unit.Index(),
-                                           node_unit.Name(),
-                                           1,
-                                           QNN_OP_CONV_2D_PARAM_GROUP,
-                                           param_tensor_names));
-
     // Input originally having 3D shape is guaranteed in IsOpSupported.
     RETURN_IF_NOT(output_info.shape.size() == 3, "Unexpected MatMulNBits output rank.");
     std::vector<uint32_t> conv2d_output_shape = {output_info.shape[0], 1, output_info.shape[1], output_info.shape[2]};
@@ -697,23 +660,21 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                                    : output_info.quant_param.Copy();
 
     const std::string conv2d_output_name = utils::UniqueNameGenerator().New(output_tensor.name, "_conv2d");
-    QnnTensorWrapper conv2d_output_tensor_wrapper(conv2d_output_name,
-                                                  QNN_TENSOR_TYPE_NATIVE,
-                                                  conv2d_output_dtype,
-                                                  std::move(conv2d_output_qparam),
-                                                  std::vector<uint32_t>(conv2d_output_shape));
-    RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(conv2d_output_tensor_wrapper)),
-                  "Failed to add Conv2d output tensor.");
 
-    RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
-                                                  QNN_OP_PACKAGE_NAME_QTI_AISW,
-                                                  QNN_OP_CONV_2D,
-                                                  std::move(input_names),
-                                                  {conv2d_output_name},
-                                                  std::move(param_tensor_names),
-                                                  do_op_validation),
-                  "Failed to add Conv2d node.");
+    // 1. BW_FLOAT_BLOCK, LPBQ (BLOCKWISE_EXPANSION) and native BQ(BLOCK) use
+    // AddConv2DNodeforBQLowering for the Conv2D node.
+    // LPBQ and native BQ(BLOCK): Conv2D outputs directly in target dtype (INT16).
+    // BW_FLOAT_BLOCK: Conv2D outputs FP16, then Cast/Quantize is applied below.
+    RETURN_IF_ERROR(bq::AddConv2DNodeforBQLowering(qnn_model_wrapper, node_unit,
+                                                   std::move(input_names),
+                                                   conv2d_output_name,
+                                                   conv2d_output_shape,
+                                                   conv2d_output_dtype,
+                                                   conv2d_output_qparam,
+                                                   /*is_graph_output=*/false,
+                                                   do_op_validation));
 
+    // BwFloatBlock post-processing: Cast or Quantize the FP16 Conv2D output.
     std::string reshape_input_name = conv2d_output_name;
     if (output_info.qnn_data_type == QNN_DATATYPE_FLOAT_32) {
       // 2. Workaround: Add post-Cast to cast float16 back to float32 to pass HTP validation.
@@ -727,7 +688,6 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                     output_info.quant_param.Copy(),
                                                     std::vector<uint32_t>(conv2d_output_shape),
                                                     do_op_validation));
-
       reshape_input_name = cast_output_name;
     } else if (utils::IsQuant16bit(output_info.qnn_data_type) && is_bw_float_block) {
       // 2. Add Quantize to FP16 → UINT16/INT16 (only needed when the kernel computed in FP16).
@@ -741,7 +701,6 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
                                                        output_info.quant_param.Copy(),
                                                        std::vector<uint32_t>(conv2d_output_shape),
                                                        do_op_validation));
-
       reshape_input_name = q_output_name;
     }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -214,6 +214,7 @@ bool IsHTPSupportedNativeBQ(QnnHtpDevice_Arch_t htp_arch,
 #else
   return false;
 #endif
+}
 
 Ort::Status RegisterWeightAsConv1x1Filter(QnnModelWrapper& qnn_model_wrapper,
                                           const std::string& weight_name,

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.cc
@@ -14,6 +14,7 @@
 
 #include "core/providers/qnn/builder/qnn_def.h"
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
 #include "core/providers/qnn/common/inlined_containers.h"
 
 namespace onnxruntime {
@@ -213,6 +214,83 @@ bool IsHTPSupportedNativeBQ(QnnHtpDevice_Arch_t htp_arch,
 #else
   return false;
 #endif
+
+Ort::Status RegisterWeightAsConv1x1Filter(QnnModelWrapper& qnn_model_wrapper,
+                                          const std::string& weight_name,
+                                          const TensorInfo& weight_info,
+                                          std::vector<uint8_t> weight_data,
+                                          std::vector<std::string>& input_names) {
+  RETURN_IF_NOT(weight_info.shape.size() == 2,
+                "LPBQ 1x1 filter lowering requires weight to be rank-2 [K, N]");
+  RETURN_IF_NOT(weight_info.quant_param.IsLPBQ(),
+                "LPBQ 1x1 filter lowering requires LPBQ quant params");
+
+  const uint32_t K = weight_info.shape[0];
+  const uint32_t N = weight_info.shape[1];
+
+  std::vector<uint32_t> conv_weight_shape = {1u, 1u, K, N};
+  QnnQuantParamsWrapper conv_weight_quant = weight_info.quant_param.Copy();
+  RETURN_IF_ERROR(conv_weight_quant.HandleUnsqueeze<uint32_t>(weight_info.shape, conv_weight_shape));
+
+  const std::string conv_weight_name = utils::UniqueNameGenerator().New(weight_name, "_reshape");
+
+  Qnn_TensorType_t tensor_type = qnn_model_wrapper.GetTensorType(weight_name);
+  QnnTensorWrapper weight_tensorwrapper(conv_weight_name, tensor_type, weight_info.qnn_data_type,
+                                        std::move(conv_weight_quant), std::move(conv_weight_shape),
+                                        std::move(weight_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(weight_tensorwrapper)),
+                "Failed to add LPBQ 1x1 filter weight tensor.");
+  input_names.emplace_back(conv_weight_name);
+  return Ort::Status();
+}
+
+Ort::Status AddConv2DNodeforBQLowering(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       std::vector<std::string>&& input_names,
+                                       const std::string& conv2d_output_name,
+                                       const std::vector<uint32_t>& conv2d_output_shape,
+                                       Qnn_DataType_t conv2d_output_dtype,
+                                       const QnnQuantParamsWrapper& conv2d_output_quant_param,
+                                       bool is_graph_output,
+                                       bool do_op_validation) {
+  // Build Conv2D params: stride=[1,1], pad=[[0,0],[0,0]], dilation=[1,1], group=1.
+  std::vector<std::string> param_tensor_names;
+
+  QnnParamWrapper stride_param(node_unit.Index(), node_unit.Name(),
+                               QNN_OP_CONV_2D_PARAM_STRIDE, {2}, {1u, 1u});
+  param_tensor_names.push_back(stride_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(stride_param));
+
+  QnnParamWrapper pad_param(node_unit.Index(), node_unit.Name(),
+                            QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, {2, 2}, {0u, 0u, 0u, 0u});
+  param_tensor_names.push_back(pad_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(pad_param));
+
+  QnnParamWrapper dilation_param(node_unit.Index(), node_unit.Name(),
+                                 QNN_OP_CONV_2D_PARAM_DILATION, {2}, {1u, 1u});
+  param_tensor_names.push_back(dilation_param.GetParamTensorName());
+  qnn_model_wrapper.AddParamWrapper(std::move(dilation_param));
+
+  RETURN_IF_ERROR(AddQnnScalar<uint32_t>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), 1u,
+                                         QNN_OP_CONV_2D_PARAM_GROUP, param_tensor_names));
+
+  const Qnn_TensorType_t conv2d_tensor_type = is_graph_output
+                                                  ? QNN_TENSOR_TYPE_APP_READ
+                                                  : QNN_TENSOR_TYPE_NATIVE;
+
+  QnnTensorWrapper conv2d_output_wrapper(conv2d_output_name, conv2d_tensor_type, conv2d_output_dtype,
+                                         conv2d_output_quant_param.Copy(),
+                                         std::vector<uint32_t>(conv2d_output_shape));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(conv2d_output_wrapper)),
+                "Failed to add Conv2D output tensor.");
+
+  RETURN_IF_NOT(qnn_model_wrapper.CreateQnnNode(utils::UniqueNameGenerator().New(node_unit),
+                                                QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_CONV_2D,
+                                                std::move(input_names), {conv2d_output_name},
+                                                std::move(param_tensor_names), do_op_validation),
+                "Failed to add Conv2D node.");
+
+  return Ort::Status();
 }
 
 }  // namespace bq

--- a/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_bq_utils.h
@@ -20,6 +20,7 @@ namespace onnxruntime {
 namespace qnn {
 
 class QnnModelWrapper;
+struct TensorInfo;
 
 // Shared helpers for block-quantized (BQ) weight handling in the QNN HTP
 // BW_FLOAT_BLOCK op-builder paths (Conv, MatMul, Gemm).
@@ -102,6 +103,29 @@ bool IsHTPSupportedNativeBQ(QnnHtpDevice_Arch_t htp_arch,
                             uint32_t block_size,
                             uint32_t output_channel,
                             gsl::span<const float> offsets);
+
+// Registers an LPBQ weight tensor as a [1, 1, K, N] (HWCN 1×1 filter).
+// Precondition: weight_info.shape == [K, N] and weight_info.quant_param.IsLPBQ().
+// Unsqueezes [K, N] → [1, 1, K, N] and updates the LPBQ quant axis (1 → 3).
+// Pushes the registered tensor name to input_names.
+Ort::Status RegisterWeightAsConv1x1Filter(QnnModelWrapper& qnn_model_wrapper,
+                                          const std::string& weight_name,
+                                          const TensorInfo& weight_info,
+                                          std::vector<uint8_t> weight_data,
+                                          std::vector<std::string>& input_names);
+
+// Creates a QNN Conv2D node (stride=1, pad=0, dilation=1, group=1) for LPBQ/BwFloatBlock lowering.
+// Registers the Conv2D output tensor with conv2d_output_name, conv2d_output_shape, and
+// conv2d_output_dtype.
+Ort::Status AddConv2DNodeforBQLowering(QnnModelWrapper& qnn_model_wrapper,
+                                       const OrtNodeUnit& node_unit,
+                                       std::vector<std::string>&& input_names,
+                                       const std::string& conv2d_output_name,
+                                       const std::vector<uint32_t>& conv2d_output_shape,
+                                       Qnn_DataType_t conv2d_output_dtype,
+                                       const QnnQuantParamsWrapper& conv2d_output_quant_param,
+                                       bool is_graph_output,
+                                       bool do_op_validation);
 
 }  // namespace bq
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -2104,6 +2104,150 @@ Ort::Status DequantizeInt32BiasToFp16(gsl::span<const uint8_t> raw_int32_bytes,
   return Ort::Status();
 }
 
+Ort::Status RequantizeBiasIfNeeded(QnnModelWrapper& qnn_model_wrapper,
+                                   const Ort::Logger& logger,
+                                   const OrtNodeUnitIODef& bias_def,
+                                   const TensorInfo& bias_info,
+                                   gsl::span<const float> weights_scales,
+                                   float activation_scale,
+                                   std::vector<std::string>& input_names,
+                                   bool& was_requantized) {
+  was_requantized = false;
+  int32_t bias_quant_axis = 0;
+  std::vector<float> current_scales;
+  std::vector<int32_t> current_offsets;
+  RETURN_IF_ERROR(GetBiasQuantScalesAndOffsets(bias_info.quant_param, current_scales,
+                                               current_offsets, bias_quant_axis));
+
+  const size_t num_channels = current_scales.size();
+  bool needs_requantization = false;
+  for (size_t i = 0; i < num_channels && !needs_requantization; ++i) {
+    const float w = (i < weights_scales.size()) ? weights_scales[i] : weights_scales[0];
+    if (current_offsets[i] != 0 ||
+        !CheckBiasScaleMatch(current_scales[i], w, activation_scale, 1e-5f)) {
+      needs_requantization = true;
+    }
+  }
+
+  if (!needs_requantization) {
+    return Ort::Status();  // Scales already match; caller processes bias normally.
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Requantizing bias " + bias_def.name).c_str());
+
+  std::vector<uint8_t> original_bias_data;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
+
+  std::vector<uint8_t> new_bias_data;
+  std::vector<float> new_scales;
+  std::vector<int32_t> new_offsets;
+  const auto axis_opt = (num_channels > 1) ? std::optional<int64_t>(bias_quant_axis) : std::nullopt;
+  RETURN_IF_ERROR(RequantizeBiasTensor(
+      original_bias_data, bias_info.shape, current_scales, current_offsets,
+      weights_scales, activation_scale, bias_info.qnn_data_type,
+      new_bias_data, new_scales, new_offsets, axis_opt));
+
+  QnnQuantParamsWrapper new_quant_params = (new_scales.size() == 1)
+                                               ? QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0])
+                                               : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
+
+  const std::string rq_bias_name = UniqueNameGenerator().New(bias_def.name, "_rq");
+  QnnTensorWrapper bias_wrapper(rq_bias_name, QNN_TENSOR_TYPE_STATIC, bias_info.qnn_data_type,
+                                std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
+                                std::move(new_bias_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
+                "Failed to add requantized bias tensor.");
+  input_names.push_back(rq_bias_name);
+  was_requantized = true;
+  return Ort::Status();
+}
+
+Ort::Status QuantizeFloatBias(QnnModelWrapper& qnn_model_wrapper,
+                              const Ort::Logger& logger,
+                              const OrtNodeUnitIODef& bias_def,
+                              const TensorInfo& bias_info,
+                              gsl::span<const float> weights_scales,
+                              float activation_scale,
+                              std::vector<std::string>& input_names) {
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("Quantizing float bias " + bias_def.name + " using activation_scale * weight_scale[c]").c_str());
+  std::vector<uint8_t> original_bias_data;
+  RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(bias_info.initializer_tensor, original_bias_data));
+  const size_t num_channels = bias_info.shape[0];
+  RETURN_IF_NOT(original_bias_data.size() == num_channels * sizeof(float),
+                "Unexpected bias data size for float bias quantization");
+  std::vector<uint8_t> new_bias_data;
+  std::vector<float> new_scales;
+  std::vector<int32_t> new_offsets;
+  RETURN_IF_ERROR(QuantizeFloatBiasTensor(
+      gsl::make_span<const float>(reinterpret_cast<const float*>(original_bias_data.data()), num_channels),
+      weights_scales, activation_scale, new_bias_data, new_scales, new_offsets));
+
+  constexpr int32_t bias_quant_axis = 0;
+  QnnQuantParamsWrapper new_quant_params = (new_scales.size() == 1)
+                                               ? QnnQuantParamsWrapper::PerTensor(new_scales[0], new_offsets[0])
+                                               : QnnQuantParamsWrapper::PerChannel(new_scales, new_offsets, bias_quant_axis);
+
+  const std::string q_bias_name = UniqueNameGenerator().New(bias_def.name, "_q");
+  QnnTensorWrapper bias_wrapper(q_bias_name, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_32,
+                                std::move(new_quant_params), std::vector<uint32_t>(bias_info.shape),
+                                std::move(new_bias_data));
+  RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(bias_wrapper)),
+                "Failed to add quantized float bias tensor.");
+  input_names.push_back(q_bias_name);
+  return Ort::Status();
+}
+
+Ort::Status ProcessBiasForQuantizedOp(QnnModelWrapper& qnn_model_wrapper,
+                                      const Ort::Logger& logger,
+                                      const OrtNodeUnitIODef& bias_def,
+                                      const QnnQuantParamsWrapper& act_quant_param,
+                                      const QnnQuantParamsWrapper& weight_quant_param,
+                                      std::vector<std::string>& input_names,
+                                      bool& was_handled) {
+  was_handled = false;
+
+  TensorInfo bias_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(bias_def, bias_info));
+
+  if (!bias_info.is_initializer) {
+    return Ort::Status();  // Non-initializer: caller handles normally.
+  }
+
+  if (!act_quant_param.IsQuantized() || !weight_quant_param.IsQuantized()) {
+    return Ort::Status();  // Not quantized: caller handles normally.
+  }
+
+  RETURN_IF_NOT(act_quant_param.IsPerTensor(/*include_bw*/ true),
+                "Activation must be per-tensor quantized for quantized-domain bias processing");
+
+  const auto& act_qp = act_quant_param.Get();
+  const float activation_scale = (act_qp.quantizationEncoding == QNN_QUANTIZATION_ENCODING_SCALE_OFFSET)
+                                     ? act_qp.scaleOffsetEncoding.scale
+                                     : act_qp.bwScaleOffsetEncoding.scale;
+  std::vector<float> weights_scales;
+  RETURN_IF_ERROR(GetWeightQuantScales(weight_quant_param, weights_scales));
+  RETURN_IF(weights_scales.empty(), "No weight scales found for bias quantization");
+
+  if (bias_info.quant_param.IsQuantized()) {
+    bool was_requantized = false;
+    RETURN_IF_ERROR(RequantizeBiasIfNeeded(qnn_model_wrapper, logger, bias_def, bias_info,
+                                           weights_scales, activation_scale, input_names,
+                                           was_requantized));
+    if (was_requantized) {
+      was_handled = true;
+    }
+    // If not requantized, scales already match: caller processes bias normally.
+    return Ort::Status();
+  } else {
+    // Float bias: quantize using activation_scale * weight_scale[c].
+    RETURN_IF_ERROR(QuantizeFloatBias(qnn_model_wrapper, logger, bias_def, bias_info,
+                                      weights_scales, activation_scale, input_names));
+    was_handled = true;
+    return Ort::Status();
+  }
+}
+
 bool AreZeroPointsSymmetricConstant(QnnModelWrapper& qnn_model_wrapper, const std::string& zp_tensor_name,
                                     int64_t bits) {
   std::vector<uint8_t> per_block_uint8_zp;

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -985,6 +985,19 @@ bool AreZeroPointsSymmetricConstant(QnnModelWrapper& qnn_model_wrapper,
                                     const std::string& zp_tensor_name,
                                     int64_t bits);
 
+// Processes a bias tensor for quantized ops (LPBQ Conv2D, etc.).
+// Handles: INT32 quantized (check/requantize if mismatch), float (quantize).
+// Sets was_handled=true if the bias was added to input_names.
+// Sets was_handled=false if the bias should be processed normally by the caller
+// (e.g., non-initializer, or activation/weight not quantized, or scales already match).
+Ort::Status ProcessBiasForQuantizedOp(QnnModelWrapper& qnn_model_wrapper,
+                                      const Ort::Logger& logger,
+                                      const OrtNodeUnitIODef& bias_def,
+                                      const QnnQuantParamsWrapper& act_quant_param,
+                                      const QnnQuantParamsWrapper& weight_quant_param,
+                                      std::vector<std::string>& input_names,
+                                      bool& was_handled);
+
 }  // namespace utils
 }  // namespace qnn
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -813,12 +813,7 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_static_weight) {
   }
 }
 
-#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
-
-#if defined(__linux__)
-
 // Tests MatMul with ONNX block-quantized (BQ) weight using the BQ -> QNN LPBQ conversion path.
-// Currently BQ -> LPBQ conversion is only supported on Linux. It will be later enabled for windows as well.
 TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_BlockQuant) {
   RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
   RunQDQBlockQuantMatMulOpTest<int16_t, Int4x2, int16_t>({4, 128}, {128, 64}, 32, 0, QDQTolerance(0.05f));
@@ -827,7 +822,7 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_BlockQuant) {
   RunQDQBlockQuantMatMulOpTest<uint16_t, Int4x2, uint16_t>({2, 3, 4, 16}, {16, 8}, 8, 0, QDQTolerance(0.05f));
 }
 
-#endif  // defined(__linux__)
+#endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if defined(_M_ARM64)
 //


### PR DESCRIPTION
### Description
Refactors the block-quantized (BQ) and LPBQ weight lowering logic across the QNN EP op builders (Conv, MatMul, MatMulNBits) to eliminate code duplication and consolidate shared helpers.

__`qnn_bq_utils`__ :

- `RegisterWeightAsConv1x1Filter`: registers an LPBQ weight `[K, N]` as a `[1, 1, K, N]` HWCN 1×1 Conv2D filter, updating the LPBQ quant axis.
- `AddConv2DNodeforBQLowering`: creates a QNN Conv2D node (stride=1, pad=0, dilation=1, group=1) shared by both LPBQ and BwFloatBlock lowering paths.

__`qnn_utils`__ :

- `ProcessBiasForQuantizedOp`: handles bias processing for quantized ops, requantizes INT32 bias if scales mismatch or quantizes float bias using `activation_scale * weight_scale[c]`.

__`conv_op_builder`__ : removed duplicated helpers (`GetActivationScale`, `BuildBiasQuantParams`, `AddStaticBiasTensor`, `ProcessRequantizeBias`, `ProcessFloatBias`).

__`matmul_op_builder` / `matmulnbits_op_builder`__ : updated to use the new shared helpers.

__`matmul_test`__ : enabled `MatMulOp_QDQ_BlockQuant` on Windows in addition to Linux.


### Motivation and Context
The LPBQ lowering code was duplicated across various op builders like `conv_op_builder`, `matmul_op_builder`, and `matmulnbits_op_builder`. This refactor centralizes the shared logic into `qnn_bq_utils` and `qnn_utils`, making future changes (e.g., adding LPBQ support to new op builders) require only a single implementation.