### PR TITLE
[QNN EP] Conditional Preserve dynamic MatMul UINT16

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmul_op_builder.cc
@@ -18,6 +18,16 @@ namespace onnxruntime {
 namespace qnn {
 
 namespace {
+bool ShouldUseSymmetricU16ForMatMul(float input1_scale) {
+  constexpr float kMaximumValueQuantError = 0.1f;
+
+  // Re-encoding U16 as U8 increases the value-domain quantization step from
+  // input1_scale to input1_scale * 65535 / 255. A value can move
+  // by at most half of that U8 step when it is rounded. Keep symmetric U16
+  // when that error exceeds the 10% value-domain budget.
+  const float u8_half_step = input1_scale * 65535.0f / 255.0f / 2.0f;
+  return u8_half_step > kMaximumValueQuantError;
+}
 // Detects a block-quantized MatMul weight (ONNX MatMul input[1]).
 // Accepts weight rank 2–4: shape [..., K, N] where any leading dims beyond K/N must equal 1
 // (i.e. reshapeable to [1, 1, K, N]). Per ONNX opset 21 the scale has the same rank as the
@@ -358,11 +368,12 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
   //                         |
   //     input_1_uint16 -----+
   //
-  // For dynamic weights, QNN graph that passes validation:
-  //     input_0_uint16 ---------------------------> MatMul ---> output_uint16
-  //                                                   ^
-  //                                                   |
-  //     input_1_uint16_asym --> Convert(uint16_sym) --+
+  // Dynamic asymmetric U16 input[1] uses the value-domain U16-to-U8 error gate:
+  //     input_0_uint16 ----------------------------------> MatMul ---> output_uint16
+  //                                                        ^
+  //                                                        |
+  //     input_1_uint16_low_error --> Convert(uint8_asym) -+
+  //     input_1_uint16_high_error --> Convert(uint16_sym) -+
   //
   // For static weights, QNN graph that passes validation:
   //     input_0_uint16 ---------------------> MatMul ---> output_uint16
@@ -388,15 +399,18 @@ Ort::Status MatMulOpBuilder::ProcessInputsForQnnMatMul(QnnModelWrapper& qnn_mode
       // QNN offsets negate ONNX zero points, so symmetric uint16 uses -32768.
       constexpr int32_t kSymmetricU16Offset = -32768;
       if (quant_param.scaleOffsetEncoding.offset != kSymmetricU16Offset) {
+        const bool use_symmetric_u16 =
+            ShouldUseSymmetricU16ForMatMul(quant_param.scaleOffsetEncoding.scale);
         RETURN_IF_ERROR(utils::InsertConvertOp(qnn_model_wrapper,
                                                convert_input_name,
                                                convert_output_name,
                                                input_info_1.qnn_data_type,
-                                               QNN_DATATYPE_UFIXED_POINT_16,
+                                               use_symmetric_u16 ? QNN_DATATYPE_UFIXED_POINT_16
+                                                                 : QNN_DATATYPE_UFIXED_POINT_8,
                                                quant_param.scaleOffsetEncoding.offset,
                                                quant_param.scaleOffsetEncoding.scale,
                                                input_1_shape,
-                                               true,  // symmetric
+                                               use_symmetric_u16,
                                                do_op_validation));
         input_names.push_back(convert_output_name);
       } else {

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -714,47 +714,82 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_dynamic_inputs) {
   }
 }
 
-TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_U16DynamicInput1_ConvertOnlyIfAsymmetric) {
-  namespace fs = std::filesystem;
-  struct TestCase {
-    const char* name;
-    float input1_min;
-    size_t expected_convert_count;
-  };
-
-  for (const TestCase& test_case : {TestCase{"symmetric", -0.1f, 0},
-                                    TestCase{"asymmetric", -0.05f, 1}}) {
-    SCOPED_TRACE(test_case.name);
-    const fs::path graph_dir = fs::temp_directory_path() /
-                               (std::string("MatMulOp_QDQ_U16DynamicInput1_") + test_case.name);
-    fs::remove_all(graph_dir);
-    ASSERT_TRUE(fs::create_directories(graph_dir));
-    auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
-
-    ProviderOptions provider_options;
-    provider_options["backend_type"] = "htp";
-    provider_options["offload_graph_io_quantization"] = "0";
-    provider_options["dump_json_qnn_graph"] = "1";
-    provider_options["json_qnn_graph_dir"] = graph_dir.string();
+static ProviderOptions GetQDQMatMulProviderOptions(const std::filesystem::path& graph_dir) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = graph_dir.string();
 #ifdef __linux__
-    provider_options["htp_arch"] = "73";
+  provider_options["htp_arch"] = "73";
 #endif
+  return provider_options;
+}
 
-    TestInputDef<float> input0_def({2, 3}, false, GetFloatDataInRange(-0.1f, 0.1f, 6));
-    TestInputDef<float> input1_def({3, 2}, false, GetFloatDataInRange(test_case.input1_min, 0.1f, 6));
-    ASSERT_EQ(GetTestInputQuantParams<uint16_t>(input1_def).IsSymmetric(),
-              test_case.expected_convert_count == 0);
+static void RunDynamicInput1QuantErrorTest(const char* test_name,
+                                           float input1_min,
+                                           float input1_max,
+                                           Qnn_DataType_t expected_convert_type,
+                                           size_t expected_convert_count = 1) {
+  namespace fs = std::filesystem;
+  const fs::path graph_dir = fs::temp_directory_path() /
+                             (std::string("MatMulOp_QDQ_U16DynamicInput1_") + test_name);
+  fs::remove_all(graph_dir);
+  ASSERT_TRUE(fs::create_directories(graph_dir));
+  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
 
-    TestQDQModelAccuracy(
-        BuildMatMulOpTestCase(input0_def, input1_def),
-        BuildMatMulOpQDQTestCase<uint16_t, uint16_t, uint16_t>(input0_def, input1_def, false),
-        provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
+  ProviderOptions provider_options = GetQDQMatMulProviderOptions(graph_dir);
 
-    if (::testing::Test::IsSkipped()) {
-      return;
-    }
-    AssertOpInQnnGraph(graph_dir, "Convert", test_case.expected_convert_count);
+  TestInputDef<float> input0_def({2, 3}, false, GetFloatDataInRange(-0.1f, 0.1f, 6));
+  TestInputDef<float> input1_def({3, 2}, false, GetFloatDataInRange(input1_min, input1_max, 6));
+
+  const auto f32_model = BuildMatMulOpTestCase(input0_def, input1_def);
+  const auto qdq_model = BuildMatMulOpQDQTestCase<uint16_t, uint16_t, uint16_t>(input0_def, input1_def, false);
+  TestQDQModelAccuracy(f32_model, qdq_model, provider_options, 21,
+                       ExpectedEPNodeAssignment::All, QDQTolerance());
+
+  if (::testing::Test::IsSkipped()) {
+    return;
   }
+  AssertOpInQnnGraph(graph_dir, "Convert", expected_convert_count);
+  if (expected_convert_count != 0) {
+    AssertConvertOutputDataType(graph_dir, expected_convert_type);
+  }
+}
+
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_U16DynamicInput1_LowQuantErrorUsesAsymmetricU8) {
+  RunDynamicInput1QuantErrorTest("low_error", 0.0f, 0.2f, QNN_DATATYPE_UFIXED_POINT_8);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_U16DynamicInput1_HighQuantErrorUsesSymmetricU16) {
+  RunDynamicInput1QuantErrorTest("high_error", 0.0f, 100.0f, QNN_DATATYPE_UFIXED_POINT_16);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_U16SymmetricDynamicInput1_PassesThrough) {
+  RunDynamicInput1QuantErrorTest("symmetric_input", -0.1f, 0.1f, QNN_DATATYPE_UFIXED_POINT_16,
+                                 /*expected_convert_count=*/0);
+}
+
+TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_NonU16Input1DoesNotUseU16ConversionGate) {
+  namespace fs = std::filesystem;
+  const fs::path graph_dir = fs::temp_directory_path() / "MatMulOp_QDQ_NonU16Input1";
+  fs::remove_all(graph_dir);
+  ASSERT_TRUE(fs::create_directories(graph_dir));
+  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
+
+  ProviderOptions provider_options = GetQDQMatMulProviderOptions(graph_dir);
+
+  TestInputDef<float> input0_def({2, 3}, false, GetFloatDataInRange(-0.1f, 0.1f, 6));
+  TestInputDef<float> input1_def({3, 2}, false, GetFloatDataInRange(0.0f, 100.0f, 6));
+  TestQDQModelAccuracy(
+      BuildMatMulOpTestCase(input0_def, input1_def),
+      BuildMatMulOpQDQTestCase<uint16_t, uint8_t, uint16_t>(input0_def, input1_def, false),
+      provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
+
+  if (::testing::Test::IsSkipped()) {
+    return;
+  }
+  AssertOpInQnnGraph(graph_dir, "Convert", 0);
 }
 
 // Tests MatMul with two uint16 (quantized) inputs with weight as static.
@@ -812,7 +847,6 @@ TEST_F(QnnHTPBackendTests, MatMulOp_QDQ_Regression_uint16_static_weight) {
         provider_options, 21, ExpectedEPNodeAssignment::All, QDQTolerance());
   }
 }
-
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 
 #if defined(__linux__)

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
@@ -99,6 +99,47 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
       << " occurrence(s), found " << actual_count << " in " << json_path;
 }
 
