### PR TITLE
[QNN EP] Fix operator and node-group fusion conformance issues

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc
@@ -91,7 +91,7 @@ Ort::Status CastOpBuilder::ProcessExtraInputForNotEqual(QnnModelWrapper& qnn_mod
   }
 
   // Build additional static input with value 0.
-  const std::string& input_name = utils::UniqueNameGenerator().New(node_unit, "_notequal_zero");
+  const std::string input_name = node_unit.Name() + "_notequal_zero";
 
   Qnn_DataType_t qnn_data_type = QNN_DATATYPE_UNDEFINED;
   ONNXTensorElementDataType input_type = input.type;
@@ -193,8 +193,8 @@ Ort::Status CastOpBuilder::EmitSignAbsCastDecomposition(QnnModelWrapper& qnn_mod
                 "Cannot get shape for FP-to-Bool Cast input.");
 
   // 2. Reserve deterministic intermediate names so DLC inspection and context cache lookups stay stable.
-  const std::string sign_out_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_sign");
-  const std::string abs_out_name = utils::UniqueNameGenerator().New(node_unit, "_signabs_abs");
+  const std::string sign_out_name = node_unit.Name() + "_signabs_sign";
+  const std::string abs_out_name = node_unit.Name() + "_signabs_abs";
 
   // 3. Register the two NATIVE intermediates with the same shape/dtype as the Cast input.
   QnnTensorWrapper sign_out_wrapper(sign_out_name,

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc
@@ -204,7 +204,7 @@ Ort::Status GemmOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
       input_shape[0] = old_input_shape[1];
       input_shape[1] = old_input_shape[0];
       const std::string& node_input_name(input_name);
-      input_tensor_name = utils::UniqueNameGenerator().New(input_tensor_name, "_transpose");
+      input_tensor_name = input_tensor_name + "_transpose";
       std::vector<uint32_t> perm{1, 0};
       RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(node_unit.Index(), node_input_name, input_tensor_name,
                                                          old_input_shape, perm, input_shape,
@@ -291,7 +291,7 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
     if (trans_a != 0) {
       RETURN_IF_NOT(act_shape_2d.size() == 2, "QNN EP: BQ Gemm transA=1 requires a rank-2 activation");
       const std::vector<uint32_t> transposed_shape = {act_shape_2d[1], act_shape_2d[0]};
-      const std::string transposed_name = utils::UniqueNameGenerator().New(fp16_name, "_transpose");
+      const std::string transposed_name = fp16_name + "_transpose";
       RETURN_IF_ERROR(qnn_model_wrapper.AddTransposeNode(node_unit.Index(), fp16_name, transposed_name,
                                                          act_shape_2d, /*transpose_perm=*/{1u, 0u},
                                                          transposed_shape, QNN_DATATYPE_FLOAT_16,
@@ -397,7 +397,7 @@ Ort::Status GemmOpBuilder::ProcessInputsForBQGemm(QnnModelWrapper& qnn_model_wra
       bias_shape = {bias_shape[1]};
     }
 
-    const std::string fp16_bias_name = utils::UniqueNameGenerator().New(inputs[2].name, "_fp16");
+    const std::string fp16_bias_name = inputs[2].name + "_fp16";
     std::vector<uint8_t> fp16_bias_bytes(static_cast<size_t>(N) * sizeof(uint16_t));
 
     RETURN_IF_NOT(bias_info.qnn_data_type == QNN_DATATYPE_SFIXED_POINT_32,
@@ -515,7 +515,7 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     const bool final_is_graph_output = qnn_model_wrapper.IsGraphOutput(final_output_name);
 
     // FC intermediate tensor: rank-2 shape, same encoding as the final output.
-    const std::string fc_output_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(final_output_name, "_fc");
+    const std::string fc_output_name = final_output_name + "_fc";
     QnnTensorWrapper fc_out_wrapper(fc_output_name, QNN_TENSOR_TYPE_NATIVE, final_output_info.qnn_data_type,
                                     final_output_info.quant_param.Copy(), std::vector<uint32_t>(fc_output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fc_out_wrapper)),
@@ -569,7 +569,7 @@ Ort::Status GemmOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     std::vector<std::string> gemm_input_0_1;
     gemm_input_0_1.push_back(input_names[0]);
     gemm_input_0_1.push_back(input_names[1]);
-    const std::string fc_output_name = onnxruntime::qnn::utils::UniqueNameGenerator().New(org_output_name, "_fc");
+    const std::string fc_output_name = org_output_name + "_fc";
     QnnTensorWrapper fully_connected_output(fc_output_name, QNN_TENSOR_TYPE_NATIVE, input_info.qnn_data_type,
                                             QnnQuantParamsWrapper(), std::vector<uint32_t>(output_shape));
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(fully_connected_output)),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc
@@ -374,6 +374,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
       std::vector<uint8_t> quant_data, weight_data;
       Qnn_TensorType_t weight_tensor_type = qnn_model_wrapper.GetTensorType(weight_tensor_name);
       const OrtValueInfo* weight_tensor_proto = qnn_model_wrapper.GetConstantTensor(weight_tensor_name);
+      RETURN_IF_NOT(weight_tensor_proto != nullptr, "MatMulNBits weight must be a constant initializer.");
       std::vector<uint32_t> weight_shape = {};
       Qnn_DataType_t weight_datatype = QNN_DATATYPE_UNDEFINED;
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(weight_tensor_proto, quant_data, false));
@@ -382,6 +383,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
       // 2.2 Block-quantized scales.
       std::vector<uint8_t> per_block_uint8_scale;
       const OrtValueInfo* scale_tensor_proto = qnn_model_wrapper.GetConstantTensor(scales_tensor.name);
+      RETURN_IF_NOT(scale_tensor_proto != nullptr, "MatMulNBits scales must be a constant initializer.");
       RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(scale_tensor_proto, per_block_uint8_scale));
 
       const size_t elem_byte_size = utils::GetElementSizeByType(scales_tensor.type);
@@ -500,6 +502,7 @@ Ort::Status MatMulNBitsOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapp
             // Unpack block-quantized offsets to float each.
             std::vector<uint8_t> per_block_uint8_zp;
             const OrtValueInfo* zp_tensor_proto = qnn_model_wrapper.GetConstantTensor(inputs[3].name);
+            RETURN_IF_NOT(zp_tensor_proto != nullptr, "MatMulNBits zero_points must be a constant initializer.");
             RETURN_IF_ERROR(qnn_model_wrapper.UnpackInitializerData(zp_tensor_proto, per_block_uint8_zp));
             UnpackDataToDatatype<float>(per_block_uint8_zp, bits, num_zp_per_uint8, per_block_float_zp);
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc
@@ -183,7 +183,7 @@ Ort::Status ResizeOpBuilder::ProcessTfHalfPixelForNN(QnnModelWrapper& qnn_model_
 
   const size_t input_rank = output_shape.size();
 
-  const std::string resize_out_name = utils::UniqueNameGenerator().New(node_unit, "_tfhp_resize_out");
+  const std::string resize_out_name = node_unit.Name() + "_tfhp_resize_out";
   const std::string resize_node_name = utils::UniqueNameGenerator().New(node_unit, "_tfhp_resize");
 
   // Compute 2x output shape: double only the spatial dims (indices 1 .. rank-2 in NHWC).

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc
@@ -56,7 +56,7 @@ Ort::Status ProcessScatterNDIndices(QnnModelWrapper& qnn_model_wrapper,
 
     // Rename so a sibling op reusing the same ONNX initializer under a different
     // axis bound cannot alias our rewritten copy.
-    indices_tensor_name = utils::UniqueNameGenerator().New(indices_tensor_name, "_qnn_idx");
+    indices_tensor_name = indices_tensor_name + "_qnn_idx";
   }
 
   return utils::AddNormalizedIndicesTensor(qnn_model_wrapper, std::move(indices_info),

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -329,7 +329,7 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
     if (!inputs[i].quant_param.has_value()) {
       continue;
     }
-    const std::string dq_name = utils::UniqueNameGenerator().New(input_names[i], "_to_f32");
+    const std::string dq_name = input_names[i] + "_to_f32";
     RETURN_IF_ERROR(qnn_model_wrapper.AddDequantizeNode(input_names[i], dq_name, QNN_DATATYPE_FLOAT_32,
                                                         shapes[i], do_op_validation));
     input_names[i] = dq_name;
@@ -347,7 +347,7 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
     std::string out_name;
 
     if (!is_last || output_quantized || needs_int64_cast) {
-      out_name = utils::UniqueNameGenerator().New(node_unit, "_fold" + std::to_string(i));
+      out_name = node_unit.Name() + "_fold_" + std::to_string(i);
       RETURN_IF_NOT(add_tensor(out_name, QNN_TENSOR_TYPE_NATIVE, intermediate_dtype,
                                QnnQuantParamsWrapper(), std::vector<uint32_t>(running_shape)),
                     "AddTensorWrapper failed for fold output.");
@@ -377,7 +377,7 @@ Ort::Status ProcessVariadicToBinaryChain(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_ERROR(qnn_model_wrapper.AddCastNode(utils::UniqueNameGenerator().New(node_unit, "_cast_int64"),
                                                   lhs_name, output.name, QNN_TENSOR_TYPE_APP_READ,
                                                   output_info.qnn_data_type, output_info.quant_param.Copy(),
-                                                  std::vector<uint32_t>(output_info.shape), false));
+                                                  std::vector<uint32_t>(output_info.shape), do_op_validation));
   }
 
   return Ort::Status();

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc
@@ -86,7 +86,7 @@ Ort::Status TopKOpBuilder::ProcessInputs(QnnModelWrapper& qnn_model_wrapper,
   }
 
   // Add Transpose to permute axis to the last.
-  const std::string transpose_output_name = utils::UniqueNameGenerator().New(input_names[0], "_transpose");
+  const std::string transpose_output_name = input_names[0] + "_transpose";
   std::vector<uint32_t> transpose_perm;
   RETURN_IF_ERROR(utils::GetPermToLastAxis(static_cast<uint32_t>(axis),
                                            static_cast<uint32_t>(input_rank),
@@ -166,7 +166,7 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     // Since user may not be aware of the additional Transpose, the original output name of TopK node must be used by
     // the additional Transpose node which has the same output as original TopK node.
     const std::string& output_name = output.name;
-    const std::string transpose_input_name = utils::UniqueNameGenerator().New(output_name, "_transpose");
+    const std::string transpose_input_name = output_name + "_transpose";
     transpose_input_names.push_back(std::move(transpose_input_name));
 
     // Since the input of TopK node is permuted, its output shape must be manually calculated.
@@ -220,7 +220,7 @@ Ort::Status TopKOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mode
     bool is_cast_required = output_idx == 1 && output_info.qnn_data_type == QNN_DATATYPE_INT_64 && is_graph_output;
     std::string cast_input_name = "";
     if (is_cast_required) {
-      cast_input_name = utils::UniqueNameGenerator().New(transpose_output_name, "_cast");
+      cast_input_name = output_name + "_cast";
       // For the same reason described above, the original output name is now used by this Cast.
       transpose_output_name = cast_input_name;
       // Since additional Cast is added, below Transpose is no longer graph output.

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc
@@ -147,10 +147,11 @@ static std::unique_ptr<IQnnNodeGroup> TryQnnFusions(
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
   // For now, all fusions involve standalone node units (i.e., no wrapping DQ/Q nodes) except
-  // MatMul w/ LPBQ encodings, Erf, and Reshape.
+  // MatMul/Gemm w/ LPBQ encodings, Erf, Reshape, and a few others.
   if (starting_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode &&
       starting_node_unit.OpType() != "Gather" &&
       starting_node_unit.OpType() != "MatMul" &&
+      starting_node_unit.OpType() != "Gemm" &&
       starting_node_unit.OpType() != "Erf" &&
       starting_node_unit.OpType() != "Tanh" &&
       starting_node_unit.OpType() != "Reshape") {

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc
@@ -83,8 +83,104 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
                                   const OrtNodeUnit& post_reshape_node_unit,
                                   const Ort::Logger& logger,
                                   bool do_op_validation) {
+  const OrtNodeUnitIODef& pre_reshape_input_def = pre_reshape_node_unit.Inputs()[0];
+  const OrtNodeUnitIODef& pre_reshape_output_def = pre_reshape_node_unit.Outputs()[0];
+  const OrtNodeUnitIODef& einsum_output_def = einsum_node_unit.Outputs()[0];
+  const OrtNodeUnitIODef& post_reshape_output_def = post_reshape_node_unit.Outputs()[0];
+
+  // Get the 6D pre-reshape output shape — used by both validate and create paths.
+  TensorInfo pre_reshape_output_info = {};
+  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(pre_reshape_output_def, pre_reshape_output_info));
+  // If any QDQ node exists, the previous matching will fail and thus it is guaranteed not quantized.
+  assert(!pre_reshape_output_info.quant_param.IsQuantized());
+
+  // 4D reshape output shape: collapse last 3 dims for DepthToSpace input.
+  const std::vector<uint32_t> reshape4d_shape = {
+      pre_reshape_output_info.shape[0],
+      pre_reshape_output_info.shape[1],
+      pre_reshape_output_info.shape[2],
+      pre_reshape_output_info.shape[3] * pre_reshape_output_info.shape[4] * pre_reshape_output_info.shape[5]};
+
+  // D2S output shape.
+  const std::vector<uint32_t> d2s_out_shape = {
+      pre_reshape_output_info.shape[0],
+      pre_reshape_output_info.shape[1] * pre_reshape_output_info.shape[3],
+      pre_reshape_output_info.shape[2] * pre_reshape_output_info.shape[4],
+      pre_reshape_output_info.shape[5]};
+
+  if (do_op_validation) {
+    // Validate path: build tensors/params on the stack and call ValidateQnnNode directly.
+    // This does NOT modify the QnnModelWrapper, so TryFusion can call safely without
+    // interfering with the subsequent IsSupported call.
+
+    // Input tensor (read QNN type/shape from model without registering).
+    QnnTensorWrapper input_wrapper;
+    RETURN_IF_ERROR(qnn_model_wrapper.MakeTensorWrapper(pre_reshape_input_def, input_wrapper));
+
+    // 4D reshape output (synthetic — not in ONNX graph at this rank).
+    QnnTensorWrapper reshape_out_wrapper(pre_reshape_output_def.name, QNN_TENSOR_TYPE_NATIVE,
+                                         pre_reshape_output_info.qnn_data_type, QnnQuantParamsWrapper(),
+                                         std::vector<uint32_t>(reshape4d_shape));
+
+    // D2S output (synthetic).
+    TensorInfo einsum_output_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(einsum_output_def, einsum_output_info));
+    QnnTensorWrapper d2s_out_wrapper(einsum_output_def.name, QNN_TENSOR_TYPE_NATIVE,
+                                     einsum_output_info.qnn_data_type, QnnQuantParamsWrapper(),
+                                     std::vector<uint32_t>(d2s_out_shape));
+
+    // Final (Transpose) output.
+    TensorInfo post_reshape_output_info = {};
+    RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(post_reshape_output_def, post_reshape_output_info));
+    const bool is_graph_output = qnn_model_wrapper.IsGraphOutput(post_reshape_output_def.name);
+    QnnTensorWrapper final_out_wrapper(post_reshape_output_def.name,
+                                       is_graph_output ? QNN_TENSOR_TYPE_APP_READ : QNN_TENSOR_TYPE_NATIVE,
+                                       post_reshape_output_info.qnn_data_type, QnnQuantParamsWrapper(),
+                                       std::vector<uint32_t>(post_reshape_output_info.shape));
+
+    // D2S params: block_size tensor + mode scalar.
+    QnnParamWrapper block_size_param(einsum_node_unit.Index(), einsum_node_unit.Name(),
+                                     QNN_OP_DEPTH_TO_SPACE_PARAM_BLOCK_SIZE,
+                                     {2},
+                                     {pre_reshape_output_info.shape[3], pre_reshape_output_info.shape[4]});
+    Qnn_Scalar_t mode_scalar = {};
+    mode_scalar.dataType = QNN_DATATYPE_UINT_32;
+    mode_scalar.uint32Value = static_cast<uint32_t>(QNN_OP_DEPTH_TO_SPACE_MODE_DCR);
+    QnnParamWrapper mode_param(einsum_node_unit.Index(), einsum_node_unit.Name(),
+                               QNN_OP_DEPTH_TO_SPACE_PARAM_MODE, mode_scalar);
+
+    // Transpose param: perm = [0, 3, 1, 2].
+    QnnParamWrapper perm_param(post_reshape_node_unit.Index(), post_reshape_node_unit.Name(),
+                               QNN_OP_TRANSPOSE_PARAM_PERM,
+                               {4}, {0u, 3u, 1u, 2u});
+
+    // Validate Reshape.
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(
+        utils::UniqueNameGenerator().New(pre_reshape_node_unit),
+        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_RESHAPE,
+        {input_wrapper.GetQnnTensor()}, {reshape_out_wrapper.GetQnnTensor()}, {}));
+
+    // Validate DepthToSpace.
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(
+        utils::UniqueNameGenerator().New(einsum_node_unit),
+        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_DEPTH_TO_SPACE,
+        {reshape_out_wrapper.GetQnnTensor()}, {d2s_out_wrapper.GetQnnTensor()},
+        {block_size_param.GetQnnParam(), mode_param.GetQnnParam()}));
+
+    // Validate Transpose.
+    RETURN_IF_ERROR(qnn_model_wrapper.ValidateQnnNode(
+        utils::UniqueNameGenerator().New(post_reshape_node_unit),
+        QNN_OP_PACKAGE_NAME_QTI_AISW, QNN_OP_TRANSPOSE,
+        {d2s_out_wrapper.GetQnnTensor()}, {final_out_wrapper.GetQnnTensor()},
+        {perm_param.GetQnnParam()}));
+
+    return Ort::Status();
+  }
+
+  // Create path: add tensors/params to the model and materialise QNN nodes.
+
   // Reshape.
-  const OrtNodeUnitIODef& pre_reshape_input = pre_reshape_node_unit.Inputs()[0];
+  const OrtNodeUnitIODef& pre_reshape_input = pre_reshape_input_def;
   if (qnn_model_wrapper.IsQnnTensorWrapperExist(pre_reshape_input.name)) {
     ORT_CXX_LOG(logger,
                 ORT_LOGGING_LEVEL_VERBOSE,
@@ -95,18 +191,11 @@ Ort::Status CreateOrValidateOnQnn(QnnModelWrapper& qnn_model_wrapper,
     RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(pre_reshape_input_wrapper)), "Failed to add tensor.");
   }
 
-  const OrtNodeUnitIODef& pre_reshape_output = pre_reshape_node_unit.Outputs()[0];
-  TensorInfo pre_reshape_output_info = {};
-  RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(pre_reshape_output, pre_reshape_output_info));
-  // If any QDQ node exists, the previous matching will fail and thus it is guaranteed not quantized.
-  assert(!pre_reshape_output_info.quant_param.IsQuantized());
+  const OrtNodeUnitIODef& pre_reshape_output = pre_reshape_output_def;
+  // pre_reshape_output_info already computed above.
 
   // Combine the last 3 dimensions to serve as the input depth for the following DepthToSpace.
-  std::vector<uint32_t> pre_reshape_output_shape = {
-      pre_reshape_output_info.shape[0],
-      pre_reshape_output_info.shape[1],
-      pre_reshape_output_info.shape[2],
-      pre_reshape_output_info.shape[3] * pre_reshape_output_info.shape[4] * pre_reshape_output_info.shape[5]};
+  std::vector<uint32_t> pre_reshape_output_shape(reshape4d_shape);
   QnnTensorWrapper pre_reshape_output_wrapper(pre_reshape_output.name,
                                               QNN_TENSOR_TYPE_NATIVE,
                                               pre_reshape_output_info.qnn_data_type,
@@ -223,7 +312,7 @@ std::unique_ptr<IQnnNodeGroup> ReshapeEinsumReshapeNodeGroup::TryFusion(
     QnnModelWrapper& qnn_model_wrapper, const OrtNodeUnit& einsum_node_unit,
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
-    const Ort::Logger& /*logger*/) {
+    const Ort::Logger& logger) {
   if (einsum_node_unit.OpType() != "Einsum" || einsum_node_unit.UnitType() != OrtNodeUnit::Type::SingleNode) {
     return nullptr;
   }
@@ -275,9 +364,19 @@ std::unique_ptr<IQnnNodeGroup> ReshapeEinsumReshapeNodeGroup::TryFusion(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeEinsumReshapeNodeGroup>(pre_reshape_node_unit,
-                                                         &einsum_node_unit,
-                                                         post_reshape_node_unit);
+  // Validate on QNN before claiming NodeUnits — catches backend rejections early.
+  auto fused = std::make_unique<ReshapeEinsumReshapeNodeGroup>(pre_reshape_node_unit,
+                                                               &einsum_node_unit,
+                                                               post_reshape_node_unit);
+  if (const auto status = CreateOrValidateOnQnn(qnn_model_wrapper,
+                                                *pre_reshape_node_unit,
+                                                einsum_node_unit,
+                                                *post_reshape_node_unit,
+                                                logger, /*do_op_validation=*/true);
+      !status.IsOK()) {
+    return nullptr;
+  }
+  return fused;
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -411,8 +411,6 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion2(
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
-  ORT_UNUSED_PARAMETER(logger);
-
   if (!IsValidGemmForFusion(qnn_model_wrapper, gemm_node_unit)) {
     return nullptr;
   }
@@ -440,8 +438,12 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion2(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmFusionGroup>(
+  auto fused = std::make_unique<ReshapeGemmFusionGroup>(
       std::vector<const OrtNodeUnit*>{input_reshape, &gemm_node_unit});
+  if (auto status = fused->CreateOrValidateOnQnn(qnn_model_wrapper, logger, true); !status.IsOK()) {
+    return nullptr;
+  }
+  return fused;
 }
 
 // 3-node fusion: Reshape -> Gemm -> Reshape
@@ -450,8 +452,6 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion3(
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
-  ORT_UNUSED_PARAMETER(logger);
-
   if (!IsValidGemmForFusion(qnn_model_wrapper, gemm_node_unit)) {
     return nullptr;
   }
@@ -486,8 +486,12 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion3(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmFusionGroup>(
+  auto fused = std::make_unique<ReshapeGemmFusionGroup>(
       std::vector<const OrtNodeUnit*>{input_reshape, &gemm_node_unit, output_reshape});
+  if (auto status = fused->CreateOrValidateOnQnn(qnn_model_wrapper, logger, true); !status.IsOK()) {
+    return nullptr;
+  }
+  return fused;
 }
 
 // 4-node fusion: Reshape -> Gemm -> Reshape -> Reshape
@@ -496,8 +500,6 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion4(
     const std::unordered_map<const OrtNode*, const OrtNodeUnit*>& node_to_node_unit,
     const std::unordered_map<const OrtNodeUnit*, const IQnnNodeGroup*>& node_unit_to_qnn_node_group,
     const Ort::Logger& logger) {
-  ORT_UNUSED_PARAMETER(logger);
-
   if (!IsValidGemmForFusion(qnn_model_wrapper, gemm_node_unit)) {
     return nullptr;
   }
@@ -545,8 +547,12 @@ std::unique_ptr<IQnnNodeGroup> ReshapeGemmFusionGroup::TryFusion4(
     return nullptr;
   }
 
-  return std::make_unique<ReshapeGemmFusionGroup>(
+  auto fused = std::make_unique<ReshapeGemmFusionGroup>(
       std::vector<const OrtNodeUnit*>{input_reshape, &gemm_node_unit, output_reshape1, output_reshape2});
+  if (auto status = fused->CreateOrValidateOnQnn(qnn_model_wrapper, logger, true); !status.IsOK()) {
+    return nullptr;
+  }
+  return fused;
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc
@@ -367,7 +367,7 @@ Ort::Status CreateOrValidateFusedFCOnQnn(QnnModelWrapper& qnn_model_wrapper,
 // ReshapeGemmFusionGroup implementation
 // ============================================================================
 
-ReshapeGemmFusionGroup::ReshapeGemmFusionGroup(std::vector<const OrtNodeUnit*> node_units)
+ReshapeGemmFusionGroup::ReshapeGemmFusionGroup(std::vector<const OrtNodeUnit*> node_units) noexcept
     : node_units_(std::move(node_units)) {
 }
 

--- a/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h
+++ b/onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.h
@@ -26,7 +26,7 @@ class QnnModelWrapper;
 /// </summary>
 class ReshapeGemmFusionGroup : public IQnnNodeGroup {
  public:
-  explicit ReshapeGemmFusionGroup(std::vector<const OrtNodeUnit*> node_units);
+  explicit ReshapeGemmFusionGroup(std::vector<const OrtNodeUnit*> node_units) noexcept;
   ORT_DISALLOW_COPY_AND_ASSIGNMENT(ReshapeGemmFusionGroup);
 
   Ort::Status IsSupported(QnnModelWrapper& qmw, const Ort::Logger& logger) const override;


### PR DESCRIPTION
## Description

Fixes a set of correctness issues across QNN EP node-group fusions and op builders: missing QDQ-start exception list entry for Gemm, three fusions that returned a group object without first validating it on the QNN backend, and multiple op builders that used a globally-stateful `UniqueNameGenerator` for intermediate tensor names (producing counter-drift between the validate and create passes) or hardcoded `do_op_validation=false` in decomposition helper calls.

Building on top of PR #540 from @tirupath-qti. This PR is expected to solve the functional failure caused by PR #200 

---

## Motivation & Context

### Node-group fusions

The QNN EP's `TryFusion` path is called during Phase 1 (`GetCapability`) with a temporary `QnnModelWrapper`. The contract requires that the fusion group validates its QNN node chain on the backend **before** returning a non-null group object. If a fusion returns a group without first calling `CreateOrValidateOnQnn(do_op_validation=true)`, any backend rejection (unsupported op, bad dtype, shape constraint) is silently swallowed during `GetCapability` and only surfaces later as a crash or garbage output during `Compile`.

Three fusions violated this contract:

- **`ReshapeGemmFusionGroup` (`TryFusion2/3/4`)** — all three overloads constructed and returned the group object without calling `CreateOrValidateOnQnn` in validate mode.

- **`ReshapeEinsumReshapeNodeGroup` (`TryFusion`)** — same issue. Additionally, the `CreateOrValidateOnQnn` function had no dedicated validate branch; both validate and create paths fell through to the same `AddTensorWrapper` + `CreateQnnNode` code, meaning a `TryFusion`-triggered validate call would have mutated the model wrapper state by adding tensors — a side-effect that must not happen during Phase 1 validation.

- **`qnn_node_group.cc` QDQ-start filter** — the early-return guard that allows QDQ-wrapped starting nodes through to `TryFusion` listed `MatMul` but not `Gemm`. Because `ReshapeGemmFusionGroup` operates on QDQ-wrapped Gemm nodes, it was never reached for QDQ models.

### Op builders — `UniqueNameGenerator` cross-pass drift

`utils::UniqueNameGenerator` maintains a global, process-wide counter. Every call to `.New()` increments the counter and appends the new value to the base string to produce a unique name. This is intentional for QNN node names (which need only be unique, not stable), but is incorrect for **intermediate tensor names** in multi-node decompositions.

When an op builder decomposes one ONNX op into a chain of QNN nodes (e.g. Sign → Abs → Cast, or a pre-Transpose → FC → Reshape), intermediate tensors are:
1. Registered in the `QnnModelWrapper` as output of node A.
2. Referenced by node B as its input.

Both A and B must use **the same string** for that tensor within a single pass. With `UniqueNameGenerator`, A and B each call `.New()` at different counter values, so the names already differ within the same pass if any other `.New()` calls intervene between them. More critically, the entire validate pass (Phase 1, `IsOpSupported`) and create pass (Phase 2, `AddToModelBuilder`) can have different counter states, so the same decomposition produces different intermediate names in each pass.

The fix is to replace all `UniqueNameGenerator().New(base, suffix)` calls that produce intermediate **tensor** names with deterministic string concatenation: `base + suffix`, where `base` is already a unique ONNX tensor or node name.

`UniqueNameGenerator` is still used (and is correct) for QNN node names, where uniqueness is sufficient and stability is not required.

### Op builders — hardcoded `do_op_validation=false`

`AddCastNode`, `AddTransposeNode`, and similar helpers accept a `do_op_validation` flag that controls whether they call `ValidateQnnNode` or `CreateQnnNode`. Hardcoding `false` silently skips backend validation during `IsOpSupported`, allowing unsupported configurations through `GetCapability` that will fail or produce incorrect results at runtime.

### Op builders — missing null guards after `GetConstantTensor`

`QnnModelWrapper::GetConstantTensor` returns `nullptr` when the named tensor is not a registered constant initializer. Several `MatMulNBits` code paths passed the result directly to `UnpackInitializerData` without a null check, which would crash or produce undefined behaviour if the weight, scale, or zero_points inputs were not constant (e.g. in a malformed or unexpected graph).

---

## Files Changed

| File | Change |
|------|--------|
| `onnxruntime/core/providers/qnn/builder/qnn_node_group/qnn_node_group.cc` | Added `"Gemm"` to the QDQ-start exception list so QDQ-wrapped Gemm nodes are forwarded to `TryFusion` instead of being rejected by the early-return guard. Updated comment. |
| `onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_gemm_fusion.cc` | `TryFusion2`, `TryFusion3`, `TryFusion4`: after constructing the candidate `ReshapeGemmFusionGroup`, call `CreateOrValidateOnQnn(do_op_validation=true)` and return `nullptr` on failure before returning the group. Removed unused `ORT_UNUSED_PARAMETER(logger)` in each overload. |
| `onnxruntime/core/providers/qnn/builder/qnn_node_group/reshape_einsum_reshape.cc` | Added a pure-validate branch at the top of `CreateOrValidateOnQnn`: when `do_op_validation=true`, builds all tensors and params on the stack and calls `ValidateQnnNode` for the three QNN nodes (Reshape, DepthToSpace, Transpose) without touching model wrapper state. Updated `TryFusion` to call this validate path and return `nullptr` on failure before returning the group. |
| `onnxruntime/core/providers/qnn/builder/opbuilder/matmulnbits_op_builder.cc` | Added `RETURN_IF_NOT(ptr != nullptr, ...)` guards after each of the three `GetConstantTensor` calls (weight at line 376, scales at line 384, zero_points at line 502) before passing the pointer to `UnpackInitializerData`. |
| `onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc` | `ProcessVariadicToBinaryChain`: replaced `UniqueNameGenerator` with deterministic names for DQ intermediate tensors (`input_names[i] + "_to_f32"`) and fold-chain output tensors (`node_unit.Name() + "_fold_" + i`). Fixed `AddCastNode` call for int64 graph-output cast: changed hardcoded `false` to `do_op_validation`. |
| `onnxruntime/core/providers/qnn/builder/opbuilder/gemm_op_builder.cc` | `ProcessInputs`: replaced `UniqueNameGenerator` with `input_tensor_name + "_transpose"` for the non-constant transposed-weight intermediate. `ProcessInputsForBQGemm`: replaced `UniqueNameGenerator` with `fp16_name + "_transpose"` (transA path) and `inputs[2].name + "_fp16"` (bias dequantize). `ProcessAttributesAndOutputs`: replaced `UniqueNameGenerator` with `final_output_name + "_fc"` (absorbed-Reshape path) and `org_output_name + "_fc"` (FC+Add decomposition path). |
| `onnxruntime/core/providers/qnn/builder/opbuilder/resize_op_builder.cc` | `ProcessTfHalfPixelForNN`: replaced `UniqueNameGenerator` with `node_unit.Name() + "_tfhp_resize_out"` for the intermediate tensor connecting the 2× Resize node to the StridedSlice node. (The resize node name and all param names were and remain UniqueNameGenerator since they are not referenced cross-node.) |
| `onnxruntime/core/providers/qnn/builder/opbuilder/cast_op_builder.cc` | `ProcessExtraInputForNotEqual`: replaced `const std::string&` binding to temporary with `const std::string`, and replaced `UniqueNameGenerator` with `node_unit.Name() + "_notequal_zero"`. `EmitSignAbsCastDecomposition`: replaced `UniqueNameGenerator` with `node_unit.Name() + "_signabs_sign"` and `node_unit.Name() + "_signabs_abs"` for the Sign and Abs intermediate tensors. |
| `onnxruntime/core/providers/qnn/builder/opbuilder/topk_op_builder.cc` | `ProcessInputs`: replaced `UniqueNameGenerator` with `input_names[0] + "_transpose"` for the pre-TopK axis-permutation output. `ProcessAttributesAndOutputs`: replaced `UniqueNameGenerator` with `output_name + "_transpose"` for post-TopK output intermediates and `output_name + "_cast"` for the INT64 cast-back input tensor. |
| `onnxruntime/core/providers/qnn/builder/opbuilder/scatternd_op_builder.cc` | `ProcessScatterNDIndices`: replaced `UniqueNameGenerator` with `indices_tensor_name + "_qnn_idx"` for the renamed rewritten-indices initializer tensor. |