### PR TITLE
[QNN EP] Clarify enable_htp_fp16_precision behavior on QAIRT 2.35+

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -205,8 +205,10 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 
 |`"enable_htp_fp16_precision"`|Description [Example](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/c_cxx/QNN_EP/mobilenetv2_classification)|
 |---|---|
-|'0'|Default. Disabled. Inference with fp32 precision if it's fp32 model.|
-|'1'|Enable the float32 model to be inferenced with fp16 precision.|
+|'0'|Default. Does not request the legacy HTP FP16 precision configuration. With QAIRT 2.35 or later, this does not select FP32 precision.|
+|'1'|Requests the legacy HTP FP16 precision configuration. With QAIRT 2.35 or later, this setting no longer changes HTP execution precision.|
+
+> **Note:** Starting with QAIRT 2.35, HTP floating-point operations use FP16 math on SoCs with floating-point model support, regardless of this setting. `htp_bf16_enable` configures BF16 separately on supported SoCs.
 
 |`"enable_htp_monolithic_lstm"`|Description|
 |---|---|

--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -205,8 +205,8 @@ Refer to the [QAIRT SDK documentation](https://docs.qualcomm.com/doc/80-63442-10
 
 |`"enable_htp_fp16_precision"`|Description [Example](https://github.com/microsoft/onnxruntime-inference-examples/tree/main/c_cxx/QNN_EP/mobilenetv2_classification)|
 |---|---|
-|'0'|Default. Does not request the legacy HTP FP16 precision configuration. With QAIRT 2.35 or later, this does not select FP32 precision.|
-|'1'|Requests the legacy HTP FP16 precision configuration. With QAIRT 2.35 or later, this setting no longer changes HTP execution precision.|
+|'0'|Default. Does not add `QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION`. With QAIRT 2.35 or later, this does not select FP32 precision.|
+|'1'|Adds `QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION` with `QNN_PRECISION_FLOAT16`. With QAIRT 2.35 or later, this configuration no longer changes HTP execution precision.|
 
 > **Note:** Starting with QAIRT 2.35, HTP floating-point operations use FP16 math on SoCs with floating-point model support, regardless of this setting. `htp_bf16_enable` configures BF16 separately on supported SoCs.
 


### PR DESCRIPTION
### Description

Clarifies the effective behavior of `enable_htp_fp16_precision` with QAIRT 2.35 and later:

- `0` does not add `QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION` and does not select FP32 precision.
- `1` adds `QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION` with `QNN_PRECISION_FLOAT16`; this configuration no longer changes HTP execution precision.
- On SoCs with floating-point model support, HTP floating-point operations use FP16 math regardless of this setting. BF16 remains a separate option.

### Motivation and Context

The current provider-option table says that value `0` runs an FP32 model with FP32 precision. That is no longer true for the QAIRT versions supported by the current QNN EP.

PR #603 corrected the documented default marker but was closed after reviewers noted that HTP FP32 is no longer supported and that the option appears to be a no-op. Microsoft ONNX Runtime PR [#26499](https://github.com/microsoft/onnxruntime/pull/26499) separately updated HTP tests because the default floating-point precision changed from FP32 to FP16 in QNN 2.35 and `QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION` was deprecated.

This documentation-only change does not remove the provider option or alter runtime behavior.

### Validation

- Ran `git diff --check`.
- Cross-checked the current implementation: value `0` omits `QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION`, while value `1` adds it with `QNN_PRECISION_FLOAT16`.
- Cross-checked the QAIRT 2.35+ behavior against Microsoft ONNX Runtime PR #26499 and the discussion in #603.
