### PR TITLE
[QNN EP] Cleanup prepare_and_load

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -428,6 +428,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   // Release the current QNN context handles (frees HW resources).
   // Idempotent — safe to call even if no context is active.
   Ort::Status ReleaseContext();
+
   bool IsDx12SharedMemoryAllocatorSupported();
 
   power::HtpPowerConfigManager& GetHtpPowerConfigManager() {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -3067,11 +3067,11 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   // After compilation timing: reload compiled context for multi-PD inference if requested.
   // Runs after the timing window intentionally — reload is post-compile work.
   if (ep->prepare_and_load_) {
-    RETURN_IF_NOT_NULL(PrepareAndLoadContext(ep, graphs, fused_nodes, count));
+    RETURN_IF_NOT_NULL(ReloadCompiledContext(ep, graphs, fused_nodes, count));
   }
 
   // Clean up transient GetCapability→Compile state.
-  // onnx_graph_io_names_ is deferred to here because PrepareAndLoadContext needs it.
+  // onnx_graph_io_names_ is deferred to here because ReloadCompiledContext needs it.
   ep->onnx_graph_io_names_.reset();
 
   if (ep->prepare_only_) {
@@ -3084,7 +3084,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   return nullptr;
 }
 
-OrtStatus* QnnEp::PrepareAndLoadContext(QnnEp* ep,
+OrtStatus* QnnEp::ReloadCompiledContext(QnnEp* ep,
                                         const OrtGraph** graphs,
                                         const OrtNode** fused_nodes,
                                         size_t count) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -3067,7 +3067,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   // After compilation timing: reload compiled context for multi-PD inference if requested.
   // Runs after the timing window intentionally — reload is post-compile work.
   if (ep->prepare_and_load_) {
-    RETURN_IF_NOT_NULL(ReloadCompiledContext(ep, graphs, fused_nodes, count));
+    RETURN_IF_NOT_NULL(ep->ReloadCompiledContext(graphs, fused_nodes, count));
   }
 
   // Clean up transient GetCapability→Compile state.
@@ -3084,29 +3084,28 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   return nullptr;
 }
 
-OrtStatus* QnnEp::ReloadCompiledContext(QnnEp* ep,
-                                        const OrtGraph** graphs,
+OrtStatus* QnnEp::ReloadCompiledContext(const OrtGraph** graphs,
                                         const OrtNode** fused_nodes,
                                         size_t count) {
-  ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
               "prepare_and_load mode: reloading compiled context for multi-PD inference.");
 
   // 1. Extract the compiled context binary (while compile context is still alive).
   //    Wrap immediately in unique_ptr so the buffer is freed on all return paths (RAII).
   uint64_t buffer_size = 0;
   unsigned char* raw_context_buffer = nullptr;
-  Ort::Status get_buf_status = ep->qnn_backend_manager_->GetContextBinaryBuffer(
+  Ort::Status get_buf_status = qnn_backend_manager_->GetContextBinaryBuffer(
       /*is_multi_soc_buffer=*/false, &raw_context_buffer, buffer_size);
   if (!get_buf_status.IsOK()) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                    ("prepare_and_load: Failed to extract context binary buffer: " +
-                                     std::string(get_buf_status.GetErrorMessage()))
-                                        .c_str());
+    return ort_api.CreateStatus(ORT_EP_FAIL,
+                                ("prepare_and_load: Failed to extract context binary buffer: " +
+                                 std::string(get_buf_status.GetErrorMessage()))
+                                    .c_str());
   }
   std::unique_ptr<unsigned char[]> context_buffer(raw_context_buffer);
   if (buffer_size == 0) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                    "prepare_and_load: Context binary buffer is empty.");
+    return ort_api.CreateStatus(ORT_EP_FAIL,
+                                "prepare_and_load: Context binary buffer is empty.");
   }
 
   // 2. Collect fused node names before clearing models.