+void AssertConvertOutputDataType(const std::filesystem::path& dump_dir,
+                                 uint32_t expected_data_type) {
+  std::filesystem::path json_path;
+  ASSERT_TRUE(FindQnnJsonGraph(dump_dir, json_path))
+      << "No QNN JSON graph file found in " << dump_dir;
+
+  nlohmann::json root;
+  ASSERT_TRUE(ParseQnnJsonGraph(json_path, root))
+      << "Failed to parse QNN JSON graph: " << json_path;
+  ASSERT_TRUE(root.is_object() && root.contains("graph") && root["graph"].is_object() &&
+              root["graph"].contains("nodes") && root["graph"]["nodes"].is_object() &&
+              root["graph"].contains("tensors") && root["graph"]["tensors"].is_object())
+      << "JSON missing 'graph.nodes' or 'graph.tensors' object in: " << json_path;
+
+  const auto& nodes = root["graph"]["nodes"];
+  const auto& tensors = root["graph"]["tensors"];
+  const nlohmann::json* convert = nullptr;
+  try {
+    for (const auto& [node_name, node] : nodes.items()) {
+      if (node.is_object() && node.contains("type") && node["type"].is_string() &&
+          node["type"].get<std::string>() == "Convert") {
+        ASSERT_EQ(convert, nullptr) << "Expected one Convert node, found more than one";
+        convert = &node;
+      }
+    }
+  } catch (const std::exception& ex) {
+    FAIL() << "Failed to iterate QNN graph nodes in " << json_path << ": " << ex.what();
+  }
+
+  ASSERT_NE(convert, nullptr) << "No Convert node found in " << json_path;
+  ASSERT_TRUE(convert->contains("output_names") && (*convert)["output_names"].is_array() &&
+              (*convert)["output_names"].size() == 1 && (*convert)["output_names"][0].is_string())
+      << "Convert node has invalid output_names in " << json_path;
+  const std::string output_name = (*convert)["output_names"][0].get<std::string>();
+  ASSERT_TRUE(tensors.contains(output_name)) << "Convert output tensor not found: " << output_name;
+  ASSERT_TRUE(tensors[output_name].is_object() && tensors[output_name].contains("data_type"));
+  ASSERT_TRUE(tensors[output_name]["data_type"].is_number_unsigned());
+  EXPECT_EQ(tensors[output_name]["data_type"].get<uint32_t>(), expected_data_type)
+      << "Unexpected Convert output datatype in " << json_path;
+}
+
 void AssertNodeNotInQnnGraph(const std::filesystem::path& dump_dir,
                              const std::string& node_name) {
   std::filesystem::path json_path;

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <cstdint>
 #include <string>
 
 namespace onnxruntime {
@@ -16,6 +17,10 @@ namespace test {
 void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
                         const std::string& op,
                         size_t count = 1);
+
+// Checks the datatype of the tensor produced by the single Convert node.
+void AssertConvertOutputDataType(const std::filesystem::path& dump_dir,
+                                 uint32_t expected_data_type);
 
 // Asserts that a node with the exact `node_name` does not appear in
 // the compiled QNN graph JSON (root["graph"]["nodes"]).


### PR DESCRIPTION
## Motivation

Using symmetric U16 for MatMul can improve accuracy on some models. However, QA regression testing showed that applying this conversion to every dynamic MatMul can also cause regressions.

This change keeps the existing conversion as the default and uses a simple quantization-error metric to identify high-risk dynamic asymmetric-U16 MatMuls. Only those MatMuls are converted to symmetric U16; the remaining cases keep the existing path.

## Conversion policy

The existing dynamic-U16 eligibility checks are evaluated first. For an eligible asymmetric-U16 input1, estimate the maximum value-domain error from converting U16 to U8:

```text
max_rounding_error = input1_scale * (65535 / 255) / 2
```

If this value is greater than `0.1`, use the symmetric-U16 conversion. Otherwise, keep the existing asymmetric-U8 conversion.

The `0.1` threshold is the selected 10% acceptable value-domain quantization-error budget. Static weights, already-symmetric U16 inputs, and non-eligible MatMuls keep their existing behavior.