### PR TITLE
[QNN EP] Wire prepare_app/run_app encryption sample apps into build

### DIFF
--- a/cmake/onnxruntime_unittests.cmake
+++ b/cmake/onnxruntime_unittests.cmake
@@ -469,6 +469,32 @@ endif()
     endif()
 
     set_target_properties(ep_weight_sharing_ctx_gen PROPERTIES FOLDER "ONNXRuntimeTest")
+
+    # Compiled-model-encryption prepare/run sample apps
+    set(qnn_enc_apps_src_dir ${TEST_SRC_DIR}/qnn_ep_context_encryption_apps)
+
+    onnxruntime_add_executable(prepare_app
+      ${qnn_enc_apps_src_dir}/prepare_app.cc
+      ${qnn_enc_apps_src_dir}/enc_common.h)
+    target_include_directories(prepare_app PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDES} ${qnn_enc_apps_src_dir})
+
+    onnxruntime_add_executable(run_app
+      ${qnn_enc_apps_src_dir}/run_app.cc
+      ${qnn_enc_apps_src_dir}/enc_common.h)
+    target_include_directories(run_app PRIVATE ${ONNXRUNTIME_APPLICATION_INCLUDES} ${qnn_enc_apps_src_dir})
+
+    if (onnxruntime_BUILD_SHARED_LIB)
+      set(qnn_enc_apps_libs onnxruntime ${onnxruntime_EXTERNAL_LIBRARIES})
+      target_link_libraries(prepare_app PRIVATE ${qnn_enc_apps_libs})
+      target_link_libraries(run_app PRIVATE ${qnn_enc_apps_libs})
+    else()
+      set(qnn_enc_apps_libs onnxruntime_session ${onnxruntime_test_providers_libs} ${onnxruntime_EXTERNAL_LIBRARIES})
+      target_link_libraries(prepare_app PRIVATE ${qnn_enc_apps_libs})
+      target_link_libraries(run_app PRIVATE ${qnn_enc_apps_libs})
+    endif()
+
+    set_target_properties(prepare_app PROPERTIES FOLDER "ONNXRuntimeTest")
+    set_target_properties(run_app PROPERTIES FOLDER "ONNXRuntimeTest")
   endif()
 
   #some ETW tools

