### PR TITLE
[QNN EP] Fix graph splitting config incorrectly applied to VTCM binary-load path

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -361,7 +361,7 @@ The `enable_htp_prepare_and_load` option performs AOT compilation and context lo
 |`"enable_htp_graph_splitting"`|Description|
 |---|---|
 |'0'|Default. Disabled.|
-|'1'|Enable HTP graph splitting: the HTP backend splits the model graph into independently-prepareable sub-graphs, reducing context preparation time. Effective in both JIT (compile-and-run) and AOT (context binary generation) workflows, including on-device AOT. Has no effect when loading from an already-compiled context binary. Requires QAIRT SDK 2.49+ at runtime; enabling this with an older runtime will cause context creation to fail. The number of sub-graph partitions is controlled by the `GPE_KWAY_PARTITIONS` environment variable.|
+|'1'|Enable HTP graph splitting: the HTP backend splits the model graph into independently-prepareable sub-graphs, reducing context preparation time. Effective in both JIT (compile-and-run) and AOT (context binary generation) workflows, including on-device AOT. Has no effect when loading from an already-compiled context binary or when `htp_share_resource_optimization=1` (VTCM sharing uses a binary-load API that does not support graph splitting). Requires QAIRT SDK 2.49+ at runtime; enabling this with an older runtime will cause context creation to fail. The number of sub-graph partitions is controlled by the `GPE_KWAY_PARTITIONS` environment variable.|
 
 |`"GPE_KWAY_PARTITIONS"`|Description|
 |---|---|

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -361,7 +361,7 @@ The `enable_htp_prepare_and_load` option performs AOT compilation and context lo
 |`"enable_htp_graph_splitting"`|Description|
 |---|---|
 |'0'|Default. Disabled.|
-|'1'|Enable HTP graph splitting: the HTP backend splits the model graph into independently-prepareable sub-graphs, reducing context preparation time. Effective in both JIT (compile-and-run) and AOT (context binary generation) workflows, including on-device AOT. Has no effect when loading from an already-compiled context binary or when `htp_share_resource_optimization=1` (VTCM sharing uses a binary-load API that does not support graph splitting). Requires QAIRT SDK 2.49+ at runtime; enabling this with an older runtime will cause context creation to fail. The number of sub-graph partitions is controlled by the `GPE_KWAY_PARTITIONS` environment variable.|
+|'1'|Enable HTP graph splitting: the HTP backend splits the model graph into independently-prepareable sub-graphs, reducing context preparation time. Effective in both JIT (compile-and-run) and AOT (context binary generation) workflows, including on-device AOT. Has no effect when loading from an already-compiled context binary. Requires QAIRT SDK 2.49+ at runtime; enabling this with an older runtime will cause context creation to fail. The number of sub-graph partitions is controlled by the `GPE_KWAY_PARTITIONS` environment variable.|
 
 |`"GPE_KWAY_PARTITIONS"`|Description|
 |---|---|

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -2129,13 +2129,6 @@ Ort::Status QnnBackendManager::SetupBackend(
   }
 
   if (status.IsOK() && (htp_share_resource_optimization_ == 1 || !load_from_cached_context)) {
-    if (htp_share_resource_optimization_ == 1 && enable_htp_graph_splitting) {
-      ORT_CXX_LOG_PTR(logger_ptr_,
-                      ORT_LOGGING_LEVEL_WARNING,
-                      "enable_htp_graph_splitting=1 has no effect when htp_share_resource_optimization=1. "
-                      "Graph splitting is a context-creation feature; the VTCM sharing path uses "
-                      "QnnContext_createFromBinaryListAsync (a binary-load API) and does not support it.");
-    }
     status = htp_share_resource_optimization_ == 1
                  ? CreateContextVtcmBackupBufferSharingEnabled(context_bin_map,
                                                                io_dispatch)

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1283,8 +1283,7 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
 
 Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
     std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map,
-    const qnn::EpContextIoDispatch& io_dispatch,
-    bool enable_htp_graph_splitting) {
+    const qnn::EpContextIoDispatch& io_dispatch) {
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 26)
   QnnContext_Config_t context_config_resource_sharing = QNN_CONTEXT_CONFIG_INIT;
   QnnHtpContext_CustomConfig_t resource_sharing_custom_config;
