### PR TITLE
Support constant-only QNN graphs on the GPU

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/qnn_model.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_model.cc
@@ -879,7 +879,14 @@ Ort::Status QnnModel::SetupTensors(std::vector<QnnTensorInfo>& qnn_tensor_infos,
                                    const std::vector<QnnTensorWrapper>& tensor_wrappers,
                                    bool is_input) {
   size_t tensor_count = tensor_wrappers.size();
-  RETURN_IF(0 == tensor_count, "Zero tensor size!");
+  if (tensor_count == 0) {
+    RETURN_IF_NOT(is_input, "The count of graph outputs should be nonzero!");
+    RETURN_IF_NOT(IsGpuBackend(qnn_backend_manager_->GetQnnBackendType()),
+                  "Having zero graph inputs is not supported on this backend.");
+    qnn_tensor_infos.clear();
+    return Ort::Status();
+  }
+
   if (is_input) {
     auto input_count = graph_inputs_.indices.size();
     RETURN_IF(input_count < tensor_count, "The count of graph inputs should be at least the count of tensor_wrapper!");

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -3629,6 +3629,23 @@ TEST_F(QnnGPUBackendTests, import_memory_inference_output_input) {
   CloseHandle(d3d12buffer_shared_handle);
 }
 
+// Test that the QNN EP can execute a graph with no runtime inputs if using the GPU backend.
+TEST_F(QnnGPUBackendTests, ConstantOnlyGraph) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "gpu";
+
+  // Float16 Abs with a constant tensor is not folded by ORT Core because it has no CPU kernel.
+  RunQnnModelTest(
+      BuildOpTestCase<Ort::Float16_t>(
+          "abs_node", "Abs",
+          {TestInputDef<Ort::Float16_t>({6}, true,
+                                         {Ort::Float16_t(-3.0f), Ort::Float16_t(-2.0f), Ort::Float16_t(-1.0f),
+                                          Ort::Float16_t(0.0f), Ort::Float16_t(1.0f), Ort::Float16_t(2.0f)})},
+          {}, {}),
+      provider_options,
+      13,
+      EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(0.001f)});
+}
 #endif  // defined(_WIN32) && defined(_M_ARM64) && !BUILD_QNN_EP_STATIC_LIB
 
 // ============================ QNN EP input graph dump ============================

--- a/onnxruntime/test/providers/qnn/qnn_basic_test.cc
+++ b/onnxruntime/test/providers/qnn/qnn_basic_test.cc
@@ -3639,8 +3639,8 @@ TEST_F(QnnGPUBackendTests, ConstantOnlyGraph) {
       BuildOpTestCase<Ort::Float16_t>(
           "abs_node", "Abs",
           {TestInputDef<Ort::Float16_t>({6}, true,
-                                         {Ort::Float16_t(-3.0f), Ort::Float16_t(-2.0f), Ort::Float16_t(-1.0f),
-                                          Ort::Float16_t(0.0f), Ort::Float16_t(1.0f), Ort::Float16_t(2.0f)})},
+                                        {Ort::Float16_t(-3.0f), Ort::Float16_t(-2.0f), Ort::Float16_t(-1.0f),
+                                         Ort::Float16_t(0.0f), Ort::Float16_t(1.0f), Ort::Float16_t(2.0f)})},
           {}, {}),
       provider_options,
       13,


### PR DESCRIPTION
* Allow QNN models with zero runtime inputs when using the GPU backend.
* This fixes QNN EP rejecting simple graphs when the ORT Core `ConstantFolding` graph transformer does not activate. The GPU backend is able to handle these graphs, but this does not seem to be supported on HTP or QNN CPU currently.
* Fixes multiple WebNN conformance failures on the GPU.