--- a/onnxruntime/test/qnn_ep_context_encryption_apps/enc_common.h
+++ b/onnxruntime/test/qnn_ep_context_encryption_apps/enc_common.h
@@ -1,0 +1,238 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// Shared helpers for prepare_app.cc and run_app.cc.
+//
+// Example only: the cipher is a single-byte XOR, just to make the write/read
+// callback mechanism obvious. Swap WriteCb/ReadCb in prepare_app.cc/run_app.cc
+// for your own encryption to use this for real.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "onnxruntime_cxx_api.h"
+
+#if ORT_API_VERSION >= 28
+#include "onnxruntime_experimental_c_api.h"
+#include "onnxruntime_experimental_cxx_api.h"
+#endif
+
+namespace encapp {
+
+// Default XOR key. Both apps must agree; overridable on the command line.
+constexpr uint8_t kDefaultKey = 0x5A;
+
+// The registration name the QNN EP is published under.
+inline const char* QnnEpName() { return "QNNExecutionProvider"; }
+
+// Checks that onnxruntime.dll actually supports ORT_API_VERSION (1.28+),
+// before any Ort C++ call that would dereference a null API pointer on an
+// older runtime. Call this first thing in main().
+inline bool EnsureRuntimeApiAvailable() {
+  const OrtApiBase* base = OrtGetApiBase();
+  if (base == nullptr) {
+    std::fprintf(stderr,
+                 "[error] OrtGetApiBase() returned null — onnxruntime.dll is missing or "
+                 "corrupt.\n");
+    return false;
+  }
+  if (base->GetApi(ORT_API_VERSION) == nullptr) {
+    const char* ver = (base->GetVersionString != nullptr) ? base->GetVersionString() : "<unknown>";
+    std::fprintf(stderr,
+                 "[error] This build requires ORT API version %d (ONNX Runtime 1.28+), but the "
+                 "loaded onnxruntime.dll only reports version \"%s\" and does not provide it.\n"
+                 "        The EPContext encryption callbacks are a 1.28 feature. Replace "
+                 "onnxruntime.dll (and onnxruntime_providers_shared.dll) with a 1.28+ build.\n",
+                 static_cast<int>(ORT_API_VERSION), ver);
+    return false;
+  }
+  return true;
+}
+
+// XOR a buffer in place.
+inline void XorInPlace(uint8_t* data, size_t n, uint8_t key) {
+  for (size_t i = 0; i < n; ++i) data[i] ^= key;
+}
+
+// ---------------------------------------------------------------------------
+// Real-input / answer-output support
+//
+// Both apps can optionally run on a real float32 input and dump their output
+// to a flat .raw file — prepare_app from the plaintext model, run_app from
+// the decrypted context model. Comparing the two is left to a separate tool
+// (compare_answers.py); neither app judges pass/fail on its own output.
+// ---------------------------------------------------------------------------
+
+// Read a whole file as raw bytes.
+inline bool ReadFileBytes(const char* path, std::vector<uint8_t>& out) {
+  std::ifstream in(path, std::ios::binary | std::ios::ate);
+  if (!in.good()) {
+    std::fprintf(stderr, "[error] cannot open file: %s\n", path);
+    return false;
+  }
+  const auto size = static_cast<size_t>(in.tellg());
+  in.seekg(0);
+  out.resize(size);
+  if (size > 0 && !in.read(reinterpret_cast<char*>(out.data()),
+                           static_cast<std::streamsize>(size))) {
+    std::fprintf(stderr, "[error] failed reading file: %s\n", path);
+    return false;
+  }
+  return true;
+}
+
+// Load a flat float32 .raw file into `out`.
+inline bool ReadFloatRaw(const char* path, std::vector<float>& out) {
+  std::vector<uint8_t> bytes;
+  if (!ReadFileBytes(path, bytes)) return false;
+  if (bytes.empty() || (bytes.size() % sizeof(float)) != 0) {
+    std::fprintf(stderr,
+                 "[error] %s is %zu bytes — not a whole number of float32 values.\n",
+                 path, bytes.size());
+    return false;
+  }
+  out.resize(bytes.size() / sizeof(float));
+  std::memcpy(out.data(), bytes.data(), bytes.size());
+  return true;
+}
+
+// Write a float32 vector as a flat .raw file.
+inline bool WriteFloatRaw(const char* path, const std::vector<float>& v) {
+  std::ofstream o(path, std::ios::binary);
+  if (!o.is_open()) {
+    std::fprintf(stderr, "[error] cannot open for write: %s\n", path);
+    return false;
+  }
+  o.write(reinterpret_cast<const char*>(v.data()),
+          static_cast<std::streamsize>(v.size() * sizeof(float)));
+  if (!o) {
+    std::fprintf(stderr, "[error] failed writing: %s\n", path);
+    return false;
+  }
+  return true;
+}
+
+// Run `session` on a single float32 input loaded from `input_raw` and return
+// the first output as float32. Dynamic input dims are pinned to 1.
+inline bool RunWithFloatInput(Ort::Session& session,
+                              const char* input_raw_path,
+                              std::vector<float>& out_values) {
+  std::vector<float> input_data;
+  if (!ReadFloatRaw(input_raw_path, input_data)) return false;
+
+  Ort::AllocatorWithDefaultOptions allocator;
+  if (session.GetInputCount() != 1 || session.GetOutputCount() < 1) {
+    std::fprintf(stderr,
+                 "[error] expected a single-input model with at least one output, got "
+                 "%zu input(s) / %zu output(s).\n",
+                 session.GetInputCount(), session.GetOutputCount());
+    return false;
+  }
+
+  Ort::AllocatedStringPtr in_name = session.GetInputNameAllocated(0, allocator);
+  Ort::AllocatedStringPtr out_name = session.GetOutputNameAllocated(0, allocator);
+
+  Ort::TypeInfo ti = session.GetInputTypeInfo(0);
+  auto tsi = ti.GetTensorTypeAndShapeInfo();
+  if (tsi.GetElementType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    std::fprintf(stderr,
+                 "[error] model input 0 is not float32 — this app's real-input path "
+                 "supports float32 input models only.\n");
+    return false;
+  }
+  std::vector<int64_t> shape = tsi.GetShape();
+  size_t expected = 1;
+  for (auto& d : shape) {
+    if (d < 0) d = 1;  // pin dynamic dims to 1
+    expected *= static_cast<size_t>(d);
+  }
+  if (expected != input_data.size()) {
+    std::fprintf(stderr,
+                 "[error] %s holds %zu float(s) but model input 0 needs %zu.\n",
+                 input_raw_path, input_data.size(), expected);
+    return false;
+  }
+
+  Ort::MemoryInfo mem_info("Cpu", OrtDeviceAllocator, 0, OrtMemTypeDefault);
+  std::vector<Ort::Value> inputs;
+  inputs.push_back(Ort::Value::CreateTensor(mem_info, input_data.data(), input_data.size(),
+                                            shape.data(), shape.size()));
+  const char* in_names[] = {in_name.get()};
+  const char* out_names[] = {out_name.get()};
+  std::vector<Ort::Value> outputs =
+      session.Run(Ort::RunOptions{nullptr}, in_names, inputs.data(), 1, out_names, 1);
+
+  if (outputs.empty() || !outputs[0].IsTensor()) {
+    std::fprintf(stderr, "[error] model produced no output tensor.\n");
+    return false;
+  }
+  auto oi = outputs[0].GetTensorTypeAndShapeInfo();
+  if (oi.GetElementType() != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+    std::fprintf(stderr, "[error] model output 0 is not float32.\n");
+    return false;
+  }
+  const float* data = outputs[0].GetTensorData<float>();
+  const size_t n = oi.GetElementCount();
+  out_values.assign(data, data + n);
+  return true;
+}
+
+// Appends the QNN EP (HTP/NPU device if present) to `session_options`.
+// Assumes the plugin library is already registered on `env`.
+// Returns true if an NPU (HTP) device was selected, false if it fell back to
+// a compile-only CPU device.
+inline bool AppendQnnEp(Ort::Env& env,
+                        Ort::SessionOptions& session_options,
+                        const std::unordered_map<std::string, std::string>& ep_options) {
+  std::vector<Ort::ConstEpDevice> all = env.GetEpDevices();
+  size_t chosen = SIZE_MAX;
+  size_t npu = SIZE_MAX;
+  for (size_t i = 0; i < all.size(); ++i) {
+    if (std::string(all[i].EpName()) != QnnEpName()) continue;
+    if (chosen == SIZE_MAX) chosen = i;
+    if (all[i].Device().Type() == OrtHardwareDeviceType_NPU) npu = i;
+  }
+  size_t target = (npu != SIZE_MAX) ? npu : chosen;
+  if (target == SIZE_MAX) {
+    throw std::runtime_error("QNN EP registered but no matching Ep device was found");
+  }
+
+  if (npu != SIZE_MAX) {
+    std::fprintf(stderr, "[enc_common] Selected device: NPU (HTP) — hardware execution available\n");
+  } else {
+    std::fprintf(stderr,
+                 "[enc_common] Selected device: CPU (compile-only, no HTP hardware) — "
+                 "expected on x86_64 prepare hosts; run_app on this device would fail\n");
+  }
+
+  std::vector<Ort::ConstEpDevice> devices{all[target]};
+  session_options.AppendExecutionProvider_V2(env, devices, ep_options);
+  return npu != SIZE_MAX;
+}
+
+// Registers the QNN EP plugin library on `env` (once per process) and appends
+// it to `session_options`. Returns true if an NPU (HTP) device was selected.
+inline bool RegisterAndAppendQnnEp(Ort::Env& env,
+                                   Ort::SessionOptions& session_options,
+                                   const std::unordered_map<std::string, std::string>& ep_options) {
+  static bool registered = false;
+  if (!registered) {
+#if defined(_WIN32)
+    const std::basic_string<ORTCHAR_T> library_path = ORT_TSTR("onnxruntime_providers_qnn.dll");
+#else
+    const std::basic_string<ORTCHAR_T> library_path = ORT_TSTR("libonnxruntime_providers_qnn.so");
+#endif
+    env.RegisterExecutionProviderLibrary(QnnEpName(), library_path);
+    registered = true;
+  }
+  return AppendQnnEp(env, session_options, ep_options);
+}
+
+}  // namespace encapp

