### PR TITLE
[QNN EP] Reduce attention mask value

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/base_op_builder.cc
@@ -281,7 +281,6 @@ Ort::Status BaseOpBuilder::ProcessOutputs(QnnModelWrapper& qnn_model_wrapper,
       RETURN_IF_ERROR(OverrideOutputQuantParam(qnn_model_wrapper, node_unit, logger, input_names,
                                                output_idx, output_info.qnn_data_type, output_info.quant_param));
     }
-
     Qnn_DataType_t supported_qnn_data_type = GetSupportedOutputDataType(output_idx, output_info.qnn_data_type);
     bool is_graph_output = qnn_model_wrapper.IsGraphOutput(output_name);
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.cc
@@ -83,7 +83,6 @@ Ort::Status QnnModelWrapper::MakeTensorWrapper(const OrtNodeUnitIODef& tensor, Q
 
   TensorInfo tensor_info = {};
   RETURN_IF_ERROR(GetTensorInfo(tensor, tensor_info));
-
   std::vector<uint8_t> unpacked_tensor;
   if (tensor_info.is_initializer) {
     RETURN_IF_ERROR(UnpackInitializerData(tensor_info.initializer_tensor, unpacked_tensor));
@@ -876,6 +875,9 @@ Ort::Status QnnModelWrapper::GetTensorInfo(const OrtNodeUnitIODef& tensor, Tenso
 
   // Fill in quantization param info.
   RETURN_IF_ERROR(tensor_info.quant_param.Init(*this, tensor));
+  if (const auto it = quant_param_overrides_.find(name); it != quant_param_overrides_.end()) {
+    tensor_info.quant_param = it->second.Copy();
+  }
 
   // Fill in QNN data type.
   tensor_info.qnn_data_type = QNN_DATATYPE_FLOAT_32;

--- a/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model_wrapper.h
@@ -104,6 +104,11 @@ class QnnModelWrapper {
   // Add to internal tensor wrapper table
   bool AddTensorWrapper(QnnTensorWrapper&& tensor_wrapper);
 
+  void SetQuantParamOverride(const std::string& tensor_name,
+                             const QnnQuantParamsWrapper& quant_param) {
+    quant_param_overrides_[tensor_name] = quant_param.Copy();
+  }
+
   // Add to internal param wrapper table
   bool AddParamWrapper(QnnParamWrapper&& param_wrapper);
 
@@ -600,6 +605,8 @@ class QnnModelWrapper {
   std::unordered_map<std::string, QnnTensorWrapper> model_tensors_map_;
   // All QnnParamWrapper for the graph
   std::unordered_map<std::string, QnnParamWrapper> model_params_map_;
+  // Quantization overrides installed by node-groups before tensor metadata is consumed.
+  std::unordered_map<std::string, QnnQuantParamsWrapper> quant_param_overrides_;
   std::vector<QnnOpProperty> qnn_op_property_list_;
   std::unordered_set<std::string> qnn_node_names_;
   // <tensor_name, qnn_tensor_id> -- stores the QNN-assigned ID once the tensor is created

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/attn_mask_value_reduction_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/attn_mask_value_reduction_fusion.cc
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "core/providers/qnn/builder/qnn_node_group/attn_mask_value_reduction_fusion.h"
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/providers/qnn/builder/op_builder_factory.h"
+#include "core/providers/qnn/builder/opbuilder/base_op_builder.h"
+#include "core/providers/qnn/builder/qnn_model_wrapper.h"
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+
+namespace onnxruntime::qnn {
+
+constexpr double kReplacementMaskMagnitude = 100.0;
+
+struct AttnMaskValueReductionFusion::Match {
+  const OrtNodeUnit* softmax = nullptr;
+  const OrtNodeUnit* gated_add = nullptr;
+  const OrtNodeUnit* masked_add = nullptr;
+  const OrtNodeUnit* mask_mul = nullptr;
+  const OrtNodeUnitIODef* mask_bias = nullptr;
+  double original_mask_magnitude = 0.0;
+  bool owns_shared_mask_chain = false;
+  std::vector<const OrtNodeUnit*> node_units;
+};
+
+namespace {
+
+bool IsBinary(const OrtNodeUnit* node, const char* op_type) {
+  return node != nullptr && node->OpType() == op_type && node->Inputs().size() == 2 && node->Outputs().size() == 1;
+}
+
+bool IsRank4(const OrtNodeUnitIODef& io) {
+  return io.shape.has_value() && io.shape->size() == 4;
+}
+
+bool SameShape(const OrtNodeUnitIODef& lhs, const OrtNodeUnitIODef& rhs) {
+  return lhs.shape.has_value() && rhs.shape.has_value() && *lhs.shape == *rhs.shape;
+}
+
+bool MatchAttnMaskValueReductionPattern(
+    const QnnModelWrapper& qmw, const OrtNodeUnit& softmax,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+    AttnMaskValueReductionFusion::Match& match) {
+  static const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*> no_claims;
+  match = {};
+  if (softmax.OpType() != "Softmax" || softmax.Inputs().size() != 1 || softmax.Outputs().size() != 1 ||
+      !IsRank4(softmax.Inputs()[0]) || !SameShape(softmax.Inputs()[0], softmax.Outputs()[0])) {
+    return false;
+  }
+  const OrtNodeAttrHelper attrs(softmax);
+  const int64_t axis = attrs.Get("axis", static_cast<int64_t>(-1));
+  if (axis != -1 && axis != 3) return false;
+
+  const OrtNodeUnit* gated_add = GetParentOfInput(qmw, softmax, softmax.Inputs()[0], node_to_node_unit,
+                                                  node_unit_to_qnn_node_group);
+  if (!IsBinary(gated_add, "Add")) return false;
+  const OrtNodeUnit* lhs = GetParentOfInput(qmw, *gated_add, gated_add->Inputs()[0], node_to_node_unit,
+                                            node_unit_to_qnn_node_group);
+  const OrtNodeUnit* rhs = GetParentOfInput(qmw, *gated_add, gated_add->Inputs()[1], node_to_node_unit,
+                                            node_unit_to_qnn_node_group);
+  const OrtNodeUnit* masked_add = nullptr;
+  const OrtNodeUnit* gate = nullptr;
+  if (IsBinary(lhs, "Add") && IsBinary(rhs, "Mul")) {
+    masked_add = lhs;
+    gate = rhs;
+  } else if (IsBinary(lhs, "Mul") && IsBinary(rhs, "Add")) {
+    masked_add = rhs;
+    gate = lhs;
+  }
+  if (masked_add == nullptr || gate == nullptr || !IsRank4(gate->Outputs()[0]) ||
+      !SameShape(gate->Outputs()[0], softmax.Inputs()[0])) {
+    return false;
+  }
+
+  const OrtNodeUnit* masked_lhs =
+      GetParentOfInput(qmw, *masked_add, masked_add->Inputs()[0], node_to_node_unit, no_claims);
+  const OrtNodeUnit* masked_rhs =
+      GetParentOfInput(qmw, *masked_add, masked_add->Inputs()[1], node_to_node_unit, no_claims);
+  const OrtNodeUnit* score = nullptr;
+  const OrtNodeUnit* mask_mul = nullptr;
+  if (IsBinary(masked_lhs, "Div") && IsBinary(masked_rhs, "Mul")) {
+    score = masked_lhs;
+    mask_mul = masked_rhs;
+  } else if (IsBinary(masked_lhs, "Mul") && IsBinary(masked_rhs, "Div")) {
+    score = masked_rhs;
+    mask_mul = masked_lhs;
+  }
+  if (score == nullptr || mask_mul == nullptr || !IsRank4(score->Outputs()[0]) ||
+      !SameShape(score->Outputs()[0], softmax.Inputs()[0])) {
+    return false;
+  }
+
+  const OrtNodeUnit* mul_lhs = GetParentOfInput(qmw, *mask_mul, mask_mul->Inputs()[0], node_to_node_unit, no_claims);
+  const OrtNodeUnit* mul_rhs = GetParentOfInput(qmw, *mask_mul, mask_mul->Inputs()[1], node_to_node_unit, no_claims);
+  const OrtNodeUnit* mask_sub = IsBinary(mul_lhs, "Sub") ? mul_lhs : (IsBinary(mul_rhs, "Sub") ? mul_rhs : nullptr);
+  if (mask_sub == nullptr || !IsRank4(mask_sub->Outputs()[0]) ||
+      !IsStaticQdqInputWithValue(qmw, *mask_sub, 0, node_to_node_unit, 1.0, /*require_scalar=*/true) ||
+      qmw.IsConstantInput(mask_sub->Inputs()[1].name) || !IsRank4(mask_sub->Inputs()[1])) {
+    return false;
+  }
+  const size_t mask_bias_index = mul_lhs == mask_sub ? 1 : 0;
+  const OrtNodeUnitIODef& mask_bias_input = mask_mul->Inputs()[mask_bias_index];
+  const auto mask_bias_value =
+      GetStaticQdqInputValue(qmw, *mask_mul, mask_bias_index, node_to_node_unit, /*require_scalar=*/false);
+  if (!mask_bias_value.has_value() || !std::isfinite(*mask_bias_value) || *mask_bias_value >= 0.0) {
+    return false;
+  }
+  const double original_mask_magnitude = -*mask_bias_value;
+
+  const OrtNodeUnitIODef& attention_mask = mask_sub->Inputs()[1];
+  if (!SameShape(mask_sub->Outputs()[0], attention_mask) || attention_mask.shape->at(0) != softmax.Inputs()[0].shape->at(0) ||
+      attention_mask.shape->at(3) != softmax.Inputs()[0].shape->at(3)) {
+    return false;
+  }
+  TensorInfo mask_info = {};
+  float mask_scale = 0.0f;
+  int32_t mask_offset = 0;
+  if (!qmw.GetTensorInfo(attention_mask, mask_info).IsOK() || mask_info.qnn_data_type != QNN_DATATYPE_UFIXED_POINT_16 ||
+      !mask_info.quant_param.IsPerTensor() || !mask_info.quant_param.GetPerTensorScaleOffset(mask_scale, mask_offset).IsOK() ||
+      mask_scale <= 0.0f) {
+    return false;
+  }
+
+  const bool owns_shared_mask_chain = node_unit_to_qnn_node_group.find(mask_mul) == node_unit_to_qnn_node_group.end();
+  match = {&softmax, gated_add, masked_add, mask_mul, &mask_bias_input, original_mask_magnitude, owns_shared_mask_chain, {}};
+  return true;
+}
+
+Ort::Status DeriveReducedMaskValueQuantParams(const QnnModelWrapper& qmw, const OrtNodeUnitIODef& tensor,
+                                              double original_mask_magnitude, QnnQuantParamsWrapper& replacement) {
+  QnnQuantParamsWrapper original;
+  // Use the QDQ encoding, not a previously installed override from a shared mask chain.
+  RETURN_IF_ERROR(original.Init(qmw, tensor));
+  float old_scale = 0.0f;
+  int32_t old_offset = 0;
+  RETURN_IF_NOT(original.IsPerTensor() &&
+                    original.GetPerTensorScaleOffset(old_scale, old_offset).IsOK() &&
+                    old_scale > 0.0f,
+                "AttnMaskValueReduction fusion requires a positive per-tensor output encoding.");
+
+  float replacement_scale = 0.0f;
+  int32_t replacement_offset = 0;
+  const double replacement_min = static_cast<double>(old_offset) * old_scale +
+                                 (original_mask_magnitude - kReplacementMaskMagnitude);
+  RETURN_IF_NOT(DeriveUInt16EncodingWithMin(old_scale, old_offset, replacement_min,
+                                            replacement_scale, replacement_offset),
+                "Invalid reduced mask value output quantization range.");
+  replacement = QnnQuantParamsWrapper::PerTensor(replacement_scale, replacement_offset);
+  return Ort::Status();
+}
+
+Ort::Status ValidateUInt16Tensor(const QnnModelWrapper& qmw, const OrtNodeUnitIODef& tensor) {
+  TensorInfo tensor_info = {};
+  RETURN_IF_ERROR(qmw.GetTensorInfo(tensor, tensor_info));
+  RETURN_IF_NOT(tensor_info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16,
+                "AttnMaskValueReduction fusion supports uint16 tensors only.");
+  return Ort::Status();
+}
+
+Ort::Status CreateAttnMaskValueReductionGraph(QnnModelWrapper& qmw,
+                                              const AttnMaskValueReductionFusion::Match& match,
+                                              bool validate_only,
+                                              const Ort::Logger& logger) {
+  RETURN_IF_NOT(match.mask_bias != nullptr, "AttnMaskValueReduction fusion has no mask-bias input.");
+  RETURN_IF_NOT(match.original_mask_magnitude > 0.0, "AttnMaskValueReduction fusion requires a negative mask value.");
+  for (const OrtNodeUnitIODef* tensor : {match.mask_bias, &match.mask_mul->Outputs()[0],
+                                         &match.masked_add->Outputs()[0], &match.gated_add->Outputs()[0]}) {
+    RETURN_IF_ERROR(ValidateUInt16Tensor(qmw, *tensor));
+  }
+
+  float mask_scale = 0.0f;
+  int32_t mask_offset = 0;
+  QnnQuantParamsWrapper original_mask_quant;
+  RETURN_IF_ERROR(original_mask_quant.Init(qmw, *match.mask_bias));
+  RETURN_IF_NOT(original_mask_quant.IsPerTensor() &&
+                    original_mask_quant.GetPerTensorScaleOffset(mask_scale, mask_offset).IsOK() &&
+                    mask_scale > 0.0f,
+                "AttnMaskValueReduction fusion requires a per-tensor mask-bias encoding.");
+  const QnnQuantParamsWrapper replacement_mask_quant =
+      QnnQuantParamsWrapper::PerTensor(
+          static_cast<float>(static_cast<double>(mask_scale) * kReplacementMaskMagnitude /
+                             match.original_mask_magnitude),
+          mask_offset);
+  QnnQuantParamsWrapper mask_mul_quant;
+  QnnQuantParamsWrapper masked_add_quant;
+  QnnQuantParamsWrapper gated_add_quant;
+  RETURN_IF_ERROR(DeriveReducedMaskValueQuantParams(qmw, match.mask_mul->Outputs()[0],
+                                                    match.original_mask_magnitude, mask_mul_quant));
+  RETURN_IF_ERROR(DeriveReducedMaskValueQuantParams(qmw, match.masked_add->Outputs()[0],
+                                                    match.original_mask_magnitude, masked_add_quant));
+  RETURN_IF_ERROR(DeriveReducedMaskValueQuantParams(qmw, match.gated_add->Outputs()[0],
+                                                    match.original_mask_magnitude, gated_add_quant));
+
+  if (!validate_only) {
+    // Keep the payload and topology; change encodings only.
+    if (match.owns_shared_mask_chain) {
+      qmw.SetQuantParamOverride(match.mask_bias->name, replacement_mask_quant);
+      qmw.SetQuantParamOverride(match.mask_mul->Outputs()[0].name, mask_mul_quant);
+    }
+    qmw.SetQuantParamOverride(match.masked_add->Outputs()[0].name, masked_add_quant);
+    qmw.SetQuantParamOverride(match.gated_add->Outputs()[0].name, gated_add_quant);
+  }
+
+  std::vector<const OrtNodeUnit*> nodes_to_build;
+  if (match.owns_shared_mask_chain) {
+    nodes_to_build.push_back(match.mask_mul);
+  }
+  nodes_to_build.insert(nodes_to_build.end(), {match.masked_add, match.gated_add, match.softmax});
+  for (const OrtNodeUnit* node : nodes_to_build) {
+    const auto* builder = GetOpBuilder(node->OpType());
+    RETURN_IF_NOT(builder != nullptr, ("Missing QNN OpBuilder for " + node->OpType()).c_str());
+    RETURN_IF_ERROR(builder->AddToModelBuilder(qmw, *node, logger, validate_only));
+  }
+  return Ort::Status();
+}
+
+}  // namespace
+
+std::unique_ptr<IQnnNodeGroup> AttnMaskValueReductionFusion::TryFusion(
+    QnnModelWrapper& qmw, const OrtNodeUnit& softmax_node_unit,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+    const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& claimed,
+    [[maybe_unused]] const Ort::Logger& logger) {
+  auto match = std::make_unique<Match>();
+  if (!MatchAttnMaskValueReductionPattern(qmw, softmax_node_unit, node_to_node_unit, claimed, *match)) return nullptr;
+  return std::make_unique<AttnMaskValueReductionFusion>(std::move(match));
+}
+
+AttnMaskValueReductionFusion::AttnMaskValueReductionFusion(std::unique_ptr<Match> match) : match_(std::move(match)) {
+  match_->node_units = {match_->masked_add, match_->gated_add, match_->softmax};
+  if (match_->owns_shared_mask_chain) {
+    match_->node_units.push_back(match_->mask_mul);
+  }
+}
+
+AttnMaskValueReductionFusion::~AttnMaskValueReductionFusion() = default;
+
+Ort::Status AttnMaskValueReductionFusion::IsSupported(QnnModelWrapper& qmw,
+                                                      const Ort::Logger& logger) const {
+  return CreateAttnMaskValueReductionGraph(qmw, *match_, true, logger);
+}
+
+Ort::Status AttnMaskValueReductionFusion::AddToModelBuilder(QnnModelWrapper& qmw,
+                                                            const Ort::Logger& logger) const {
+  return CreateAttnMaskValueReductionGraph(qmw, *match_, false, logger);
+}
+
+gsl::span<const OrtNodeUnit* const> AttnMaskValueReductionFusion::GetNodeUnits() const {
+  return match_->node_units;
+}
+
+const OrtNodeUnit* AttnMaskValueReductionFusion::GetTargetNodeUnit() const {
+  return match_->softmax;
+}
+
+}  // namespace onnxruntime::qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/attn_mask_value_reduction_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/attn_mask_value_reduction_fusion.h
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+
+namespace onnxruntime::qnn {
+
+// Recognized QDQ attention tail:
+//
+//   attention_mask -> Sub(1, mask) -> Mul(mask, -M) -----+
+//   score ---------> Div ----------------------------------> Add -> Add(gate) -> Softmax
+//
+// The lowering keeps this topology and changes the static mask value to -100.
+class AttnMaskValueReductionFusion final : public IQnnNodeGroup {
+ public:
+  ORT_DISALLOW_COPY_AND_ASSIGNMENT(AttnMaskValueReductionFusion);
+  struct Match;
+  explicit AttnMaskValueReductionFusion(std::unique_ptr<Match> match);
+  ~AttnMaskValueReductionFusion();
+
+  Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  Ort::Status AddToModelBuilder(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;
+  gsl::span<const OrtNodeUnit* const> GetNodeUnits() const override;
+  const OrtNodeUnit* GetTargetNodeUnit() const override;
+  std::string_view Type() const override { return "AttnMaskValueReductionFusion"; }
+
+  static std::unique_ptr<IQnnNodeGroup> TryFusion(
+      QnnModelWrapper& qnn_model_wrapper,
+      const OrtNodeUnit& softmax_node_unit,
+      const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
+      const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
+      const Ort::Logger& logger);
+
+ private:
+  std::unique_ptr<Match> match_;
+};
+
+}  // namespace onnxruntime::qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -24,6 +24,7 @@
 #include "core/providers/qnn/builder/qnn_node_group/layer_norm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/lpbqgemm_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/lpbqmatmul_fusion.h"
+#include "core/providers/qnn/builder/qnn_node_group/attn_mask_value_reduction_fusion.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.h"
 #include "core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h"
@@ -104,6 +105,7 @@ static std::unordered_map<std::string, std::vector<FusionFunc>> fusions = {
     {"MatMul", {LowPowerBlockQuantizedMatMulFusion::TryFusion}},
     {"Gemm", {LowPowerBlockQuantizedGemmFusion::TryFusion, ReshapeGemmFusionGroup::TryFusion4, ReshapeGemmFusionGroup::TryFusion3, ReshapeGemmFusionGroup::TryFusion2}},
     {"Mul", {ScaleSoftmaxFusion::TryFusion}},
+    {"Softmax", {AttnMaskValueReductionFusion::TryFusion}},
     {"Cast", {CastLoneQFusion::TryFusion}},
     {"Erf", {GeluFusion::TryFusion}},
     {"Tanh", {TanhGeluFusion::TryFusion}},
@@ -153,7 +155,8 @@ static std::unique_ptr<IQnnNodeGroup> TryQnnFusions(
       starting_node_unit.OpType() != "MatMul" &&
       starting_node_unit.OpType() != "Erf" &&
       starting_node_unit.OpType() != "Tanh" &&
-      starting_node_unit.OpType() != "Reshape") {
+      starting_node_unit.OpType() != "Reshape" &&
+      starting_node_unit.OpType() != "Softmax") {
     return nullptr;
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <gsl/gsl>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string_view>
 #include <unordered_map>
@@ -15,9 +16,63 @@
 
 #include "core/providers/qnn/builder/qnn_model_wrapper.h"
 #include "core/providers/qnn/builder/qnn_node_group/qnn_node_group.h"
+#include "core/providers/qnn/builder/qnn_utils.h"
 
 namespace onnxruntime {
 namespace qnn {
+
+namespace {
+
+std::optional<double> GetUniformInitializerValue(const QnnModelWrapper& qmw, const OrtNodeUnitIODef& input,
+                                                 bool require_scalar) {
+  if (!qmw.IsConstantInput(input.name)) return std::nullopt;
+
+  TensorInfo info = {};
+  if (!qmw.GetTensorInfo(input, info).IsOK() || !info.is_initializer || info.initializer_tensor == nullptr ||
+      (require_scalar && (info.shape.size() != 0 && (info.shape.size() != 1 || info.shape[0] != 1)))) {
+    return std::nullopt;
+  }
+
+  std::vector<uint8_t> bytes;
+  if (!qmw.UnpackInitializerData(info.initializer_tensor, bytes).IsOK()) return std::nullopt;
+
+  const auto is_same_value = [](double lhs, double rhs) {
+    return std::abs(lhs - rhs) <= std::max(1e-6, std::max(std::abs(lhs), std::abs(rhs)) * 1e-5);
+  };
+  if (info.qnn_data_type == QNN_DATATYPE_FLOAT_32 && bytes.size() % sizeof(float) == 0) {
+    if (bytes.empty()) return std::nullopt;
+    float first_value = 0.0f;
+    std::memcpy(&first_value, bytes.data(), sizeof(first_value));
+    for (size_t offset = 0; offset < bytes.size(); offset += sizeof(float)) {
+      float value = 0.0f;
+      std::memcpy(&value, bytes.data() + offset, sizeof(value));
+      if (!is_same_value(value, first_value)) return std::nullopt;
+    }
+    return first_value;
+  }
+  if (info.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16 && bytes.size() % sizeof(uint16_t) == 0 &&
+      info.quant_param.IsPerTensor()) {
+    float scale = 0.0f;
+    int32_t offset = 0;
+    if (!info.quant_param.GetPerTensorScaleOffset(scale, offset).IsOK() || scale <= 0.0f || bytes.empty()) {
+      return std::nullopt;
+    }
+    uint16_t first_quantized = 0;
+    std::memcpy(&first_quantized, bytes.data(), sizeof(first_quantized));
+    const double first_value = utils::Dequantize(offset, scale, static_cast<double>(first_quantized));
+    for (size_t byte_offset = 0; byte_offset < bytes.size(); byte_offset += sizeof(uint16_t)) {
+      uint16_t quantized = 0;
+      std::memcpy(&quantized, bytes.data() + byte_offset, sizeof(quantized));
+      if (!is_same_value(utils::Dequantize(offset, scale, static_cast<double>(quantized)), first_value)) {
+        return std::nullopt;
+      }
+    }
+    return first_value;
+  }
+  return std::nullopt;
+}
+
+}  // namespace
 
 std::optional<std::vector<uint32_t>> GetReduceAxes(const QnnModelWrapper& qmw,
                                                    const OrtNodeUnit& node_unit) {
@@ -324,6 +379,34 @@ const OrtNodeUnit* GetParentOfInput(const QnnModelWrapper& /*qnn_model_wrapper*/
     return p_parent_node_unit;
   }
   return nullptr;
+}
+
+std::optional<double> GetStaticQdqInputValue(
+    const QnnModelWrapper& qmw, const OrtNodeUnit& node_unit, size_t input_index,
+    const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map, bool require_scalar) {
+  if (input_index >= node_unit.Inputs().size()) return std::nullopt;
+
+  const OrtNodeUnitIODef& input = node_unit.Inputs()[input_index];
+  if (auto value = GetUniformInitializerValue(qmw, input, require_scalar); value.has_value()) return value;
+
+  static const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*> no_claims;
+  const OrtNodeUnit* parent = GetParentOfInput(qmw, node_unit, input, node_unit_map, no_claims);
+  if (parent == nullptr || parent->UnitType() != OrtNodeUnit::Type::QDQGroup || parent->Inputs().empty()) {
+    return std::nullopt;
+  }
+
+  return GetUniformInitializerValue(qmw, parent->Inputs()[0], require_scalar);
+}
+
+bool IsStaticQdqInputWithValue(const QnnModelWrapper& qmw,
+                               const OrtNodeUnit& node_unit,
+                               size_t input_index,
+                               const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
+                               double expected_value,
+                               bool require_scalar) {
+  const auto value = GetStaticQdqInputValue(qmw, node_unit, input_index, node_unit_map, require_scalar);
+  return value.has_value() && std::abs(*value - expected_value) <=
+                                  std::max(1e-6, std::max(std::abs(*value), std::abs(expected_value)) * 1e-5);
 }
 
 const OrtNodeUnit* GetOnlyChildOfOutput(const QnnModelWrapper& /*qnn_model_wrapper*/,

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/utils.h
@@ -5,8 +5,10 @@
 
 #include <gsl/gsl>
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -73,6 +75,46 @@ const OrtNodeUnit* GetParentOfInput(const QnnModelWrapper& qnn_model_wrapper,
                                     const OrtNodeUnitIODef& input,
                                     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
                                     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& qnn_node_group_map);
+
+// Returns the uniform value of an input or its QDQ source initializer.
+std::optional<double> GetStaticQdqInputValue(const QnnModelWrapper& qnn_model_wrapper,
+                                             const OrtNodeUnit& node_unit,
+                                             size_t input_index,
+                                             const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
+                                             bool require_scalar);
+
+// Returns true if an input or its QDQ source initializer contains expected_value.
+bool IsStaticQdqInputWithValue(const QnnModelWrapper& qnn_model_wrapper,
+                               const OrtNodeUnit& node_unit,
+                               size_t input_index,
+                               const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_unit_map,
+                               double expected_value,
+                               bool require_scalar);
+
+// Derives a uint16 per-tensor encoding with `replacement_min` as its minimum
+// real value while preserving the original encoding's maximum real value.
+inline bool DeriveUInt16EncodingWithMin(float original_scale,
+                                        int32_t original_offset,
+                                        double replacement_min,
+                                        float& replacement_scale,
+                                        int32_t& replacement_offset) {
+  constexpr uint32_t kUInt16QMax = std::numeric_limits<uint16_t>::max();
+  if (!std::isfinite(original_scale) || original_scale <= 0.0f || !std::isfinite(replacement_min)) {
+    return false;
+  }
+
+  const double original_max = (static_cast<double>(kUInt16QMax) + original_offset) * original_scale;
+  const double new_scale = (original_max - replacement_min) / kUInt16QMax;
+  if (!std::isfinite(new_scale) || new_scale <= 0.0) {
+    return false;
+  }
+
+  const int32_t new_zero_point = static_cast<int32_t>(std::clamp(
+      std::lround(-replacement_min / new_scale), 0l, static_cast<long>(kUInt16QMax)));
+  replacement_scale = static_cast<float>(new_scale);
+  replacement_offset = -new_zero_point;
+  return true;
+}
 
 const OrtNodeUnit* GetOnlyChildOfOutput(const QnnModelWrapper& qnn_model_wrapper,
                                         const OrtNodeUnit& node_unit,

--- a/onnxruntime/test/providers/qnn/qnn_node_group/attn_mask_value_reduction_fusion_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/attn_mask_value_reduction_fusion_test.cc
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !defined(ORT_MINIMAL_BUILD)
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "core/providers/qnn/builder/qnn_node_group/utils.h"
+#include "gtest/gtest.h"
+
+namespace onnxruntime::test {
+namespace {
+
+constexpr uint32_t kUInt16QMax = std::numeric_limits<uint16_t>::max();
+constexpr double kReplacementMaskMagnitude = 100.0;
+
+TEST(AttnMaskValueReductionFusionTests, DerivesReplacementEncodingForDifferentMaskMagnitudes) {
+  struct TestCase {
+    double original_mask_magnitude;
+    float original_scale;
+    int32_t original_offset;
+  };
+
+  constexpr std::array<TestCase, 2> test_cases{{{1000.0, 0.025f, -40000}, {10000.0, 0.25f, -40000}}};
+  for (const TestCase& test_case : test_cases) {
+    float replacement_scale = 0.0f;
+    int32_t replacement_offset = 0;
+    const double old_min = static_cast<double>(test_case.original_offset) * test_case.original_scale;
+    const double old_max = (static_cast<double>(kUInt16QMax) + test_case.original_offset) * test_case.original_scale;
+    const double new_min = old_min + (test_case.original_mask_magnitude - kReplacementMaskMagnitude);
+    ASSERT_TRUE(qnn::DeriveUInt16EncodingWithMin(test_case.original_scale, test_case.original_offset, new_min,
+                                                 replacement_scale, replacement_offset));
+
+    const double expected_scale = (old_max - new_min) / kUInt16QMax;
+    const int32_t expected_offset = -static_cast<int32_t>(std::lround(-new_min / expected_scale));
+    EXPECT_NEAR(replacement_scale, expected_scale, 1e-7);
+    EXPECT_EQ(replacement_offset, expected_offset);
+
+    // The replacement encoding preserves the original upper real-value bound.
+    const double replacement_max = (static_cast<double>(kUInt16QMax) + replacement_offset) * replacement_scale;
+    EXPECT_NEAR(replacement_max, old_max, replacement_scale);
+  }
+}
+
+TEST(AttnMaskValueReductionFusionTests, RejectsNonPositiveScale) {
+  float replacement_scale = 0.0f;
+  int32_t replacement_offset = 0;
+  EXPECT_FALSE(qnn::DeriveUInt16EncodingWithMin(0.0f, 0, 0.0,
+                                                replacement_scale, replacement_offset));
+}
+
+}  // namespace
+}  // namespace onnxruntime::test
+
+#endif  // !defined(ORT_MINIMAL_BUILD)


### PR DESCRIPTION
## Summary

Recognize a QDQ attention tail in the QNN node group and reduce the mask value while preserving the original model structure.

## Validation

Validated on a V81 device with the target quantized attention model across 566 cases.