@@ -3114,41 +3113,41 @@ OrtStatus* QnnEp::ReloadCompiledContext(QnnEp* ep,
   fused_node_names.reserve(count);
   for (size_t i = 0; i < count; ++i) {
     const char* node_name = nullptr;
-    auto st = ep->ort_api.Node_GetName(fused_nodes[i], &node_name);
+    auto st = ort_api.Node_GetName(fused_nodes[i], &node_name);
     if (st != nullptr) {
-      ep->ort_api.ReleaseStatus(st);
-      return ep->ort_api.CreateStatus(ORT_EP_FAIL, "prepare_and_load: Failed to get fused node name.");
+      ort_api.ReleaseStatus(st);
+      return ort_api.CreateStatus(ORT_EP_FAIL, "prepare_and_load: Failed to get fused node name.");
     }
     fused_node_names.emplace_back(node_name);
   }
 
   // 3. Clear compile-time QNN models (drops compile-time graph handles).
-  ep->qnn_models_.clear();
+  qnn_models_.clear();
 
   // 4. Release the compile-time QNN context (frees single-PD HW allocation).
-  Ort::Status release_status = ep->qnn_backend_manager_->ReleaseContext();
+  Ort::Status release_status = qnn_backend_manager_->ReleaseContext();
   if (!release_status.IsOK()) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                    ("prepare_and_load: ReleaseContext failed: " +
-                                     std::string(release_status.GetErrorMessage()))
-                                        .c_str());
+    return ort_api.CreateStatus(ORT_EP_FAIL,
+                                ("prepare_and_load: ReleaseContext failed: " +
+                                 std::string(release_status.GetErrorMessage()))
+                                    .c_str());
   }
 
   // 5. Load from the in-memory binary buffer via AOT path (multi-PD).
   std::unordered_map<std::string, std::unique_ptr<qnn::QnnModel>> loaded_models;
-  Ort::Status load_status = ep->qnn_backend_manager_->LoadCachedQnnContextFromBuffer(
+  Ort::Status load_status = qnn_backend_manager_->LoadCachedQnnContextFromBuffer(
       reinterpret_cast<char*>(context_buffer.get()),
       buffer_size,
       "",  // no file path needed for in-memory load
       fused_node_names[0],
       loaded_models,
       0,
-      *ep->io_dispatch_);
+      *io_dispatch_);
   if (!load_status.IsOK()) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                    ("prepare_and_load: Failed to reload context: " +
-                                     std::string(load_status.GetErrorMessage()))
-                                        .c_str());
+    return ort_api.CreateStatus(ORT_EP_FAIL,
+                                ("prepare_and_load: Failed to reload context: " +
+                                 std::string(load_status.GetErrorMessage()))
+                                    .c_str());
   }
 
   // 6. Wire up loaded models: SetGraphInputOutputInfo + SetupQnnInputOutput.
@@ -3162,29 +3161,29 @@ OrtStatus* QnnEp::ReloadCompiledContext(QnnEp* ep,
       if (loaded_models.size() == 1 && count == 1) {
         model_it = loaded_models.begin();
       } else {
-        return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                        ("prepare_and_load: No loaded model found for fused node: " +
-                                         fused_node_name)
-                                            .c_str());
+        return ort_api.CreateStatus(ORT_EP_FAIL,
+                                    ("prepare_and_load: No loaded model found for fused node: " +
+                                     fused_node_name)
+                                        .c_str());
       }
     }
 
     auto qnn_model = std::move(model_it->second);
     loaded_models.erase(model_it);
 
-    const auto& onnx_input_names = ep->onnx_graph_io_names_->first;
-    const auto& onnx_output_names = ep->onnx_graph_io_names_->second;
+    const auto& onnx_input_names = onnx_graph_io_names_->first;
+    const auto& onnx_output_names = onnx_graph_io_names_->second;
 
     RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(
-        qnn::QnnModelContext{*graphs[graph_idx], *fused_nodes[graph_idx], ep->logger_,
+        qnn::QnnModelContext{*graphs[graph_idx], *fused_nodes[graph_idx], logger_,
                              &onnx_input_names, &onnx_output_names,
                              nullptr, nullptr, nullptr, std::string{}}));
-    RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(ep->logger_));
+    RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(logger_));
 
-    ep->qnn_models_.emplace(fused_node_name, std::move(qnn_model));
+    qnn_models_.emplace(fused_node_name, std::move(qnn_model));
   }
 
-  ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+  ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_INFO,
               "prepare_and_load mode: context reload complete. Session is ready for inference.");
   return nullptr;
 }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -3053,114 +3053,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
     RETURN_IF_NOT_NULL(ep->CreateEPContextNodes(graphs[0], fused_nodes, count, ep_context_nodes));
   }
 
