### PR TITLE
[QNN EP] Speed up 2D initializer transpose

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -456,7 +456,8 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnFullyConnected(QnnModelWrapper& 
                                                    original_shape_copy,  // Will be modified to new shape (unnecessary)
                                                    input_info_1.initializer_tensor,
                                                    unpacked_tensor,
-                                                   logger));
+                                                   logger,
+                                                   do_op_validation));
     } else {
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(input_info_1.initializer_tensor, unpacked_tensor));
     }

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1607,17 +1607,17 @@ Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
   const size_t elem_byte_size = qnn::utils::GetElementSizeByType(onnx_type);
   RETURN_IF_NOT(elem_byte_size != 0, "Can't get element byte size from given ONNX type");
 
+  if (skip_output_data_copy) {
+    ORT_CXX_LOG(logger,
+                ORT_LOGGING_LEVEL_VERBOSE,
+                "Skipping initializer data transpose during op validation.");
+    data_shape = std::move(output_shape);
+    return Ort::Status();
+  }
+
   std::vector<uint8_t> input_buffer;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(initializer, input_buffer));
   transposed_data.resize(input_buffer.size(), 0);
-
-  if (skip_output_data_copy) {  // Only shape & dtype validation are needed, no need for real tensor
-    ORT_CXX_LOG(logger,
-                ORT_LOGGING_LEVEL_VERBOSE,
-                "Only shape and dtype validation are required, so we can use dummy tensor to avoid heavy memcpy.");
-    data_shape = std::move(output_shape);  // Update parameter with final transposed shape
-    return Ort::Status();
-  }
 
   // Actual tensor content is required.
   const size_t rows = data_shape[0];

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1557,6 +1557,30 @@ static Ort::Status TransposeDataRank5(gsl::span<const int64_t> input_shape,
   return Ort::Status();
 }
 
+template <size_t ElementSize>
+static void TransposeDataRank2(size_t rows,
+                               size_t cols,
+                               gsl::span<const uint8_t> input_buffer,
+                               gsl::span<uint8_t> output_buffer) {
+  constexpr size_t tile_size = 32;
+  for (size_t row_start = 0; row_start < rows; row_start += tile_size) {
+    const size_t row_end = std::min(row_start + tile_size, rows);
+    for (size_t col_start = 0; col_start < cols; col_start += tile_size) {
+      const size_t col_end = std::min(col_start + tile_size, cols);
+      for (size_t col = col_start; col < col_end; ++col) {
+        size_t dst_byte_index = (col * rows + row_start) * ElementSize;
+        for (size_t row = row_start; row < row_end; ++row) {
+          const size_t src_byte_index = (row * cols + col) * ElementSize;
+          assert(src_byte_index < input_buffer.size());
+          assert(dst_byte_index < output_buffer.size());
+          std::memcpy(&output_buffer[dst_byte_index], &input_buffer[src_byte_index], ElementSize);
+          dst_byte_index += ElementSize;
+        }
+      }
+    }
+  }
+}
+
 Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
                                   std::vector<uint32_t>& data_shape,
                                   const OrtValueInfo* initializer,
@@ -1598,18 +1622,31 @@ Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
   // Actual tensor content is required.
   const size_t rows = data_shape[0];
   const size_t cols = data_shape[1];
