### PR TITLE
Update QNN CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,19 @@
-* @qti-chuteng @qti-jkilpatrick @qti-kromero @qti-yuduo @tirupath-qti @yath1 @qti-ashwshan
+# Build & CI
+/.github/ @qti-mbadnara @qti-kromero @huaychou
+/.vscode/ @qti-mbadnara @qti-kromero @huaychou
+/cmake/ @qti-mbadnara @qti-kromero @huaychou
+/csharp/ @qti-mbadnara @qti-kromero @huaychou
+/docs/ @qti-mbadnara @qti-kromero @huaychou
+/java/ @qti-mbadnara @qti-kromero @huaychou
+/qcom/ @qti-mbadnara @qti-kromero @huaychou
+/tools/ @qti-mbadnara @qti-kromero @huaychou
+
+# Runtime
+/onnxruntime/core/providers/qnn/ @qti-kromero @quic-calvnguy
+/onnxruntime/test/providers/qnn/ @qti-kromero @quic-calvnguy
+
+# Compiler
+/onnxruntime/core/providers/qnn/builder/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
+/onnxruntime/core/providers/qnn/op_affinity/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
+/onnxruntime/test/providers/qnn/qnn_node_group/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
+/onnxruntime/test/providers/qnn/optimizer/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng


### PR DESCRIPTION
## Summary
- Split CODEOWNERS into Build & CI, Runtime, and Compiler sections.
- Build & CI covers tracked top-level infrastructure, packaging, docs, and tool folders.
- Runtime covers the QNN provider implementation and QNN provider tests by default.
- Compiler overrides Runtime for the QNN builder, op-affinity, node-group tests, and optimizer tests.
- Removed the broad fallback rule so unmatched paths do not request a large owner set.
- Code owner (that auto-tagged as code reviewer) is mainly to avoid surprises. **PR author still expect to identify proper reviewer and add them manually as fit.** 