-  // prepare_and_load mode: after compilation (and optional context save), reload the compiled
-  // binary via the AOT path so the QNN runtime can spread splits across multiple PDs.
-  if (ep->prepare_and_load_) {
-    ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
-                "prepare_and_load mode: reloading compiled context for multi-PD inference.");
-
-    // 1. Extract the compiled context binary (while compile context is still alive).
-    //    Wrap immediately in unique_ptr so the buffer is freed on all return paths (RAII).
-    uint64_t buffer_size = 0;
-    unsigned char* raw_context_buffer = nullptr;
-    Ort::Status get_buf_status = ep->qnn_backend_manager_->GetContextBinaryBuffer(
-        /*is_multi_soc_buffer=*/false, &raw_context_buffer, buffer_size);
-    if (!get_buf_status.IsOK()) {
-      return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                      ("prepare_and_load: Failed to extract context binary buffer: " +
-                                       std::string(get_buf_status.GetErrorMessage()))
-                                          .c_str());
-    }
-    std::unique_ptr<unsigned char[]> context_buffer(raw_context_buffer);
-    if (buffer_size == 0) {
-      return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                      "prepare_and_load: Context binary buffer is empty.");
-    }
-
-    // 2. Collect fused node names before clearing models
-    InlinedVector<std::string> fused_node_names;
-    fused_node_names.reserve(count);
-    for (size_t i = 0; i < count; ++i) {
-      const char* node_name = nullptr;
-      auto st = ep->ort_api.Node_GetName(fused_nodes[i], &node_name);
-      if (st != nullptr) {
-        ep->ort_api.ReleaseStatus(st);
-        return ep->ort_api.CreateStatus(ORT_EP_FAIL, "prepare_and_load: Failed to get fused node name.");
-      }
-      fused_node_names.emplace_back(node_name);
-    }
-
-    // 3. Clear compile-time QNN models (drops compile-time graph handles)
-    ep->qnn_models_.clear();
-
-    // 4. Release the compile-time QNN context (frees single-PD HW allocation)
-    Ort::Status release_status = ep->qnn_backend_manager_->ReleaseContext();
-    if (!release_status.IsOK()) {
-      return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                      ("prepare_and_load: ReleaseContext failed: " +
-                                       std::string(release_status.GetErrorMessage()))
-                                          .c_str());
-    }
-
-    // 5. Load from the in-memory binary buffer via AOT path (multi-PD)
-    std::unordered_map<std::string, std::unique_ptr<qnn::QnnModel>> loaded_models;
-    Ort::Status load_status = ep->qnn_backend_manager_->LoadCachedQnnContextFromBuffer(
-        reinterpret_cast<char*>(context_buffer.get()),
-        buffer_size,
-        "",  // no file path needed for in-memory load
-        fused_node_names[0],
-        loaded_models,
-        0,
-        *ep->io_dispatch_);
-
-    if (!load_status.IsOK()) {
-      return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                      ("prepare_and_load: Failed to reload context: " +
-                                       std::string(load_status.GetErrorMessage()))
-                                          .c_str());
-    }
-
-    // 6. Wire up loaded models: SetGraphInputOutputInfo + SetupQnnInputOutput
-    for (size_t graph_idx = 0; graph_idx < count; ++graph_idx) {
-      const std::string& fused_node_name = fused_node_names[graph_idx];
-
-      // Find the model in loaded_models by fused node name
-      auto model_it = loaded_models.find(fused_node_name);
-      if (model_it == loaded_models.end()) {
-        // For single-graph case or when QNN uses different internal names,
-        // take the first available model if there's exactly one
-        if (loaded_models.size() == 1 && count == 1) {
-          model_it = loaded_models.begin();
-        } else {
-          return ep->ort_api.CreateStatus(ORT_EP_FAIL,
-                                          ("prepare_and_load: No loaded model found for fused node: " +
-                                           fused_node_name)
-                                              .c_str());
-        }
-      }
-
-      auto qnn_model = std::move(model_it->second);
-      loaded_models.erase(model_it);
-
-      const auto& onnx_input_names = ep->onnx_graph_io_names_->first;
-      const auto& onnx_output_names = ep->onnx_graph_io_names_->second;
-
-      RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(
-          qnn::QnnModelContext{*graphs[graph_idx], *fused_nodes[graph_idx], ep->logger_,
-                               &onnx_input_names, &onnx_output_names,
-                               nullptr, nullptr, nullptr, std::string{}}));
-      RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(ep->logger_));
-
-      ep->qnn_models_.emplace(fused_node_name, std::move(qnn_model));
-    }
-
-    ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
-                "prepare_and_load mode: context reload complete. Session is ready for inference.");
-  }
-
-  // Clean up transient GetCapability→Compile state (after prepare_and_load reload which needs
-  // onnx_graph_io_names_, and after CreateEPContextNodes which needs tensor_name_overrides_).
-  ep->onnx_graph_io_names_.reset();
+  // Clean up tensor_name_overrides_ now that CreateEPContextNodes has serialized it.
   ep->tensor_name_overrides_.clear();
 
 #if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
