### PR TITLE
Move QNN test ownership from Runtime to Compiler in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+# Ownership is resolved per file; for each file the LAST matching pattern wins.
+
 # Build & CI
 /.github/ @qti-mbadnara @qti-kromero @huaychou
 /.vscode/ @qti-mbadnara @qti-kromero @huaychou
@@ -8,12 +10,10 @@
 /qcom/ @qti-mbadnara @qti-kromero @huaychou
 /tools/ @qti-mbadnara @qti-kromero @huaychou
 
-# Runtime
+# Runtime: EP core (session, context cache, allocator, telemetry, backend manager)
 /onnxruntime/core/providers/qnn/ @qti-kromero @quic-calvnguy
-/onnxruntime/test/providers/qnn/ @qti-kromero @quic-calvnguy
 
-# Compiler
+# Compiler: graph/op lowering, and all QNN EP tests
 /onnxruntime/core/providers/qnn/builder/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
 /onnxruntime/core/providers/qnn/op_affinity/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
-/onnxruntime/test/providers/qnn/qnn_node_group/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
-/onnxruntime/test/providers/qnn/optimizer/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng
+/onnxruntime/test/providers/qnn/ @qti-ashwshan @qti-shubham @minfhong-qti @qti-yuduo @tirupath-qti @qti-chuteng


### PR DESCRIPTION
CODEOWNERS matches per file and the last matching pattern wins, so every matched owner set gets a review request. The ~85 op-level tests sit flat in `onnxruntime/test/providers/qnn/`, which Runtime owned wholesale — so any op-builder PR with a test also tagged Runtime. Example: #773 touches only `rmsnormalization_op_builder.cc` + `rmsnormalization_test.cc`, and the test file pulled in Runtime.

Fix: give the QNN test tree to Compiler. The `qnn_node_group/` and `optimizer/` lines are now redundant and dropped.

Verified over every file under `onnxruntime/{core,test}/providers/qnn/`: #773's two files resolve to Compiler only, the EP core stays with Runtime, nothing is unowned.

Trade-off: a test-only change to e.g. `qnn_ep_context_test.cc` now tags Compiler. Those changes almost always touch `core/providers/qnn/` too, which still tags Runtime.
