### PR TITLE
[QNN EP] Fix UDO HTP op-package build with QAIRT 2.50 SDK

### DIFF
--- a/onnxruntime/test/providers/qnn/udo/HTP_Makefile
+++ b/onnxruntime/test/providers/qnn/udo/HTP_Makefile
@@ -82,7 +82,7 @@ LIBRARY_NAME := libQnn$(PACKAGE_NAME).so
 SUPPORTED_TARGETS = x86_64-linux-clang hexagon-v68 hexagon-v69 hexagon-v73 hexagon-v75 hexagon-v79  hexagon-v81  hexagon-v85 aarch64-android
 
 
-COMMON_CXX_FLAGS = -std=c++17 -I$(QNN_INCLUDE) -fPIC -Wall -Wreorder -Wno-missing-braces -Wno-unused-function
+COMMON_CXX_FLAGS = -std=c++17 -I$(QNN_INCLUDE) -I$(QNN_INCLUDE)/HTP/core -fPIC -Wall -Wreorder -Wno-missing-braces -Wno-unused-function
 COMMON_CXX_FLAGS += -Werror -Wno-format -Wno-unused-command-line-argument -fvisibility=default -stdlib=libc++
 COMMON_CXX_FLAGS += -DQNN_API="__attribute__((visibility(\"default\")))"  -D__QAIC_HEADER_EXPORT="__attribute__((visibility(\"default\")))"
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Add -I$(QNN_INCLUDE)/HTP/core to COMMON_CXX_FLAGS, matching the fix already present in the 2.50 SDK's own OpPackageGenerator HTP Makefile template. Change is backward-compatible with 2.46–2.49 since the directory exists in all those SDK versions.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- QAIRT 2.50 restructured HTP BE headers: HTP/core/tens/block_enumeration.h now includes "allocator.h" directly, but allocator.h lives in HTP/core/, a directory that was not previously on the include path.