### PR TITLE
[QNN EP] Add support for Swish

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -663,6 +663,7 @@ ort.unregister_execution_provider_library(ep_registration_name)
 |ai.onnx:Squeeze||
 |ai.onnx:Sub||
 |ai.onnx:Sum||
+|ai.onnx:Swish||
 |ai.onnx:Tan||
 |ai.onnx:Tanh||
 |ai.onnx:ThresholdedRelu||

--- a/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
+++ b/onnxruntime/core/providers/qnn/builder/op_builder_factory.cc
@@ -60,7 +60,9 @@ OpBuilderRegistrations::OpBuilderRegistrations() {
   CreatePoolOpBuilder("MaxPool", *this);
   CreateQLinearConvOpBuilder("QLinearConv", *this);
   CreateQLinearMatMulOpBuilder("QLinearMatMul", *this);
+  // QuickGelu and Swish share x * sigmoid(alpha * x); the builder applies each schema's default alpha.
   CreateQuickGeluOpBuilder("QuickGelu", *this);
+  CreateQuickGeluOpBuilder("Swish", *this);
   CreateRandomNormalLikeOpBuilder("RandomNormalLike", *this);
   CreateRandomUniformLikeOpBuilder("RandomUniformLike", *this);
   CreateRangeOpBuilder("Range", *this);

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/quickgelu_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/quickgelu_op_builder.cc
@@ -27,14 +27,16 @@ Ort::Status QuickGeluOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn
                                                             std::vector<std::string>&& input_names,
                                                             const Ort::Logger& logger,
                                                             bool do_op_validation) const {
-  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("Processing QuickGelu operator: " + node_unit.Name()).c_str());
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+              ("Processing " + node_unit.OpType() + " operator: " + node_unit.Name()).c_str());
 
   const std::string& input_name = input_names[0];
   const auto& outputs = node_unit.Outputs();
   const std::string& output_name = outputs[0].name;
 
   OrtNodeAttrHelper node_helper(node_unit);
-  float alpha = node_helper.Get("alpha", 1.702f);
+  const float default_alpha = node_unit.OpType() == "Swish" ? 1.0f : 1.702f;
+  float alpha = node_helper.Get("alpha", default_alpha);
 
   TensorInfo input_info = {};
   RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(node_unit.Inputs()[0], input_info));

--- a/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
+++ b/onnxruntime/core/providers/qnn/qnn_ep_utils.cc
@@ -1677,6 +1677,7 @@ void OrtSelectorManager::CreateSelectors() {
       {"Softplus", {}},
       {"SpaceToDepth", {}},
       {"Sqrt", {}},
+      {"Swish", {}},
       {"Tanh", {}}};
   ort_selectors_.RegisterSelector(unary_ops, std::make_unique<OrtUnaryNodeGroupSelector>());
 

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -211,6 +211,22 @@ TEST_F(QnnCPUBackendTests, UnaryOp_HardSwish) {
                  ExpectedEPNodeAssignment::All);
 }
 
+TEST_F(QnnCPUBackendTests, UnaryOp_Swish_DefaultAlpha) {
+  RunOpTestOnCPU("Swish",
+                 {TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})},
+                 {},
+                 24,
+                 ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnCPUBackendTests, UnaryOp_Swish_CustomAlpha) {
+  RunOpTestOnCPU("Swish",
+                 {TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})},
+                 {test::MakeAttribute("alpha", 0.5f)},
+                 24,
+                 ExpectedEPNodeAssignment::All);
+}
+
 // Test float HardSwish on the QNN HTP backend.
 TEST_F(QnnHTPBackendTests, UnaryOp_HardSwish_FP32) {
   QNN_SKIP_TEST_ON_ARM64("Fails on ARM64/AARCH64");
@@ -427,6 +443,34 @@ TEST_F(QnnHTPBackendTests, UnaryOp_Sigmoid_U16) {
                          true);  // Use MS domain Q/DQ ops
 }
 
