### PR TITLE
[QNN EP] Gate uint16 MatMul Convert workarounds on the NPU backend

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -346,6 +346,12 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
 
   // Inserts a QNN Convert op before uint16 input[1] to avoid QNN HTP validation failure.
   //
+  // Gated on the NPU backend: the constraints worked around here (input[1] must be symmetric, and
+  // must be per-tensor quantized) are imposed by the HTP backend, not by the QNN API, and HTP has
+  // relaxed them across releases. The DLC/Saver serializer flows still report their intended
+  // backend here (see QnnBackendManager::LoadQnnSerializerBackend), so a serialized HTP graph
+  // keeps the workaround.
+  //
   // QNN graph that fails validation:
   //     input_0_uint16 ---> MatMul ---> output_uint16
   //                         ^
@@ -363,7 +369,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
   //                                             ^
   //                                             |
   //     input_1_uint16 --> Convert(int16_sym) --+
-  if (!input_info_0.is_initializer &&
+  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+      !input_info_0.is_initializer &&
       input_info_0.qnn_data_type == input_info_1.qnn_data_type &&
       input_info_0.qnn_data_type == QNN_DATATYPE_UFIXED_POINT_16) {
     RETURN_IF_NOT(input_info_1.quant_param.IsPerTensor(),
@@ -474,7 +481,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   input_names.emplace_back(input_1_name);
 
   // Workaround that inserts a QNN Convert op before input[1] (converts from quantized uint16 to signed symmetric int16)
-  // to avoid a QNN validation failure.
+  // to avoid a QNN HTP validation failure. Gated on the NPU backend for the same reason as the
+  // uint16 workaround in ProcessInputsForQnnMatMul().
   //
   // QNN graph WITHOUT workaround (fails validation):
   //     input_0_uint16 ---> FC ---> output_uint16
@@ -491,7 +499,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
   std::string weight_input_name = input_names.back();
   const auto& weight_tensor_wrapper = qnn_model_wrapper.GetQnnTensorWrapper(weight_input_name);
 
-  if (weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
+  if (IsNpuBackend(qnn_model_wrapper.GetQnnBackendType()) &&
+      weight_tensor_wrapper.GetTensorDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
     const auto& quant_param_wrapper = weight_tensor_wrapper.GetQnnQuantParams();
     const Qnn_QuantizeParams_t& quant_param = quant_param_wrapper.Get();
     const auto& transformed_input1_shape = weight_tensor_wrapper.GetTensorDims();


### PR DESCRIPTION
Follow-up to #765, addressing https://github.com/onnxruntime/onnxruntime-qnn/pull/765#discussion_r3875476138.

## Summary
The uint16 `input[1]` Convert insertions in `ProcessInputsForQnnMatMul` and `ProcessInputsForQnnFullyConnected` work around HTP backend validation constraints, not QNN API constraints, so both are now gated on `IsNpuBackend`. Two conditions, plus comments recording why.

Evidence the constraints are HTP-specific: #23419 added the workaround to "pass QNN validation" on HTP; #24846 ("QNN's 16x16 FC doesn't support asymmetric int16 weight") scoped it to the HTP accelerator; #300 removed part of it because "HTP **now** supports symmetric uint16 for MatMul input 1" — a constraint that moves with HTP releases is not a QNN API constraint. `softmax_op_builder.cc` describes the same requirement as applying to "older HTP archs" and already gates its equivalent Convert workaround this way.

The per-tensor assertion stays inside the gated block: it guards the direct `scaleOffsetEncoding` union reads that follow.

## No behavior change on any shipped backend
Measured on a Snapdragon X Elite (HTP v73), QAIRT 2.49.40 — same uint16 QDQ MatMul compiled before and after the change:

| backend / input[1] | before | after |
|---|---|---|
| htp, dsp | workaround applies | unchanged (same branch taken) |
| cpu / dynamic | 2/7 nodes assigned | 2/7 nodes assigned |
| cpu / static | 0/6 assigned | 0/6 assigned |
| gpu / dynamic | 0/7 assigned | 0/7 assigned |
| gpu / static | 0/6 assigned | 0/6 assigned |

On CPU/GPU the QNN validator rejects the uint16 `MatMul`/`FullyConnected` with error `3110` either way; the gate only stops a doomed `Convert` from being validated first. (The 2 assigned nodes in `cpu/dynamic` are the Q/DQ pair, not the MatMul.)

The only observable difference is `backend_type=ir`/`saver`, where the composed graph no longer carries the Convert. Serializing an HTP-targeted DLC is unaffected: `QnnBackendManager::LoadQnnSerializerBackend()` reports the *intended* backend, so `dump_qnn_ir_dlc=1` on top of `backend_type=htp` still sees HTP and keeps the workaround.

**Open question for reviewers:** should bare `backend_type=ir` be treated as HTP-intent instead (`IsNpuBackend || IsIrBackend`, as `lstm_op_builder.cc` does for its HTP-gated path)? I left it out because `backend_type=ir` declares no target backend, but it is a judgement call.

Secondary effect: on non-NPU backends a per-channel uint16 `input[1]` no longer hard-errors out of the op builder; QNN validation rejects the node instead, reaching the same end state without the spurious error.