### PR TITLE
[QNN EP] Preserve symmetric U16 MatMul input encoding

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -378,8 +378,9 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
       input_1_shape = {input_info_1.shape[0], 1};
     }
     if (!input_info_1.is_initializer) {
-      // Only insert Convert for asymmetric quantization (i.e., offset != 2^(16-1)).
-      if (quant_param.scaleOffsetEncoding.offset != 32768) {
+      // QNN offsets negate ONNX zero points, so symmetric uint16 uses -32768.
+      constexpr int32_t kSymmetricU16Offset = -32768;
+      if (quant_param.scaleOffsetEncoding.offset != kSymmetricU16Offset) {
         RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
                                                convert_input_name,
                                                convert_output_name,

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -4,9 +4,11 @@
 #include "qnn_test_utils.h"
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 
 #include "gtest/gtest.h"
@@ -709,6 +711,49 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_dynamic_inputs) {
         BuildMatMulOpTestCase(input0_def, input1_def),
         BuildMatMulOpQDQTestCase<uint16_t, uint16_t, uint16_t>(input0_def, input1_def, false),
         provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
+  }
+}
+
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_U16DynamicInput1_ConvertOnlyIfAsymmetric) {
+  namespace fs = std::filesystem;
+  struct TestCase {
+    const char* name;
+    float input1_min;
+    size_t expected_convert_count;
+  };
+
+  for (const TestCase& test_case : {TestCase{"symmetric", -0.1f, 0},
+                                    TestCase{"asymmetric", -0.05f, 1}}) {
+    SCOPED_TRACE(test_case.name);
+    const fs::path graph_dir = fs::temp_directory_path() /
+                               (std::string("MatMulOp_QDQ_U16DynamicInput1_") + test_case.name);
+    fs::remove_all(graph_dir);
+    ASSERT_TRUE(fs::create_directories(graph_dir));
+    auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
+
+    ProviderOptions provider_options;
+    provider_options["backend_type"] = "htp";
+    provider_options["offload_graph_io_quantization"] = "0";
+    provider_options["dump_json_qnn_graph"] = "1";
+    provider_options["json_qnn_graph_dir"] = graph_dir.string();
+#ifdef __linux__
+    provider_options["htp_arch"] = "73";
+#endif
+
+    TestInputDef<float> input0_def({2, 3}, false, GetFloatDataInRange(-0.1f, 0.1f, 6));
+    TestInputDef<float> input1_def({3, 2}, false, GetFloatDataInRange(test_case.input1_min, 0.1f, 6));
+    ASSERT_EQ(GetTestInputQuantParams<uint16_t>(input1_def).IsSymmetric(),
+              test_case.expected_convert_count == 0);
+
+    TestQDQModelAccuracy(
+        BuildMatMulOpTestCase(input0_def, input1_def),
+        BuildMatMulOpQDQTestCase<uint16_t, uint16_t, uint16_t>(input0_def, input1_def, false),
+        provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
+
+    if (::testing::Test::IsSkipped()) {
+      return;
+    }
+    AssertOpInQnnGraph(graph_dir, "Convert", test_case.expected_convert_count);
   }
 }
 


### PR DESCRIPTION
## Problem
QNN stores a per-tensor offset as the negated ONNX zero point. The dynamic U16 MatMul workaround compared that offset with `+32768`, so an already symmetric input (`zero_point = 32768`, QNN `offset = -32768`) was treated as asymmetric.

The inserted `Convert` is not semantically neutral: it derives a new symmetric encoding and can change the scale. This produced a measurable device-output difference.

## Fix
Compare with the correct QNN symmetric offset, `-32768`. Keep the existing `Convert` for asymmetric dynamic input 1.

The regression test asserts both branches in the dumped QNN graph:
- symmetric U16 input: zero `Convert` nodes
- asymmetric U16 input: one `Convert` node