### PR TITLE
[Docs][Android] Correct the QNN Runtime Maven version

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -70,7 +70,8 @@ For build instructions, please see the [BUILD page](./build.md).
     | Dependency | Maven Coordinate | Version |
     |---|---|---|
     | ONNX Runtime Android | `com.microsoft.onnxruntime:onnxruntime-android` | `1.26.0` |
-    | QNN Runtime | `com.qualcomm.qti:qnn-runtime` | `2.49.40` |
+    | QNN Runtime | `com.qualcomm.qti:qnn-runtime` | `2.49.0` |
+  - **Version note:** QNN EP v2.5.0 was built and tested with QAIRT SDK 2.49.40; the public Android Maven runtime artifact is versioned `2.49.0`.
 
 ## Qualcomm AI Hub
 Qualcomm AI Hub can be used to optimize and run models on Qualcomm hosted devices.


### PR DESCRIPTION
### Description

Corrects the Android Maven dependency table for QNN EP v2.5.0:

- QAIRT SDK compatibility remains `2.49.40`.
- The public Android Maven artifact is `com.qualcomm.qti:qnn-runtime:2.49.0`.

The added note distinguishes the QAIRT SDK version from the Android Maven artifact version.

### Motivation and Context

The documentation currently uses the QAIRT SDK version as the Maven artifact version, but `qnn-runtime:2.49.40` is not published to Maven Central. The repository's Android test already falls back from `2.49.40` to `2.49.0`, and the discussion in #738 records that `2.49.40` is unavailable from Maven Central.

This change is documentation-only and does not change provider, runtime, packaging, or test behavior.

### Validation

- Ran `git diff --check`.
- Verified that [Maven Central metadata](https://repo.maven.apache.org/maven2/com/qualcomm/qti/qnn-runtime/maven-metadata.xml) lists `2.49.0` as the latest and release version.
- Verified that the `2.49.0` POM resolves successfully and the `2.49.40` POM returns 404.
- Verified the existing `2.49.40` to `2.49.0` fallback in `java/src/test/android/app/build.gradle`.