--- a/onnxruntime/test/qnn_ep_context_encryption_apps/encryption_test.py
+++ b/onnxruntime/test/qnn_ep_context_encryption_apps/encryption_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: MIT
+#
+# Drives the full prepare_app -> run_app round trip and reports PASS/FAIL.
+#
+# Runs prepare_app (compile + encrypt, dumps answer_prepare.raw from the
+# plaintext model) then run_app (decrypt + run, dumps answer_run.raw from the
+# decrypted context model), then compares the two answer files itself.
+#
+# Usage:
+#   python encryption_test.py <prepare_app.exe> <run_app.exe> <input_model.onnx>
+#                              <input.raw> [--xor-key 5a] [--tol 1e-3]
+#                              [--workdir DIR] [--htp-arch ARCH]
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+DEFAULT_ABS_TOL = 1e-3
+DEFAULT_XOR_KEY = "5a"
+
+
+def run_app(args, label):
+    print(f"[encryption_test] running: {' '.join(str(a) for a in args)}")
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        print(f"[encryption_test] FAIL: {label} exited with code {result.returncode}", file=sys.stderr)
+        return False
+    return True
+
+
+def compare_raw(path_a, path_b, tol):
+    a = np.fromfile(path_a, dtype=np.float32)
+    b = np.fromfile(path_b, dtype=np.float32)
+
+    if a.size != b.size:
+        print(
+            f"[encryption_test] FAIL: size mismatch: {path_a} has {a.size} value(s), {path_b} has {b.size} value(s).",
+            file=sys.stderr,
+        )
+        return False
+
+    finite = np.isfinite(a) & np.isfinite(b)
+    if not finite.all():
+        bad = np.flatnonzero(~finite)[:5]
+        for i in bad:
+            print(f"[encryption_test] FAIL: non-finite value at index {i}: a={a[i]}, b={b[i]}", file=sys.stderr)
+        return False
+
+    abs_diff = np.abs(a - b)
+    max_abs_diff = float(abs_diff.max()) if abs_diff.size else 0.0
+    bad_mask = abs_diff > tol
+    bad_count = int(bad_mask.sum())
+
+    if bad_count > 0:
+        bad_idx = np.flatnonzero(bad_mask)[:5]
+        for i in bad_idx:
+            print(
+                f"[encryption_test] FAIL: mismatch at index {i}: a={a[i]}, b={b[i]} (|diff|={abs_diff[i]} > {tol})",
+                file=sys.stderr,
+            )
+        print(
+            f"[encryption_test] FAIL: {bad_count} of {a.size} value(s) outside tolerance {tol} "
+            f"(max |diff| = {max_abs_diff})",
+            file=sys.stderr,
+        )
+        return False
+
+    print(f"[encryption_test] PASS: {a.size} value(s) within {tol} (max |diff| = {max_abs_diff})")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("prepare_app", help="path to prepare_app(.exe)")
+    parser.add_argument("run_app", help="path to run_app(.exe)")
+    parser.add_argument("input_model", help="ONNX model prepare_app compiles (e.g. a QDQ model)")
+    parser.add_argument("input_raw", help="float32 .raw input fed to both the plaintext and decrypted model")
+    parser.add_argument("--xor-key", default=DEFAULT_XOR_KEY, help="1-byte XOR key in hex (default 5a)")
+    parser.add_argument("--tol", type=float, default=DEFAULT_ABS_TOL, help="max allowed abs diff")
+    parser.add_argument("--workdir", default=".", help="directory for intermediate/output files")
+    parser.add_argument("--htp-arch", default=None, help="optional target HTP arch passed to prepare_app")
+    args = parser.parse_args()
+
+    workdir = Path(args.workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    ctx_model = workdir / "enc_ctx.onnx"
+    cipher_bin = workdir / "enc_cipher.bin"
+    answer_prepare = workdir / "answer_prepare.raw"
+    answer_run = workdir / "answer_run.raw"
+
+    prepare_cmd = [
+        args.prepare_app,
+        args.input_model,
+        str(ctx_model),
+        str(cipher_bin),
+        args.xor_key,
+        args.input_raw,
+        str(answer_prepare),
+    ]
+    if args.htp_arch:
+        prepare_cmd.append(args.htp_arch)
+    if not run_app(prepare_cmd, "prepare_app"):
+        return 1
+
+    run_cmd = [args.run_app, str(ctx_model), str(cipher_bin), args.xor_key, args.input_raw, str(answer_run)]
+    if not run_app(run_cmd, "run_app"):
+        return 1
+
+    if not compare_raw(answer_prepare, answer_run, args.tol):
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/onnxruntime/test/qnn_ep_context_encryption_apps/prepare_app.cc
+++ b/onnxruntime/test/qnn_ep_context_encryption_apps/prepare_app.cc
@@ -1,0 +1,246 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// prepare_app — "Prepare" stage of the compiled-model-encryption example.
+//
+// Compiles an ONNX model with the QNN EP (embed_mode=0) and registers a write
+// callback (ORT 1.28 EPContext API) that encrypts the external _qnn.bin
+// instead of letting ORT write it as plaintext.
+//
+// This is an EXAMPLE: WriteCb below just XORs the bytes, to keep the callback
+// mechanism obvious. Replace WriteCb with your own encryption to use this for
+// real — everything else (how ORT hands you the bytes) stays the same.
+//
+// Usage:
+//   prepare_app <input_model.onnx> <output_ctx.onnx> <output_cipher.bin> [xor_key_hex]
+//               [input.raw answer_prepare.raw] [htp_arch]
+//
+//   input_model.onnx     a model QNN EP can offload to HTP (e.g. a QDQ model)
+//   output_ctx.onnx      the compiled EPContext wrapper model ORT writes
+//   output_cipher.bin    where the write callback stores the encrypted _qnn.bin
+//   xor_key_hex          optional 1-byte key in hex (default 5a)
+//   input.raw            optional float32 input; when given, the plaintext model
+//                        runs once on it and writes answer_prepare.raw
+//   answer_prepare.raw   where to write that plaintext-model output (float32)
+//   htp_arch             optional target HTP arch (81/73) for cross-platform
+//                        compile on a host with no real HTP device
+//
+// Whether the decrypted-model output (from run_app) matches answer_prepare.raw
+// is not checked by this app — see compare_answers.py.
+//
+// Exit code 0 on success; non-zero with a message on failure.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+#include "enc_common.h"
+
+#if ORT_API_VERSION >= 28
+
+namespace {
+
+// State handed to the write callback via the opaque void* state pointer.
+struct WriteState {
+  uint8_t key = encapp::kDefaultKey;
+  std::ofstream out;
+  size_t total = 0;
+  bool io_error = false;
+};
+
+// OrtWriteNamedBufferFunc: (state, file_name, buffer, size) -> OrtStatus*.
+// Example cipher: XOR the EPContext bytes and append to the cipher file.
+// Replace this body with your own encryption. Returning non-null fails the
+// compile (fail-closed).
+OrtStatus* WriteCb(void* state, const char* file_name,
+                   const void* buffer, size_t n) noexcept {
+  auto* s = static_cast<WriteState*>(state);
+  const auto* src = static_cast<const uint8_t*>(buffer);
+  std::vector<uint8_t> enc(n);
+  for (size_t i = 0; i < n; ++i) enc[i] = src[i] ^ s->key;
+  s->out.write(reinterpret_cast<const char*>(enc.data()),
+               static_cast<std::streamsize>(n));
+  if (!s->out) {
+    s->io_error = true;
+    return Ort::GetApi().CreateStatus(ORT_FAIL, "prepare_app: failed writing cipher file");
+  }
+  s->total += n;
+  std::fprintf(stderr, "[prepare] write callback fired for \"%s\": %zu bytes\n",
+               file_name ? file_name : "<null>", n);
+  return nullptr;
+}
+
+// Parse a 1-byte hex key like "5a" / "0x5A".
+uint8_t ParseKey(const char* arg) {
+  if (arg == nullptr) return encapp::kDefaultKey;
+  const char* p = arg;
+  if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) p += 2;
+  return static_cast<uint8_t>(std::strtoul(p, nullptr, 16) & 0xFF);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 4) {
+    std::fprintf(stderr,
+                 "usage: %s <input_model.onnx> <output_ctx.onnx> <output_cipher.bin> [xor_key_hex]"
+                 " [input.raw answer_prepare.raw] [htp_arch]\n",
+                 argv[0]);
+    return 2;
+  }
+  const char* input_model = argv[1];
+  const std::string output_ctx = argv[2];
+  const char* output_cipher = argv[3];
+  const uint8_t key = ParseKey(argc >= 5 ? argv[4] : nullptr);
+  // Optional real-input / answer-output pair. Both or neither.
+  const char* input_raw = (argc >= 7) ? argv[5] : nullptr;
+  const char* answer_raw = (argc >= 7) ? argv[6] : nullptr;
+  if ((argc == 6) || (argc > 8)) {
+    std::fprintf(stderr,
+                 "[error] input.raw and answer_prepare.raw must be given together (got %d arg(s)).\n",
+                 argc - 1);
+    return 2;
+  }
+  // Optional target HTP arch for cross-platform compile (see usage comment above).
+  const char* htp_arch = (argc == 8) ? argv[7] : nullptr;
+
+  // Fail fast if the loaded runtime doesn't support ORT_API_VERSION — must run
+  // before Ort::GetApi(), which would otherwise dereference null on <1.28.
+  if (!encapp::EnsureRuntimeApiAvailable()) return 1;
+
+  const OrtApi& c_api = Ort::GetApi();
+
+  try {
+    Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "prepare_app");
+    Ort::SessionOptions session_options;
+
+    std::unordered_map<std::string, std::string> ep_options;
+    ep_options["backend_type"] = "htp";
+    // Target arch when this host has no real HTP device to auto-detect from.
+    if (htp_arch != nullptr) {
+      ep_options["htp_arch"] = htp_arch;
+    }
+    encapp::RegisterAndAppendQnnEp(env, session_options, ep_options);
+
+    // Optional: run the plaintext model once and save its output. Whether
+    // this matches run_app's decrypted-path output is checked separately by
+    // compare_answers.py, not by this app.
+    if (input_raw != nullptr) {
+      std::fprintf(stderr, "[prepare] running plaintext model on \"%s\"\n", input_raw);
+      Ort::SessionOptions plain_options;
+      encapp::RegisterAndAppendQnnEp(env, plain_options, ep_options);
+#if defined(_WIN32)
+      std::wstring model_w(input_model, input_model + std::strlen(input_model));
+      Ort::Session plain_session(env, model_w.c_str(), plain_options);
+#else
+      Ort::Session plain_session(env, input_model, plain_options);
+#endif
+      std::vector<float> answer;
+      if (!encapp::RunWithFloatInput(plain_session, input_raw, answer)) {
+        env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+        return 1;
+      }
+      if (!encapp::WriteFloatRaw(answer_raw, answer)) {
+        env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+        return 1;
+      }
+      std::fprintf(stdout, "[prepare] answer written: %zu float value(s) -> \"%s\"\n",
+                   answer.size(), answer_raw);
+    }
+
+    WriteState ws;
+    ws.key = key;
+    ws.out.open(output_cipher, std::ios::binary);
+    if (!ws.out.is_open()) {
+      std::fprintf(stderr, "[error] cannot open cipher output file: %s\n", output_cipher);
+      env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+      return 1;
+    }
+
+    Ort::ModelCompilationOptions compile_options(env, session_options);
+
+    // embed_mode=0 → external _qnn.bin, which the write callback intercepts.
+#if defined(_WIN32)
+    std::wstring input_model_w(input_model, input_model + std::strlen(input_model));
+    std::wstring output_ctx_w(output_ctx.begin(), output_ctx.end());
+    const ORTCHAR_T* input_model_p = input_model_w.c_str();
+    const ORTCHAR_T* output_ctx_p = output_ctx_w.c_str();
+#else
+    const ORTCHAR_T* input_model_p = input_model;
+    const ORTCHAR_T* output_ctx_p = output_ctx.c_str();
+#endif
+
+    compile_options.SetInputModelPath(input_model_p);
+    compile_options.SetEpContextEmbedMode(false);
+    compile_options.SetOutputModelPath(output_ctx_p);
+    compile_options.SetGraphOptimizationLevel(ORT_ENABLE_BASIC);
+
+    // Resolve and register the write callback (ORT 1.28 experimental API).
+    auto* set_fn =
+        Ort::Experimental::Get_OrtCompileApi_ModelCompilationOptions_SetEpContextDataWriteFunc_SinceV28_Fn(&c_api);
+    if (set_fn == nullptr) {
+      std::fprintf(stderr,
+                   "[error] SetEpContextDataWriteFunc_SinceV28 not available — "
+                   "ORT runtime is older than 1.28.\n");
+      ws.out.close();
+      env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+      return 1;
+    }
+    if (auto* st = set_fn(compile_options, WriteCb, &ws)) {
+      c_api.ReleaseStatus(st);
+      std::fprintf(stderr, "[error] SetEpContextDataWriteFunc returned non-OK\n");
+      ws.out.close();
+      env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+      return 1;
+    }
+
+    Ort::Status cs = Ort::CompileModel(env, compile_options);
+    ws.out.close();
+
+    if (!cs.IsOK()) {
+      std::fprintf(stderr, "[error] CompileModel failed: %s\n", cs.GetErrorMessage().c_str());
+      env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+      return 1;
+    }
+    if (ws.io_error) {
+      std::fprintf(stderr, "[error] cipher file write error during compile\n");
+      env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+      return 1;
+    }
+    if (ws.total == 0) {
+      std::fprintf(stderr,
+                   "[error] write callback never fired — the model was not offloaded "
+                   "to QNN HTP (no _qnn.bin produced). Use a model QNN can compile.\n");
+      env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+      return 1;
+    }
+
+    std::fprintf(stdout,
+                 "[prepare] OK: compiled \"%s\" -> ctx \"%s\", encrypted %zu bytes -> \"%s\" (key=0x%02x)\n",
+                 input_model, output_ctx.c_str(), ws.total, output_cipher, key);
+
+    env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+    return 0;
+  } catch (const Ort::Exception& e) {
+    std::fprintf(stderr, "[error] Ort exception: %s\n", e.what());
+    return 1;
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "[error] exception: %s\n", e.what());
+    return 1;
+  }
+}
+
+#else  // ORT_API_VERSION < 28
+
+int main(int, char**) {
+  std::fprintf(stderr,
+               "[error] prepare_app requires ORT_API_VERSION >= 28 (ONNX Runtime 1.28+); "
+               "this build was compiled against API version %d.\n",
+               static_cast<int>(ORT_API_VERSION));
+  return 1;
+}
+
+#endif  // ORT_API_VERSION >= 28

