### PR TITLE
[QNN EP] Add 2-bit BQ STD Symmetric Support

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -484,8 +484,22 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
           }
         }
 
-        if (!used_lpbq) {
-          // Non-LPBQ block-quant path: native BQ (BLOCK) or BW_FLOAT_BLOCK, decided below.
+        bool used_bw_block_mapped = false;
+        // 2-bit Standard Symmetric BW_BLOCK_MAPPED: keeps int16 activations natively (no DQ needed).
+        if (!used_lpbq && bits == 2 && is_act_16bitquant && zp_is_symmetric) {
+          const std::vector<uint32_t> block_sizes = {1, 1, gsl::narrow_cast<uint32_t>(block_size), 1};
+          const std::vector<int32_t> per_block_int32_offset(total_blocks, 0);
+          quantize_param = QnnQuantParamsWrapper::BwBlockMapped(per_block_float_scale,
+                                                                per_block_int32_offset,
+                                                                gsl::narrow_cast<uint32_t>(bits),
+                                                                block_sizes,
+                                                                QNN_QUANTIZATION_ENCODING_MAPPING_STANDARD_SYMMETRIC);
+          used_bw_block_mapped = true;
+          ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("MatMulNBits weight encoding: BW_BLOCK_MAPPED (STANDARD_SYMMETRIC) for " + weight_tensor_name).c_str());
+        }
+
+        if (!used_lpbq && !used_bw_block_mapped) {
+          // Non-LPBQ, non-BW_BLOCK_MAPPED path: native BQ (BLOCK) or BW_FLOAT_BLOCK, decided below.
           const char* reason = !is_act_16bitquant ? "activation not 16-bit quantized"
                                : bits != 4        ? "bits != 4 (LPBQ only supports INT4)"
                                : !zp_is_symmetric ? "zero-points not symmetric"
@@ -686,8 +700,8 @@ Ort::Status MatMulNBitsOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& q
     std::vector<uint32_t> conv2d_output_shape = {output_info.shape[0], 1, output_info.shape[1], output_info.shape[2]};
 
     // Determine the Conv2D output data type from the registered weight tensor's quant encoding.
-    // Only BW_FLOAT_BLOCK forces the kernel to compute in FP16; LPBQ (BLOCKWISE_EXPANSION) and native BQ
-    // (BLOCK) both produce the actual output data type (e.g. uint16/int16 for QDQ models) directly.
+    // Only BW_FLOAT_BLOCK forces the kernel to compute in FP16; LPBQ (BLOCKWISE_EXPANSION), native BQ
+    // (BLOCK), and BW_BLOCK_MAPPED all produce the actual output data type (e.g. uint16/int16) directly.
     // NOTE: IsBlockQuantized() is true for both BLOCK and BW_FLOAT_BLOCK, so match the encoding directly.
     bool is_bw_float_block = false;
     if (qnn_model_wrapper.IsQnnTensorWrapperExist(input_names[1])) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -486,18 +486,43 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
 
         bool used_bw_block_mapped = false;
 #if defined(QNN_SDK_VERSION_MINOR) && (QNN_SDK_VERSION_MAJOR > 2 || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR >= 51))
-        // 2-bit Standard Symmetric BW_BLOCK_MAPPED: keeps int16 activations natively (no DQ needed).
+        // 2-bit BW_BLOCK_MAPPED: keeps int16 activations natively (no DQ needed).
         // Gated to SDK >= 2.51: the native W2A16 HTP kernel is not available until 2.51.
-        if (!used_lpbq && bits == 2 && is_act_16bitquant && zp_is_symmetric) {
+        // Symmetric → STANDARD_SYMMETRIC (offsets=0), Asymmetric → ASYMMETRIC_PLUS_ONE (offsets from ZP tensor).
+        if (!used_lpbq && bits == 2 && is_act_16bitquant) {
           const std::vector<uint32_t> block_sizes = {1, 1, gsl::narrow_cast<uint32_t>(block_size), 1};
-          const std::vector<int32_t> per_block_int32_offset(total_blocks, 0);
+
+          Qnn_QuantizationEncodingMapping_t mapping;
+          std::vector<int32_t> per_block_int32_offset;
+          if (zp_is_symmetric) {
+            mapping = QNN_QUANTIZATION_ENCODING_MAPPING_STANDARD_SYMMETRIC;
+            per_block_int32_offset.assign(total_blocks, 0);
+          } else {
+            mapping = QNN_QUANTIZATION_ENCODING_MAPPING_ASYMMETRIC_PLUS_ONE;
+            // Unpack block-quantized zero-points and convert to int32 offsets per QNN convention.
+            std::vector<uint8_t> per_block_uint8_zp;
+            const OrtValueInfo* zp_tensor_proto = qnn_model_wrapper.GetConstantTensor(inputs[3].name);
+            RETURN_IF_NOT(zp_tensor_proto != nullptr, "MatMulNBits zero_points must be a constant initializer.");
+            RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(zp_tensor_proto, per_block_uint8_zp));
+            std::vector<float> per_block_float_zp;
+            UnpackDataToDatatype<float>(per_block_uint8_zp, bits, num_zp_per_uint8, per_block_float_zp);
+
+            const float offset_shift = static_cast<float>(1 << (bits - 1));
+            per_block_int32_offset.resize(per_block_float_zp.size());
+            for (size_t idx = 0; idx < per_block_float_zp.size(); ++idx) {
+              per_block_int32_offset[idx] = static_cast<int32_t>(-(per_block_float_zp[idx] - offset_shift));
+            }
+          }
+
           quantize_param = QnnQuantParamsWrapper::BwBlockMapped(per_block_float_scale,
                                                                 per_block_int32_offset,
                                                                 gsl::narrow_cast<uint32_t>(bits),
                                                                 block_sizes,
-                                                                QNN_QUANTIZATION_ENCODING_MAPPING_STANDARD_SYMMETRIC);
+                                                                mapping);
           used_bw_block_mapped = true;
-          ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("MatMulNBits weight encoding: BW_BLOCK_MAPPED (STANDARD_SYMMETRIC) for " + weight_tensor_name).c_str());
+          const char* mapping_str = zp_is_symmetric ? "STANDARD_SYMMETRIC" : "ASYMMETRIC_PLUS_ONE";
+          ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                      ("MatMulNBits weight encoding: BW_BLOCK_MAPPED (" + std::string(mapping_str) + ") for " + weight_tensor_name).c_str());
         }
 #endif  // QNN_SDK_VERSION_MINOR >= 51
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -485,7 +485,9 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
         }
 
         bool used_bw_block_mapped = false;