@@ -1316,30 +1315,12 @@ Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
   QnnContext_Config_t context_priority_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, context_priority_config));
 
-#ifdef QNN_HTP_GRAPH_SPLITTING_AVAILABLE
-  QnnContext_Config_t context_config_graph_splitting_vtcm = QNN_CONTEXT_CONFIG_INIT;
-  QnnHtpContext_CustomConfig_t graph_splitting_custom_config_vtcm;
-  if (enable_htp_graph_splitting) {
-    graph_splitting_custom_config_vtcm.option = QNN_HTP_CONTEXT_CONFIG_OPTION_GRAPH_SPLITTING_CONFIGS;
-    graph_splitting_custom_config_vtcm.graphSplittingConfigs.graphSplittingEnabled = true;
-    context_config_graph_splitting_vtcm.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
-    context_config_graph_splitting_vtcm.customConfig = &graph_splitting_custom_config_vtcm;
-  }
-#else
-  ORT_UNUSED_PARAMETER(enable_htp_graph_splitting);
-#endif
-
   std::vector<const QnnContext_Config_t*> configs_vec;
   configs_vec.push_back(&context_priority_config);
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 26)
   configs_vec.push_back(&context_config_resource_sharing);
   configs_vec.push_back(&resource_sharing_opt_type_config);
   configs_vec.push_back(&context_config_weight_sharing);
-#endif
-#ifdef QNN_HTP_GRAPH_SPLITTING_AVAILABLE
-  if (enable_htp_graph_splitting) {
-    configs_vec.push_back(&context_config_graph_splitting_vtcm);
-  }
 #endif
   configs_vec.push_back(nullptr);
 
@@ -2001,8 +1982,7 @@ Ort::Status QnnBackendManager::SetupBackend(
       if (first_mapping_it == ep_context_handle_map_.end()) {
         ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Creating context for new set of context binaries");
         return CreateContextVtcmBackupBufferSharingEnabled(context_bin_map,
-                                                           io_dispatch,
-                                                           enable_htp_graph_splitting);
+                                                           io_dispatch);
       }
 
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Mapping contexts to new EP main context nodes");
@@ -2149,10 +2129,16 @@ Ort::Status QnnBackendManager::SetupBackend(
   }
 
   if (status.IsOK() && (htp_share_resource_optimization_ == 1 || !load_from_cached_context)) {
+    if (htp_share_resource_optimization_ == 1 && enable_htp_graph_splitting) {
+      ORT_CXX_LOG_PTR(logger_ptr_,
+                      ORT_LOGGING_LEVEL_WARNING,
+                      "enable_htp_graph_splitting=1 has no effect when htp_share_resource_optimization=1. "
+                      "Graph splitting is a context-creation feature; the VTCM sharing path uses "
+                      "QnnContext_createFromBinaryListAsync (a binary-load API) and does not support it.");
+    }
     status = htp_share_resource_optimization_ == 1
                  ? CreateContextVtcmBackupBufferSharingEnabled(context_bin_map,
-                                                               io_dispatch,
-                                                               enable_htp_graph_splitting)
+                                                               io_dispatch)
                  : CreateContext(enable_htp_weight_sharing,
                                  enable_htp_extended_udma_mode,
                                  enable_htp_prepare_only,

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -500,8 +500,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
 
   Ort::Status CreateContextVtcmBackupBufferSharingEnabled(std::unordered_map<std::string,
                                                                              std::unique_ptr<std::vector<std::string>>>& context_bin_map,
-                                                          const qnn::EpContextIoDispatch& io_dispatch,
-                                                          bool enable_htp_graph_splitting = false);
+                                                          const qnn::EpContextIoDispatch& io_dispatch);
 
   Ort::Status CreateContextFromListAsync(const QnnContext_Config_t** configs,
                                          std::unordered_map<std::string,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1368,6 +1368,12 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     enable_htp_graph_splitting_ = false;
   }
 #endif
