### PR TITLE
Guard noexcept functions with QNN_EP_API_IMPL_BEGIN/END

### DIFF
--- a/onnxruntime/core/providers/qnn/genie/genie_node_compute_info.cc
+++ b/onnxruntime/core/providers/qnn/genie/genie_node_compute_info.cc
@@ -24,6 +24,7 @@ GenieNodeComputeInfo::GenieNodeComputeInfo(QnnEp& ep,
 OrtStatus* GenieNodeComputeInfo::CreateStateImpl(OrtNodeComputeInfo* this_ptr,
                                                  OrtNodeComputeContext* compute_context,
                                                  void** compute_state) {
+  QNN_EP_API_IMPL_BEGIN
   auto* node_compute_info = static_cast<GenieNodeComputeInfo*>(this_ptr);
   auto& ep = node_compute_info->ep;
   auto& builder = node_compute_info->builder;
@@ -61,21 +62,16 @@ OrtStatus* GenieNodeComputeInfo::CreateStateImpl(OrtNodeComputeInfo* this_ptr,
                                     std::filesystem::is_directory(parent_folder_path, dir_ec) &&
                                     !dir_ec;
   if (parent_is_searchable) {
-    try {
-      for (const auto& entry : std::filesystem::directory_iterator(parent_folder_path)) {
-        if (entry.is_regular_file()) {
-          const std::string filename = entry.path().filename().string();
-          if (filename.rfind("tmp", 0) == 0 &&
-              filename.size() >= 5 &&
-              filename.compare(filename.size() - 5, 5, ".json") == 0) {
-            extension_path = entry.path().string();
-            break;
-          }
+    for (const auto& entry : std::filesystem::directory_iterator(parent_folder_path)) {
+      if (entry.is_regular_file()) {
+        const std::string filename = entry.path().filename().string();
+        if (filename.rfind("tmp", 0) == 0 &&
+            filename.size() >= 5 &&
+            filename.compare(filename.size() - 5, 5, ".json") == 0) {
+          extension_path = entry.path().string();
+          break;
         }
       }
-    } catch (const std::filesystem::filesystem_error& e) {
-      std::string error_msg = std::string("Error searching for extension file: ") + e.what();
-      return ep.ort_api.CreateStatus(ORT_EP_FAIL, error_msg.c_str());
     }
   } else if (!parent_folder_path.empty()) {
     ORT_CXX_LOG(ep.logger_, ORT_LOGGING_LEVEL_WARNING,
@@ -139,11 +135,13 @@ OrtStatus* GenieNodeComputeInfo::CreateStateImpl(OrtNodeComputeInfo* this_ptr,
   *compute_state = static_cast<void*>(st.release());
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* GenieNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
                                              void* compute_state,
                                              OrtKernelContext* kernel_context) {
+  QNN_EP_API_IMPL_BEGIN
 #if (GENIE_API_VERSION_MAJOR > 1) || (GENIE_API_VERSION_MAJOR == 1 && GENIE_API_VERSION_MINOR >= 17)
   auto* node_compute_info = static_cast<GenieNodeComputeInfo*>(this_ptr);
   auto& ep = node_compute_info->ep;
@@ -297,12 +295,15 @@ OrtStatus* GenieNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
   ORT_UNUSED_PARAMETER(kernel_context);
   return nullptr;
 #endif  // GENIE_API_VERSION_MAJOR > 1 || GENIE_API_VERSION_MINOR >= 17
+  QNN_EP_API_IMPL_END
 }
 
 void GenieNodeComputeInfo::ReleaseStateImpl(OrtNodeComputeInfo* this_ptr,
                                             void* compute_state) {
+  QNN_EP_API_IMPL_BEGIN
   ORT_UNUSED_PARAMETER(this_ptr);
   std::unique_ptr<GenieNodeState, GenieNodeStateDeleter> state(static_cast<GenieNodeState*>(compute_state));
+  QNN_EP_API_IMPL_END_VOID
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/ort_api.h
+++ b/onnxruntime/core/providers/qnn/ort_api.h
@@ -240,6 +240,59 @@ class OrtLoggingManager {
   }
 };
 
+// Best-effort logging of an exception caught at the C API boundary by a function that has no
+// OrtStatus* to return it through.
+inline void LogApiBoundaryException(const char* message,
+                                    const ORTCHAR_T* file,
+                                    int line,
+                                    const char* func) noexcept {
+  const OrtLogger* logger = OrtLoggingManager::GetDefaultLoggerPtr();
+  if (logger == nullptr) {
+    // No logger. Give up.
+    return;
+  }
+
+  if (OrtStatus* status = Ort::GetApi().Logger_LogMessage(logger, ORT_LOGGING_LEVEL_ERROR,
+                                                          message, file, line, func)) {
+    Ort::GetApi().ReleaseStatus(status);
+  }
+}
+
+#define QNN_EP_API_IMPL_BEGIN try {
+#define QNN_EP_API_IMPL_END                                             \
+  }                                                                     \
+  catch (const Ort::Exception& ex) {                                    \
+    return Ort::GetApi().CreateStatus(ex.GetOrtErrorCode(), ex.what()); \
+  }                                                                     \
+  catch (const std::exception& ex) {                                    \
+    return Ort::GetApi().CreateStatus(ORT_FAIL, ex.what());             \
+  }                                                                     \
+  catch (...) {                                                         \
+    return Ort::GetApi().CreateStatus(ORT_FAIL, "Unknown exception");   \
+  }
+
+#define QNN_EP_API_IMPL_END_RETURN(fallback)                                             \
+  }                                                                                      \
+  catch (const std::exception& ex) {                                                     \
+    ::onnxruntime::LogApiBoundaryException(ex.what(), ORT_FILE, __LINE__, __FUNCTION__); \
+    return (fallback);                                                                   \
+  }                                                                                      \
+  catch (...) {                                                                          \
+    ::onnxruntime::LogApiBoundaryException("Unknown exception", ORT_FILE, __LINE__,      \
+                                           __FUNCTION__);                                \
+    return (fallback);                                                                   \
+  }
+
+#define QNN_EP_API_IMPL_END_VOID                                                         \
+  }                                                                                      \
+  catch (const std::exception& ex) {                                                     \
+    ::onnxruntime::LogApiBoundaryException(ex.what(), ORT_FILE, __LINE__, __FUNCTION__); \
+  }                                                                                      \
+  catch (...) {                                                                          \
+    ::onnxruntime::LogApiBoundaryException("Unknown exception", ORT_FILE, __LINE__,      \
+                                           __FUNCTION__);                                \
+  }
+
 struct ApiPtrs {
   const OrtApi& ort_api;
   const OrtEpApi& ep_api;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1575,10 +1575,8 @@ QnnEp::~QnnEp() {
 }
 
 const char* ORT_API_CALL QnnEp::GetNameImpl(const OrtEp* this_ptr) noexcept {
-  QNN_EP_API_IMPL_BEGIN
   const auto* qnn_ep = static_cast<const QnnEp*>(this_ptr);
   return qnn_ep->name_.c_str();
-  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 // Logs information about the supported/unsupported nodes.
@@ -2002,32 +2000,33 @@ static void GetContextOnnxModelFilePath(const std::string& user_context_cache_pa
   }
 }
 
-OrtStatus* ORT_API_CALL QnnEp::GetGenieCapability(OrtEp* this_ptr,
-                                                  const OrtGraph* graph,
-                                                  OrtEpGraphSupportInfo* graph_support_info) {
-  QNN_EP_API_IMPL_BEGIN
+OrtStatus* QnnEp::GetGenieCapability(const OrtGraph* graph,
+                                     OrtEpGraphSupportInfo* graph_support_info) {
   // CREATE GENIE_BACKEND_MANAGER
-  QnnEp* ep = static_cast<QnnEp*>(this_ptr);
-  if (!ep->genie_backend_manager_) {
-    ep->genie_backend_manager_ = qnn::GenieBackendManager::Create(
-        qnn::GenieBackendManagerConfig{kDefaultGenieBackendPath}, ep->logger_);
-    auto setup_st = ep->genie_backend_manager_->SetupBackend();
+  if (!genie_backend_manager_) {
+    genie_backend_manager_ = qnn::GenieBackendManager::Create(
+        qnn::GenieBackendManagerConfig{kDefaultGenieBackendPath}, logger_);
+    auto setup_st = genie_backend_manager_->SetupBackend();
     if (!setup_st.IsOK()) {
-      return ep->ort_api.CreateStatus(ORT_EP_FAIL, setup_st.GetErrorMessage().c_str());
+      return ort_api.CreateStatus(ORT_EP_FAIL, setup_st.GetErrorMessage().c_str());
     }
   }
-  ep->genie_api_loader_ = std::make_shared<GenieApiLoader>((ep->genie_backend_manager_)->GetGenieBackendHandle());
+  genie_api_loader_ = std::make_shared<GenieApiLoader>(genie_backend_manager_->GetGenieBackendHandle());
   // Get all nodes from the graph
   size_t num_nodes = 0;
-  if (ep->ort_api.Graph_GetNumNodes(graph, &num_nodes) != nullptr) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Graph_GetNumNodes failed");
+  auto get_num_nodes_status = ort_api.Graph_GetNumNodes(graph, &num_nodes);
+  if (get_num_nodes_status != nullptr) {
+    ort_api.ReleaseStatus(get_num_nodes_status);
+    return ort_api.CreateStatus(ORT_EP_FAIL, "Graph_GetNumNodes failed");
   }
   if (num_nodes != 1) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Number of nodes must be 1 for Genie");
+    return ort_api.CreateStatus(ORT_EP_FAIL, "Number of nodes must be 1 for Genie");
   }
   std::vector<const OrtNode*> graph_nodes(num_nodes);
-  if (ep->ort_api.Graph_GetNodes(graph, graph_nodes.data(), graph_nodes.size()) != nullptr) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Graph Creation error");
+  auto get_nodes_status = ort_api.Graph_GetNodes(graph, graph_nodes.data(), graph_nodes.size());
+  if (get_nodes_status != nullptr) {
+    ort_api.ReleaseStatus(get_nodes_status);
+    return ort_api.CreateStatus(ORT_EP_FAIL, "Graph Creation error");
   }
 
   // Identify the single node in the graph (which should be the only node)
@@ -2035,15 +2034,15 @@ OrtStatus* ORT_API_CALL QnnEp::GetGenieCapability(OrtEp* this_ptr,
   std::vector<const OrtNode*> supported_group{node};
   OrtNodeFusionOptions node_fusion_options = {};
   node_fusion_options.ort_version_supported = ORT_API_VERSION;
-  auto add_status = ep->ep_api.EpGraphSupportInfo_AddNodesToFuse(graph_support_info,
-                                                                 supported_group.data(),
-                                                                 supported_group.size(),
-                                                                 &node_fusion_options);
+  auto add_status = ep_api.EpGraphSupportInfo_AddNodesToFuse(graph_support_info,
+                                                             supported_group.data(),
+                                                             supported_group.size(),
+                                                             &node_fusion_options);
   if (add_status != nullptr) {
-    return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Error adding Node.");
+    ort_api.ReleaseStatus(add_status);
+    return ort_api.CreateStatus(ORT_EP_FAIL, "Error adding Node.");
   }
   return nullptr;
-  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
@@ -2096,7 +2095,7 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
   // Genie Pathway
   if (qnn::GraphHasDlcContextNode(graph, ep->ort_api)) {
 #if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
-    return ep->GetGenieCapability(this_ptr, graph, graph_support_info);
+    return ep->GetGenieCapability(graph, graph_support_info);
 #else
     return ep->ort_api.CreateStatus(ORT_EP_FAIL,
                                     "Genie execution pathway is unsupported on this platform.");

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1575,8 +1575,10 @@ QnnEp::~QnnEp() {
 }
 
 const char* ORT_API_CALL QnnEp::GetNameImpl(const OrtEp* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   const auto* qnn_ep = static_cast<const QnnEp*>(this_ptr);
   return qnn_ep->name_.c_str();
+  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 // Logs information about the supported/unsupported nodes.
@@ -2003,6 +2005,7 @@ static void GetContextOnnxModelFilePath(const std::string& user_context_cache_pa
 OrtStatus* ORT_API_CALL QnnEp::GetGenieCapability(OrtEp* this_ptr,
                                                   const OrtGraph* graph,
                                                   OrtEpGraphSupportInfo* graph_support_info) {
+  QNN_EP_API_IMPL_BEGIN
   // CREATE GENIE_BACKEND_MANAGER
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
   if (!ep->genie_backend_manager_) {
@@ -2040,11 +2043,13 @@ OrtStatus* ORT_API_CALL QnnEp::GetGenieCapability(OrtEp* this_ptr,
     return ep->ort_api.CreateStatus(ORT_EP_FAIL, "Error adding Node.");
   }
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
                                                  const OrtGraph* graph,
                                                  OrtEpGraphSupportInfo* graph_support_info) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
   // Best-effort diagnostic dump of the ONNX graph the EP just received.
@@ -2348,6 +2353,7 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
   }
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* QnnEp::CompileOnnxModel(const OrtGraph** graphs,
@@ -2975,6 +2981,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
                                            _In_ size_t count,
                                            _Out_writes_all_(count) OrtNodeComputeInfo** node_compute_infos,
                                            _Out_writes_(count) OrtNode** ep_context_nodes) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
   if (qnn::IsOrtGraphHasCtxNode(graphs, count, ep->ort_api)) {
@@ -3082,6 +3089,7 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
   }
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* QnnEp::ReloadCompiledContext(const OrtGraph** graphs,
@@ -3191,12 +3199,14 @@ OrtStatus* QnnEp::ReloadCompiledContext(const OrtGraph** graphs,
 void ORT_API_CALL QnnEp::ReleaseNodeComputeInfosImpl(OrtEp* this_ptr,
                                                      OrtNodeComputeInfo** node_compute_infos,
                                                      size_t num_node_compute_infos) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   ORT_UNUSED_PARAMETER(this_ptr);
   for (size_t idx = 0; idx < num_node_compute_infos; ++idx) {
     // All derived types share QnnNodeComputeInfoBase, which provides the virtual destructor
     // required to safely delete through the OrtNodeComputeInfo C-API base.
     delete static_cast<QnnNodeComputeInfoBase*>(node_compute_infos[idx]);
   }
+  QNN_EP_API_IMPL_END_VOID
 }
 
 OrtStatus* ORT_API_CALL QnnEp::GetPreferredDataLayoutImpl(_In_ OrtEp* this_ptr,
@@ -3211,6 +3221,7 @@ OrtStatus* ORT_API_CALL QnnEp::ShouldConvertDataLayoutForOpImpl(_In_ OrtEp* this
                                                                 _In_z_ const char* op_type,
                                                                 _In_ OrtEpDataLayout target_data_layout,
                                                                 _Outptr_ int* should_convert) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   ORT_UNUSED_PARAMETER(this_ptr);
   ORT_UNUSED_PARAMETER(target_data_layout);
 
@@ -3261,6 +3272,7 @@ OrtStatus* ORT_API_CALL QnnEp::ShouldConvertDataLayoutForOpImpl(_In_ OrtEp* this
   }
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 void QnnEp::GetPerThreadHtpPowerConfigs(qnn::PerThreadHtpPowerConfigs_t& per_thread_htp_power_configs,
@@ -3318,6 +3330,7 @@ void QnnEp::GetPerThreadHtpPowerConfigs(qnn::PerThreadHtpPowerConfigs_t& per_thr
 }
 
 OrtStatus* ORT_API_CALL QnnEp::OnRunStartImpl(_In_ OrtEp* this_ptr, _In_ const ::OrtRunOptions* run_options) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
   if (ep->prepare_only_) {
@@ -3349,11 +3362,13 @@ OrtStatus* ORT_API_CALL QnnEp::OnRunStartImpl(_In_ OrtEp* this_ptr, _In_ const :
   }
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEp::OnRunEndImpl(_In_ OrtEp* this_ptr,
                                             _In_ const ::OrtRunOptions* /*run_options*/,
                                             _In_ bool /*sync_stream*/) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
   if (ep->prepare_only_) {
@@ -3374,11 +3389,13 @@ OrtStatus* ORT_API_CALL QnnEp::OnRunEndImpl(_In_ OrtEp* this_ptr,
   }
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEp::CreateAllocatorImpl(_In_ OrtEp* this_ptr,
                                                    _In_ const OrtMemoryInfo* memory_info,
                                                    _Outptr_result_maybenull_ OrtAllocator** allocator) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   *allocator = nullptr;
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
@@ -3403,12 +3420,14 @@ OrtStatus* ORT_API_CALL QnnEp::CreateAllocatorImpl(_In_ OrtEp* this_ptr,
   }
 #endif  // _WIN32
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEp::SetDynamicOptionsImpl(_In_ OrtEp* this_ptr,
                                                      _In_reads_(num_options) const char* const* option_keys,
                                                      _In_reads_(num_options) const char* const* option_values,
                                                      _In_ size_t num_options) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
   if (ep->prepare_only_) {
@@ -3470,9 +3489,12 @@ OrtStatus* ORT_API_CALL QnnEp::SetDynamicOptionsImpl(_In_ OrtEp* this_ptr,
   }  // end for loop
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
+
 const char* ORT_API_CALL QnnEp::GetCompiledModelCompatibilityInfoImpl(_In_ OrtEp* this_ptr,
                                                                       _In_ const OrtGraph* /*graph*/) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   QnnEp* ep = static_cast<QnnEp*>(this_ptr);
 
   Ort::Status status = ep->qnn_cache_compatibility_manager_->SerializeCompatibilityInfo(ep->compatibility_info_,
@@ -3488,6 +3510,7 @@ const char* ORT_API_CALL QnnEp::GetCompiledModelCompatibilityInfoImpl(_In_ OrtEp
               ORT_LOGGING_LEVEL_INFO,
               ("Model compatibility info: " + ep->compatibility_info_string_).c_str());
   return ep->compatibility_info_string_.c_str();
+  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 OrtStatus* QnnEp::ValidateCompiledModelCompatibilityInfo(const OrtHardwareDevice* const* /*devices*/,
@@ -3659,6 +3682,7 @@ QnnEp::QnnNodeComputeInfo::QnnNodeComputeInfo(QnnEp& ep) : ep(ep) {
 OrtStatus* QnnEp::QnnNodeComputeInfo::CreateStateImpl(OrtNodeComputeInfo* this_ptr,
                                                       OrtNodeComputeContext* compute_context,
                                                       void** compute_state) {
+  QNN_EP_API_IMPL_BEGIN
   auto* node_compute_info = static_cast<QnnNodeComputeInfo*>(this_ptr);
   QnnEp& ep = node_compute_info->ep;
 
@@ -3686,11 +3710,13 @@ OrtStatus* QnnEp::QnnNodeComputeInfo::CreateStateImpl(OrtNodeComputeInfo* this_p
 
   *compute_state = qnn_model_it->second.get();
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* QnnEp::QnnNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
                                                   void* compute_state,
                                                   OrtKernelContext* kernel_context) {
+  QNN_EP_API_IMPL_BEGIN
   auto* node_compute_info = static_cast<QnnNodeComputeInfo*>(this_ptr);
   QnnEp& ep = node_compute_info->ep;
 
@@ -3704,6 +3730,7 @@ OrtStatus* QnnEp::QnnNodeComputeInfo::ComputeImpl(OrtNodeComputeInfo* this_ptr,
   RETURN_IF_NOT_OK(model->ExecuteGraph(kernel_context, ep.logger_, *ep.io_dispatch_));
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 void QnnEp::QnnNodeComputeInfo::ReleaseStateImpl(OrtNodeComputeInfo* this_ptr, void* compute_state) {

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -65,9 +65,6 @@ class QnnEp : public OrtEp, public ApiPtrs {
   static OrtStatus* ORT_API_CALL GetCapabilityImpl(OrtEp* this_ptr,
                                                    const OrtGraph* graph,
                                                    OrtEpGraphSupportInfo* graph_support_info) noexcept;
-  static OrtStatus* ORT_API_CALL GetGenieCapability(OrtEp* this_ptr,
-                                                    const OrtGraph* graph,
-                                                    OrtEpGraphSupportInfo* graph_support_info);
   static OrtStatus* ORT_API_CALL CompileImpl(_In_ OrtEp* this_ptr,
                                              _In_ const OrtGraph** graphs,
                                              _In_ const OrtNode** fused_nodes,
@@ -97,6 +94,9 @@ class QnnEp : public OrtEp, public ApiPtrs {
                                                        _In_ size_t num_options) noexcept;
   static const char* ORT_API_CALL GetCompiledModelCompatibilityInfoImpl(_In_ OrtEp* this_ptr,
                                                                         _In_ const OrtGraph* graph) noexcept;
+
+  OrtStatus* GetGenieCapability(const OrtGraph* graph,
+                                OrtEpGraphSupportInfo* graph_support_info);
 
   OrtStatus* ReloadCompiledContext(const OrtGraph** graphs,
                                    const OrtNode** fused_nodes,

--- a/onnxruntime/core/providers/qnn/qnn_external_resource_importer.cc
+++ b/onnxruntime/core/providers/qnn/qnn_external_resource_importer.cc
@@ -31,6 +31,7 @@ QnnExternalMemoryHandle::QnnExternalMemoryHandle()
 
 void ORT_API_CALL QnnExternalMemoryHandle::ReleaseCallback(
     _In_ OrtExternalMemoryHandle* handle) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   if (handle == nullptr) return;
   QnnExternalMemoryHandle* derived = static_cast<QnnExternalMemoryHandle*>(handle);
 
@@ -43,6 +44,7 @@ void ORT_API_CALL QnnExternalMemoryHandle::ReleaseCallback(
   QnnExternalResourceImporterImpl::mem_handle_registry_.erase(derived);
 
   delete derived;
+  QNN_EP_API_IMPL_END_VOID
 }
 
 // ============================================================================
@@ -61,9 +63,11 @@ QnnExternalSemaphoreHandle::QnnExternalSemaphoreHandle() {
 
 void ORT_API_CALL QnnExternalSemaphoreHandle::ReleaseCallback(
     _In_ OrtExternalSemaphoreHandle* handle) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   if (handle == nullptr) return;
   auto* derived = static_cast<QnnExternalSemaphoreHandle*>(handle);
   delete derived;
+  QNN_EP_API_IMPL_END_VOID
 }
 
 // ============================================================================
@@ -113,6 +117,7 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::ImportMemoryImpl(
     _In_ OrtExternalResourceImporterImpl* this_ptr,
     _In_ const OrtExternalMemoryDescriptor* desc,
     _Outptr_ OrtExternalMemoryHandle** out_handle) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto& impl = *static_cast<QnnExternalResourceImporterImpl*>(this_ptr);
 
   if (desc == nullptr || out_handle == nullptr) {
@@ -162,15 +167,18 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::ImportMemoryImpl(
   mem_handle_registry_.insert(raw_handle);
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 void ORT_API_CALL QnnExternalResourceImporterImpl::ReleaseMemoryImpl(
     _In_ OrtExternalResourceImporterImpl* /*this_ptr*/,
     _In_ OrtExternalMemoryHandle* handle) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   // The handle has a Release callback that does the actual cleanup
   if (handle) {
     handle->Release(handle);
   }
+  QNN_EP_API_IMPL_END_VOID
 }
 
 OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::CreateTensorFromMemoryImpl(
@@ -178,6 +186,7 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::CreateTensorFromMemoryI
     _In_ const OrtExternalMemoryHandle* mem_handle,
     _In_ const OrtExternalTensorDescriptor* tensor_desc,
     _Outptr_ OrtValue** out_tensor) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto& impl = *static_cast<QnnExternalResourceImporterImpl*>(this_ptr);
 
   if (mem_handle == nullptr || tensor_desc == nullptr || out_tensor == nullptr) {
@@ -195,11 +204,7 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::CreateTensorFromMemoryI
   const auto* qnn_handle = static_cast<const QnnExternalMemoryHandle*>(mem_handle);
 
   size_t tensor_size_bytes = 0;
-  try {
-    tensor_size_bytes = qnn::utils::GetOnnxTensorDataSizeInBytes(gsl::span{tensor_desc->shape, tensor_desc->rank}, tensor_desc->element_type);
-  } catch (...) {
-    return impl.ort_api_.CreateStatus(ORT_INVALID_ARGUMENT, "Unsupported tensor element type");
-  }
+  tensor_size_bytes = qnn::utils::GetOnnxTensorDataSizeInBytes(gsl::span{tensor_desc->shape, tensor_desc->rank}, tensor_desc->element_type);
 
   size_t available_size = qnn_handle->descriptor.size_bytes - qnn_handle->descriptor.offset_bytes - tensor_desc->offset_bytes;
 
@@ -242,6 +247,7 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::CreateTensorFromMemoryI
   impl.ort_api_.ReleaseMemoryInfo(memory_info);
 
   return status;
+  QNN_EP_API_IMPL_END
 }
 
 // ============================================================================
@@ -314,10 +320,12 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::ImportSemaphoreImpl(
 void ORT_API_CALL QnnExternalResourceImporterImpl::ReleaseSemaphoreImpl(
     _In_ OrtExternalResourceImporterImpl* /*this_ptr*/,
     _In_ OrtExternalSemaphoreHandle* handle) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   // The handle has a Release callback that does the actual cleanup
   if (handle) {
     handle->Release(handle);
   }
+  QNN_EP_API_IMPL_END_VOID
 }
 
 OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::WaitSemaphoreImpl(
@@ -368,10 +376,12 @@ OrtStatus* ORT_API_CALL QnnExternalResourceImporterImpl::SignalSemaphoreImpl(
 
 void ORT_API_CALL QnnExternalResourceImporterImpl::ReleaseImpl(
     _In_ OrtExternalResourceImporterImpl* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   if (this_ptr == nullptr) {
     return;
   }
   delete static_cast<QnnExternalResourceImporterImpl*>(this_ptr);
+  QNN_EP_API_IMPL_END_VOID
 }
 
 // ============================================================================
@@ -401,10 +411,12 @@ void* ORT_API_CALL QnnSyncStreamImpl::GetHandleImpl(
 
 void ORT_API_CALL QnnSyncStreamImpl::ReleaseImpl(
     _In_ OrtSyncStreamImpl* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   if (this_ptr == nullptr) {
     return;
   }
   delete static_cast<QnnSyncStreamImpl*>(this_ptr);
+  QNN_EP_API_IMPL_END_VOID
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -107,31 +107,23 @@ QnnEpFactory::QnnEpFactory(const char* ep_name,
 // Returns the name for the EP. Each unique factory configuration must have a unique name.
 // Ex: a factory that supports NPU should have a different than a factory that supports GPU.
 const char* ORT_API_CALL QnnEpFactory::GetNameImpl(const OrtEpFactory* this_ptr) noexcept {
-  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->ep_name_.c_str();
-  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 const char* ORT_API_CALL QnnEpFactory::GetVendorImpl(const OrtEpFactory* this_ptr) noexcept {
-  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->vendor_.c_str();
-  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 uint32_t ORT_API_CALL QnnEpFactory::GetVendorIdImpl(const OrtEpFactory* this_ptr) noexcept {
-  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->vendor_id_;
-  QNN_EP_API_IMPL_END_RETURN(0)
 }
 
 const char* ORT_API_CALL QnnEpFactory::GetVersionImpl(const OrtEpFactory* this_ptr) noexcept {
-  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->ep_version_.c_str();
-  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 // Creates and returns OrtEpDevice instances for all OrtHardwareDevices that this factory supports.
@@ -374,17 +366,13 @@ void ORT_API_CALL QnnEpFactory::ReleaseAllocatorImpl(OrtEpFactory* this_ptr, Ort
 
 OrtStatus* ORT_API_CALL QnnEpFactory::CreateDataTransferImpl(OrtEpFactory* /* this_ptr */,
                                                              OrtDataTransferImpl** data_transfer) noexcept {
-  QNN_EP_API_IMPL_BEGIN;
   *data_transfer = nullptr;
 
   return nullptr;
-  QNN_EP_API_IMPL_END;
 }
 
 bool ORT_API_CALL QnnEpFactory::IsStreamAwareImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
-  QNN_EP_API_IMPL_BEGIN;
   return false;
-  QNN_EP_API_IMPL_END;
 }
 
 OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl(

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -509,6 +509,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::CreateExternalResourceImporterForDeviceImp
     OrtEpFactory* this_ptr,
     const OrtEpDevice* /*ep_device*/,
     OrtExternalResourceImporterImpl** out_importer) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
 
   if (out_importer == nullptr) {
@@ -526,17 +527,14 @@ OrtStatus* ORT_API_CALL QnnEpFactory::CreateExternalResourceImporterForDeviceImp
   int device_id = 0;
 
   // Create the external resource importer
-  try {
-    *out_importer = std::make_unique<QnnExternalResourceImporterImpl>(device_id, factory->ort_api).release();
-  } catch (...) {
-    return factory->ort_api.CreateStatus(ORT_FAIL, "Failed to create external resource importer");
-  }
+  *out_importer = std::make_unique<QnnExternalResourceImporterImpl>(device_id, factory->ort_api).release();
 
   return nullptr;
 #else
   return factory->ort_api.CreateStatus(
       ORT_NOT_IMPLEMENTED, "External resource import is not supported on non-Windows platforms");
 #endif
+  QNN_EP_API_IMPL_END
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
+++ b/onnxruntime/core/providers/qnn/qnn_provider_factory.cc
@@ -107,23 +107,31 @@ QnnEpFactory::QnnEpFactory(const char* ep_name,
 // Returns the name for the EP. Each unique factory configuration must have a unique name.
 // Ex: a factory that supports NPU should have a different than a factory that supports GPU.
 const char* ORT_API_CALL QnnEpFactory::GetNameImpl(const OrtEpFactory* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->ep_name_.c_str();
+  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 const char* ORT_API_CALL QnnEpFactory::GetVendorImpl(const OrtEpFactory* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->vendor_.c_str();
+  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 uint32_t ORT_API_CALL QnnEpFactory::GetVendorIdImpl(const OrtEpFactory* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->vendor_id_;
+  QNN_EP_API_IMPL_END_RETURN(0)
 }
 
 const char* ORT_API_CALL QnnEpFactory::GetVersionImpl(const OrtEpFactory* this_ptr) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   const auto* factory = static_cast<const QnnEpFactory*>(this_ptr);
   return factory->ep_version_.c_str();
+  QNN_EP_API_IMPL_END_RETURN("")
 }
 
 // Creates and returns OrtEpDevice instances for all OrtHardwareDevices that this factory supports.
@@ -133,6 +141,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this
                                                               OrtEpDevice** ep_devices,
                                                               size_t max_ep_devices,
                                                               size_t* p_num_ep_devices) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
 
   size_t& num_ep_devices = *p_num_ep_devices;
@@ -207,6 +216,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetSupportedDevicesImpl(OrtEpFactory* this
   }
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEpFactory::CreateEpImpl(OrtEpFactory* this_ptr,
@@ -216,6 +226,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::CreateEpImpl(OrtEpFactory* this_ptr,
                                                    _In_ const OrtSessionOptions* session_options,
                                                    _In_ const OrtLogger* logger,
                                                    _Out_ OrtEp** ep) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
   *ep = nullptr;
 
@@ -313,14 +324,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::CreateEpImpl(OrtEpFactory* this_ptr,
     session_options = autoep_session_options.get();
   }
 
-  std::unique_ptr<QnnEp> qnn_ep;
-  try {
-    qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *session_options, logger);
-  } catch (const std::runtime_error& e) {
-    return factory->ort_api.CreateStatus(ORT_FAIL, e.what());
-  } catch (...) {
-    return factory->ort_api.CreateStatus(ORT_FAIL, "Unknown exception occurred while creating QNN EP.");
-  }
+  auto qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *session_options, logger);
 
   factory->qnn_allocator_type_ = qnn_ep->qnn_allocator_type_;
   if (factory->qnn_allocator_type_ != qnn::QnnAllocatorType::NONE) {
@@ -333,18 +337,22 @@ OrtStatus* ORT_API_CALL QnnEpFactory::CreateEpImpl(OrtEpFactory* this_ptr,
   *ep = qnn_ep.release();
 
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 void ORT_API_CALL QnnEpFactory::ReleaseEpImpl(OrtEpFactory* /*this_ptr*/, OrtEp* ep) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   if (ep == nullptr) {
     return;
   }
 
   QnnEp* dummy_ep = static_cast<QnnEp*>(ep);
   delete dummy_ep;
+  QNN_EP_API_IMPL_END_VOID
 }
 
 void ORT_API_CALL QnnEpFactory::ReleaseAllocatorImpl(OrtEpFactory* this_ptr, OrtAllocator* allocator) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
 
   if (qnn::IsHtpSharedMemoryAllocator(factory->qnn_allocator_type_)) {
@@ -361,17 +369,22 @@ void ORT_API_CALL QnnEpFactory::ReleaseAllocatorImpl(OrtEpFactory* this_ptr, Ort
                                                      __LINE__,
                                                      __FUNCTION__);
   }
+  QNN_EP_API_IMPL_END_VOID
 }
 
 OrtStatus* ORT_API_CALL QnnEpFactory::CreateDataTransferImpl(OrtEpFactory* /* this_ptr */,
                                                              OrtDataTransferImpl** data_transfer) noexcept {
+  QNN_EP_API_IMPL_BEGIN;
   *data_transfer = nullptr;
 
   return nullptr;
+  QNN_EP_API_IMPL_END;
 }
 
 bool ORT_API_CALL QnnEpFactory::IsStreamAwareImpl(const OrtEpFactory* /*this_ptr*/) noexcept {
+  QNN_EP_API_IMPL_BEGIN;
   return false;
+  QNN_EP_API_IMPL_END;
 }
 
 OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl(
@@ -380,7 +393,10 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
     _In_ size_t num_devices,
     _In_ const char* compatibility_info,
     _Out_ OrtCompiledModelCompatibility* model_compatibility) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
+
+  *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
 
   if (factory->qnn_ep_ != nullptr) {
     return factory->qnn_ep_->ValidateCompiledModelCompatibilityInfo(devices,
@@ -402,7 +418,6 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
     }
   }
   if (backend_type.empty()) {
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
     return factory->ort_api.CreateStatus(ORT_EP_FAIL,
                                          "Currently QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl only supports OrtHardwareDeviceType_NPU, but "
                                          "no OrtHardwareDeviceType_NPU is found in the `devices` argument.");
@@ -410,46 +425,32 @@ OrtStatus* ORT_API_CALL QnnEpFactory::ValidateCompiledModelCompatibilityInfoImpl
 
   using SessionOptionsUniquePtr = std::unique_ptr<OrtSessionOptions, std::function<void(OrtSessionOptions*)>>;
   OrtSessionOptions* temp_session_options = nullptr;
-  if (OrtStatus* _status = factory->ort_api.CreateSessionOptions(&temp_session_options)) {
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return _status;
-  }
+  RETURN_IF_NOT_NULL(factory->ort_api.CreateSessionOptions(&temp_session_options));
   SessionOptionsUniquePtr session_options(temp_session_options, factory->ort_api.ReleaseSessionOptions);
 
-  if (OrtStatus* _status = factory->ort_api.AddSessionConfigEntry(session_options.get(),
-                                                                  (provider_prefix + "backend_type").c_str(),
-                                                                  backend_type.c_str())) {
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return _status;
-  }
+  RETURN_IF_NOT_NULL(factory->ort_api.AddSessionConfigEntry(session_options.get(),
+                                                            (provider_prefix + "backend_type").c_str(),
+                                                            backend_type.c_str()));
 
   if (!OrtLoggingManager::HasDefaultLogger()) {
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
     return factory->ort_api.CreateStatus(ORT_EP_FAIL, "Default logger is not available for model compatibility check.");
   }
   const OrtLogger* logger = OrtLoggingManager::GetDefaultLoggerPtr();
 
-  std::unique_ptr<QnnEp> temp_qnn_ep;
-  try {
-    temp_qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *session_options.get(), logger);
-  } catch (const std::exception& e) {
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return factory->ort_api.CreateStatus(ORT_EP_FAIL, e.what());
-  } catch (...) {
-    *model_compatibility = OrtCompiledModelCompatibility_EP_NOT_APPLICABLE;
-    return factory->ort_api.CreateStatus(ORT_EP_FAIL, "Unknown exception occurred while creating temporary QNN EP for compatibility check.");
-  }
+  auto temp_qnn_ep = std::make_unique<QnnEp>(*factory, factory->ep_name_, *session_options.get(), logger);
 
   return temp_qnn_ep->ValidateCompiledModelCompatibilityInfo(devices,
                                                              num_devices,
                                                              compatibility_info,
                                                              model_compatibility);
+  QNN_EP_API_IMPL_END
 }
 
 OrtStatus* ORT_API_CALL QnnEpFactory::GetHardwareDeviceIncompatibilityDetailsImpl(
     _In_ OrtEpFactory* this_ptr,
     _In_ const OrtHardwareDevice* hw,
     _Inout_ OrtDeviceEpIncompatibilityDetails* details) noexcept {
+  QNN_EP_API_IMPL_BEGIN
   auto* factory = static_cast<QnnEpFactory*>(this_ptr);
   const auto provider_prefix = GetProviderOptionPrefix(factory->ep_name_);
 
@@ -502,6 +503,7 @@ OrtStatus* ORT_API_CALL QnnEpFactory::GetHardwareDeviceIncompatibilityDetailsImp
         "Unknown exception occurred while creating QNN EP for compatibility check");
   }
   return nullptr;
+  QNN_EP_API_IMPL_END
 }
 
 }  // namespace onnxruntime
@@ -516,6 +518,8 @@ OrtStatus* CreateEpFactories(const char* registration_name,
                              OrtEpFactory** factories,
                              size_t max_factories,
                              size_t* num_factories) {
+  // NOTE: Do not use QNN_EP_API_IMPL_BEGIN/END in this function,
+  // because Ort::InitApi() is not called until midway through.
   if (ort_api_base == nullptr) {
     return nullptr;
   }


### PR DESCRIPTION
* Implementations of ORT API functions marked noexcept should not throw. The previous strategy has been to attempt to isolate potentially-throwing parts of these functions and wrap them in try/catch. But this is brittle and other projects advocate for function-level exception guards instead ([0], [1]).
* This change adds such exception guards and and places them on all noexcept API entrypoints.

[0]: https://github.com/microsoft/onnxruntime/blob/v1.29.0/docs/C_API_Guidelines.md
[1]: https://github.com/microsoft/wil/wiki/Error-handling-helpers#using-exception-based-code-in-a-routine-that-cannot-throw