+#if defined(QNN_SDK_VERSION_MINOR) && (QNN_SDK_VERSION_MAJOR > 2 || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR >= 51))
         // 2-bit Standard Symmetric BW_BLOCK_MAPPED: keeps int16 activations natively (no DQ needed).
+        // Gated to SDK >= 2.51: the native W2A16 HTP kernel is not available until 2.51.
         if (!used_lpbq && bits == 2 && is_act_16bitquant && zp_is_symmetric) {
           const std::vector<uint32_t> block_sizes = {1, 1, gsl::narrow_cast<uint32_t>(block_size), 1};
           const std::vector<int32_t> per_block_int32_offset(total_blocks, 0);
@@ -497,6 +499,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
           used_bw_block_mapped = true;
           ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("MatMulNBits weight encoding: BW_BLOCK_MAPPED (STANDARD_SYMMETRIC) for " + weight_tensor_name).c_str());
         }
+#endif  // QNN_SDK_VERSION_MINOR >= 51
 
         if (!used_lpbq && !used_bw_block_mapped) {
           // Non-LPBQ, non-BW_BLOCK_MAPPED path: native BQ (BLOCK) or BW_FLOAT_BLOCK, decided below.

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.cc
@@ -258,6 +258,48 @@ QnnQuantParamsWrapper QnnQuantParamsWrapper::BwFloatBlock(gsl::span<const float>
   return qp;
 }
 
+// Block-encoded quantization with explicit bitwidth and QNN encoding mapping (BW_BLOCK_MAPPED).
+QnnQuantParamsWrapper QnnQuantParamsWrapper::BwBlockMapped(gsl::span<const float> scales,
+                                                           gsl::span<const int32_t> offsets,
+                                                           uint32_t bitwidth,
+                                                           gsl::span<const uint32_t> block_sizes,
+                                                           Qnn_QuantizationEncodingMapping_t mapping) {
+  assert(scales.size() > 0);
+  assert(scales.size() == offsets.size());
+  assert(bitwidth > 0);
+  assert(block_sizes.size() > 0);
+
+  QnnQuantParamsWrapper qp;
+  qp.params_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qp.params_.quantizationEncoding = QNN_QUANTIZATION_ENCODING_BW_BLOCK_MAPPED;
+
+  qp.block_encoding_tensor_rank_ = static_cast<uint32_t>(block_sizes.size());
+  qp.block_encoding_axis_data_ = std::make_unique<uint32_t[]>(qp.block_encoding_tensor_rank_);
+  std::memcpy(qp.block_encoding_axis_data_.get(),
+              block_sizes.data(),
+              static_cast<size_t>(qp.block_encoding_tensor_rank_) * sizeof(uint32_t));
+
+  qp.num_blocks_ = static_cast<uint32_t>(scales.size());
+  qp.block_encoding_scale_offsets_data_ = std::make_unique<Qnn_ScaleOffset_t[]>(qp.num_blocks_);
+  for (size_t i = 0; i < qp.num_blocks_; ++i) {
+    qp.block_encoding_scale_offsets_data_[i].scale = scales[i];
+    qp.block_encoding_scale_offsets_data_[i].offset = offsets[i];
+  }
+
+  // Allocate the Qnn_BwBlockMapped_t struct itself (the union member is a pointer to it).
+  const size_t bbm_num_bytes = sizeof(Qnn_BwBlockMapped_t);
+  constexpr std::uintptr_t bbm_align = alignof(Qnn_BwBlockMapped_t);
+  qp.bw_block_mapped_data_ = std::make_unique<char[]>(bbm_num_bytes + bbm_align);
+  Qnn_BwBlockMapped_t* bbm_ptr = ALIGN_PTR_UP(qp.bw_block_mapped_data_.get(), bbm_align, Qnn_BwBlockMapped_t*);
+  bbm_ptr->bitwidth = bitwidth;
+  bbm_ptr->mapping = mapping;
+  bbm_ptr->blockSize = qp.block_encoding_axis_data_.get();
+  bbm_ptr->scaleOffset = qp.block_encoding_scale_offsets_data_.get();
+
+  qp.params_.bwBlockMappedEncoding = bbm_ptr;
+  return qp;
+}
+
 // Get a copy of scales. Works for both per-tensor and per-channel.
 Ort::Status QnnQuantParamsWrapper::GetScales(/*out*/ std::vector<float>& scales) const {
   RETURN_IF_NOT(params_.encodingDefinition == QNN_DEFINITION_DEFINED, "Unquantized qparams does not have scales");
@@ -469,6 +511,37 @@ Ort::Status QnnQuantParamsWrapper::Init(const Qnn_QuantizeParams_t& params, cons
         bw_float_block_encoding_scale_offsets_data_[i].offset = params.bwFloatBlockEncoding.floatScaleOffset[i].offset;
       }
       params_.bwFloatBlockEncoding.floatScaleOffset = bw_float_block_encoding_scale_offsets_data_.get();
+
+      break;
+    }
+    case QNN_QUANTIZATION_ENCODING_BW_BLOCK_MAPPED: {
+      assert(num_scaleoffsets && "Can't create BwBlockMapped encoding object with zero ScaleOffsets");
+      params_.encodingDefinition = params.encodingDefinition;
+      params_.quantizationEncoding = params.quantizationEncoding;
+
+      num_blocks_ = static_cast<uint32_t>(num_scaleoffsets);
+      block_encoding_tensor_rank_ = static_cast<uint32_t>(tensor_rank);
+      block_encoding_axis_data_ = std::make_unique<uint32_t[]>(block_encoding_tensor_rank_);
+      std::memcpy(block_encoding_axis_data_.get(),
+                  params.bwBlockMappedEncoding->blockSize,
+                  static_cast<size_t>(block_encoding_tensor_rank_) * sizeof(uint32_t));
+
+      block_encoding_scale_offsets_data_ = std::make_unique<Qnn_ScaleOffset_t[]>(num_scaleoffsets);
+      for (size_t i = 0; i < num_scaleoffsets; ++i) {
+        block_encoding_scale_offsets_data_[i].scale = params.bwBlockMappedEncoding->scaleOffset[i].scale;
+        block_encoding_scale_offsets_data_[i].offset = params.bwBlockMappedEncoding->scaleOffset[i].offset;
+      }
+
+      // Deep copy the Qnn_BwBlockMapped_t struct itself (union member is a pointer to it).
+      const size_t bbm_num_bytes = sizeof(Qnn_BwBlockMapped_t);
+      constexpr std::uintptr_t bbm_align = alignof(Qnn_BwBlockMapped_t);
+      bw_block_mapped_data_ = std::make_unique<char[]>(bbm_num_bytes + bbm_align);
+      Qnn_BwBlockMapped_t* bbm_aligned_dst = ALIGN_PTR_UP(bw_block_mapped_data_.get(), bbm_align, Qnn_BwBlockMapped_t*);
+      bbm_aligned_dst->bitwidth = params.bwBlockMappedEncoding->bitwidth;
+      bbm_aligned_dst->mapping = params.bwBlockMappedEncoding->mapping;
+      bbm_aligned_dst->blockSize = block_encoding_axis_data_.get();
+      bbm_aligned_dst->scaleOffset = block_encoding_scale_offsets_data_.get();
+      params_.bwBlockMappedEncoding = bbm_aligned_dst;
 
       break;
     }

--- a/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_quant_params_wrapper.h
@@ -64,6 +64,12 @@ class QnnQuantParamsWrapper {
                                             uint32_t bitwidth,
                                             gsl::span<const uint32_t> block_sizes);
 
+  static QnnQuantParamsWrapper BwBlockMapped(gsl::span<const float> scales,
+                                             gsl::span<const int32_t> offsets,
+                                             uint32_t bitwidth,
+                                             gsl::span<const uint32_t> block_sizes,
+                                             Qnn_QuantizationEncodingMapping_t mapping);
+
   Qnn_QuantizeParams_t& Get() { return params_; }
   const Qnn_QuantizeParams_t& Get() const { return params_; }
 
@@ -118,7 +124,13 @@ class QnnQuantParamsWrapper {
   bool IsBlockQuantized() const {
     return params_.encodingDefinition == QNN_DEFINITION_DEFINED &&
            (params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BLOCK ||
-            params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK);
+            params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_FLOAT_BLOCK ||
+            params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_BLOCK_MAPPED);
+  }
+
+  bool IsBwBlockMapped() const {
+    return params_.encodingDefinition == QNN_DEFINITION_DEFINED &&
+           params_.quantizationEncoding == QNN_QUANTIZATION_ENCODING_BW_BLOCK_MAPPED;
   }
 
   // Returns the number of per-channel scale entries stored in this wrapper.
@@ -238,6 +250,11 @@ class QnnQuantParamsWrapper {
 
   // Store BwFloatBlockEncoding scale offset data.
   std::unique_ptr<Qnn_FloatScaleOffset_t[]> bw_float_block_encoding_scale_offsets_data_;
+
+  // Store the Qnn_BwBlockMapped_t struct itself (union member is a pointer to it).
+  // blockSize/scaleOffset within it point into block_encoding_axis_data_ /
+  // block_encoding_scale_offsets_data_ above, reused from the BLOCK encoding.
+  std::unique_ptr<char[]> bw_block_mapped_data_;
 };
 
 }  // namespace qnn