--- a/onnxruntime/test/qnn_ep_context_encryption_apps/run_app.cc
+++ b/onnxruntime/test/qnn_ep_context_encryption_apps/run_app.cc
@@ -1,0 +1,311 @@
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MIT
+//
+// run_app — "Run" stage of the compiled-model-encryption example.
+//
+// Loads a compiled EPContext model (from prepare_app) and registers a read
+// callback (ORT 1.28 EPContext API) that decrypts the cipher file and hands
+// the plaintext back to the QNN EP, which runs inference. ARM64 only.
+//
+// This is an EXAMPLE: ReadCb below just XORs the bytes, to keep the callback
+// mechanism obvious. Replace ReadCb with your own decryption (matching
+// whatever WriteCb in prepare_app.cc used) to use this for real.
+//
+// Usage:
+//   run_app <ctx_model.onnx> <cipher.bin> [xor_key_hex] [input.raw answer_run.raw]
+//
+//   ctx_model.onnx     the EPContext wrapper model prepare_app wrote
+//   cipher.bin         the encrypted _qnn.bin prepare_app produced
+//   xor_key_hex        optional 1-byte key in hex (default 5a); must match prepare
+//   input.raw          optional float32 input (same one passed to prepare_app)
+//   answer_run.raw     where to write the decrypted-model output (float32)
+//
+// This app only verifies the decrypt+load+run path; it does not check the
+// output against prepare_app's answer. Use compare_answers.py for that.
+//
+// Exit 0 on success.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "enc_common.h"
+
+#if ORT_API_VERSION >= 28
+
+namespace {
+
+struct ReadState {
+  uint8_t key = encapp::kDefaultKey;
+  std::string cipher_path;
+  int call_count = 0;
+  size_t bytes_returned = 0;
+};
+
+// OrtReadNamedBufferFunc: (state, file_name, allocator, out_buf, out_size).
+// Example cipher: read the ciphertext, XOR-decrypt into an allocator-owned
+// buffer, and return it. Replace this body with your own decryption.
+OrtStatus* ReadCb(void* state, const char* file_name, OrtAllocator* allocator,
+                  void** buffer, size_t* data_size) noexcept {
+  auto* s = static_cast<ReadState*>(state);
+  s->call_count++;
+  const OrtApi& c_api = Ort::GetApi();
+
+  std::ifstream in(s->cipher_path, std::ios::binary | std::ios::ate);
+  if (!in.good()) return c_api.CreateStatus(ORT_FAIL, "run_app: cipher file missing");
+  const auto sz = static_cast<size_t>(in.tellg());
+  if (sz == 0) return c_api.CreateStatus(ORT_FAIL, "run_app: cipher file empty");
+  in.seekg(0);
+
+  void* mem = allocator->Alloc(allocator, sz);
+  if (mem == nullptr) return c_api.CreateStatus(ORT_FAIL, "run_app: allocator failed");
+  in.read(static_cast<char*>(mem), static_cast<std::streamsize>(sz));
+  if (!in) {
+    allocator->Free(allocator, mem);
+    return c_api.CreateStatus(ORT_FAIL, "run_app: cipher read failed");
+  }
+
+  encapp::XorInPlace(static_cast<uint8_t*>(mem), sz, s->key);
+  *buffer = mem;
+  *data_size = sz;
+  s->bytes_returned = sz;
+  std::fprintf(stderr, "[run] read callback fired for \"%s\": decrypted %zu bytes\n",
+               file_name ? file_name : "<null>", sz);
+  return nullptr;
+}
+
+uint8_t ParseKey(const char* arg) {
+  if (arg == nullptr) return encapp::kDefaultKey;
+  const char* p = arg;
+  if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) p += 2;
+  return static_cast<uint8_t>(std::strtoul(p, nullptr, 16) & 0xFF);
+}
+
+// Byte size of one element of the given tensor type (numeric types only).
+size_t ElemSize(ONNXTensorElementDataType t) {
+  switch (t) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8:
+      return 1;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      return 2;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32:
+      return 4;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64:
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    std::fprintf(stderr,
+                 "usage: %s <ctx_model.onnx> <cipher.bin> [xor_key_hex] [input.raw answer_run.raw]\n",
+                 argv[0]);
+    return 2;
+  }
+  const std::string ctx_model = argv[1];
+  const char* cipher_path = argv[2];
+  const uint8_t key = ParseKey(argc >= 4 ? argv[3] : nullptr);
+  // Optional real-input / answer-output pair. Both or neither.
+  const char* input_raw = (argc >= 6) ? argv[4] : nullptr;
+  const char* answer_raw = (argc >= 6) ? argv[5] : nullptr;
+  if ((argc == 5) || (argc > 6)) {
+    std::fprintf(stderr,
+                 "[error] input.raw and answer_run.raw must be given together (got %d arg(s)).\n",
+                 argc - 1);
+    return 2;
+  }
+
+  // Fail fast if the loaded runtime doesn't support ORT_API_VERSION — must run
+  // before Ort::GetApi(), which would otherwise dereference null on <1.28.
+  if (!encapp::EnsureRuntimeApiAvailable()) return 1;
+
+  const OrtApi& c_api = Ort::GetApi();
+
+  try {
+    Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "run_app");
+
+    // Everything touching the QNN EP plugin library (SessionOptions, Session,
+    // and every Ort::Value from it) must be destroyed before
+    // env.UnregisterExecutionProviderLibrary() unloads it below — hence this
+    // nested scope, which closes before that call.
+    int rs_call_count = 0;
+    size_t rs_bytes_returned = 0;
+    size_t num_outputs_returned = 0;
+    {
+      Ort::SessionOptions session_options;
+      std::unordered_map<std::string, std::string> ep_options;
+      ep_options["backend_type"] = "htp";
+      const bool has_htp = encapp::RegisterAndAppendQnnEp(env, session_options, ep_options);
+
+      // Fail fast if there's no real HTP device — run_app only works on ARM64.
+      if (!has_htp) {
+        std::fprintf(stderr,
+                     "[error] no HTP (NPU) device available — run_app requires real QNN HTP "
+                     "hardware and only runs on ARM64. This host reports a compile-only CPU "
+                     "device (expected on x86_64); use prepare_app there instead.\n");
+        env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+        return 1;
+      }
+
+      ReadState rs;
+      rs.key = key;
+      rs.cipher_path = cipher_path;
+
+      auto* set_fn =
+          Ort::Experimental::Get_OrtApi_SessionOptions_SetEpContextDataReadFunc_SinceV28_Fn(&c_api);
+      if (set_fn == nullptr) {
+        std::fprintf(stderr,
+                     "[error] SetEpContextDataReadFunc_SinceV28 not available — "
+                     "ORT runtime is older than 1.28.\n");
+        env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+        return 1;
+      }
+      if (auto* st = set_fn(session_options, ReadCb, &rs)) {
+        c_api.ReleaseStatus(st);
+        std::fprintf(stderr, "[error] SetEpContextDataReadFunc returned non-OK\n");
+        env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+        return 1;
+      }
+
+#if defined(_WIN32)
+      std::wstring ctx_w(ctx_model.begin(), ctx_model.end());
+      Ort::Session session(env, ctx_w.c_str(), session_options);
+#else
+      Ort::Session session(env, ctx_model.c_str(), session_options);
+#endif
+
+      if (rs.call_count == 0) {
+        std::fprintf(stderr,
+                     "[error] read callback never fired — the model may not have an "
+                     "external _qnn.bin, or file mapping bypassed the callback.\n");
+        env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+        return 1;
+      }
+
+      // With input.raw/answer_run.raw: run on that input and dump the output
+      // for a separate tool to compare. Without: run on zeroed inputs (only
+      // checks decrypt+load+run works).
+      if (input_raw != nullptr) {
+        std::vector<float> actual;
+        if (!encapp::RunWithFloatInput(session, input_raw, actual)) {
+          env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+          return 1;
+        }
+        if (!encapp::WriteFloatRaw(answer_raw, actual)) {
+          env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+          return 1;
+        }
+
+        rs_call_count = rs.call_count;
+        rs_bytes_returned = rs.bytes_returned;
+        num_outputs_returned = 1;
+
+        std::fprintf(stdout,
+                     "[run] OK: read callback fired %d time(s), decrypted %zu bytes "
+                     "(key=0x%02x)\n",
+                     rs_call_count, rs_bytes_returned, key);
+
+        const size_t show = actual.size() < 5 ? actual.size() : 5;
+        std::fprintf(stdout, "[run] first %zu output value(s):", show);
+        for (size_t i = 0; i < show; ++i) std::fprintf(stdout, " %g", actual[i]);
+        std::fprintf(stdout, "\n");
+        std::fprintf(stdout, "[run] answer written: %zu float value(s) -> \"%s\"\n",
+                     actual.size(), answer_raw);
+      } else {
+        // No answer to write — just prove the decrypted context binary loads
+        // and runs.
+        Ort::AllocatorWithDefaultOptions allocator;
+        const size_t num_inputs = session.GetInputCount();
+        const size_t num_outputs = session.GetOutputCount();
+
+        std::vector<std::string> input_name_storage;
+        std::vector<Ort::Value> input_values;
+        for (size_t i = 0; i < num_inputs; ++i) {
+          Ort::AllocatedStringPtr name = session.GetInputNameAllocated(i, allocator);
+          input_name_storage.emplace_back(name.get());
+
+          Ort::TypeInfo ti = session.GetInputTypeInfo(i);
+          auto tsi = ti.GetTensorTypeAndShapeInfo();
+          std::vector<int64_t> shape = tsi.GetShape();
+          size_t count = 1;
+          for (auto& d : shape) {
+            if (d < 0) d = 1;  // pin dynamic dims to 1
+            count *= static_cast<size_t>(d);
+          }
+          const auto elem_type = tsi.GetElementType();
+
+          Ort::Value v = Ort::Value::CreateTensor(allocator, shape.data(), shape.size(), elem_type);
+          void* raw = v.GetTensorMutableRawData();
+          const size_t total_bytes = count * ElemSize(elem_type);
+          if (raw != nullptr && total_bytes > 0) std::memset(raw, 0, total_bytes);
+          input_values.emplace_back(std::move(v));
+        }
+        std::vector<const char*> input_names;
+        for (const auto& n : input_name_storage) input_names.push_back(n.c_str());
+
+        std::vector<std::string> output_name_storage;
+        for (size_t i = 0; i < num_outputs; ++i) {
+          Ort::AllocatedStringPtr name = session.GetOutputNameAllocated(i, allocator);
+          output_name_storage.emplace_back(name.get());
+        }
+        std::vector<const char*> output_names;
+        for (const auto& n : output_name_storage) output_names.push_back(n.c_str());
+
+        std::vector<Ort::Value> outputs =
+            session.Run(Ort::RunOptions{nullptr},
+                        input_names.data(), input_values.data(), input_values.size(),
+                        output_names.data(), output_names.size());
+
+        rs_call_count = rs.call_count;
+        rs_bytes_returned = rs.bytes_returned;
+        num_outputs_returned = outputs.size();
+
+        std::fprintf(stdout,
+                     "[run] OK: read callback fired %d time(s), decrypted %zu bytes; "
+                     "inference produced %zu output tensor(s) (key=0x%02x)\n",
+                     rs_call_count, rs_bytes_returned, num_outputs_returned, key);
+        std::fprintf(stdout,
+                     "[run] NOTE: ran with zeroed inputs — no answer file written. Pass "
+                     "input.raw + answer_run.raw to dump output for comparison.\n");
+      }
+      // session, outputs, input_values, session_options are destroyed here,
+      // while the QNN EP library is still loaded.
+    }
+
+    env.UnregisterExecutionProviderLibrary(encapp::QnnEpName());
+    return 0;
+  } catch (const Ort::Exception& e) {
+    std::fprintf(stderr, "[error] Ort exception: %s\n", e.what());
+    return 1;
+  } catch (const std::exception& e) {
+    std::fprintf(stderr, "[error] exception: %s\n", e.what());
+    return 1;
+  }
+}
+
+#else  // ORT_API_VERSION < 28
+
+int main(int, char**) {
+  std::fprintf(stderr,
+               "[error] run_app requires ORT_API_VERSION >= 28 (ONNX Runtime 1.28+); "
+               "this build was compiled against API version %d.\n",
+               static_cast<int>(ORT_API_VERSION));
+  return 1;
+}
+
+#endif  // ORT_API_VERSION >= 28


### PR DESCRIPTION
## Summary
- Adds `prepare_app`/`run_app` build targets (gated on `onnxruntime_USE_QNN`) so the EPContext binary encryption sample apps build automatically as part of the normal build, landing alongside `onnxruntime_provider_test.exe`.
- Adds `encryption_test.py`, which drives the full `prepare_app` -> `run_app` round trip and reports PASS/FAIL, replacing the golden-comparison logic that used to be embedded in `run_app`.

Goal: after a normal build, `prepare_app.exe`/`run_app.exe` are produced as testing artifacts, and the encryption round trip can be verified end-to-end via `encryption_test.py`.

Test:
Artifact already verify on v81 and v73 with script encryption_test.py