+TEST_F(QnnHTPBackendTests, UnaryOp_Swish_FP16) {
+  RunFP16OpTest("Swish",
+                {TestInputDef<float>({7}, false, {-4.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 4.0f})},
+                {},
+                24,
+                ExpectedEPNodeAssignment::All,
+                kOnnxDomain,
+                0.01f);
+}
+
+TEST_F(QnnHTPBackendTests, UnaryOp_Swish_QDQ_U8) {
+  RunQDQOpTest<uint8_t>("Swish",
+                        {TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})},
+                        {},
+                        24,
+                        ExpectedEPNodeAssignment::All);
+}
+
+TEST_F(QnnHTPBackendTests, UnaryOp_Swish_QDQ_U16) {
+  RunQDQOpTest<uint16_t>("Swish",
+                         {TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})},
+                         {},
+                         24,
+                         ExpectedEPNodeAssignment::All,
+                         kOnnxDomain,
+                         true);
+}
+
 // Test the accuracy of QDQ Tanh.
 TEST_F(QnnHTPBackendTests, UnaryOp_Tanh) {
   RunQDQOpTest<uint8_t>("Tanh",
@@ -577,6 +621,35 @@ static bool HasQnnJsonGraph(const std::filesystem::path& dump_dir) {
     }
   }
   return false;
+}
+
+TEST_F(QnnHTPBackendTests, UnaryOp_Swish_QnnGraph) {
+  const std::filesystem::path json_qnn_graph_dir = "UnaryOp_Swish_QnnGraph";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+  auto cleanup =
+      gsl::finally([&json_qnn_graph_dir]() { std::filesystem::remove_all(json_qnn_graph_dir); });
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  const std::vector<TestInputDef<float>> input_defs = {
+      TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})};
+  TestQDQModelAccuracy(BuildOpTestCase<float>("Swish_node", "Swish", input_defs, {}, {}),
+                       BuildQDQOpTestCase<uint8_t>("Swish_node", "Swish", input_defs, {}, {}),
+                       provider_options,
+                       24,
+                       ExpectedEPNodeAssignment::All);
+
+  if (!HasQnnJsonGraph(json_qnn_graph_dir)) {
+    return;
+  }
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "Sigmoid", 1);
+  AssertOpInQnnGraph(json_qnn_graph_dir, "ElementWiseMultiply", 1);
 }
 
 // Builds a QDQ model and asserts the op emits as its dedicated fine-grained QNN op name.

--- a/onnxruntime/test/providers/qnn/simple_op_test.cc
+++ b/onnxruntime/test/providers/qnn/simple_op_test.cc
@@ -211,22 +211,6 @@ TEST_F(QnnCPUBackendTests, UnaryOp_HardSwish) {
                  ExpectedEPNodeAssignment::All);
 }
 
-TEST_F(QnnCPUBackendTests, UnaryOp_Swish_DefaultAlpha) {
-  RunOpTestOnCPU("Swish",
-                 {TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})},
-                 {},
-                 24,
-                 ExpectedEPNodeAssignment::All);
-}
-
-TEST_F(QnnCPUBackendTests, UnaryOp_Swish_CustomAlpha) {
-  RunOpTestOnCPU("Swish",
-                 {TestInputDef<float>({7}, false, {-10.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 10.0f})},
-                 {test::MakeAttribute("alpha", 0.5f)},
-                 24,
-                 ExpectedEPNodeAssignment::All);
-}
-
 // Test float HardSwish on the QNN HTP backend.
 TEST_F(QnnHTPBackendTests, UnaryOp_HardSwish_FP32) {
   QNN_SKIP_TEST_ON_ARM64("Fails on ARM64/AARCH64");


### PR DESCRIPTION
### Description

Add QNN EP support for the ONNX opset-24 `Swish` operator.

`Swish` and `QuickGelu` use the same `x * sigmoid(alpha * x)` formulation, so this reuses the existing decomposition into QNN `Sigmoid` and `ElementWiseMultiply` nodes. The shared builder now selects the schema-specific default alpha (`1.0` for `Swish`, `1.702` for `QuickGelu`) and continues to support explicit alpha values.

`Swish` is also added to QDQ unary-op selection.

### Motivation and Context

ONNX opset-24 models that retain `Swish` currently fall back at every activation and split otherwise QNN-compatible graphs. This was observed in an autoregressive Qwen2.5-0.5B export: replacing `Swish` with `Sigmoid` + `Mul` removed the partition breaks and enabled full QNN capture. Supporting the equivalent lowering directly in QNN EP avoids requiring an external model rewrite.