--- a/onnxruntime/test/providers/qnn/matmulnbits_test.cc
+++ b/onnxruntime/test/providers/qnn/matmulnbits_test.cc
@@ -1108,6 +1108,47 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K64_B4_BS16_AZP) {
   RunHtpQDQMatMulNBitsTest<4, int16_t>(params);
 }
 
+// W2A16 Standard Symmetric BW_BLOCK_MAPPED (bits=2, 16-bit activation, symmetric zero-point).
+// No zero_point tensor at all -> treated as symmetric, triggers BW_BLOCK_MAPPED encoding.
+TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N4_K64_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 4;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = false;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
+// W2A16 Standard Symmetric BW_BLOCK_MAPPED (bits=2, 16-bit activation, explicit symmetric zero-point).
+TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N8_K128_BS32_ZP) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 8;
+  params.K = 128;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  params.is_zp_symmetric = true;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
+// Should fallback to BW_FLOAT_BLOCK (bits=2, asymmetric zero-point)
+TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_Fallback_AsymZP_M1_N4_K64_BS16) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 4;
+  params.K = 64;
+  params.block_size = 16;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/matmulnbits_test.cc
+++ b/onnxruntime/test/providers/qnn/matmulnbits_test.cc
@@ -1109,8 +1109,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K64_B4_BS16_AZP) {
 }
 
 // W2A16 Standard Symmetric BW_BLOCK_MAPPED (bits=2, 16-bit activation, symmetric zero-point).
