### PR TITLE
[QNN EP] Uplevel UDO unit tests from Python 3.10 to 3.12 for CI coverage

### DIFF
--- a/cmake/onnxruntime_unittests_udo.cmake
+++ b/cmake/onnxruntime_unittests_udo.cmake
@@ -13,10 +13,11 @@ set(_LLVM_VERSION "21.1.8")
 # Must match qcom/packages.yml:hexagon_linux_x86_64.version (also referenced from
 # onnxruntime/test/providers/qnn/udo/HTP_Makefile HEXAGON_SDK_ROOT_V*).
 set(_HEXAGON_SDK_VERSION "6.5.0.0")
-# qnn-op-package-generator requires Python 3.10. Skip the UDO unit test build when the
-# discovered interpreter is any other version (e.g. Windows CI uses 3.11+).
-if(NOT (Python_VERSION_MAJOR EQUAL 3 AND Python_VERSION_MINOR EQUAL 10))
-    message(STATUS "Skipping QNN UDO unit test build: requires Python 3.10, found ${Python_VERSION}")
+# qnn-op-package-generator ships Python-version-tagged extensions in the QAIRT SDK.
+# The Linux x86_64 SDK provides 3.10 and 3.12 variants; skip other interpreter versions
+# (e.g. 3.11/3.13/3.14) which have no matching extension.
+if(NOT (Python_VERSION_MAJOR EQUAL 3 AND (Python_VERSION_MINOR EQUAL 10 OR Python_VERSION_MINOR EQUAL 12)))
+    message(STATUS "Skipping QNN UDO unit test build: requires Python 3.10 or 3.12, found ${Python_VERSION}")
     return()
 endif()
 if(UNIX)

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -1589,7 +1589,7 @@ Once registered, UDOs integrate transparently into model conversion and runtime 
 
 **HTP UDO is not supported on Windows.** `qnn-op-package-generator` and the Hexagon toolchain only target HTP on Linux; the `x86_64-windows-msvc` host platform supports the CPU backend only. On Windows, CPU UDO must be generated with the `--gen_cmakelists` flag (see Step 2), which produces a `CMakeLists.txt`-based build instead of the Linux Makefile flow.
 
-**The shipped UDO unit test runs on Linux x86_64 only.** `qnn-op-package-generator` requires Python 3.10, while the Windows CI environment ships with Python 3.11+, so the end-to-end UDO build/run loop is currently gated on Linux x86_64. Windows-side UDO support has separate CI coverage via `ParseOpPackages` parsing tests in `qnn_basic_test.cc`.
+**The shipped UDO unit test runs on Linux x86_64 only.** The Linux x86_64 CI build uses Python 3.12, and `qnn-op-package-generator` supports Python 3.10 and 3.12 via version-tagged extensions in the QAIRT SDK. Windows is excluded because the Hexagon toolchain only targets HTP on Linux; Windows-side UDO support has separate CI coverage via `ParseOpPackages` parsing tests in `qnn_basic_test.cc`.
 
 ### UDO Workflow
 

--- a/onnxruntime/test/providers/qnn/udo_op_test.cc
+++ b/onnxruntime/test/providers/qnn/udo_op_test.cc
@@ -21,8 +21,9 @@
 #include "gtest/gtest.h"
 namespace onnxruntime {
 namespace test {
-// qnn-op-package-generator requires Python 3.10, while our CI only supports 3.11 and later on Windows,
-// so we do not add the UDO unit test on Windows.
+// qnn-op-package-generator supports Python 3.10 and 3.12 on Linux x86_64 (via version-tagged
+// SDK extensions). Windows is excluded by the platform guard below because the Hexagon toolchain
+// only targets HTP on Linux and the Windows CI environment uses Python 3.11+.
 #if defined(__linux__) && defined(__x86_64__) && defined(BUILD_QNN_UDO_TEST)
 constexpr std::string_view kUdoDomain = "udo_domain";
 /*

--- a/tools/ci_build/github/linux/python/requirements.txt
+++ b/tools/ci_build/github/linux/python/requirements.txt
@@ -16,5 +16,5 @@ jinja2
 markupsafe
 onnx==1.21.0; python_version < "3.14"
 # Required by qnn-op-package-generator (UDO unit test build, see cmake/onnxruntime_unittests_udo.cmake).
-mako==1.3.5; python_version == "3.10"
-lxml==5.2.2; python_version == "3.10"
+mako==1.3.5; python_version == "3.10" or python_version == "3.12"
+lxml==5.2.2; python_version == "3.10" or python_version == "3.12"


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Relax the CMake gate in onnxruntime_unittests_udo.cmake from "exactly 3.10" to "3.10 or 3.12"
- Extend the mako/lxml pip markers in requirements.txt to cover 3.12
- Refresh the stale Python-3.10-only comments in udo_op_test.cc and QNN-ExecutionProvider.md.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- The qnn-op-package-generator in the pinned QAIRT SDK ships cpython-312 extension modules alongside cpython-310 ones on Linux x86_64, so the tool runs correctly under Python 3.12 once numpy/lxml/mako are present.