-  const size_t output_cols = output_shape[1];
-
-  for (size_t row = 0; row < rows; row++) {
-    for (size_t col = 0; col < cols; col++) {
-      const size_t src_elem_index = (row * cols + col);
-      const size_t dst_elem_index = (col * output_cols + row);
-      const size_t src_byte_index = src_elem_index * elem_byte_size;
-      const size_t dst_byte_index = dst_elem_index * elem_byte_size;
-      assert(src_byte_index < input_buffer.size());
-      assert(dst_byte_index < transposed_data.size());
-
-      std::memcpy(&transposed_data[dst_byte_index], &input_buffer[src_byte_index], elem_byte_size);
+  switch (elem_byte_size) {
+    case 1:
+      TransposeDataRank2<1>(rows, cols, input_buffer, transposed_data);
+      break;
+    case 2:
+      TransposeDataRank2<2>(rows, cols, input_buffer, transposed_data);
+      break;
+    case 4:
+      TransposeDataRank2<4>(rows, cols, input_buffer, transposed_data);
+      break;
+    case 8:
+      TransposeDataRank2<8>(rows, cols, input_buffer, transposed_data);
+      break;
+    default: {
+      const size_t output_cols = output_shape[1];
+      for (size_t row = 0; row < rows; ++row) {
+        for (size_t col = 0; col < cols; ++col) {
+          const size_t src_byte_index = (row * cols + col) * elem_byte_size;
+          const size_t dst_byte_index = (col * output_cols + row) * elem_byte_size;
+          assert(src_byte_index < input_buffer.size());
+          assert(dst_byte_index < transposed_data.size());
+          std::memcpy(&transposed_data[dst_byte_index], &input_buffer[src_byte_index], elem_byte_size);
+        }
+      }
+      break;
     }
   }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.cc
@@ -1557,11 +1557,16 @@ static Ort::Status TransposeDataRank5(gsl::span<const int64_t> input_shape,
   return Ort::Status();
 }
 
+// Internal function to transpose a rank-2 buffer of fixed-size elements, one cache tile at a time.
 template <size_t ElementSize>
-static void TransposeDataRank2(size_t rows,
-                               size_t cols,
-                               gsl::span<const uint8_t> input_buffer,
-                               gsl::span<uint8_t> output_buffer) {
+static void TransposeTiled2D(size_t rows,
+                             size_t cols,
+                             gsl::span<const uint8_t> input_buffer,
+                             gsl::span<uint8_t> output_buffer) {
+  // A 32x32 tile of elements up to 8 bytes wide spans at most 32 cache lines on each of the source
+  // and destination sides (2 KB per side), which stays resident in L1 for the whole tile. Every
+  // source line is therefore loaded once and fully consumed, instead of once per element as in the
+  // untiled loop below.
   constexpr size_t tile_size = 32;
   for (size_t row_start = 0; row_start < rows; row_start += tile_size) {
     const size_t row_end = std::min(row_start + tile_size, rows);
@@ -1579,6 +1584,45 @@ static void TransposeDataRank2(size_t rows,
       }
     }
   }
+}
+
+Ort::Status TwoDimensionTranspose(size_t rows,
+                                  size_t cols,
+                                  size_t elem_byte_size,
+                                  gsl::span<const uint8_t> input_buffer,
+                                  gsl::span<uint8_t> output_buffer) {
+  RETURN_IF_NOT(elem_byte_size != 0, "Expected a non-zero element byte size");
+
+  const size_t num_bytes = rows * cols * elem_byte_size;
+  RETURN_IF_NOT(input_buffer.size() == num_bytes && output_buffer.size() == num_bytes,
+                "Expected both transpose buffers to hold rows * cols * elem_byte_size bytes");
+
+  switch (elem_byte_size) {
+    case 1:
+      TransposeTiled2D<1>(rows, cols, input_buffer, output_buffer);
+      break;
+    case 2:
+      TransposeTiled2D<2>(rows, cols, input_buffer, output_buffer);
+      break;
+    case 4:
+      TransposeTiled2D<4>(rows, cols, input_buffer, output_buffer);
+      break;
+    case 8:
+      TransposeTiled2D<8>(rows, cols, input_buffer, output_buffer);
+      break;
+    default:
+      // Uncommon element size: fall back to an untiled element-by-element transpose.
+      for (size_t row = 0; row < rows; ++row) {
+        for (size_t col = 0; col < cols; ++col) {
+          const size_t src_byte_index = (row * cols + col) * elem_byte_size;
+          const size_t dst_byte_index = (col * rows + row) * elem_byte_size;
+          std::memcpy(&output_buffer[dst_byte_index], &input_buffer[src_byte_index], elem_byte_size);
+        }
+      }
+      break;
+  }
+
+  return Ort::Status();
 }
 
 Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
@@ -1607,48 +1651,25 @@ Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
   const size_t elem_byte_size = qnn::utils::GetElementSizeByType(onnx_type);
   RETURN_IF_NOT(elem_byte_size != 0, "Can't get element byte size from given ONNX type");
 
-  if (skip_output_data_copy) {
+  const size_t rows = data_shape[0];
+  const size_t cols = data_shape[1];
+
+  if (skip_output_data_copy) {  // Only shape & dtype validation are needed, no need for real tensor
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
-                "Skipping initializer data transpose during op validation.");
-    data_shape = std::move(output_shape);
+                "Only shape and dtype validation are required, so we can use dummy tensor to avoid heavy memcpy.");
+    // Callers still size their QNN tensor from this buffer, so keep the byte count and skip only the
+    // initializer read and the transpose itself.
+    transposed_data.assign(rows * cols * elem_byte_size, 0);
+    data_shape = std::move(output_shape);  // Update parameter with final transposed shape
     return Ort::Status();
   }
 
+  // Actual tensor content is required.
   std::vector<uint8_t> input_buffer;
   RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(initializer, input_buffer));
   transposed_data.resize(input_buffer.size(), 0);