@@ -3171,6 +3064,16 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
               ("Total compile time for all fused nodes: " + std::to_string(total_compile_time.count()) + " ms").c_str());
 #endif
 
+  // After compilation timing: reload compiled context for multi-PD inference if requested.
+  // Runs after the timing window intentionally — reload is post-compile work.
+  if (ep->prepare_and_load_) {
+    RETURN_IF_NOT_NULL(PrepareAndLoadContext(ep, graphs, fused_nodes, count));
+  }
+
+  // Clean up transient GetCapability→Compile state.
+  // onnx_graph_io_names_ is deferred to here because PrepareAndLoadContext needs it.
+  ep->onnx_graph_io_names_.reset();
+
   if (ep->prepare_only_) {
     ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                 "prepare_only mode: context saved. Releasing QNN device resources.");
@@ -3178,6 +3081,111 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
     ep->qnn_backend_manager_.reset();
   }
 
+  return nullptr;
+}
+
+OrtStatus* QnnEp::PrepareAndLoadContext(QnnEp* ep,
+                                        const OrtGraph** graphs,
+                                        const OrtNode** fused_nodes,
+                                        size_t count) {
+  ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+              "prepare_and_load mode: reloading compiled context for multi-PD inference.");
+
+  // 1. Extract the compiled context binary (while compile context is still alive).
+  //    Wrap immediately in unique_ptr so the buffer is freed on all return paths (RAII).
+  uint64_t buffer_size = 0;
+  unsigned char* raw_context_buffer = nullptr;
+  Ort::Status get_buf_status = ep->qnn_backend_manager_->GetContextBinaryBuffer(
+      /*is_multi_soc_buffer=*/false, &raw_context_buffer, buffer_size);
+  if (!get_buf_status.IsOK()) {
+    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                    ("prepare_and_load: Failed to extract context binary buffer: " +
+                                     std::string(get_buf_status.GetErrorMessage()))
+                                        .c_str());
+  }
+  std::unique_ptr<unsigned char[]> context_buffer(raw_context_buffer);
+  if (buffer_size == 0) {
+    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                    "prepare_and_load: Context binary buffer is empty.");
+  }
+
+  // 2. Collect fused node names before clearing models.
+  InlinedVector<std::string> fused_node_names;
+  fused_node_names.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    const char* node_name = nullptr;
+    auto st = ep->ort_api.Node_GetName(fused_nodes[i], &node_name);
+    if (st != nullptr) {
+      ep->ort_api.ReleaseStatus(st);
+      return ep->ort_api.CreateStatus(ORT_EP_FAIL, "prepare_and_load: Failed to get fused node name.");
+    }
+    fused_node_names.emplace_back(node_name);
+  }
+
+  // 3. Clear compile-time QNN models (drops compile-time graph handles).
+  ep->qnn_models_.clear();
+
+  // 4. Release the compile-time QNN context (frees single-PD HW allocation).
+  Ort::Status release_status = ep->qnn_backend_manager_->ReleaseContext();
+  if (!release_status.IsOK()) {
+    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                    ("prepare_and_load: ReleaseContext failed: " +
+                                     std::string(release_status.GetErrorMessage()))
+                                        .c_str());
+  }
+
+  // 5. Load from the in-memory binary buffer via AOT path (multi-PD).
+  std::unordered_map<std::string, std::unique_ptr<qnn::QnnModel>> loaded_models;
+  Ort::Status load_status = ep->qnn_backend_manager_->LoadCachedQnnContextFromBuffer(
+      reinterpret_cast<char*>(context_buffer.get()),
+      buffer_size,
+      "",  // no file path needed for in-memory load
+      fused_node_names[0],
+      loaded_models,
+      0,
+      *ep->io_dispatch_);
+  if (!load_status.IsOK()) {
+    return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                    ("prepare_and_load: Failed to reload context: " +
+                                     std::string(load_status.GetErrorMessage()))
+                                        .c_str());
+  }
+
+  // 6. Wire up loaded models: SetGraphInputOutputInfo + SetupQnnInputOutput.
+  for (size_t graph_idx = 0; graph_idx < count; ++graph_idx) {
+    const std::string& fused_node_name = fused_node_names[graph_idx];
+
+    auto model_it = loaded_models.find(fused_node_name);
+    if (model_it == loaded_models.end()) {
+      // For single-graph case or when QNN uses different internal names,
+      // take the only available model if there is exactly one.
+      if (loaded_models.size() == 1 && count == 1) {
+        model_it = loaded_models.begin();
+      } else {
+        return ep->ort_api.CreateStatus(ORT_EP_FAIL,
+                                        ("prepare_and_load: No loaded model found for fused node: " +
+                                         fused_node_name)
+                                            .c_str());
+      }
+    }
+
+    auto qnn_model = std::move(model_it->second);
+    loaded_models.erase(model_it);
+
+    const auto& onnx_input_names = ep->onnx_graph_io_names_->first;
+    const auto& onnx_output_names = ep->onnx_graph_io_names_->second;
+
+    RETURN_IF_NOT_OK(qnn_model->SetGraphInputOutputInfo(
+        qnn::QnnModelContext{*graphs[graph_idx], *fused_nodes[graph_idx], ep->logger_,
+                             &onnx_input_names, &onnx_output_names,
+                             nullptr, nullptr, nullptr, std::string{}}));
+    RETURN_IF_NOT_OK(qnn_model->SetupQnnInputOutput(ep->logger_));
+
+    ep->qnn_models_.emplace(fused_node_name, std::move(qnn_model));
+  }
+
+  ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_INFO,
+              "prepare_and_load mode: context reload complete. Session is ready for inference.");
   return nullptr;
 }
 

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -74,10 +74,6 @@ class QnnEp : public OrtEp, public ApiPtrs {
                                              _In_ size_t count,
                                              _Out_writes_all_(count) OrtNodeComputeInfo** node_compute_infos,
                                              _Out_writes_(count) OrtNode** ep_context_nodes) noexcept;