+  if (enable_htp_graph_splitting_ && htp_share_resource_optimization_ == 1) {
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                "enable_htp_graph_splitting=1 has no effect when htp_share_resource_optimization=1. "
+                "Graph splitting is a context-creation feature; the VTCM sharing path uses "
+                "QnnContext_createFromBinaryListAsync (a binary-load API) and does not support it.");
+  }
 
   // Option to skip QNN API interface version check to use other QNN library other than default.
   static const std::string SKIP_QNN_VERSION_CHECK = "skip_qnn_version_check";

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1368,14 +1368,11 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     enable_htp_graph_splitting_ = false;
   }
 #endif
+
   if (enable_htp_graph_splitting_ && !context_cache_enabled_) {
-    ORT_CXX_LOG(...);
-    enable_htp_graph_splitting_ = false;
-  }
     ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
-                "enable_htp_graph_splitting=1 has no effect when htp_share_resource_optimization=1. "
-                "Graph splitting is a context-creation feature; the VTCM sharing path uses "
-                "QnnContext_createFromBinaryListAsync (a binary-load API) and does not support it.");
+                "enable_htp_graph_splitting=1 has no effect without context caching enabled. "
+                "Enable context caching (ep_context_enable=1) to persist the split context binary.");
   }
 
   // Option to skip QNN API interface version check to use other QNN library other than default.

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1369,12 +1369,6 @@ QnnEp::QnnEp(QnnEpFactory& factory,
   }
 #endif
 
-  if (enable_htp_graph_splitting_ && !context_cache_enabled_) {
-    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
-                "enable_htp_graph_splitting=1 has no effect without context caching enabled. "
-                "Enable context caching (ep_context_enable=1) to persist the split context binary.");
-  }
-
   // Option to skip QNN API interface version check to use other QNN library other than default.
   static const std::string SKIP_QNN_VERSION_CHECK = "skip_qnn_version_check";
   auto skip_qnn_version_check = ParseBoolOption(ort_api,
@@ -2988,6 +2982,11 @@ OrtStatus* ORT_API_CALL QnnEp::CompileImpl(_In_ OrtEp* this_ptr,
       ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_WARNING,
                   "prepare_and_load=1 is ignored because the input model is already a pre-compiled context model. "
                   "The model will be loaded directly via the AOT path.");
+    }
+    if (ep->enable_htp_graph_splitting_) {
+      ORT_CXX_LOG(ep->logger_, ORT_LOGGING_LEVEL_WARNING,
+                  "enable_htp_graph_splitting=1 has no effect because the input model is already a pre-compiled "
+                  "context binary. Graph splitting is applied at context creation time, not at load time.");
     }
     uint32_t htp_power_config_id = 0;
     bool power_config_valid = ep->GetHtpPowerConfigId(htp_power_config_id);

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -1368,7 +1368,10 @@ QnnEp::QnnEp(QnnEpFactory& factory,
     enable_htp_graph_splitting_ = false;
   }
 #endif
-  if (enable_htp_graph_splitting_ && htp_share_resource_optimization_ == 1) {
+  if (enable_htp_graph_splitting_ && !context_cache_enabled_) {
+    ORT_CXX_LOG(...);
+    enable_htp_graph_splitting_ = false;
+  }
     ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
                 "enable_htp_graph_splitting=1 has no effect when htp_share_resource_optimization=1. "
                 "Graph splitting is a context-creation feature; the VTCM sharing path uses "


### PR DESCRIPTION
### Description

Follow-up on #645 

CreateContextVtcmBackupBufferSharingEnabled always terminates via QnnContext_createFromBinaryListAsync. Graph splitting is a context-creation feature, it is applied at QnnContext_create time and baked into the context binary.

### Changes

-   Remove enable_htp_graph_splitting from CreateContextVtcmBackupBufferSharingEnabled signature and call sites
-   Remove graph splitting config block from that function; keep it only in CreateContext
-   Emit a warning when enable_htp_graph_splitting=1 and htp_share_resource_optimization=1 are both set, since the VTCM path always routes through the binary-load API and graph splitting silently has no effect