-
-  // Actual tensor content is required.
-  const size_t rows = data_shape[0];
-  const size_t cols = data_shape[1];
-  switch (elem_byte_size) {
-    case 1:
-      TransposeDataRank2<1>(rows, cols, input_buffer, transposed_data);
-      break;
-    case 2:
-      TransposeDataRank2<2>(rows, cols, input_buffer, transposed_data);
-      break;
-    case 4:
-      TransposeDataRank2<4>(rows, cols, input_buffer, transposed_data);
-      break;
-    case 8:
-      TransposeDataRank2<8>(rows, cols, input_buffer, transposed_data);
-      break;
-    default: {
-      const size_t output_cols = output_shape[1];
-      for (size_t row = 0; row < rows; ++row) {
-        for (size_t col = 0; col < cols; ++col) {
-          const size_t src_byte_index = (row * cols + col) * elem_byte_size;
-          const size_t dst_byte_index = (col * output_cols + row) * elem_byte_size;
-          assert(src_byte_index < input_buffer.size());
-          assert(dst_byte_index < transposed_data.size());
-          std::memcpy(&transposed_data[dst_byte_index], &input_buffer[src_byte_index], elem_byte_size);
-        }
-      }
-      break;
-    }
-  }
+  RETURN_IF_ERROR(TwoDimensionTranspose(rows, cols, elem_byte_size, input_buffer, transposed_data));
 
   data_shape = std::move(output_shape);  // Update parameter with final transposed shape
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -680,14 +680,14 @@ Ort::Status TwoDimensionTranspose(const std::vector<T>& data,
                                   /* out */ std::vector<T>& transposed_data,
                                   const Ort::Logger& logger,
                                   bool skip_output_data_copy = false) {
-  transposed_data.resize(data.size(), 0);
-
   if (skip_output_data_copy) {
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
-                "Only shape and dtype validation are required, so we can use dummy tensor to avoid heavy memcpy.");
+                "Skipping initializer data transpose during op validation.");
     return Ort::Status();
   }
+
+  transposed_data.resize(data.size(), 0);
 
   const size_t rows = data_shape[0];
   const size_t cols = data_shape[1];

--- a/onnxruntime/core/providers/qnn/builder/qnn_utils.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_utils.h
@@ -674,20 +674,28 @@ Ort::Status TwoDimensionTranspose(const QnnModelWrapper& qnn_model_wrapper,
                                   const Ort::Logger& logger,
                                   bool skip_output_data_copy = false);
 
+// Transposes a [rows, cols] buffer of `elem_byte_size`-wide elements into a [cols, rows] buffer.
+// Both buffers must hold exactly rows * cols * elem_byte_size bytes.
+Ort::Status TwoDimensionTranspose(size_t rows,
+                                  size_t cols,
+                                  size_t elem_byte_size,
+                                  gsl::span<const uint8_t> input_buffer,
+                                  gsl::span<uint8_t> output_buffer);
+
 template <typename T>
 Ort::Status TwoDimensionTranspose(const std::vector<T>& data,
                                   const std::vector<uint32_t>& data_shape,
                                   /* out */ std::vector<T>& transposed_data,
                                   const Ort::Logger& logger,
                                   bool skip_output_data_copy = false) {
+  transposed_data.resize(data.size(), 0);
+
   if (skip_output_data_copy) {
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
-                "Skipping initializer data transpose during op validation.");
+                "Only shape and dtype validation are required, so we can use dummy tensor to avoid heavy memcpy.");
     return Ort::Status();
   }
-
-  transposed_data.resize(data.size(), 0);
 
   const size_t rows = data_shape[0];
   const size_t cols = data_shape[1];

