### PR TITLE
[QNN EP] Add reused_io_limit_mb and io_memory_estimation feature

### DIFF
--- a/docs/execution_providers/QNN-ExecutionProvider.md
+++ b/docs/execution_providers/QNN-ExecutionProvider.md
@@ -321,6 +321,15 @@ For more information, see the [Parallel Graph Preparation](#parallel-graph-prepa
 
 **Note:** `htp_share_resource_optimization` and `enable_vtcm_backup_buffer_sharing` both enable the same underlying feature. Prefer `htp_share_resource_optimization`.
 
+|`"io_memory_estimation"`|Description|
+|---|---|
+|'0'|Default. Disabled.|
+|'1'|Enable HTP I/O memory estimation during context-binary loading. May increase peak RAM during context initialization, but sustained RAM is unaffected. Requires QNN API version >= 2.35.|
+
+|`"reused_io_limit_mb"`|Description|
+|---|---|
+|Unsigned integer|Default `0` leaves the QAIRT default behavior unchanged. When nonzero, sets the HTP reused I/O buffer limit in MB for context-binary loading. Requires `io_memory_estimation=1` to take effect (auto-enabled if not set). Requires QNN API version >= 2.35.|
+
 |`"disable_file_mapped_weights"`|Description|
 |---|---|
 |'0'|Default. File-mapped weights enabled (when supported).|

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.cc
@@ -1284,7 +1284,8 @@ Ort::Status QnnBackendManager::ReadContextBinIfValid(const std::string& context_
 
 Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
     std::unordered_map<std::string, std::unique_ptr<std::vector<std::string>>>& context_bin_map,
-    const qnn::EpContextIoDispatch& io_dispatch) {
+    const qnn::EpContextIoDispatch& io_dispatch,
+    const HtpContextConfigs_t& htp_context_configs) {
 #if QNN_API_VERSION_MAJOR == 2 && (QNN_API_VERSION_MINOR >= 26)
   QnnContext_Config_t context_config_resource_sharing = QNN_CONTEXT_CONFIG_INIT;
   QnnHtpContext_CustomConfig_t resource_sharing_custom_config;
@@ -1308,10 +1309,33 @@ Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
   custom_config.weightSharingEnabled = true;
   context_config_weight_sharing.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
   context_config_weight_sharing.customConfig = &custom_config;
+
+#if QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 35
+  QnnContext_Config_t io_memory_estimation_config = QNN_CONTEXT_CONFIG_INIT;
+  QnnHtpContext_CustomConfig_t io_memory_estimation_custom_config = QNN_HTP_CONTEXT_CUSTOM_CONFIG_INIT;
+  if (htp_context_configs.enable_io_memory_estimation) {
+    io_memory_estimation_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_IO_MEM_ESTIMATION;
+    io_memory_estimation_custom_config.ioMemEstimation = true;
+    io_memory_estimation_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+    io_memory_estimation_config.customConfig = &io_memory_estimation_custom_config;
+  }
+
+  QnnContext_Config_t reused_io_limit_config = QNN_CONTEXT_CONFIG_INIT;
+  QnnHtpContext_CustomConfig_t reused_io_limit_custom_config = QNN_HTP_CONTEXT_CUSTOM_CONFIG_INIT;
+  if (htp_context_configs.reused_io_limit_mb > 0) {
+    reused_io_limit_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REUSED_IO_LIMIT;
+    reused_io_limit_custom_config.reusedIoLimitMb = htp_context_configs.reused_io_limit_mb;
+    reused_io_limit_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+    reused_io_limit_config.customConfig = &reused_io_limit_custom_config;
+  }
+#else
+  ORT_UNUSED_PARAMETER(htp_context_configs);
+#endif
 #else
   ORT_CXX_LOG_PTR(logger_ptr_,
                   ORT_LOGGING_LEVEL_WARNING,
                   "Called CreateContextVtcmBackupBufferSharingEnabled() but QNN API version is older than 2.26!");
+  ORT_UNUSED_PARAMETER(htp_context_configs);
 #endif
   QnnContext_Config_t context_priority_config = QNN_CONTEXT_CONFIG_INIT;
   RETURN_IF_ERROR(SetQnnContextConfig(context_priority_, context_priority_config));
@@ -1322,6 +1346,14 @@ Ort::Status QnnBackendManager::CreateContextVtcmBackupBufferSharingEnabled(
   configs_vec.push_back(&context_config_resource_sharing);
   configs_vec.push_back(&resource_sharing_opt_type_config);
   configs_vec.push_back(&context_config_weight_sharing);
+#if QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 35
+  if (htp_context_configs.enable_io_memory_estimation) {
+    configs_vec.push_back(&io_memory_estimation_config);
+  }
+  if (htp_context_configs.reused_io_limit_mb > 0) {
+    configs_vec.push_back(&reused_io_limit_config);
+  }
+#endif
 #endif
   configs_vec.push_back(nullptr);
 
@@ -1836,7 +1868,41 @@ Ort::Status QnnBackendManager::LoadCachedQnnContextFromBuffer(
                     ORT_LOGGING_LEVEL_VERBOSE,
                     ("Max spill fill buffer size: " + std::to_string(max_spill_fill_size)).c_str());
 
-    const QnnContext_Config_t* context_configs[] = {&qnn_context_config, spill_fill_config_pointer, nullptr};
+#if QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 35)
+    QnnContext_Config_t io_memory_estimation_config = QNN_CONTEXT_CONFIG_INIT;
+    QnnHtpContext_CustomConfig_t io_memory_estimation_custom_config = QNN_HTP_CONTEXT_CUSTOM_CONFIG_INIT;
+    if (htp_context_configs_.enable_io_memory_estimation) {
+      io_memory_estimation_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_IO_MEM_ESTIMATION;
+      io_memory_estimation_custom_config.ioMemEstimation = true;
+      io_memory_estimation_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+      io_memory_estimation_config.customConfig = &io_memory_estimation_custom_config;
+    }
+
+    QnnContext_Config_t reused_io_limit_config = QNN_CONTEXT_CONFIG_INIT;
+    QnnHtpContext_CustomConfig_t reused_io_limit_custom_config = QNN_HTP_CONTEXT_CUSTOM_CONFIG_INIT;
+    if (htp_context_configs_.reused_io_limit_mb > 0) {
+      reused_io_limit_custom_config.option = QNN_HTP_CONTEXT_CONFIG_OPTION_REUSED_IO_LIMIT;
+      reused_io_limit_custom_config.reusedIoLimitMb = htp_context_configs_.reused_io_limit_mb;
+      reused_io_limit_config.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+      reused_io_limit_config.customConfig = &reused_io_limit_custom_config;
+    }
+#endif
+
+    std::vector<const QnnContext_Config_t*> context_configs_vec;
+    context_configs_vec.push_back(&qnn_context_config);
+    if (spill_fill_config_pointer != nullptr) {
+      context_configs_vec.push_back(spill_fill_config_pointer);
+    }
+#if QNN_API_VERSION_MAJOR > 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR >= 35)
+    if (htp_context_configs_.enable_io_memory_estimation) {
+      context_configs_vec.push_back(&io_memory_estimation_config);
+    }
+    if (htp_context_configs_.reused_io_limit_mb > 0) {
+      context_configs_vec.push_back(&reused_io_limit_config);
+    }
+#endif
+    context_configs_vec.push_back(nullptr);
+    const QnnContext_Config_t** context_configs = context_configs_vec.data();
 
     RETURN_IF(nullptr == qnn_interface_.contextCreateFromBinary,
               "Invalid function pointer for contextCreateFromBinary.");
@@ -1962,8 +2028,10 @@ Ort::Status QnnBackendManager::SetupBackend(
     const qnn::EpContextIoDispatch& io_dispatch,
     bool enable_htp_extended_udma_mode,
     bool enable_htp_prepare_only,
-    bool enable_htp_graph_splitting) {
+    bool enable_htp_graph_splitting,
+    const HtpContextConfigs_t& htp_context_configs) {
   std::lock_guard<std::recursive_mutex> lock(logger_recursive_mutex_);
+  htp_context_configs_ = htp_context_configs;
   if (backend_setup_completed_) {
     ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Backend setup already!");
 
@@ -1983,7 +2051,8 @@ Ort::Status QnnBackendManager::SetupBackend(
       if (first_mapping_it == ep_context_handle_map_.end()) {
         ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Creating context for new set of context binaries");
         return CreateContextVtcmBackupBufferSharingEnabled(context_bin_map,
-                                                           io_dispatch);
+                                                           io_dispatch,
+                                                           htp_context_configs_);
       }
 
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "Mapping contexts to new EP main context nodes");
@@ -2002,7 +2071,6 @@ Ort::Status QnnBackendManager::SetupBackend(
   }
 
   htp_share_resource_optimization_ = htp_share_resource_optimization;
-
   auto status = Ort::Status();
   if (!qnn_serializer_config_) {
     status = LoadBackend();
@@ -2132,12 +2200,13 @@ Ort::Status QnnBackendManager::SetupBackend(
   if (status.IsOK() && (htp_share_resource_optimization_ == 1 || !load_from_cached_context)) {
     status = htp_share_resource_optimization_ == 1
                  ? CreateContextVtcmBackupBufferSharingEnabled(context_bin_map,
-                                                               io_dispatch)
+                                                               io_dispatch,
+                                                               htp_context_configs_)
                  : CreateContext(enable_htp_weight_sharing,
-                                 enable_htp_extended_udma_mode,
-                                 enable_htp_prepare_only,
-                                 false /*enable_htp_ref_weight_sharing*/,
-                                 enable_htp_graph_splitting);
+                                  enable_htp_extended_udma_mode,
+                                  enable_htp_prepare_only,
+                                  false /*enable_htp_ref_weight_sharing*/,
+                                  enable_htp_graph_splitting);
 
     if (status.IsOK()) {
       ORT_CXX_LOG_PTR(logger_ptr_, ORT_LOGGING_LEVEL_VERBOSE, "CreateContext succeed.");

--- a/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_backend_manager.h
@@ -233,7 +233,8 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
       const qnn::EpContextIoDispatch& io_dispatch = qnn::EpContextIoDispatch(nullptr),
       bool enable_htp_extended_udma_mode = false,
       bool enable_htp_prepare_only = false,
-      bool enable_htp_graph_splitting = false);
+      bool enable_htp_graph_splitting = false,
+      const HtpContextConfigs_t& htp_context_configs = {});
 
   // Below functions are especially for multi-SoC EP context scenarios.
   Ort::Status SetupBackendExceptDeviceAndContext();
@@ -499,8 +500,9 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   Ort::Status GetFileSizeIfValid(const std::string& filepath, size_t& file_size);
 
   Ort::Status CreateContextVtcmBackupBufferSharingEnabled(std::unordered_map<std::string,
-                                                                             std::unique_ptr<std::vector<std::string>>>& context_bin_map,
-                                                          const qnn::EpContextIoDispatch& io_dispatch);
+                                                                              std::unique_ptr<std::vector<std::string>>>& context_bin_map,
+                                                          const qnn::EpContextIoDispatch& io_dispatch,
+                                                          const HtpContextConfigs_t& htp_context_configs = {});
 
   Ort::Status CreateContextFromListAsync(const QnnContext_Config_t** configs,
                                          std::unordered_map<std::string,
@@ -780,6 +782,7 @@ class QnnBackendManager : public std::enable_shared_from_this<QnnBackendManager>
   bool backend_setup_completed_ = false;
   bool backend_partial_setup_completed_ = false;  // For SetupBackendExceptDeviceAndContext and SetupDeviceAndContext.
   int htp_share_resource_optimization_ = -1;
+  HtpContextConfigs_t htp_context_configs_;
 
   uint32_t backend_id_ = QNN_BACKEND_ID_CPU;
   Qnn_Version_t core_api_version_ = QNN_VERSION_INIT;

--- a/onnxruntime/core/providers/qnn/builder/qnn_def.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_def.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <climits>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -165,6 +166,12 @@ typedef struct HtpGraphConfigs {
   bool enable_htp_monolithic_lstm = false;
   bool enable_htp_fp16_clamp_overflow = false;  // Intentionally undocumented; for internal/diagnostic use only.
 } HtpGraphConfigs_t;
+
+// Define context configs used by HTP backend.
+typedef struct HtpContextConfigs {
+  bool enable_io_memory_estimation = false;
+  uint64_t reused_io_limit_mb = 0;
+} HtpContextConfigs_t;
 
 enum class QnnBackendType : uint8_t {
   CPU = 0,

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -346,44 +346,6 @@ static bool ParseBoolOption(const OrtApi& ort_api,
   return result;
 }
 
-static uint64_t ParseUint64Option(const OrtApi& ort_api,
-                                  const OrtSessionOptions& session_options,
-                                  const std::string& key,
-                                  uint64_t default_value,
-                                  const Ort::Logger& logger) {
-  uint64_t result = default_value;
-  std::string value_str;
-  GetSessionConfigEntryOrDefault(ort_api, session_options, key, std::to_string(default_value), value_str);
-
-  if (!value_str.empty()) {
-    try {
-      size_t parsed_chars = 0;
-      if (value_str.front() == '-') {
-        throw std::invalid_argument("negative value");
-      }
-      uint64_t parsed_value = std::stoull(value_str, &parsed_chars);
-      if (parsed_chars == value_str.size()) {
-        result = parsed_value;
-      } else {
-        ORT_CXX_LOG(logger,
-                    ORT_LOGGING_LEVEL_VERBOSE,
-                    ("Invalid value for " + key + " (" + value_str + "). Only unsigned integers allowed.").c_str());
-      }
-    } catch (const std::invalid_argument& /*ex*/) {
-      ORT_CXX_LOG(logger,
-                  ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Invalid value for " + key + " (" + value_str + "). Only unsigned integers allowed.").c_str());
-    } catch (const std::out_of_range& /*ex*/) {
-      ORT_CXX_LOG(logger,
-                  ORT_LOGGING_LEVEL_VERBOSE,
-                  ("Invalid value for " + key + " (" + value_str + "). Value is out of range.").c_str());
-    }
-  }
-
-  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("User specified " + key + ": " + std::to_string(result)).c_str());
-  return result;
-}
-
 // Creates `dir` (and any missing parents) and verifies it is writable by
 // round-tripping a small probe file. Returns true on success. On failure,
 // logs a WARNING tagged with `feature_name` so callers can disable the
@@ -1396,11 +1358,19 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                                      FormatEPConfigKey("io_memory_estimation"),
                                                                      false,
                                                                      logger_);
-  htp_context_configs_.reused_io_limit_mb = ParseUint64Option(ort_api,
-                                                              session_options_,
-                                                              FormatEPConfigKey("reused_io_limit_mb"),
-                                                              0,
-                                                              logger_);
+  std::string reused_io_limit_mb_str;
+  GetSessionConfigEntryOrDefault(ort_api, session_options_, FormatEPConfigKey("reused_io_limit_mb"), "0",
+                                 reused_io_limit_mb_str);
+  if (!reused_io_limit_mb_str.empty() && reused_io_limit_mb_str != "0") {
+    try {
+      htp_context_configs_.reused_io_limit_mb = std::stoull(reused_io_limit_mb_str);
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_VERBOSE,
+                  ("reused_io_limit_mb: " + reused_io_limit_mb_str).c_str());
+    } catch (const std::exception& /*ex*/) {
+      ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                  ("Ignoring malformed reused_io_limit_mb, expecting a positive integer: " + reused_io_limit_mb_str).c_str());
+    }
+  }
 
   if (htp_context_configs_.reused_io_limit_mb > 0 && !htp_context_configs_.enable_io_memory_estimation) {
     htp_context_configs_.enable_io_memory_estimation = true;

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.cc
@@ -346,6 +346,44 @@ static bool ParseBoolOption(const OrtApi& ort_api,
   return result;
 }
 
+static uint64_t ParseUint64Option(const OrtApi& ort_api,
+                                  const OrtSessionOptions& session_options,
+                                  const std::string& key,
+                                  uint64_t default_value,
+                                  const Ort::Logger& logger) {
+  uint64_t result = default_value;
+  std::string value_str;
+  GetSessionConfigEntryOrDefault(ort_api, session_options, key, std::to_string(default_value), value_str);
+
+  if (!value_str.empty()) {
+    try {
+      size_t parsed_chars = 0;
+      if (value_str.front() == '-') {
+        throw std::invalid_argument("negative value");
+      }
+      uint64_t parsed_value = std::stoull(value_str, &parsed_chars);
+      if (parsed_chars == value_str.size()) {
+        result = parsed_value;
+      } else {
+        ORT_CXX_LOG(logger,
+                    ORT_LOGGING_LEVEL_VERBOSE,
+                    ("Invalid value for " + key + " (" + value_str + "). Only unsigned integers allowed.").c_str());
+      }
+    } catch (const std::invalid_argument& /*ex*/) {
+      ORT_CXX_LOG(logger,
+                  ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Invalid value for " + key + " (" + value_str + "). Only unsigned integers allowed.").c_str());
+    } catch (const std::out_of_range& /*ex*/) {
+      ORT_CXX_LOG(logger,
+                  ORT_LOGGING_LEVEL_VERBOSE,
+                  ("Invalid value for " + key + " (" + value_str + "). Value is out of range.").c_str());
+    }
+  }
+
+  ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE, ("User specified " + key + ": " + std::to_string(result)).c_str());
+  return result;
+}
+
 // Creates `dir` (and any missing parents) and verifies it is writable by
 // round-tripping a small probe file. Returns true on success. On failure,
 // logs a WARNING tagged with `feature_name` so callers can disable the
@@ -1353,6 +1391,31 @@ QnnEp::QnnEp(QnnEpFactory& factory,
                                                    false,
                                                    logger_);
 
+  htp_context_configs_.enable_io_memory_estimation = ParseBoolOption(ort_api,
+                                                                     session_options_,
+                                                                     FormatEPConfigKey("io_memory_estimation"),
+                                                                     false,
+                                                                     logger_);
+  htp_context_configs_.reused_io_limit_mb = ParseUint64Option(ort_api,
+                                                              session_options_,
+                                                              FormatEPConfigKey("reused_io_limit_mb"),
+                                                              0,
+                                                              logger_);
+
+  if (htp_context_configs_.reused_io_limit_mb > 0 && !htp_context_configs_.enable_io_memory_estimation) {
+    htp_context_configs_.enable_io_memory_estimation = true;
+    ORT_CXX_LOG(logger_, ORT_LOGGING_LEVEL_WARNING,
+                "reused_io_limit_mb requires io_memory_estimation=1 to take effect. Auto-enabling io_memory_estimation.");
+  }
+
+#if QNN_API_VERSION_MAJOR < 2 || (QNN_API_VERSION_MAJOR == 2 && QNN_API_VERSION_MINOR < 35)
+  if (htp_context_configs_.enable_io_memory_estimation || htp_context_configs_.reused_io_limit_mb > 0) {
+    ORT_CXX_LOG(logger_,
+                ORT_LOGGING_LEVEL_WARNING,
+                "io_memory_estimation and reused_io_limit_mb require QNN API version >= 2.35. Ignoring.");
+  }
+#endif
+
   // HTP Graph Splitting (Graph Program Executor). Requires QAIRT SDK 2.49+ at runtime.
   // Supported in both JIT and AOT workflows.
   enable_htp_graph_splitting_ = ParseBoolOption(ort_api,
@@ -2152,7 +2215,8 @@ OrtStatus* ORT_API_CALL QnnEp::GetCapabilityImpl(OrtEp* this_ptr,
                                                 *ep->io_dispatch_,
                                                 ep->enable_htp_extended_udma_mode_,
                                                 ep->prepare_only_,
-                                                ep->enable_htp_graph_splitting_);
+                                                ep->enable_htp_graph_splitting_,
+                                                ep->htp_context_configs_);
   } else {
     rt = ep->qnn_backend_manager_->SetupBackendExceptDeviceAndContext();
   }

--- a/onnxruntime/core/providers/qnn/qnn_execution_provider.h
+++ b/onnxruntime/core/providers/qnn/qnn_execution_provider.h
@@ -255,6 +255,7 @@ class QnnEp : public OrtEp, public ApiPtrs {
   uint32_t dynamic_rpc_polling_time_ = 0;
   qnn::ModelSettings model_settings_ = {};
   qnn::HtpGraphConfigs_t htp_graph_configs_;
+  qnn::HtpContextConfigs_t htp_context_configs_;
 
   bool dump_json_qnn_graph_ = false;
   std::string json_qnn_graph_dir_ = "";

--- a/onnxruntime/test/providers/qnn/unit/qnn_execution_provider_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_execution_provider_test.cc
@@ -783,28 +783,6 @@ TEST_F(QnnUnit_ExecutionProviderTest, Ctor_IoMemoryEstimationTrue_Succeeds) {
                "User specified ep.qnnexecutionprovider.io_memory_estimation: 1");
 }
 
-TEST_F(QnnUnit_ExecutionProviderTest, Ctor_ReusedIoLimitMbValid_Succeeds) {
-  EpStubContext ctx;
-  ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
-  ctx.session_config[EPKey("reused_io_limit_mb")] = "100";
-  auto factory = MakeFactory(ctx);
-
-  EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); });
-  ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
-               "User specified ep.qnnexecutionprovider.reused_io_limit_mb: 100");
-}
-
-TEST_F(QnnUnit_ExecutionProviderTest, Ctor_ReusedIoLimitMbInvalid_LogsVerbose) {
-  EpStubContext ctx;
-  ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
-  ctx.session_config[EPKey("reused_io_limit_mb")] = "-1";
-  auto factory = MakeFactory(ctx);
-
-  EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); });
-  ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
-               "Invalid value for ep.qnnexecutionprovider.reused_io_limit_mb");
-}
-
 // IR backend path AND dump enabled → "IR  backend path" info log in InitQnnSerializerConfig.
 TEST_F(QnnUnit_ExecutionProviderTest, Ctor_IrBackendPathWithDumpEnabled_LogsInfo) {
   EpStubContext ctx;

--- a/onnxruntime/test/providers/qnn/unit/qnn_execution_provider_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qnn_execution_provider_test.cc
@@ -772,6 +772,39 @@ TEST_F(QnnUnit_ExecutionProviderTest, Ctor_BoolOptionInvalidValue_LogsVerbose) {
                "Invalid value for ep.qnnexecutionprovider.offload_graph_io_quantization");
 }
 
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_IoMemoryEstimationTrue_Succeeds) {
+  EpStubContext ctx;
+  ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+  ctx.session_config[EPKey("io_memory_estimation")] = "1";
+  auto factory = MakeFactory(ctx);
+
+  EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); });
+  ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
+               "User specified ep.qnnexecutionprovider.io_memory_estimation: 1");
+}
+
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_ReusedIoLimitMbValid_Succeeds) {
+  EpStubContext ctx;
+  ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+  ctx.session_config[EPKey("reused_io_limit_mb")] = "100";
+  auto factory = MakeFactory(ctx);
+
+  EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); });
+  ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
+               "User specified ep.qnnexecutionprovider.reused_io_limit_mb: 100");
+}
+
+TEST_F(QnnUnit_ExecutionProviderTest, Ctor_ReusedIoLimitMbInvalid_LogsVerbose) {
+  EpStubContext ctx;
+  ctx.log_severity = ORT_LOGGING_LEVEL_VERBOSE;
+  ctx.session_config[EPKey("reused_io_limit_mb")] = "-1";
+  auto factory = MakeFactory(ctx);
+
+  EXPECT_NO_THROW({ auto ep = MakeEp(*factory, ctx); });
+  ExpectLogged(ctx, ORT_LOGGING_LEVEL_VERBOSE,
+               "Invalid value for ep.qnnexecutionprovider.reused_io_limit_mb");
+}
+
 // IR backend path AND dump enabled → "IR  backend path" info log in InitQnnSerializerConfig.
 TEST_F(QnnUnit_ExecutionProviderTest, Ctor_IrBackendPathWithDumpEnabled_LogsInfo) {
   EpStubContext ctx;


### PR DESCRIPTION
### Description
- exposes two HTP context config options for context-binary loading
- io_memory_estimation: enables HTP I/O memory estimation path
- reused_io_limit_mb: sets reused I/O buffer limit hint in MB



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


