### PR TITLE
Prevent inf limits in clip op

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -196,6 +196,7 @@ Ort::Status ClipOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   float min_value = std::numeric_limits<float>::lowest();
   if (num_inputs > 1 && !inputs[1].name.empty()) {
     RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[1], min_value));
+    min_value = std::max(min_value, std::numeric_limits<float>::lowest());
   }
   RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), min_value,
                                       QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE, param_tensor_names));
@@ -204,6 +205,7 @@ Ort::Status ClipOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   float max_value = std::numeric_limits<float>::max();
   if (num_inputs > 2 && !inputs[2].name.empty()) {
     RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[2], max_value));
+    max_value = std::min(max_value, std::numeric_limits<float>::max());
   }
   RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), max_value,
                                       QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE, param_tensor_names));

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/clip_op_builder.cc
@@ -35,6 +35,7 @@ class ClipOpBuilder : public BaseOpBuilder {
 
 static Ort::Status ProcessClipMinMax(QnnModelWrapper& qnn_model_wrapper,
                                      const OrtNodeUnitIODef& input,
+                                     bool is_min,
                                      float& float_value) {
   TensorInfo input_info = {};
   std::vector<uint8_t> val_bytes;
@@ -153,6 +154,13 @@ static Ort::Status ProcessClipMinMax(QnnModelWrapper& qnn_model_wrapper,
     }
   }
 
+  // Avoid infinite bounds, which may not place nicely with all backends
+  if (is_min) {
+    float_value = std::max(float_value, std::numeric_limits<float>::lowest());
+  } else {
+    float_value = std::min(float_value, std::numeric_limits<float>::max());
+  }
+
   return Ort::Status();
 }
 
@@ -195,8 +203,7 @@ Ort::Status ClipOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   // Set the 'min' parameter.
   float min_value = std::numeric_limits<float>::lowest();
   if (num_inputs > 1 && !inputs[1].name.empty()) {
-    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[1], min_value));
-    min_value = std::max(min_value, std::numeric_limits<float>::lowest());
+    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[1], true, min_value));
   }
   RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), min_value,
                                       QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE, param_tensor_names));
@@ -204,8 +211,7 @@ Ort::Status ClipOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
   // Set the 'max' parameter.
   float max_value = std::numeric_limits<float>::max();
   if (num_inputs > 2 && !inputs[2].name.empty()) {
-    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[2], max_value));
-    max_value = std::min(max_value, std::numeric_limits<float>::max());
+    RETURN_IF_ERROR(ProcessClipMinMax(qnn_model_wrapper, inputs[2], false, max_value));
   }
   RETURN_IF_ERROR(AddQnnScalar<float>(qnn_model_wrapper, node_unit.Index(), node_unit.Name(), max_value,
                                       QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE, param_tensor_names));

--- a/onnxruntime/test/providers/qnn/clip_test.cc
+++ b/onnxruntime/test/providers/qnn/clip_test.cc
@@ -54,6 +54,28 @@ TEST_F(QnnCPUBackendTests, Clip_4D_f32_DefaultMinMax) {
                      ExpectedEPNodeAssignment::All);
 }
 
+// clip in range [-inf, 5.0] on CPU
+TEST_F(QnnCPUBackendTests, Clip_NegativeInfMin) {
+  RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
+                     {TestInputDef<float>({}, true, {-std::numeric_limits<float>::infinity()}),
+                      TestInputDef<float>({}, true, {5.0f})},
+                     ExpectedEPNodeAssignment::All,
+                     "cpu",
+                     13,
+                     5e-3f);
+}
+
+// clip in range [-5.0, inf] on CPU
+TEST_F(QnnCPUBackendTests, Clip_PositiveInfMin) {
+  RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
+                     {TestInputDef<float>({}, true, {-5.0}),
+                      TestInputDef<float>({}, true, {std::numeric_limits<float>::infinity()})},
+                     ExpectedEPNodeAssignment::All,
+                     "cpu",
+                     13,
+                     5e-3f);
+}
+
 // Test Clip with 5D input.
 TEST_F(QnnCPUBackendTests, Clip_5D_f32) {
   RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48)),
@@ -76,6 +98,28 @@ TEST_F(QnnHTPBackendTests, Clip_f32) {
   RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
                      {TestInputDef<float>({}, true, {-5.0f}),
                       TestInputDef<float>({}, true, {5.0f})},
+                     ExpectedEPNodeAssignment::All,
+                     "htp",
+                     13,
+                     5e-3f);
+}
+
+// clip in range [-inf, 5.0] on HTP
+TEST_F(QnnHTPBackendTests, Clip_NegativeInfMin) {
+  RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
+                     {TestInputDef<float>({}, true, {-std::numeric_limits<float>::infinity()}),
+                      TestInputDef<float>({}, true, {5.0f})},
+                     ExpectedEPNodeAssignment::All,
+                     "htp",
+                     13,
+                     5e-3f);
+}
+
+// clip in range [-5.0, inf] on HTP
+TEST_F(QnnHTPBackendTests, Clip_PositiveInfMin) {
+  RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
+                     {TestInputDef<float>({}, true, {-5.0}),
+                      TestInputDef<float>({}, true, {std::numeric_limits<float>::infinity()})},
                      ExpectedEPNodeAssignment::All,
                      "htp",
                      13,
@@ -483,6 +527,26 @@ TEST_F(QnnGPUBackendTests, Clip_fp32) {
   RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
                      {TestInputDef<float>({}, true, {-5.0f}),
                       TestInputDef<float>({}, true, {5.0f})},
+                     ExpectedEPNodeAssignment::All,
+                     "gpu",
+                     13);
+}
+
+// clip in range [-inf, 5.0] on GPU
+TEST_F(QnnGPUBackendTests, Clip_NegativeInfMin) {
+  RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
+                     {TestInputDef<float>({}, true, {-std::numeric_limits<float>::infinity()}),
+                      TestInputDef<float>({}, true, {5.0f})},
+                     ExpectedEPNodeAssignment::All,
+                     "gpu",
+                     13);
+}
+
+// clip in range [-5.0, inf] on GPU
+TEST_F(QnnGPUBackendTests, Clip_PositiveInfMin) {
+  RunClipTest<float>(TestInputDef<float>({1, 1, 3, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 12)),
+                     {TestInputDef<float>({}, true, {-5.0}),
+                      TestInputDef<float>({}, true, {std::numeric_limits<float>::infinity()})},
                      ExpectedEPNodeAssignment::All,
                      "gpu",
                      13);


### PR DESCRIPTION
* The GPU backend doesn't support min/max bounds to clip explicitly provided as +/- infinity. Work around this by clamping to the min/max finite floats instead.