--- a/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_utils_test.cc
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gsl/gsl>
@@ -1099,6 +1100,84 @@ TEST(QnnUnit_UtilsTest, TransposeFromCnhwToHwcn_Raw_WrongRankFails) {
   std::vector<uint8_t> input(24, 0);
   std::vector<uint8_t> output(24);
   EXPECT_FALSE(qnn::utils::TransposeFromCnhwToHwcn(std::move(shape), 1, input, output).IsOK());
+}
+
+// =============================================================================
+// qnn::utils::TwoDimensionTranspose(raw)
+//
+// Element sizes 1/2/4/8 run a 32x32 tiled loop and everything else an untiled one, so the shape
+// sweeps below cover partial tiles in either dimension, single rows/columns, and multi-tile extents.
+// =============================================================================
+
+// Distinct byte pattern per element, so a misplaced element is visible in the comparison.
+static std::vector<uint8_t> MakeTransposeInput(size_t num_elems, size_t elem_byte_size) {
+  std::vector<uint8_t> input(num_elems * elem_byte_size);
+  for (size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<uint8_t>(i % 251);  // Prime modulus: no aliasing with any tile or row stride.
+  }
+  return input;
+}
+
+static std::vector<uint8_t> ReferenceTranspose2D(size_t rows, size_t cols, size_t elem_byte_size,
+                                                 const std::vector<uint8_t>& input) {
+  std::vector<uint8_t> expected(input.size());
+  for (size_t row = 0; row < rows; ++row) {
+    for (size_t col = 0; col < cols; ++col) {
+      std::memcpy(&expected[(col * rows + row) * elem_byte_size],
+                  &input[(row * cols + col) * elem_byte_size],
+                  elem_byte_size);
+    }
+  }
+  return expected;
+}
+
+TEST(QnnUnit_UtilsTest, TwoDimensionTranspose_Raw_HappyPath) {
+  // [2, 3] -> [3, 2], two bytes per element.
+  std::vector<uint8_t> input = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  std::vector<uint8_t> output(input.size());
+  Ort::Status st = qnn::utils::TwoDimensionTranspose(2, 3, /*elem_byte_size=*/2, input, output);
+  EXPECT_TRUE(st.IsOK());
+  EXPECT_EQ(output, (std::vector<uint8_t>{0, 1, 6, 7, 2, 3, 8, 9, 4, 5, 10, 11}));
+}
+
+TEST(QnnUnit_UtilsTest, TwoDimensionTranspose_Raw_TiledElementSizesAcrossTileBoundaries) {
+  // Empty, degenerate rank-2, just under / exactly one tile, a partial tile in one dimension only,
+  // and partial tiles in both dimensions across several tiles.
+  const std::vector<std::pair<size_t, size_t>> shapes = {
+      {0, 0}, {0, 5}, {5, 0}, {1, 1}, {1, 70}, {70, 1}, {31, 31}, {32, 32}, {33, 31}, {31, 33}, {65, 97}};
+
+  for (size_t elem_byte_size : {1u, 2u, 4u, 8u}) {
+    for (const auto& [rows, cols] : shapes) {
+      const std::vector<uint8_t> input = MakeTransposeInput(rows * cols, elem_byte_size);
+      std::vector<uint8_t> output(input.size());
+      Ort::Status st = qnn::utils::TwoDimensionTranspose(rows, cols, elem_byte_size, input, output);
+      EXPECT_TRUE(st.IsOK()) << "[" << rows << ", " << cols << "] x " << elem_byte_size << " bytes";
+      EXPECT_EQ(output, ReferenceTranspose2D(rows, cols, elem_byte_size, input))
+          << "[" << rows << ", " << cols << "] x " << elem_byte_size << " bytes";
+    }
+  }
+}
+
+TEST(QnnUnit_UtilsTest, TwoDimensionTranspose_Raw_UncommonElementSizesUseUntiledPath) {
+  for (size_t elem_byte_size : {3u, 5u, 6u, 7u, 16u}) {
+    const std::vector<uint8_t> input = MakeTransposeInput(33 * 35, elem_byte_size);
+    std::vector<uint8_t> output(input.size());
+    Ort::Status st = qnn::utils::TwoDimensionTranspose(33, 35, elem_byte_size, input, output);
+    EXPECT_TRUE(st.IsOK()) << elem_byte_size << " bytes per element";
+    EXPECT_EQ(output, ReferenceTranspose2D(33, 35, elem_byte_size, input))
+        << elem_byte_size << " bytes per element";
+  }
+}
+
+TEST(QnnUnit_UtilsTest, TwoDimensionTranspose_Raw_BufferSizeMismatchFails) {
+  const std::vector<uint8_t> input(2 * 3 * 4, 0);
+  std::vector<uint8_t> output(input.size());
+  EXPECT_TRUE(qnn::utils::TwoDimensionTranspose(2, 3, 4, input, output).IsOK());
+
+  std::vector<uint8_t> short_output(input.size() - 4);
+  EXPECT_FALSE(qnn::utils::TwoDimensionTranspose(2, 3, 4, input, short_output).IsOK());
+  EXPECT_FALSE(qnn::utils::TwoDimensionTranspose(3, 3, 4, input, output).IsOK());
+  EXPECT_FALSE(qnn::utils::TwoDimensionTranspose(2, 3, 0, input, output).IsOK());
 }
 
 // =============================================================================


### PR DESCRIPTION
### Description

Speed up ONNX-to-QNN lowering for 2-D initializer weights.

- Transpose common 1/2/4/8-byte element types in 32x32 cache tiles.
- Skip the initializer read and the transpose itself when only QNN op validation is needed. The output buffer is still allocated and zero-filled, because callers size their QNN static tensor from it.
- Keep the existing generic transpose path for uncommon element sizes.

### Motivation and Context

Large language-model weights made the scalar transpose loop a dominant part of QNN EP session creation. Op validation also read and transposed the same initializer data even though QNN only checks shape, dtype and quantization params there.

Measured results:

- LFM initializer transpose: 3.630 s -> 0.465 s (87.2% faster).
- LFM ComposeGraph: 73.2% faster.
- LFM session creation: 10.704 s -> 7.203 s (32.7% faster).
- Qwen validation optimization, measured incrementally on tetra18-linux: 9.98 s -> 9.13 s total (8.5% faster), with combined capability time reduced 20.8%.
