### PR TITLE
Allow quantized uint8/int8 Conv on QNN CPU backend

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/conv_op_builder.cc
@@ -145,7 +145,11 @@ Ort::Status ConvOpBuilder::IsOpSupported(QnnModelWrapper& qnn_model_wrapper,
   ONNXTensorElementDataType input_data_type = input_0.type;
   std::string error_msg = "QNN EP: Data type " + std::to_string(static_cast<int>(input_data_type)) +
                           " is not supported for Conv operator in CPU backend.";
-  RETURN_IF_ERROR(DataTypeCheckForCpuBackend(qnn_model_wrapper, input_data_type, error_msg));
+  bool is_cpu_backend = IsCpuBackend(qnn_model_wrapper.GetQnnBackendType());
+  bool is_allowed_cpu_dtype = input_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT ||
+                              input_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8 ||
+                              input_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8;
+  RETURN_IF(is_cpu_backend && !is_allowed_cpu_dtype, error_msg.c_str());
 
   OrtNodeAttrHelper node_helper(node_unit);
   auto auto_pad = node_helper.Get("auto_pad", std::string("NOTSET"));


### PR DESCRIPTION
## Summary

- Allow Conv operators with uint8/int8 inputs on the QNN CPU backend.
- Replace the previous float-only validation path for Conv with a Conv-specific datatype check.
- Keep supported quantized Conv nodes within QNN partitions.

## Motivation

The QNN CPU backend supports uint8/int8 Conv execution. The previous validation logic rejected non-float Conv inputs on the CPU backend, causing quantized Conv nodes to fall back to ORT's CPUExecutionProvider.

This resulted in excessive graph fragmentation and additional execution boundaries between QNN and CPU partitions. Allowing supported quantized Conv nodes to remain on QNN reduces unnecessary fallback and improves partitioning behavior.

## Scope

- Conv only
- QNN CPU backend only
- No changes to datatype validation behavior for other operators