-  static OrtStatus* PrepareAndLoadContext(QnnEp* ep,
-                                          const OrtGraph** graphs,
-                                          const OrtNode** fused_nodes,
-                                          size_t count);
   static void ORT_API_CALL ReleaseNodeComputeInfosImpl(OrtEp* this_ptr,
                                                        OrtNodeComputeInfo** node_compute_infos,
                                                        size_t num_node_compute_infos) noexcept;
@@ -101,6 +97,11 @@ class QnnEp : public OrtEp, public ApiPtrs {
                                                        _In_ size_t num_options) noexcept;
   static const char* ORT_API_CALL GetCompiledModelCompatibilityInfoImpl(_In_ OrtEp* this_ptr,
                                                                         _In_ const OrtGraph* graph) noexcept;
+
+  static OrtStatus* ReloadCompiledContext(QnnEp* ep,
+                                          const OrtGraph** graphs,
+                                          const OrtNode** fused_nodes,
+                                          size_t count);
 
   OrtStatus* GetSupportedNodes(const OrtGraph* graph,
                                const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -98,10 +98,9 @@ class QnnEp : public OrtEp, public ApiPtrs {
   static const char* ORT_API_CALL GetCompiledModelCompatibilityInfoImpl(_In_ OrtEp* this_ptr,
                                                                         _In_ const OrtGraph* graph) noexcept;
 
-  static OrtStatus* ReloadCompiledContext(QnnEp* ep,
-                                          const OrtGraph** graphs,
-                                          const OrtNode** fused_nodes,
-                                          size_t count);
+  OrtStatus* ReloadCompiledContext(const OrtGraph** graphs,
+                                   const OrtNode** fused_nodes,
+                                   size_t count);
 
   OrtStatus* GetSupportedNodes(const OrtGraph* graph,
                                const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -74,6 +74,10 @@ class QnnEp : public OrtEp, public ApiPtrs {
                                              _In_ size_t count,
                                              _Out_writes_all_(count) OrtNodeComputeInfo** node_compute_infos,
                                              _Out_writes_(count) OrtNode** ep_context_nodes) noexcept;
+  static OrtStatus* PrepareAndLoadContext(QnnEp* ep,
+                                          const OrtGraph** graphs,
+                                          const OrtNode** fused_nodes,
+                                          size_t count);
   static void ORT_API_CALL ReleaseNodeComputeInfosImpl(OrtEp* this_ptr,
                                                        OrtNodeComputeInfo** node_compute_infos,
                                                        size_t num_node_compute_infos) noexcept;


### PR DESCRIPTION
This PR is a follow up to #517 and addresses the following

-  ReleaseContext() blank line — added in qnn_backend_manager.h:430
-  prepare_and_load_ block after timing — compile timing #if block now ends at line 3065, PrepareAndLoadContext call
-    at line 3069–3071
-  Extracted to function — PrepareAndLoadContext(QnnEp*, const OrtGraph**, const OrtNode**, size_t) declared in header, defined before ReleaseNodeComputeInfosImpl