-// Gated to SDK >= 2.51: the native W2A16 HTP kernel is not available until 2.51.
-#if defined(QNN_SDK_VERSION_MINOR) && (QNN_SDK_VERSION_MAJOR > 2 || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR >= 51))
+// On SDK >= 2.51 uses BW_BLOCK_MAPPED encoding; on older SDKs falls back to BW_FLOAT_BLOCK.
 TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N4_K64_BS16) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 
@@ -1120,7 +1119,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N4_K64_BS16
   params.K = 64;
   params.block_size = 16;
   params.has_zero_point = false;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
 
 TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N8_K128_BS32_ZP) {
@@ -1133,12 +1132,12 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N8_K128_BS3
   params.block_size = 32;
   params.has_zero_point = true;
   params.is_zp_symmetric = true;
-  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
-#endif  // QNN_SDK_VERSION_MINOR >= 51
 
-// Should fallback to BW_FLOAT_BLOCK (bits=2, asymmetric zero-point)
-TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_Fallback_AsymZP_M1_N4_K64_BS16) {
+// W2A16 Asymmetric BW_BLOCK_MAPPED (bits=2, 16-bit activation, asymmetric zero-point).
+// Uses ASYMMETRIC_PLUS_ONE mapping: {0,1,2,3} → {-1,0,1,2}.
+TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_AsymPlusOne_M1_N4_K64_BS16) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 
   TestParams params;
