### PR TITLE
[QNN EP] Keep quantized TopK inside its QDQ node group

### DIFF
--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -543,42 +543,44 @@ bool CanCreateNodeGroup(const OrtGraph* graph, const OrtApi& ort_api, const OrtN
     return false;
   }
 
-  // Check if the number of Q outputs matches the number of outputs that exist
   size_t num_outputs = 0;
   ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetNumOutputs(node, &num_outputs), ort_api);
-  if (num_outputs < q_nodes.size()) {
-    return false;
-  }
 
   std::vector<const OrtValueInfo*> outputs(num_outputs);
   ORT_RETURN_FALSE_ON_ERROR(ort_api.Node_GetOutputs(node, outputs.data(), outputs.size()), ort_api);
 
-  // Check if any of the outputs are graph outputs
-  bool produces_graph_output = false;
+  // Fusing deletes the tensor between `node` and each absorbed Q, so an output may only be absorbed
+  // if that Q is its sole consumer and it is not a graph output. An output with no Q consumer
+  // survives and is unconstrained -- TopK's integer indices output is never quantized.
+  size_t num_absorbed_outputs = 0;
   for (size_t i = 0; i < num_outputs; i++) {
     const OrtValueInfo* value_info = outputs[i];
-    bool is_graph_output = false;
-    ORT_CONTINUE_ON_ERROR(ort_api.ValueInfo_IsGraphOutput(value_info, &is_graph_output), ort_api);
 
-    if (is_graph_output) {
-      produces_graph_output = true;
-      break;
-    }
-  }
-
-  // Count the total number of consumers for all outputs
-  size_t total_consumers = 0;
-  for (size_t i = 0; i < num_outputs; i++) {
-    const OrtValueInfo* value_info = outputs[i];
     size_t num_consumers = 0;
     ORT_CONTINUE_ON_ERROR(ort_api.ValueInfo_GetValueNumConsumers(value_info, &num_consumers), ort_api);
+    if (num_consumers != 1) {
+      continue;
+    }
 
-    total_consumers += num_consumers;
+    const OrtNode* consumer = nullptr;
+    int64_t consumer_input_index = 0;
+    ORT_CONTINUE_ON_ERROR(
+        ort_api.ValueInfo_GetValueConsumers(value_info, &consumer, &consumer_input_index, 1), ort_api);
+    if (std::find(q_nodes.cbegin(), q_nodes.cend(), consumer) == q_nodes.cend()) {
+      continue;
+    }
+
+    bool is_graph_output = false;
+    ORT_CONTINUE_ON_ERROR(ort_api.ValueInfo_IsGraphOutput(value_info, &is_graph_output), ort_api);
+    if (is_graph_output) {
+      return false;
+    }
+
+    ++num_absorbed_outputs;
   }
 
-  return (num_outputs == q_nodes.size()) &&
-         (q_nodes.size() == total_consumers) &&
-         !produces_graph_output;
+  // An unabsorbed Q would be folded away while the tensor it reads is still live.
+  return num_absorbed_outputs == q_nodes.size();
 }
 
 // Helper function to check if a QDQ pair is supported

--- a/onnxruntime/test/providers/qnn/topk_test.cc
+++ b/onnxruntime/test/providers/qnn/topk_test.cc
@@ -3,11 +3,13 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
 #include "gtest/gtest.h"
 
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 
 namespace onnxruntime {
@@ -277,6 +279,36 @@ TEST_F(QnnHTPBackendTests, TopK_U16_NonLastAxis_Largest_0) {
                                 ExpectedEPNodeAssignment::All,
                                 21);  // opset
 }
+// A quantized TopK must fold its surrounding DQ/Q into one quantized QNN TopK node. TopK's second
+// output is integer indices and is never Q-wrapped, which used to make the node group
+// unrepresentable and left TopK running on dequantized float32 data.
+// Checks graph structure, not accuracy: the float island is value-preserving either way.
+TEST_F(QnnHTPBackendTests, TopK_QDQ_U8_FoldsQDQIntoQuantizedTopK) {
+  const std::filesystem::path json_qnn_graph_dir = "TopK_QDQ_U8_FoldsQDQIntoQuantizedTopK";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup = gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  auto input_def = TestInputDef<float>({1, 3, 4, 4}, false, GetFloatDataInRange(-10.0f, 10.0f, 48));
+  auto k_def = TestInputDef<int64_t>({1}, true /* is_initializer */, {2});
+
+  TestQDQModelAccuracy(BuildTopKTestCase<float>(input_def, k_def, {}),
+                       BuildQDQTopKTestCase<uint8_t>(input_def, k_def, {}),
+                       provider_options,
+                       /*opset_version=*/19,
+                       ExpectedEPNodeAssignment::All);
+
+  // `qdq_in_dq` is the DequantizeLinear feeding TopK; folding it in is what keeps TopK quantized.
+  AssertOpInQnnGraph(json_qnn_graph_dir, "TopK", 1);
+  AssertNodeNotInQnnGraph(json_qnn_graph_dir, "qdq_in_dq");
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 }  // namespace test
 }  // namespace onnxruntime


### PR DESCRIPTION
Fixes the QDQ node-group check so a quantized `TopK` stays quantized.

`CanCreateNodeGroup` required **every** output of a node to be `QuantizeLinear`-wrapped and to have exactly one consumer. `TopK`'s second output is integer indices — never quantized, and usually consumed by more than one node — so `OrtTopKNodeGroupSelector::Check` could never return `true` for a real `TopK`. The group was rejected, `TopK` stayed a standalone float node, and the EP kept a real `Dequantize` in front of it, running `TopK` on float32 data inside an otherwise fully quantized graph.

Both old constraints exist for the same reason: fusing the group deletes the float tensor between the target node and its `Q`. That only applies to outputs actually being absorbed, so both are now applied per output — an output is absorbed when a `Q` in `q_nodes` is its single consumer, and only then must it not be a graph output. Outputs with no `Q` consumer stay real tensors and constrain nothing. Every collected `Q` must end up absorbed, otherwise a `Q` would be folded away while the tensor it reads is still live.