@@ -1147,7 +1146,19 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_Fallback_AsymZP_M1_N4
   params.K = 64;
   params.block_size = 16;
   params.has_zero_point = true;
-  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+  RunHtpQDQMatMulNBitsTest<2, int16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
+}
+
+TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_AsymPlusOne_M1_N8_K128_BS32) {
+  SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
+
+  TestParams params;
+  params.M = 1;
+  params.N = 8;
+  params.K = 128;
+  params.block_size = 32;
+  params.has_zero_point = true;
+  RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, std::nullopt, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
 
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)

--- a/onnxruntime/test/providers/qnn/matmulnbits_test.cc
+++ b/onnxruntime/test/providers/qnn/matmulnbits_test.cc
@@ -1109,7 +1109,8 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_LPBQ_M1_N4_K64_B4_BS16_AZP) {
 }
 
 // W2A16 Standard Symmetric BW_BLOCK_MAPPED (bits=2, 16-bit activation, symmetric zero-point).
-// No zero_point tensor at all -> treated as symmetric, triggers BW_BLOCK_MAPPED encoding.
+// Gated to SDK >= 2.51: the native W2A16 HTP kernel is not available until 2.51.
+#if defined(QNN_SDK_VERSION_MINOR) && (QNN_SDK_VERSION_MAJOR > 2 || (QNN_SDK_VERSION_MAJOR == 2 && QNN_SDK_VERSION_MINOR >= 51))
 TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N4_K64_BS16) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 
@@ -1122,7 +1123,6 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N4_K64_BS16
   RunHtpQDQMatMulNBitsTest<2, int16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
 
-// W2A16 Standard Symmetric BW_BLOCK_MAPPED (bits=2, 16-bit activation, explicit symmetric zero-point).
 TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N8_K128_BS32_ZP) {
   SKIP_HTP_TEST_ON_ARCH_LESS_THAN_OR_EQUAL_TO(QNN_HTP_DEVICE_ARCH_V68);
 
@@ -1135,6 +1135,7 @@ TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_StdSym_M1_N8_K128_BS3
   params.is_zp_symmetric = true;
   RunHtpQDQMatMulNBitsTest<2, uint16_t>(params, ExpectedEPNodeAssignment::All, QDQTolerance(0.02f));
 }
+#endif  // QNN_SDK_VERSION_MINOR >= 51
 
 // Should fallback to BW_FLOAT_BLOCK (bits=2, asymmetric zero-point)
 TEST_F(QnnHTPBackendTests, MatMulNBits_BwBlockMapped_W2A16_Fallback_AsymZP_M1_N4_K64_BS16) {


### PR DESCRIPTION
### Description
- Add 2-bit BQ Standard Symmetric support via BW_BLOCK_MAPPED encoding
- Skip DQ insertion and use native output dtype for BW_BLOCK_MAPPED (ProcessAttributesAndOutputs)


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


