### PR TITLE
[QNN EP] Fix DLC size inflation caused by unbounded constant DequantizeLinear folding

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -114,6 +114,20 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF(output_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
             "Folded DequantizeLinear only supports float32 output.");
 
+  // Skip folding for large tensors: storing the dequantized FP32 blob in the DLC costs 4× the
+  // space of the original quantized bytes. Bias/scale tensors are small (< 1 MB) and benefit from
+  // folding because it eliminates a runtime op. Large weight tensors (e.g. 1536×6144 = 36 MB FP32)
+  // should remain as a QNN DequantizeLinear op so the DLC only stores the compact quantized data.
+  // A threshold of 1 MB (256 K float32 elements) keeps folding for bias-sized tensors.
+  constexpr size_t kMaxFoldElemCount = 256 * 1024;  // 256 K × 4 B = 1 MB FP32
+  size_t num_elems_check = 1;
+  for (uint32_t d : output_info.shape) {
+    num_elems_check *= d;
+    if (num_elems_check > kMaxFoldElemCount) {
+      return MAKE_EP_FAIL("DequantizeLinear output too large to fold; leaving as a runtime op to avoid FP32 DLC bloat.");
+    }
+  }
+
   std::vector<uint8_t> quant_bytes;
   RETURN_IF_ERROR(GetEffectivelyConstantTensorBytes(qnn_model_wrapper, input_def.name, quant_bytes));
 

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -47,13 +47,16 @@ Ort::Status GetEffectivelyConstantTensorBytes(QnnModelWrapper& qnn_model_wrapper
 
 namespace {
 
-// SafeInt guards against overflow from an adversarial shape before allocation.
+// A shape product that overflows size_t must fail rather than wrap: a wrapped count would
+// slip under the fold budget and then under-allocate the output. SafeMultiply reports
+// overflow through its return value, so this stays a status even in a no-exceptions build.
 Ort::Status ComputeNumElements(gsl::span<const uint32_t> shape, /*out*/ size_t& num_elems) {
-  SafeInt<size_t> safe_num_elems = 1;
+  size_t total = 1;
   for (uint32_t d : shape) {
-    safe_num_elems *= d;
+    RETURN_IF_NOT(SafeMultiply(total, static_cast<size_t>(d), total),
+                  "Tensor shape element count overflows size_t.");
   }
-  num_elems = safe_num_elems;
+  num_elems = total;
   return Ort::Status();
 }
 
@@ -101,44 +104,6 @@ Ort::Status RegisterFoldedStaticTensor(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-// Declining to fold only trades an FP32 blob for a compact static tensor if a runtime QNN
-// Dequantize is a faithful substitute for the folded constant. Two cases where it is not:
-//   - Per-channel: ExplicitOpCheck admits a standalone per-channel Q/DQ only on the premise that
-//     folding will remove it, and declining also stops constant-ness from propagating to later
-//     Q/DQ hops, which then lose QNN support and leave the consumer's weight as an APP_WRITE input.
-//   - INT4/INT2: the initializer reaches QNN as SFIXED_POINT_8 with its high bits masked off to
-//     work around a QNN INT4 accuracy bug (see UnpackInt4ToInt8). Only the fold path undoes that
-//     mask, so a runtime Dequantize would read negative values as q + 16.
-Ort::Status CanSubstituteRuntimeDequantize(const QnnModelWrapper& qnn_model_wrapper,
-                                           const OrtNodeUnitIODef& input_def,
-                                           /*out*/ bool& can_substitute) {
-  can_substitute = false;
-
-  std::optional<int64_t> axis;
-  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, input_def, axis));
-  if (axis.has_value()) {
-    return Ort::Status();
-  }
-
-  // A null init means the input is a previously-folded (not real-initializer)
-  // constant. Folded intermediates always hold plain bytes -- fp32 from DQ folding
-  // or 8/16/32-bit from Q folding (see GetEffectivelyConstantTensorBytes) -- so no
-  // sub-byte sign hazard applies and falling through below is correct. Per-channel
-  // folded inputs already returned above.
-  const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(input_def.name);
-  if (init != nullptr) {
-    ONNXTensorElementDataType onnx_data_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
-    RETURN_IF_ERROR(utils::GetOnnxTensorElemDataType(init, onnx_data_type));
-    if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 ||
-        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2) {
-      return Ort::Status();
-    }
-  }
-
-  can_substitute = true;
-  return Ort::Status();
-}
-
 // Only fp32 DQ output is supported; opset >= 21 fp16/bf16 outputs fall back to the normal op.
 Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit) {
@@ -153,8 +118,7 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
             "Folded DequantizeLinear only supports float32 output.");
 
   // Element count drives both the DLC-size guard below and the output allocation.
-  // (DequantizeLinear preserves shape, so output count == input count.) SafeInt
-  // rejects adversarial shapes instead of wrapping around the threshold.
+  // (DequantizeLinear preserves shape, so output count == input count.)
   size_t num_elems = 0;
   RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(output_info.shape), num_elems));
 
@@ -248,6 +212,44 @@ Ort::Status FoldConstantQuantizeLinear(QnnModelWrapper& qnn_model_wrapper,
 }
 
 }  // namespace
+
+// Declining to fold only trades an FP32 blob for a compact static tensor if a runtime QNN
+// Dequantize is a faithful substitute for the folded constant. Two cases where it is not:
+//   - Per-channel: ExplicitOpCheck admits a standalone per-channel Q/DQ only on the premise that
+//     folding will remove it, and declining also stops constant-ness from propagating to later
+//     Q/DQ hops, which then lose QNN support and leave the consumer's weight as an APP_WRITE input.
+//   - INT4/INT2: the initializer reaches QNN as SFIXED_POINT_8 with its high bits masked off to
+//     work around a QNN INT4 accuracy bug (see UnpackInt4ToInt8). Only the fold path undoes that
+//     mask, so a runtime Dequantize would read negative values as q + 16.
+Ort::Status CanSubstituteRuntimeDequantize(const QnnModelWrapper& qnn_model_wrapper,
+                                           const OrtNodeUnitIODef& input_def,
+                                           /*out*/ bool& can_substitute) {
+  can_substitute = false;
+
+  std::optional<int64_t> axis;
+  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, input_def, axis));
+  if (axis.has_value()) {
+    return Ort::Status();
+  }
+
+  // A null init means the input is a previously-folded (not real-initializer)
+  // constant. Folded intermediates always hold plain bytes -- fp32 from DQ folding
+  // or 8/16/32-bit from Q folding (see GetEffectivelyConstantTensorBytes) -- so no
+  // sub-byte sign hazard applies and falling through below is correct. Per-channel
+  // folded inputs already returned above.
+  const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(input_def.name);
+  if (init != nullptr) {
+    ONNXTensorElementDataType onnx_data_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    RETURN_IF_ERROR(utils::GetOnnxTensorElemDataType(init, onnx_data_type));
+    if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 ||
+        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2) {
+      return Ort::Status();
+    }
+  }
+
+  can_substitute = true;
+  return Ort::Status();
+}
 
 bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
                         const OrtNodeUnit& node_unit) {

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.cc
@@ -72,7 +72,7 @@ Ort::Status UnpackQuantParams(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
-Ort::Status ResolvePerChannelAxis(QnnModelWrapper& qnn_model_wrapper,
+Ort::Status ResolvePerChannelAxis(const QnnModelWrapper& qnn_model_wrapper,
                                   const OrtNodeUnitIODef& io_def,
                                   /*out*/ std::optional<int64_t>& axis) {
   bool is_per_chan = false;
@@ -101,6 +101,44 @@ Ort::Status RegisterFoldedStaticTensor(QnnModelWrapper& qnn_model_wrapper,
   return Ort::Status();
 }
 
+// Declining to fold only trades an FP32 blob for a compact static tensor if a runtime QNN
+// Dequantize is a faithful substitute for the folded constant. Two cases where it is not:
+//   - Per-channel: ExplicitOpCheck admits a standalone per-channel Q/DQ only on the premise that
+//     folding will remove it, and declining also stops constant-ness from propagating to later
+//     Q/DQ hops, which then lose QNN support and leave the consumer's weight as an APP_WRITE input.
+//   - INT4/INT2: the initializer reaches QNN as SFIXED_POINT_8 with its high bits masked off to
+//     work around a QNN INT4 accuracy bug (see UnpackInt4ToInt8). Only the fold path undoes that
+//     mask, so a runtime Dequantize would read negative values as q + 16.
+Ort::Status CanSubstituteRuntimeDequantize(const QnnModelWrapper& qnn_model_wrapper,
+                                           const OrtNodeUnitIODef& input_def,
+                                           /*out*/ bool& can_substitute) {
+  can_substitute = false;
+
+  std::optional<int64_t> axis;
+  RETURN_IF_ERROR(ResolvePerChannelAxis(qnn_model_wrapper, input_def, axis));
+  if (axis.has_value()) {
+    return Ort::Status();
+  }
+
+  // A null init means the input is a previously-folded (not real-initializer)
+  // constant. Folded intermediates always hold plain bytes -- fp32 from DQ folding
+  // or 8/16/32-bit from Q folding (see GetEffectivelyConstantTensorBytes) -- so no
+  // sub-byte sign hazard applies and falling through below is correct. Per-channel
+  // folded inputs already returned above.
+  const OrtValueInfo* init = qnn_model_wrapper.GetConstantTensor(input_def.name);
+  if (init != nullptr) {
+    ONNXTensorElementDataType onnx_data_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    RETURN_IF_ERROR(utils::GetOnnxTensorElemDataType(init, onnx_data_type));
+    if (onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 ||
+        onnx_data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT2) {
+      return Ort::Status();
+    }
+  }
+
+  can_substitute = true;
+  return Ort::Status();
+}
+
 // Only fp32 DQ output is supported; opset >= 21 fp16/bf16 outputs fall back to the normal op.
 Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
                                          const OrtNodeUnit& node_unit) {
@@ -114,18 +152,20 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   RETURN_IF(output_info.qnn_data_type != QNN_DATATYPE_FLOAT_32,
             "Folded DequantizeLinear only supports float32 output.");
 
-  // Skip folding for large tensors: storing the dequantized FP32 blob in the DLC costs 4× the
-  // space of the original quantized bytes. Bias/scale tensors are small (< 1 MB) and benefit from
-  // folding because it eliminates a runtime op. Large weight tensors (e.g. 1536×6144 = 36 MB FP32)
-  // should remain as a QNN DequantizeLinear op so the DLC only stores the compact quantized data.
-  // A threshold of 1 MB (256 K float32 elements) keeps folding for bias-sized tensors.
-  constexpr size_t kMaxFoldElemCount = 256 * 1024;  // 256 K × 4 B = 1 MB FP32
-  size_t num_elems_check = 1;
-  for (uint32_t d : output_info.shape) {
-    num_elems_check *= d;
-    if (num_elems_check > kMaxFoldElemCount) {
-      return MAKE_EP_FAIL("DequantizeLinear output too large to fold; leaving as a runtime op to avoid FP32 DLC bloat.");
-    }
+  // Element count drives both the DLC-size guard below and the output allocation.
+  // (DequantizeLinear preserves shape, so output count == input count.) SafeInt
+  // rejects adversarial shapes instead of wrapping around the threshold.
+  size_t num_elems = 0;
+  RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(output_info.shape), num_elems));
+
+  // Folding converts compact quantized weights into FP32 STATIC tensors stored
+  // in the DLC, so large faithfully-substitutable weights (e.g. 1536x6144 = 36 MB
+  // FP32) are left to a runtime QNN Dequantize. The 1 MiB budget keeps folding
+  // for bias-sized tensors.
+  bool can_substitute = false;
+  RETURN_IF_ERROR(CanSubstituteRuntimeDequantize(qnn_model_wrapper, input_def, can_substitute));
+  if (can_substitute && ShouldSkipConstantDQFold(num_elems)) {
+    return MAKE_EP_FAIL("DequantizeLinear output too large to fold; leaving as a runtime op to avoid FP32 DLC bloat.");
   }
 
   std::vector<uint8_t> quant_bytes;
@@ -138,8 +178,6 @@ Ort::Status FoldConstantDequantizeLinear(QnnModelWrapper& qnn_model_wrapper,
   std::vector<int32_t> offsets;
   RETURN_IF_ERROR(UnpackQuantParams(qnn_model_wrapper, *input_def.quant_param, scales, offsets));
 
-  size_t num_elems = 0;
-  RETURN_IF_ERROR(ComputeNumElements(gsl::make_span(input_info.shape), num_elems));
   std::vector<float> fp32_data(num_elems);
 
   std::optional<int64_t> axis;
@@ -237,6 +275,12 @@ Ort::Status TryFoldConstantQDQ(QnnModelWrapper& qnn_model_wrapper,
     return FoldConstantQuantizeLinear(qnn_model_wrapper, node_unit);
   }
   return MAKE_EP_FAIL("TryFoldConstantQDQ called on a non-Q/DQ node.");
+}
+
+bool ShouldSkipConstantDQFold(size_t num_elems) {
+  // Compared without multiplying: num_elems * sizeof(float) can wrap before any
+  // threshold check for adversarial shapes.
+  return num_elems > kQdqFoldMaxFp32Bytes / sizeof(float);
 }
 
 }  // namespace qnn

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -22,11 +22,16 @@ bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
 // this size the DLC cost outweighs the saved runtime op.
 inline constexpr size_t kQdqFoldMaxFp32Bytes = 1024 * 1024;  // 1 MiB
 
-// True when a constant-DQ fold must be skipped in favor of a runtime QNN
-// Dequantize: the folded FP32 blob exceeds the DLC budget. Callers must first
-// establish via CanSubstituteRuntimeDequantize that a runtime Dequantize is a
-// faithful substitute (per-channel and sub-byte inputs always fold).
-// Pure function of its inputs: covered by unit tests.
+// True when the constant DQ on `input_def` may be left as a runtime QNN Dequantize instead
+// of being folded, i.e. when the runtime op is a faithful substitute for the folded constant.
+// False for per-channel and INT4/INT2 inputs, which must always fold; see the definition for
+// why. Gates ShouldSkipConstantDQFold, so a "must fold" input ignores the size budget.
+Ort::Status CanSubstituteRuntimeDequantize(const QnnModelWrapper& qnn_model_wrapper,
+                                           const OrtNodeUnitIODef& input_def,
+                                           /*out*/ bool& can_substitute) ORT_MUST_USE_RESULT;
+
+// True when a foldable constant DQ exceeds the DLC budget and is better left as a runtime
+// QNN Dequantize. Only meaningful for inputs CanSubstituteRuntimeDequantize() admits.
 bool ShouldSkipConstantDQFold(size_t num_elems);
 
 // Fold the Q/DQ statically and register its output as a STATIC tensor. Caller

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/qdq_constant_folding.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "core/providers/qnn/ort_api.h"
 
 namespace onnxruntime {
@@ -14,6 +16,18 @@ class QnnModelWrapper;
 // (real initializer or previously-folded tensor) eligible for compile-time folding.
 bool CanFoldConstantQdq(const QnnModelWrapper& qnn_model_wrapper,
                         const OrtNodeUnit& node_unit);
+
+// Budget for one folded DequantizeLinear output, in FP32 bytes. Folding converts
+// compact quantized weights into FP32 STATIC tensors stored in the DLC; beyond
+// this size the DLC cost outweighs the saved runtime op.
+inline constexpr size_t kQdqFoldMaxFp32Bytes = 1024 * 1024;  // 1 MiB
+
+// True when a constant-DQ fold must be skipped in favor of a runtime QNN
+// Dequantize: the folded FP32 blob exceeds the DLC budget. Callers must first
+// establish via CanSubstituteRuntimeDequantize that a runtime Dequantize is a
+// faithful substitute (per-channel and sub-byte inputs always fold).
+// Pure function of its inputs: covered by unit tests.
+bool ShouldSkipConstantDQFold(size_t num_elems);
 
 // Fold the Q/DQ statically and register its output as a STATIC tensor. Caller
 // MUST first verify with `CanFoldConstantQdq`.

--- a/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/simple_op_builder.cc
@@ -427,6 +427,12 @@ Ort::Status SimpleOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mo
     if (fold_status.IsOK()) {
       return Ort::Status();
     }
+    // Declines (e.g. an oversize per-tensor DQ left as a runtime op) are otherwise
+    // silent; log which node fell through and why.
+    ORT_CXX_LOG(logger, ORT_LOGGING_LEVEL_VERBOSE,
+                ("QNN EP declined constant folding for node '" + node_unit.Name() +
+                 "': " + fold_status.GetErrorMessage())
+                    .c_str());
   }
 
   std::vector<std::string> param_tensor_names;

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1140,6 +1140,8 @@ static void RunLargePerTensorDQConvTest(const std::string& backend, float fp32_a
     return;
   }
   AssertOpInQnnGraph(graph_dir, "Dequantize", 1);
+  // The point of the decline: the 4 MiB FP32 blob is absent from the DLC.
+  AssertFp32StaticBytesBelow(graph_dir, /*max_bytes*/ 4096);
 }
 
 TEST_F(QnnCPUBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -4,8 +4,6 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <filesystem>
-#include <functional>
-#include <map>
 #include <optional>
 #include <string>
 
@@ -951,17 +949,6 @@ TEST_F(QnnCPUBackendTests, ConvTranspose1Df32_DynamicWeights_DefaultBias) {
                 ExpectedEPNodeAssignment::All);
 }
 
-// Repeats `values` until it holds `length` entries, so a per-channel test case can be scaled up
-// to an arbitrary output-channel count without restating the quantization parameters.
-template <typename T>
-static std::vector<T> TileToLength(const std::vector<T>& values, int64_t length) {
-  std::vector<T> tiled(static_cast<size_t>(length));
-  for (size_t i = 0; i < tiled.size(); ++i) {
-    tiled[i] = values[i % values.size()];
-  }
-  return tiled;
-}
-
 // Builds: weight_q0 (int8 init) -> DQ -> Q -> DQ -> Conv.
 // Used to regression-test chained folding; differing scale0/scale1 exercises real requant
 // on the intermediate STATIC tensor rather than a byte round-trip.
@@ -969,24 +956,20 @@ static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
     const std::vector<float>& scale0,
     const std::vector<int8_t>& zp0,
     const std::vector<float>& scale1,
-    const std::vector<int8_t>& zp1,
-    int64_t out_ch = 2,
-    int64_t in_ch = 3) {
-  return [scale0, zp0, scale1, zp1, out_ch, in_ch](ModelTestBuilder& builder) {
+    const std::vector<int8_t>& zp1) {
+  return [scale0, zp0, scale1, zp1](ModelTestBuilder& builder) {
+    constexpr int64_t out_ch = 2;
+    constexpr int64_t in_ch = 3;
     const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
     const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
 
     builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
 
-    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
-    for (size_t i = 0; i < weight_values.size(); ++i) {
-      weight_values[i] = static_cast<int8_t>((i % 6) + 1);
-    }
-    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, weight_values);
-    builder.MakeInitializer<float>("scale0", {out_ch}, TileToLength(scale0, out_ch));
-    builder.MakeInitializer<int8_t>("zp0", {out_ch}, TileToLength(zp0, out_ch));
-    builder.MakeInitializer<float>("scale1", {out_ch}, TileToLength(scale1, out_ch));
-    builder.MakeInitializer<int8_t>("zp1", {out_ch}, TileToLength(zp1, out_ch));
+    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, std::vector<int8_t>{1, 2, 3, 4, 5, 6});
+    builder.MakeInitializer<float>("scale0", {out_ch}, scale0);
+    builder.MakeInitializer<int8_t>("zp0", {out_ch}, zp0);
+    builder.MakeInitializer<float>("scale1", {out_ch}, scale1);
+    builder.MakeInitializer<int8_t>("zp1", {out_ch}, zp1);
 
     std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
     axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
@@ -1039,17 +1022,13 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
 // Builds: weight_q (int4 init) -> per-channel DQ -> Conv. QNN cannot represent a standalone
 // per-channel DQ, so it is folded to an fp32 static by decoding the initializer's bytes as int8.
 // Weights span the negative INT4 range, which a sign-handling regression would decode as q + 16.
-static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::vector<float>& scales,
-                                                                   int64_t out_ch = 2,
-                                                                   int64_t in_ch = 3) {
-  return [scales, out_ch, in_ch](ModelTestBuilder& builder) {
+static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::vector<float>& scales) {
+  return [scales](ModelTestBuilder& builder) {
+    constexpr int64_t out_ch = 2;
+    constexpr int64_t in_ch = 3;
     const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
     const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
-    const std::vector<int8_t> weight_pattern{-8, -7, -1, 1, 5, 7};
-    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
-    for (size_t i = 0; i < weight_values.size(); ++i) {
-      weight_values[i] = weight_pattern[i % weight_pattern.size()];
-    }
+    const std::vector<int8_t> weight_values{-8, -7, -1, 1, 5, 7};
 
     builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
 
@@ -1058,7 +1037,7 @@ static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::ve
       weight_data[i >> 1].SetElem(i & 1, weight_values[i]);
     }
     builder.MakeInitializer<Int4x2>("weight_q", weight_shape, weight_data);
-    builder.MakeInitializer<float>("weight_scale", {out_ch}, TileToLength(scales, out_ch));
+    builder.MakeInitializer<float>("weight_scale", {out_ch}, scales);
 
     std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
     axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
@@ -1087,55 +1066,24 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt4DQConstWeight_SignRegression) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
 }
 
-// Pins the folding decision per node: every DQ/Q/Conv in these graphs must stay
-// QNN-assigned. A wrongly-declined fold fails here (fallback to CPU) instead of
-// hiding behind output comparison. Large per-channel weights must fold (QNN has no
-// standalone per-channel Dequantize); large per-tensor weights must decline the
-// FP32 fold yet keep their runtime Dequantize on QNN.
-static std::function<void(const Ort::Session&)> PinQnnNodesOnQnn(int expect_dq, int expect_q) {
-  return [expect_dq, expect_q](const Ort::Session& session) {
-    std::map<std::string, int> counts;
-    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
-      for (const auto& node : subgraph.GetNodes()) {
-        EXPECT_EQ(subgraph.GetEpName(), kQnnExecutionProvider) << node.GetOperatorType();
-        counts[node.GetOperatorType()]++;
-      }
-    }
-    EXPECT_EQ(counts["DequantizeLinear"], expect_dq);
-    EXPECT_EQ(counts["QuantizeLinear"], expect_q);
-    EXPECT_EQ(counts["Conv"], 1);
-  };
-}
-
-// Large-weight shapes stay realistic: 512x2048 1x1 is a ResNet-bottleneck-class
-// projection (1,048,576 elems = 4 MiB FP32, past the 1 MiB fold budget), unlike a
-// channel-inflated toy that no real model contains.
+// 512x2048 1x1 is a ResNet-bottleneck-class projection: 1,048,576 elems = 4 MiB FP32, past
+// the 1 MiB fold budget, so its per-tensor DQ is declined and left as a runtime QNN op.
 constexpr int64_t kLargeConvOutCh = 512;
 constexpr int64_t kLargeConvInCh = 2048;
 
-// Tolerances for >256K-elem reductions over unit-range inputs: plain accumulation
-// noise already approaches 1e-3 on CPU, while a sign/magnitude mis-fold misses by
-// orders of magnitude, so these gates stay tight enough to catch real bugs.
-constexpr float kCpuLargeFoldTolerance = 1e-2f;
-
-TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt4DQConstWeight_AboveFoldCutoff) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
-  RunQnnModelTest(BuildPerChannelInt4DQConstWeightConvTestCase(/*scales*/ {0.1f, 0.2f},
-                                                               kLargeConvOutCh, kLargeConvInCh),
-                  provider_options,
-                  /*opset*/ 21,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
-}
-
-// Same graph with per-tensor quantization, where a runtime QNN Dequantize is a faithful
-// substitute for folding, so the size cutoff is free to decline and keep the DLC compact.
+// Per-tensor int8 weight -> DQ -> Conv, above the fold cutoff. The declined weight is no
+// longer an initializer, so Conv also has to insert its runtime HWCN transpose -- this is
+// the only test covering the resulting Dequantize -> Transpose -> Conv chain.
+//
+// The input is one-hot so each output element is a single dequantized weight, with no
+// reduction over in_ch: a 2048-term fp32 reduction diverges between the QNN CPU backend and
+// the ORT CPU reference by ~1e-3 relative (measured at 0.017-0.052 absolute on Windows CI
+// for the analogous MatMul case), which would force a tolerance far too loose to catch a
+// mis-fold. Column 1 of the weight samples pattern entries {-70, 1, 127}, so a sign or
+// scale regression still misses by orders of magnitude. Full-pattern coverage at tight
+// tolerance lives in the small folding tests above.
 static GetTestModelFn BuildPerTensorInt8DQConstWeightConvTestCase(float scale, int64_t out_ch,
-                                                                  int64_t in_ch = 3) {
+                                                                  int64_t in_ch) {
   return [scale, out_ch, in_ch](ModelTestBuilder& builder) {
     const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
     const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
@@ -1145,7 +1093,9 @@ static GetTestModelFn BuildPerTensorInt8DQConstWeightConvTestCase(float scale, i
       weight_values[i] = weight_pattern[i % weight_pattern.size()];
     }
 
-    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
+    std::vector<float> input_data(static_cast<size_t>(in_ch), 0.0f);
+    input_data[1] = 1.0f;
+    builder.MakeInput<float>("input", input_shape, input_data);
     builder.MakeInitializer<int8_t>("weight_q", weight_shape, weight_values);
     builder.MakeInitializer<float>("weight_scale", {}, {scale});
     builder.MakeInitializer<int8_t>("weight_zp", {}, {0});
@@ -1164,34 +1114,36 @@ static GetTestModelFn BuildPerTensorInt8DQConstWeightConvTestCase(float scale, i
   };
 }
 
-TEST_F(QnnCPUBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
+// Asserting on the composed QNN graph is what makes the decline observable: the ONNX DQ node
+// is marked supported either way, so EP node assignment is identical whether it folded to an
+// FP32 static or stayed a runtime op.
+static void RunLargePerTensorDQConvTest(const std::string& backend, float fp32_abs_err) {
+  namespace fs = std::filesystem;
+  const fs::path graph_dir = fs::temp_directory_path() / ("ConvLargePerTensorDQ_" + backend);
+  fs::remove_all(graph_dir);
+  ASSERT_TRUE(fs::create_directories(graph_dir));
+  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
 
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = backend;
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = graph_dir.string();
+
   RunQnnModelTest(BuildPerTensorInt8DQConstWeightConvTestCase(/*scale*/ 0.1f, kLargeConvOutCh,
                                                               kLargeConvInCh),
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
+                                       ElementwiseAbsoluteVerifier(fp32_abs_err)});
+  if (::testing::Test::IsSkipped()) {
+    return;
+  }
+  AssertOpInQnnGraph(graph_dir, "Dequantize", 1);
 }
 
-TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_AboveFoldCutoff) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
-  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
-                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
-                      /*scale1*/ {0.05f, 0.4f}, /*zp1*/ {-2, 3},
-                      kLargeConvOutCh, kLargeConvInCh),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
+TEST_F(QnnCPUBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {
+  RunLargePerTensorDQConvTest("cpu", /*fp32_abs_err*/ 1e-4f);
 }
 
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).
@@ -1410,25 +1362,15 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelInt4DQConstWeight_SignRegression) {
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
 }
 
-// Only the skip path is mirrored on HTP: it is the new behavior, and HTP validation of a
-// runtime Dequantize is the one thing CPU tests cannot cover. Per-channel large weights must
-// fold by policy (backend-agnostic, pinned on CPU above); mirroring them on HTP would demand
-// fp16-theater tolerances for >256K-elem fp16 reductions, so precision stays on the small
-// HTP tests. Gross tolerance still catches fallback and sign-scale corruption (shift ~70+).
-constexpr float kHtpSkipPathTolerance = 2.0f;
-
+// Only the skip path is mirrored on HTP: HTP graph preparation of a runtime Dequantize on a
+// 4 MiB weight is the one thing the CPU test cannot cover. The fold decision itself is
+// backend-agnostic and pinned by the unit tests.
+//
+// Tolerance is set by fp16, not by accumulation: the one-hot input makes each output a single
+// dequantized weight of at most |12.7|, where fp16 spacing is 0.0078. 0.2 leaves ~25x margin
+// while still catching a wrong scale or an INT4-style +16 decode shift (1.6).
 TEST_F(QnnHTPBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "htp";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
-  RunQnnModelTest(BuildPerTensorInt8DQConstWeightConvTestCase(/*scale*/ 0.1f, kLargeConvOutCh,
-                                                              kLargeConvInCh),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(kHtpSkipPathTolerance), &checker});
+  RunLargePerTensorDQConvTest("htp", /*fp32_abs_err*/ 0.2f);
 }
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -4,6 +4,8 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <filesystem>
+#include <functional>
+#include <map>
 #include <optional>
 #include <string>
 
@@ -949,6 +951,17 @@ TEST_F(QnnCPUBackendTests, ConvTranspose1Df32_DynamicWeights_DefaultBias) {
                 ExpectedEPNodeAssignment::All);
 }
 
+// Repeats `values` until it holds `length` entries, so a per-channel test case can be scaled up
+// to an arbitrary output-channel count without restating the quantization parameters.
+template <typename T>
+static std::vector<T> TileToLength(const std::vector<T>& values, int64_t length) {
+  std::vector<T> tiled(static_cast<size_t>(length));
+  for (size_t i = 0; i < tiled.size(); ++i) {
+    tiled[i] = values[i % values.size()];
+  }
+  return tiled;
+}
+
 // Builds: weight_q0 (int8 init) -> DQ -> Q -> DQ -> Conv.
 // Used to regression-test chained folding; differing scale0/scale1 exercises real requant
 // on the intermediate STATIC tensor rather than a byte round-trip.
@@ -956,20 +969,24 @@ static GetTestModelFn BuildPerChannelQDQChainConstWeightConvTestCase(
     const std::vector<float>& scale0,
     const std::vector<int8_t>& zp0,
     const std::vector<float>& scale1,
-    const std::vector<int8_t>& zp1) {
-  return [scale0, zp0, scale1, zp1](ModelTestBuilder& builder) {
-    constexpr int64_t out_ch = 2;
-    constexpr int64_t in_ch = 3;
+    const std::vector<int8_t>& zp1,
+    int64_t out_ch = 2,
+    int64_t in_ch = 3) {
+  return [scale0, zp0, scale1, zp1, out_ch, in_ch](ModelTestBuilder& builder) {
     const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
     const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
 
     builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
 
-    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, std::vector<int8_t>{1, 2, 3, 4, 5, 6});
-    builder.MakeInitializer<float>("scale0", {out_ch}, scale0);
-    builder.MakeInitializer<int8_t>("zp0", {out_ch}, zp0);
-    builder.MakeInitializer<float>("scale1", {out_ch}, scale1);
-    builder.MakeInitializer<int8_t>("zp1", {out_ch}, zp1);
+    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
+    for (size_t i = 0; i < weight_values.size(); ++i) {
+      weight_values[i] = static_cast<int8_t>((i % 6) + 1);
+    }
+    builder.MakeInitializer<int8_t>("weight_q0", weight_shape, weight_values);
+    builder.MakeInitializer<float>("scale0", {out_ch}, TileToLength(scale0, out_ch));
+    builder.MakeInitializer<int8_t>("zp0", {out_ch}, TileToLength(zp0, out_ch));
+    builder.MakeInitializer<float>("scale1", {out_ch}, TileToLength(scale1, out_ch));
+    builder.MakeInitializer<int8_t>("zp1", {out_ch}, TileToLength(zp1, out_ch));
 
     std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
     axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
@@ -1022,13 +1039,17 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_NonIdentity_Reg
 // Builds: weight_q (int4 init) -> per-channel DQ -> Conv. QNN cannot represent a standalone
 // per-channel DQ, so it is folded to an fp32 static by decoding the initializer's bytes as int8.
 // Weights span the negative INT4 range, which a sign-handling regression would decode as q + 16.
-static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::vector<float>& scales) {
-  return [scales](ModelTestBuilder& builder) {
-    constexpr int64_t out_ch = 2;
-    constexpr int64_t in_ch = 3;
+static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::vector<float>& scales,
+                                                                   int64_t out_ch = 2,
+                                                                   int64_t in_ch = 3) {
+  return [scales, out_ch, in_ch](ModelTestBuilder& builder) {
     const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
     const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
-    const std::vector<int8_t> weight_values{-8, -7, -1, 1, 5, 7};
+    const std::vector<int8_t> weight_pattern{-8, -7, -1, 1, 5, 7};
+    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
+    for (size_t i = 0; i < weight_values.size(); ++i) {
+      weight_values[i] = weight_pattern[i % weight_pattern.size()];
+    }
 
     builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
 
@@ -1037,7 +1058,7 @@ static GetTestModelFn BuildPerChannelInt4DQConstWeightConvTestCase(const std::ve
       weight_data[i >> 1].SetElem(i & 1, weight_values[i]);
     }
     builder.MakeInitializer<Int4x2>("weight_q", weight_shape, weight_data);
-    builder.MakeInitializer<float>("weight_scale", {out_ch}, scales);
+    builder.MakeInitializer<float>("weight_scale", {out_ch}, TileToLength(scales, out_ch));
 
     std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
     axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
@@ -1064,6 +1085,161 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt4DQConstWeight_SignRegression) {
                   provider_options,
                   /*opset*/ 21,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-4f)});
+}
+
+// Pins the folding decision per node: every DQ/Q/Conv in these graphs must stay
+// QNN-assigned. A wrongly-declined fold fails here (fallback to CPU) instead of
+// hiding behind output comparison. Large per-channel weights must fold (QNN has no
+// standalone per-channel Dequantize); large per-tensor weights must decline the
+// FP32 fold yet keep their runtime Dequantize on QNN.
+static std::function<void(const Ort::Session&)> PinQnnNodesOnQnn(int expect_dq, int expect_q) {
+  return [expect_dq, expect_q](const Ort::Session& session) {
+    std::map<std::string, int> counts;
+    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
+      for (const auto& node : subgraph.GetNodes()) {
+        EXPECT_EQ(subgraph.GetEpName(), kQnnExecutionProvider) << node.GetOperatorType();
+        counts[node.GetOperatorType()]++;
+      }
+    }
+    EXPECT_EQ(counts["DequantizeLinear"], expect_dq);
+    EXPECT_EQ(counts["QuantizeLinear"], expect_q);
+    EXPECT_EQ(counts["Conv"], 1);
+  };
+}
+
+// Large-weight shapes stay realistic: 512x2048 1x1 is a ResNet-bottleneck-class
+// projection (1,048,576 elems = 4 MiB FP32, past the 1 MiB fold budget), unlike a
+// channel-inflated toy that no real model contains.
+constexpr int64_t kLargeConvOutCh = 512;
+constexpr int64_t kLargeConvInCh = 2048;
+
+// Tolerances for >256K-elem reductions over unit-range inputs: plain accumulation
+// noise already approaches 1e-3 on CPU, while a sign/magnitude mis-fold misses by
+// orders of magnitude, so these gates stay tight enough to catch real bugs.
+constexpr float kCpuLargeFoldTolerance = 1e-2f;
+
+TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt4DQConstWeight_AboveFoldCutoff) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
+  RunQnnModelTest(BuildPerChannelInt4DQConstWeightConvTestCase(/*scales*/ {0.1f, 0.2f},
+                                                               kLargeConvOutCh, kLargeConvInCh),
+                  provider_options,
+                  /*opset*/ 21,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
+}
+
+// Builds: weight_q (int8 init) -> per-channel DQ -> Conv, with no Q hop after the DQ, so the
+// only thing under test is whether the DQ itself survives and dequantizes correctly.
+static GetTestModelFn BuildPerChannelInt8DQConstWeightConvTestCase(const std::vector<float>& scales,
+                                                                   int64_t out_ch,
+                                                                   int64_t in_ch = 3) {
+  return [scales, out_ch, in_ch](ModelTestBuilder& builder) {
+    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
+    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
+    const std::vector<int8_t> weight_pattern{-128, -70, -1, 1, 50, 127};
+    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
+    for (size_t i = 0; i < weight_values.size(); ++i) {
+      weight_values[i] = weight_pattern[i % weight_pattern.size()];
+    }
+
+    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
+    builder.MakeInitializer<int8_t>("weight_q", weight_shape, weight_values);
+    builder.MakeInitializer<float>("weight_scale", {out_ch}, TileToLength(scales, out_ch));
+
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
+    axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
+    builder.AddNode("WeightDQ", "DequantizeLinear", {"weight_q", "weight_scale"}, {"weight_dq"},
+                    kOnnxDomain, axis_attrs);
+
+    builder.MakeOutput("output");
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+    builder.AddNode("Conv", "Conv", {"input", "weight_dq"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+}
+
+// Same graph with per-tensor quantization, where a runtime QNN Dequantize is a faithful
+// substitute for folding, so the size cutoff is free to decline and keep the DLC compact.
+static GetTestModelFn BuildPerTensorInt8DQConstWeightConvTestCase(float scale, int64_t out_ch,
+                                                                  int64_t in_ch = 3) {
+  return [scale, out_ch, in_ch](ModelTestBuilder& builder) {
+    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
+    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
+    const std::vector<int8_t> weight_pattern{-128, -70, -1, 1, 50, 127};
+    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
+    for (size_t i = 0; i < weight_values.size(); ++i) {
+      weight_values[i] = weight_pattern[i % weight_pattern.size()];
+    }
+
+    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
+    builder.MakeInitializer<int8_t>("weight_q", weight_shape, weight_values);
+    builder.MakeInitializer<float>("weight_scale", {}, {scale});
+    builder.MakeInitializer<int8_t>("weight_zp", {}, {0});
+
+    builder.AddNode("WeightDQ", "DequantizeLinear", {"weight_q", "weight_scale", "weight_zp"},
+                    {"weight_dq"});
+
+    builder.MakeOutput("output");
+    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
+    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
+    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
+    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
+    builder.AddNode("Conv", "Conv", {"input", "weight_dq"}, {"output"}, kOnnxDomain, conv_attrs);
+  };
+}
+
+TEST_F(QnnCPUBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
+  RunQnnModelTest(BuildPerTensorInt8DQConstWeightConvTestCase(/*scale*/ 0.1f, kLargeConvOutCh,
+                                                              kLargeConvInCh),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
+}
+
+TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt8DQConstWeight_AboveFoldCutoff) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
+  RunQnnModelTest(BuildPerChannelInt8DQConstWeightConvTestCase(/*scales*/ {0.1f, 0.2f},
+                                                               kLargeConvOutCh, kLargeConvInCh),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
+}
+
+TEST_F(QnnCPUBackendTests, Convf32_PerChannelQDQChainConstWeight_AboveFoldCutoff) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
+  RunQnnModelTest(BuildPerChannelQDQChainConstWeightConvTestCase(
+                      /*scale0*/ {0.1f, 0.2f}, /*zp0*/ {0, 0},
+                      /*scale1*/ {0.05f, 0.4f}, /*zp1*/ {-2, 3},
+                      kLargeConvOutCh, kLargeConvInCh),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
 }
 
 // Tests for reuse_sparse_indices parameter (always false, verifies the parameter is accepted by QNN without errors).
@@ -1280,6 +1456,27 @@ TEST_F(QnnHTPBackendTests, Convf32_PerChannelInt4DQConstWeight_SignRegression) {
                   provider_options,
                   /*opset*/ 21,
                   EPVerificationParams{ExpectedEPNodeAssignment::All, ElementwiseAbsoluteVerifier(1e-3f)});
+}
+
+// Only the skip path is mirrored on HTP: it is the new behavior, and HTP validation of a
+// runtime Dequantize is the one thing CPU tests cannot cover. Per-channel large weights must
+// fold by policy (backend-agnostic, pinned on CPU above); mirroring them on HTP would demand
+// fp16-theater tolerances for >256K-elem fp16 reductions, so precision stays on the small
+// HTP tests. Gross tolerance still catches fallback and sign-scale corruption (shift ~70+).
+constexpr float kHtpSkipPathTolerance = 2.0f;
+
+TEST_F(QnnHTPBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
+  RunQnnModelTest(BuildPerTensorInt8DQConstWeightConvTestCase(/*scale*/ 0.1f, kLargeConvOutCh,
+                                                              kLargeConvInCh),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(kHtpSkipPathTolerance), &checker});
 }
 
 // Check that QNN compiles DQ -> Conv -> Q as a single unit.

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1132,40 +1132,6 @@ TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt4DQConstWeight_AboveFoldCutoff) 
                                        ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
 }
 
-// Builds: weight_q (int8 init) -> per-channel DQ -> Conv, with no Q hop after the DQ, so the
-// only thing under test is whether the DQ itself survives and dequantizes correctly.
-static GetTestModelFn BuildPerChannelInt8DQConstWeightConvTestCase(const std::vector<float>& scales,
-                                                                   int64_t out_ch,
-                                                                   int64_t in_ch = 3) {
-  return [scales, out_ch, in_ch](ModelTestBuilder& builder) {
-    const std::vector<int64_t> input_shape = {1, in_ch, 1, 1};
-    const std::vector<int64_t> weight_shape = {out_ch, in_ch, 1, 1};
-    const std::vector<int8_t> weight_pattern{-128, -70, -1, 1, 50, 127};
-    std::vector<int8_t> weight_values(static_cast<size_t>(out_ch * in_ch));
-    for (size_t i = 0; i < weight_values.size(); ++i) {
-      weight_values[i] = weight_pattern[i % weight_pattern.size()];
-    }
-
-    builder.MakeInput<float>("input", input_shape, -1.0f, 1.0f);
-    builder.MakeInitializer<int8_t>("weight_q", weight_shape, weight_values);
-    builder.MakeInitializer<float>("weight_scale", {out_ch}, TileToLength(scales, out_ch));
-
-    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
-    axis_attrs.push_back(builder.MakeScalarAttribute("axis", static_cast<int64_t>(0)));
-    builder.AddNode("WeightDQ", "DequantizeLinear", {"weight_q", "weight_scale"}, {"weight_dq"},
-                    kOnnxDomain, axis_attrs);
-
-    builder.MakeOutput("output");
-    std::vector<ONNX_NAMESPACE::AttributeProto> conv_attrs;
-    conv_attrs.push_back(builder.MakeStringAttribute("auto_pad", "NOTSET"));
-    conv_attrs.push_back(builder.MakeIntsAttribute("pads", std::vector<int64_t>{0, 0, 0, 0}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("strides", std::vector<int64_t>{1, 1}));
-    conv_attrs.push_back(builder.MakeIntsAttribute("dilations", std::vector<int64_t>{1, 1}));
-    conv_attrs.push_back(builder.MakeScalarAttribute("group", static_cast<int64_t>(1)));
-    builder.AddNode("Conv", "Conv", {"input", "weight_dq"}, {"output"}, kOnnxDomain, conv_attrs);
-  };
-}
-
 // Same graph with per-tensor quantization, where a runtime QNN Dequantize is a faithful
 // substitute for folding, so the size cutoff is free to decline and keep the DLC compact.
 static GetTestModelFn BuildPerTensorInt8DQConstWeightConvTestCase(float scale, int64_t out_ch,
@@ -1206,20 +1172,6 @@ TEST_F(QnnCPUBackendTests, Convf32_PerTensorInt8DQConstWeight_AboveFoldCutoff) {
   std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
   RunQnnModelTest(BuildPerTensorInt8DQConstWeightConvTestCase(/*scale*/ 0.1f, kLargeConvOutCh,
                                                               kLargeConvInCh),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(kCpuLargeFoldTolerance), &checker});
-}
-
-TEST_F(QnnCPUBackendTests, Convf32_PerChannelInt8DQConstWeight_AboveFoldCutoff) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
-  RunQnnModelTest(BuildPerChannelInt8DQConstWeightConvTestCase(/*scales*/ {0.1f, 0.2f},
-                                                               kLargeConvOutCh, kLargeConvInCh),
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/conv_test.cc
+++ b/onnxruntime/test/providers/qnn/conv_test.cc
@@ -1119,10 +1119,25 @@ static GetTestModelFn BuildPerTensorInt8DQConstWeightConvTestCase(float scale, i
 // FP32 static or stayed a runtime op.
 static void RunLargePerTensorDQConvTest(const std::string& backend, float fp32_abs_err) {
   namespace fs = std::filesystem;
-  const fs::path graph_dir = fs::temp_directory_path() / ("ConvLargePerTensorDQ_" + backend);
-  fs::remove_all(graph_dir);
-  ASSERT_TRUE(fs::create_directories(graph_dir));
-  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
+  // Use error_code overloads throughout: throwing filesystem calls would terminate
+  // the whole test binary (no *.results.xml, CI exit code 1) instead of failing one test.
+  std::error_code ec;
+  fs::path graph_dir;
+  try {
+    graph_dir = fs::temp_directory_path(ec) / ("ConvLargePerTensorDQ_" + backend);
+  } catch (const std::exception& ex) {
+    FAIL() << "Failed to resolve temp directory: " << ex.what();
+    return;
+  }
+  ASSERT_FALSE(ec) << "Failed to resolve temp directory: " << ec.message();
+  fs::remove_all(graph_dir, ec);
+  ASSERT_FALSE(ec) << "Failed to clean QNN graph dir " << graph_dir << ": " << ec.message();
+  ASSERT_TRUE(fs::create_directories(graph_dir, ec) && !ec)
+      << "Failed to create QNN graph dir " << graph_dir << ": " << ec.message();
+  auto cleanup = gsl::finally([&graph_dir]() {
+    std::error_code cleanup_ec;
+    fs::remove_all(graph_dir, cleanup_ec);
+  });
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = backend;

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -957,6 +957,8 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
   // 224 leaked v_proj weight inputs appeared.
   AssertOpInQnnGraph(graph_dir, "Dequantize", 0);
   AssertOpInQnnGraph(graph_dir, "Quantize", 0);
+  // The cost side of the per-channel exemption: the 4 MiB FP32 weight is in the DLC.
+  AssertFp32StaticBytesAbove(graph_dir, /*min_bytes*/ 1024 * 1024);
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -960,15 +960,17 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
 
 // w_q -> DQ -> MatMul, per-tensor. Must skip the fold and keep runtime Dequantize on QNN.
 // 1024x1024 = 4 MiB FP32, past the 1 MiB budget.
-// Runtime-DQ GEMV (K=1024) diverges from the ORT CPU reference across BLAS builds:
-// Windows x86_64/arm64 CI shows diff 0.017 (elem 0) / 0.020 (elem 1) vs 1e-2 while
-// Linux passes. 5e-2 covers that cross-platform GEMM noise and still catches real
-// fold bugs (sign/magnitude corruption misses by orders of magnitude).
-constexpr float kMatMulSkipTolerance = 5e-2f;
+// One-hot input isolates DQ correctness from GEMM accumulation noise: random
+// dense input over K=1024 diverged across BLAS builds (Windows CI: 0.017 on elem 0/1
+// at 1e-2, then 0.052 on elem 2 at 5e-2, while Linux passed). With input[0]=1 the
+// output is a direct gather of one dequantized row, so 1e-4 is tight yet stable and
+// still catches sign/magnitude fold bugs by orders of magnitude.
 TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQConstWeight_AboveFoldCutoff) {
   auto build = [](ModelTestBuilder& builder) {
     constexpr int64_t K = 1024, N = 1024;
-    builder.MakeInput<float>("input", {1, K}, -0.1f, 0.1f);
+    std::vector<float> input_data(static_cast<size_t>(K), 0.0f);
+    input_data[0] = 1.0f;
+    builder.MakeInput<float>("input", {1, K}, input_data);
     const std::vector<int8_t> pattern{-128, -70, -1, 1, 50, 127};
     std::vector<int8_t> w(static_cast<size_t>(K * N));
     for (size_t i = 0; i < w.size(); ++i) {
@@ -990,7 +992,7 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQConstWeight_AboveFoldCutoff) {
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(kMatMulSkipTolerance), &checker});
+                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -5,6 +5,8 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <filesystem>
+#include <functional>
+#include <map>
 #include <string>
 #include <unordered_map>
 
@@ -889,6 +891,112 @@ TEST_F(QnnGPUBackendTests, MatMulOp_rank1) {
 }
 
 #endif  // defined(_M_ARM64) GPU tests
+
+// Same node-pinning helper as the conv cutoff tests: a wrongly-declined fold fails
+// here (fallback to CPU) instead of hiding behind output comparison.
+static std::function<void(const Ort::Session&)> PinQnnNodesOnQnn(int expect_dq, int expect_q) {
+  return [expect_dq, expect_q](const Ort::Session& session) {
+    std::map<std::string, int> counts;
+    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
+      for (const auto& node : subgraph.GetNodes()) {
+        EXPECT_EQ(subgraph.GetEpName(), kQnnExecutionProvider) << node.GetOperatorType();
+        counts[node.GetOperatorType()]++;
+      }
+    }
+    EXPECT_EQ(counts["DequantizeLinear"], expect_dq);
+    EXPECT_EQ(counts["QuantizeLinear"], expect_q);
+    EXPECT_EQ(counts["MatMul"], 1);
+  };
+}
+
+// Builds: w_q0 (int8 init) -> DQ0 -> Q1 -> DQ1 -> MatMul. Qwen-class weight chain:
+// per-channel INT8 quantized along the output dim (axis=1 on [K,N]), with a real
+// requant hop (s0 != s1). G1 uses Qwen3-0.6B q/k/v/o-proj exact dims (1024x1024 =
+// 1M elems, past the 1 MiB fold budget); G2 sits just past the cutoff boundary.
+static GetTestModelFn BuildPerChannelQDQChainMatMulTestCase(int64_t K, int64_t N) {
+  return [K, N](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, K}, -0.1f, 0.1f);
+    std::vector<int8_t> w(static_cast<size_t>(K * N));
+    for (size_t i = 0; i < w.size(); ++i) {
+      w[i] = static_cast<int8_t>(static_cast<int>((i * 37) % 256) - 128);
+    }
+    builder.MakeInitializer<int8_t>("w_q0", {K, N}, w);
+    std::vector<float> s0(static_cast<size_t>(N), 0.02f), s1(static_cast<size_t>(N), 0.05f);
+    std::vector<int8_t> z0(static_cast<size_t>(N), 0), z1(static_cast<size_t>(N), -2);
+    builder.MakeInitializer<float>("s0", {N}, s0);
+    builder.MakeInitializer<int8_t>("z0", {N}, z0);
+    builder.MakeInitializer<float>("s1", {N}, s1);
+    builder.MakeInitializer<int8_t>("z1", {N}, z1);
+    std::vector<ONNX_NAMESPACE::AttributeProto> axis_attrs;
+    axis_attrs.push_back(builder.MakeScalarAttribute("axis", int64_t{1}));
+    builder.AddNode("DQ0", "DequantizeLinear", {"w_q0", "s0", "z0"}, {"w_dq0"}, kOnnxDomain,
+                    axis_attrs);
+    builder.AddNode("Q1", "QuantizeLinear", {"w_dq0", "s1", "z1"}, {"w_q1"}, kOnnxDomain, axis_attrs);
+    builder.AddNode("DQ1", "DequantizeLinear", {"w_q1", "s1", "z1"}, {"w_dq"}, kOnnxDomain,
+                    axis_attrs);
+    builder.MakeOutput("output");
+    builder.AddNode("MatMul", "MatMul", {"input", "w_dq"}, {"output"}, kOnnxDomain);
+  };
+}
+
+// No HTP mirrors: the fold policy is backend-agnostic (pinned here on CPU) and HTP
+// numerics of folded weights are covered by the small HTP tests; mirroring
+// >256K-elem fp16 reductions would demand theater-grade tolerances.
+TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
+  RunQnnModelTest(BuildPerChannelQDQChainMatMulTestCase(/*K*/ 1024, /*N*/ 1024),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
+}
+
+TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_CutoffBoundary_MustFold) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  // 1024x257 = 263,168 elems: just past the 1 MiB (262,144-elem) fold budget.
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
+  RunQnnModelTest(BuildPerChannelQDQChainMatMulTestCase(/*K*/ 1024, /*N*/ 257),
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
+}
+
+// Builds: w_q (uint8 init) -> DQ -> MatMul. psx0-class single per-tensor weight at
+// the issue's own example dims (1536x6144 = 9.4M elems = 36 MiB FP32): must decline
+// the fold, keep the runtime Dequantize on QNN, and match numerics.
+TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQ_PsxDims_MustSkipFold) {
+  auto build = [](ModelTestBuilder& builder) {
+    builder.MakeInput<float>("input", {1, 1536}, -0.1f, 0.1f);
+    std::vector<uint8_t> w(static_cast<size_t>(1536 * 6144));
+    for (size_t i = 0; i < w.size(); ++i) {
+      w[i] = static_cast<uint8_t>((i * 53) % 256);
+    }
+    builder.MakeInitializer<uint8_t>("w_q", {1536, 6144}, w);
+    builder.MakeInitializer<float>("s", {}, {0.05f});
+    builder.MakeInitializer<uint8_t>("zp", {}, {uint8_t{0}});
+    builder.AddNode("DQ", "DequantizeLinear", {"w_q", "s", "zp"}, {"w_dq"});
+    builder.MakeOutput("output");
+    builder.AddNode("MatMul", "MatMul", {"input", "w_dq"}, {"output"}, kOnnxDomain);
+  };
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+  provider_options["offload_graph_io_quantization"] = "0";
+
+  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
+  RunQnnModelTest(build,
+                  provider_options,
+                  /*opset*/ 13,
+                  EPVerificationParams{ExpectedEPNodeAssignment::All,
+                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
+}
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -5,8 +5,6 @@
 #if !defined(ORT_MINIMAL_BUILD)
 
 #include <filesystem>
-#include <functional>
-#include <map>
 #include <string>
 #include <unordered_map>
 
@@ -892,31 +890,22 @@ TEST_F(QnnGPUBackendTests, MatMulOp_rank1) {
 
 #endif  // defined(_M_ARM64) GPU tests
 
-// Same node-pinning helper as the conv cutoff tests: a wrongly-declined fold fails
-// here (fallback to CPU) instead of hiding behind output comparison.
-static std::function<void(const Ort::Session&)> PinQnnNodesOnQnn(int expect_dq, int expect_q) {
-  return [expect_dq, expect_q](const Ort::Session& session) {
-    std::map<std::string, int> counts;
-    for (const auto& subgraph : session.GetEpGraphAssignmentInfo()) {
-      for (const auto& node : subgraph.GetNodes()) {
-        EXPECT_EQ(subgraph.GetEpName(), kQnnExecutionProvider) << node.GetOperatorType();
-        counts[node.GetOperatorType()]++;
-      }
-    }
-    EXPECT_EQ(counts["DequantizeLinear"], expect_dq);
-    EXPECT_EQ(counts["QuantizeLinear"], expect_q);
-    EXPECT_EQ(counts["MatMul"], 1);
-  };
-}
-
 // Builds: w_q0 (int8 init) -> DQ0 -> Q1 -> DQ1 -> MatMul. Qwen-class weight chain:
 // per-channel INT8 quantized along the output dim (axis=1 on [K,N]), with a real
-// requant hop (s0 != s1). G1 uses Qwen3-0.6B q/k/v/o-proj exact dims (1024x1024 =
-// 1M elems, past the 1 MiB fold budget). The cutoff boundary itself is pinned
-// exactly by the ShouldSkipConstantDQFold unit tests.
+// requant hop (s0 != s1), at Qwen3-0.6B q/k/v/o-proj dims (1024x1024 = 1M elems, past
+// the 1 MiB fold budget). Regression test for #339: per-channel weights must keep
+// folding through every hop at any size, or the chain's tail loses QNN support and the
+// weight resurfaces as an APP_WRITE graph input.
+//
+// One-hot input, as in the conv cutoff test: output[n] becomes w_dq[0][n] with no
+// reduction, so the requantized weights are compared directly at 1e-4 instead of through
+// a 1024-term fp32 reduction whose summation order differs between QNN CPU and the ORT
+// reference. Row 0 spans all 256 int8 values (17 is coprime with 256).
 static GetTestModelFn BuildPerChannelQDQChainMatMulTestCase(int64_t K, int64_t N) {
   return [K, N](ModelTestBuilder& builder) {
-    builder.MakeInput<float>("input", {1, K}, -0.1f, 0.1f);
+    std::vector<float> input_data(static_cast<size_t>(K), 0.0f);
+    input_data[0] = 1.0f;
+    builder.MakeInput<float>("input", {1, K}, input_data);
     std::vector<int8_t> w(static_cast<size_t>(K * N));
     for (int64_t k = 0; k < K; ++k) {
       for (int64_t n = 0; n < N; ++n) {
@@ -942,57 +931,32 @@ static GetTestModelFn BuildPerChannelQDQChainMatMulTestCase(int64_t K, int64_t N
   };
 }
 
-// No HTP mirrors: the fold policy is backend-agnostic (pinned here on CPU) and HTP
-// numerics of folded weights are covered by the small HTP tests; mirroring
-// >256K-elem fp16 reductions would demand theater-grade tolerances.
+// No HTP mirror: the fold policy is backend-agnostic and the numerics of folded per-channel
+// weights are already covered by the small HTP folding tests.
 TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
+  namespace fs = std::filesystem;
+  const fs::path graph_dir = fs::temp_directory_path() / "MatMulQwenQProjMustFold";
+  fs::remove_all(graph_dir);
+  ASSERT_TRUE(fs::create_directories(graph_dir));
+  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
+
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";
   provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = graph_dir.string();
 
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
   RunQnnModelTest(BuildPerChannelQDQChainMatMulTestCase(/*K*/ 1024, /*N*/ 1024),
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(1e-2f), &checker});
-}
+                                       ElementwiseAbsoluteVerifier(1e-4f)});
 
-// w_q -> DQ -> MatMul, per-tensor. Must skip the fold and keep runtime Dequantize on QNN.
-// 1024x1024 = 4 MiB FP32, past the 1 MiB budget.
-// One-hot input isolates DQ correctness from GEMM accumulation noise: random
-// dense input over K=1024 diverged across BLAS builds (Windows CI: 0.017 on elem 0/1
-// at 1e-2, then 0.052 on elem 2 at 5e-2, while Linux passed). With input[0]=1 the
-// output is a direct gather of one dequantized row, so 1e-4 is tight yet stable and
-// still catches sign/magnitude fold bugs by orders of magnitude.
-TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQConstWeight_AboveFoldCutoff) {
-  auto build = [](ModelTestBuilder& builder) {
-    constexpr int64_t K = 1024, N = 1024;
-    std::vector<float> input_data(static_cast<size_t>(K), 0.0f);
-    input_data[0] = 1.0f;
-    builder.MakeInput<float>("input", {1, K}, input_data);
-    const std::vector<int8_t> pattern{-128, -70, -1, 1, 50, 127};
-    std::vector<int8_t> w(static_cast<size_t>(K * N));
-    for (size_t i = 0; i < w.size(); ++i) {
-      w[i] = pattern[i % pattern.size()];
-    }
-    builder.MakeInitializer<int8_t>("w_q", {K, N}, w);
-    builder.MakeInitializer<float>("s", {}, {0.05f});
-    builder.MakeInitializer<int8_t>("zp", {}, {0});
-    builder.AddNode("DQ", "DequantizeLinear", {"w_q", "s", "zp"}, {"w_dq"});
-    builder.MakeOutput("output");
-    builder.AddNode("MatMul", "MatMul", {"input", "w_dq"}, {"output"}, kOnnxDomain);
-  };
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 1, /*expect_q*/ 0);
-  RunQnnModelTest(build,
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
+  // Every hop folded: the QNN graph is MatMul alone, with the weight as a STATIC tensor. A
+  // surviving Quantize/Dequantize would mean the chain stopped folding, which is how #339's
+  // 224 leaked v_proj weight inputs appeared.
+  AssertOpInQnnGraph(graph_dir, "Dequantize", 0);
+  AssertOpInQnnGraph(graph_dir, "Quantize", 0);
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -935,10 +935,25 @@ static GetTestModelFn BuildPerChannelQDQChainMatMulTestCase(int64_t K, int64_t N
 // weights are already covered by the small HTP folding tests.
 TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
   namespace fs = std::filesystem;
-  const fs::path graph_dir = fs::temp_directory_path() / "MatMulQwenQProjMustFold";
-  fs::remove_all(graph_dir);
-  ASSERT_TRUE(fs::create_directories(graph_dir));
-  auto cleanup = gsl::finally([&graph_dir]() { fs::remove_all(graph_dir); });
+  // Use error_code overloads: throwing filesystem calls would terminate the whole
+  // test binary (no *.results.xml, CI exit code 1) instead of failing one test.
+  std::error_code ec;
+  fs::path graph_dir;
+  try {
+    graph_dir = fs::temp_directory_path(ec) / "MatMulQwenQProjMustFold";
+  } catch (const std::exception& ex) {
+    FAIL() << "Failed to resolve temp directory: " << ex.what();
+    return;
+  }
+  ASSERT_FALSE(ec) << "Failed to resolve temp directory: " << ec.message();
+  fs::remove_all(graph_dir, ec);
+  ASSERT_FALSE(ec) << "Failed to clean QNN graph dir " << graph_dir << ": " << ec.message();
+  ASSERT_TRUE(fs::create_directories(graph_dir, ec) && !ec)
+      << "Failed to create QNN graph dir " << graph_dir << ": " << ec.message();
+  auto cleanup = gsl::finally([&graph_dir]() {
+    std::error_code cleanup_ec;
+    fs::remove_all(graph_dir, cleanup_ec);
+  });
 
   ProviderOptions provider_options;
   provider_options["backend_type"] = "cpu";
@@ -951,6 +966,9 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
                                        ElementwiseAbsoluteVerifier(1e-4f)});
+  if (::testing::Test::IsSkipped()) {
+    return;
+  }
 
   // Every hop folded: the QNN graph is MatMul alone, with the weight as a STATIC tensor. A
   // surviving Quantize/Dequantize would mean the chain stopped folding, which is how #339's

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -959,7 +959,12 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
 }
 
 // w_q -> DQ -> MatMul, per-tensor. Must skip the fold and keep runtime Dequantize on QNN.
-// 1024x1024 = 4 MiB FP32, past the 1 MiB budget. 1e-2 matches the large conv tolerance.
+// 1024x1024 = 4 MiB FP32, past the 1 MiB budget.
+// Runtime-DQ GEMV (K=1024) diverges from the ORT CPU reference across BLAS builds:
+// Windows x86_64/arm64 CI shows diff 0.017 (elem 0) / 0.020 (elem 1) vs 1e-2 while
+// Linux passes. 5e-2 covers that cross-platform GEMM noise and still catches real
+// fold bugs (sign/magnitude corruption misses by orders of magnitude).
+constexpr float kMatMulSkipTolerance = 5e-2f;
 TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQConstWeight_AboveFoldCutoff) {
   auto build = [](ModelTestBuilder& builder) {
     constexpr int64_t K = 1024, N = 1024;
@@ -985,7 +990,7 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQConstWeight_AboveFoldCutoff) {
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(1e-2f), &checker});
+                                       ElementwiseAbsoluteVerifier(kMatMulSkipTolerance), &checker});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -918,8 +918,10 @@ static GetTestModelFn BuildPerChannelQDQChainMatMulTestCase(int64_t K, int64_t N
   return [K, N](ModelTestBuilder& builder) {
     builder.MakeInput<float>("input", {1, K}, -0.1f, 0.1f);
     std::vector<int8_t> w(static_cast<size_t>(K * N));
-    for (size_t i = 0; i < w.size(); ++i) {
-      w[i] = static_cast<int8_t>(static_cast<int>((i * 37) % 256) - 128);
+    for (int64_t k = 0; k < K; ++k) {
+      for (int64_t n = 0; n < N; ++n) {
+        w[static_cast<size_t>(k * N + n)] = static_cast<int8_t>(((k * 31 + n * 17) % 256) - 128);
+      }
     }
     builder.MakeInitializer<int8_t>("w_q0", {K, N}, w);
     std::vector<float> s0(static_cast<size_t>(N), 0.02f), s1(static_cast<size_t>(N), 0.05f);
@@ -953,22 +955,23 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
+                                       ElementwiseAbsoluteVerifier(1e-2f), &checker});
 }
 
-// Builds: w_q (uint8 init) -> DQ -> MatMul. psx0-class single per-tensor weight at
-// the issue's own example dims (1536x6144 = 9.4M elems = 36 MiB FP32): must decline
-// the fold, keep the runtime Dequantize on QNN, and match numerics.
-TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQ_PsxDims_MustSkipFold) {
+// w_q -> DQ -> MatMul, per-tensor. Must skip the fold and keep runtime Dequantize on QNN.
+// 1024x1024 = 4 MiB FP32, past the 1 MiB budget. 1e-2 matches the large conv tolerance.
+TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQConstWeight_AboveFoldCutoff) {
   auto build = [](ModelTestBuilder& builder) {
-    builder.MakeInput<float>("input", {1, 1536}, -0.1f, 0.1f);
-    std::vector<uint8_t> w(static_cast<size_t>(1536 * 6144));
+    constexpr int64_t K = 1024, N = 1024;
+    builder.MakeInput<float>("input", {1, K}, -0.1f, 0.1f);
+    const std::vector<int8_t> pattern{-128, -70, -1, 1, 50, 127};
+    std::vector<int8_t> w(static_cast<size_t>(K * N));
     for (size_t i = 0; i < w.size(); ++i) {
-      w[i] = static_cast<uint8_t>((i * 53) % 256);
+      w[i] = pattern[i % pattern.size()];
     }
-    builder.MakeInitializer<uint8_t>("w_q", {1536, 6144}, w);
+    builder.MakeInitializer<int8_t>("w_q", {K, N}, w);
     builder.MakeInitializer<float>("s", {}, {0.05f});
-    builder.MakeInitializer<uint8_t>("zp", {}, {uint8_t{0}});
+    builder.MakeInitializer<int8_t>("zp", {}, {0});
     builder.AddNode("DQ", "DequantizeLinear", {"w_q", "s", "zp"}, {"w_dq"});
     builder.MakeOutput("output");
     builder.AddNode("MatMul", "MatMul", {"input", "w_dq"}, {"output"}, kOnnxDomain);
@@ -982,7 +985,7 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerTensorDQ_PsxDims_MustSkipFold) {
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
+                                       ElementwiseAbsoluteVerifier(1e-2f), &checker});
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/matmul_test.cc
+++ b/onnxruntime/test/providers/qnn/matmul_test.cc
@@ -912,7 +912,8 @@ static std::function<void(const Ort::Session&)> PinQnnNodesOnQnn(int expect_dq, 
 // Builds: w_q0 (int8 init) -> DQ0 -> Q1 -> DQ1 -> MatMul. Qwen-class weight chain:
 // per-channel INT8 quantized along the output dim (axis=1 on [K,N]), with a real
 // requant hop (s0 != s1). G1 uses Qwen3-0.6B q/k/v/o-proj exact dims (1024x1024 =
-// 1M elems, past the 1 MiB fold budget); G2 sits just past the cutoff boundary.
+// 1M elems, past the 1 MiB fold budget). The cutoff boundary itself is pinned
+// exactly by the ShouldSkipConstantDQFold unit tests.
 static GetTestModelFn BuildPerChannelQDQChainMatMulTestCase(int64_t K, int64_t N) {
   return [K, N](ModelTestBuilder& builder) {
     builder.MakeInput<float>("input", {1, K}, -0.1f, 0.1f);
@@ -949,20 +950,6 @@ TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_QwenQProj_MustFold) {
 
   std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
   RunQnnModelTest(BuildPerChannelQDQChainMatMulTestCase(/*K*/ 1024, /*N*/ 1024),
-                  provider_options,
-                  /*opset*/ 13,
-                  EPVerificationParams{ExpectedEPNodeAssignment::All,
-                                       ElementwiseAbsoluteVerifier(1e-4f), &checker});
-}
-
-TEST_F(QnnCPUBackendTests, MatMulf32_PerChannelQDQChain_CutoffBoundary_MustFold) {
-  ProviderOptions provider_options;
-  provider_options["backend_type"] = "cpu";
-  provider_options["offload_graph_io_quantization"] = "0";
-
-  // 1024x257 = 263,168 elems: just past the 1 MiB (262,144-elem) fold budget.
-  std::function<void(const Ort::Session&)> checker = PinQnnNodesOnQnn(/*expect_dq*/ 2, /*expect_q*/ 1);
-  RunQnnModelTest(BuildPerChannelQDQChainMatMulTestCase(/*K*/ 1024, /*N*/ 257),
                   provider_options,
                   /*opset*/ 13,
                   EPVerificationParams{ExpectedEPNodeAssignment::All,

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
@@ -12,33 +12,86 @@
 namespace onnxruntime {
 namespace test {
 
+namespace {
+
+// Never throws: a missing/unreadable dump dir must surface as a gtest failure,
+// not as an uncaught filesystem_error that terminates the whole test binary
+// (which leaves no *.results.xml and fails the CI job with exit code 1).
+bool FindQnnJsonGraph(const std::filesystem::path& dump_dir,
+                      /*out*/ std::filesystem::path& json_path) {
+  json_path.clear();
+  try {
+    std::error_code ec;
+    std::filesystem::directory_iterator it(dump_dir, ec);
+    if (ec) {
+      return false;
+    }
+    const std::filesystem::directory_iterator end;
+    for (; it != end; it.increment(ec)) {
+      if (ec) {
+        return false;
+      }
+      try {
+        std::error_code entry_ec;
+        if (it->is_regular_file(entry_ec) && !entry_ec && it->path().extension() == ".json" &&
+            it->path().filename().string().find("_tensor_log") == std::string::npos) {
+          json_path = it->path();
+          return true;
+        }
+      } catch (const std::exception&) {
+        // Skip unreadable entries; a later entry may still be the graph dump.
+        continue;
+      }
+    }
+  } catch (const std::exception&) {
+    return false;
+  }
+  return !json_path.empty();
+}
+
+// Never throws: a truncated/invalid JSON dump must surface as a gtest failure,
+// not as an uncaught nlohmann::json exception that terminates the test binary.
+bool ParseQnnJsonGraph(const std::filesystem::path& json_path,
+                       /*out*/ nlohmann::json& root) {
+  try {
+    std::ifstream json_file(json_path);
+    if (!json_file.is_open()) {
+      return false;
+    }
+    json_file >> root;
+    return true;
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
+}  // namespace
+
 void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
                         const std::string& op,
                         size_t count) {
   std::filesystem::path json_path;
-  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
-    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-      json_path = entry.path();
-      break;
-    }
-  }
-  ASSERT_FALSE(json_path.empty()) << "No QNN JSON graph file found in " << dump_dir;
-
-  std::ifstream json_file(json_path);
-  ASSERT_TRUE(json_file.is_open()) << "Failed to open QNN JSON graph: " << json_path;
+  ASSERT_TRUE(FindQnnJsonGraph(dump_dir, json_path))
+      << "No QNN JSON graph file found in " << dump_dir;
 
   nlohmann::json root;
-  json_file >> root;
+  ASSERT_TRUE(ParseQnnJsonGraph(json_path, root))
+      << "Failed to parse QNN JSON graph: " << json_path;
 
-  ASSERT_TRUE(root.contains("graph") && root["graph"].contains("nodes"))
-      << "JSON missing 'graph.nodes' field in: " << json_path;
+  ASSERT_TRUE(root.is_object() && root.contains("graph") && root["graph"].is_object() &&
+              root["graph"].contains("nodes") && root["graph"]["nodes"].is_object())
+      << "JSON missing 'graph.nodes' object in: " << json_path;
 
   size_t actual_count = 0;
-  for (const auto& [node_name, node_json] : root["graph"]["nodes"].items()) {
-    if (node_json.value("type", "") == op) {
-      ++actual_count;
+  try {
+    for (const auto& [node_name, node_json] : root["graph"]["nodes"].items()) {
+      if (node_json.is_object() && node_json.contains("type") && node_json["type"].is_string() &&
+          node_json["type"].get<std::string>() == op) {
+        ++actual_count;
+      }
     }
+  } catch (const std::exception& ex) {
+    FAIL() << "Failed to iterate QNN graph nodes in " << json_path << ": " << ex.what();
   }
 
   EXPECT_EQ(actual_count, count)
@@ -49,26 +102,24 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
 void AssertNodeNotInQnnGraph(const std::filesystem::path& dump_dir,
                              const std::string& node_name) {
   std::filesystem::path json_path;
-  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
-    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-      json_path = entry.path();
-      break;
-    }
-  }
-  ASSERT_FALSE(json_path.empty()) << "No QNN JSON graph file found in " << dump_dir;
-
-  std::ifstream json_file(json_path);
-  ASSERT_TRUE(json_file.is_open()) << "Failed to open QNN JSON graph: " << json_path;
+  ASSERT_TRUE(FindQnnJsonGraph(dump_dir, json_path))
+      << "No QNN JSON graph file found in " << dump_dir;
 
   nlohmann::json root;
-  json_file >> root;
+  ASSERT_TRUE(ParseQnnJsonGraph(json_path, root))
+      << "Failed to parse QNN JSON graph: " << json_path;
 
-  ASSERT_TRUE(root.contains("graph") && root["graph"].contains("nodes"))
-      << "JSON missing 'graph.nodes' field in: " << json_path;
+  ASSERT_TRUE(root.is_object() && root.contains("graph") && root["graph"].is_object() &&
+              root["graph"].contains("nodes") && root["graph"]["nodes"].is_object())
+      << "JSON missing 'graph.nodes' object in: " << json_path;
 
-  EXPECT_FALSE(root["graph"]["nodes"].contains(node_name))
-      << "Unexpected QNN node found: '" << node_name << "' in " << json_path;
+  bool found = false;
+  try {
+    found = root["graph"]["nodes"].contains(node_name);
+  } catch (const std::exception& ex) {
+    FAIL() << "Failed to query QNN graph nodes in " << json_path << ": " << ex.what();
+  }
+  EXPECT_FALSE(found) << "Unexpected QNN node found: '" << node_name << "' in " << json_path;
 }
 
 namespace {
@@ -77,43 +128,79 @@ constexpr size_t kUnreadableDump = static_cast<size_t>(-1);
 
 // Summed from "dims" rather than "params_count": dims is emitted for every tensor, while
 // params_count is a stringified count present only when the dump omits static data.
+// Never throws: any malformed field returns kUnreadableDump so the caller emits a gtest
+// failure instead of terminating the test binary (which would leave no *.results.xml).
 size_t SumFp32StaticBytes(const std::filesystem::path& dump_dir) {
-  std::filesystem::path json_path;
-  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
-    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
-        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
-      json_path = entry.path();
-      break;
+  try {
+    std::filesystem::path json_path;
+    if (!FindQnnJsonGraph(dump_dir, json_path)) {
+      return kUnreadableDump;
     }
-  }
-  if (json_path.empty()) {
+
+    nlohmann::json root;
+    if (!ParseQnnJsonGraph(json_path, root)) {
+      return kUnreadableDump;
+    }
+    if (!root.is_object() || !root.contains("graph") || !root["graph"].is_object() ||
+        !root["graph"].contains("tensors") || !root["graph"]["tensors"].is_object()) {
+      return kUnreadableDump;
+    }
+
+    const int kStaticType = static_cast<int>(QNN_TENSOR_TYPE_STATIC);
+    const int kFp32Type = static_cast<int>(QNN_DATATYPE_FLOAT_32);
+
+    size_t total_bytes = 0;
+    for (const auto& [name, tensor_json] : root["graph"]["tensors"].items()) {
+      if (!tensor_json.is_object()) {
+        continue;
+      }
+      // Guard with is_number(): value("type", -1) would throw if the dump ever
+      // emits a string enum on some SDK/runner.
+      if (!tensor_json.contains("type") || !tensor_json["type"].is_number() ||
+          tensor_json["type"].get<int>() != kStaticType) {
+        continue;
+      }
+      if (!tensor_json.contains("data_type") || !tensor_json["data_type"].is_number() ||
+          tensor_json["data_type"].get<int>() != kFp32Type) {
+        continue;
+      }
+      if (!tensor_json.contains("dims") || !tensor_json["dims"].is_array()) {
+        return kUnreadableDump;
+      }
+      size_t num_elems = 1;
+      for (const auto& dim : tensor_json["dims"]) {
+        if (!dim.is_number_unsigned() && !dim.is_number_integer()) {
+          return kUnreadableDump;
+        }
+        const long long dim_val = dim.get<long long>();
+        if (dim_val < 0) {
+          return kUnreadableDump;
+        }
+        const auto dim_u = static_cast<size_t>(dim_val);
+        if (dim_u != 0 && num_elems > kUnreadableDump / dim_u) {
+          // Would wrap (or collide with the kUnreadableDump sentinel): fail
+          // gracefully instead of under-counting.
+          return kUnreadableDump;
+        }
+        num_elems *= dim_u;
+      }
+      if (num_elems != 0 && sizeof(float) > kUnreadableDump / num_elems) {
+        return kUnreadableDump;
+      }
+      const size_t add = num_elems * sizeof(float);
+      if (total_bytes > kUnreadableDump - add) {
+        return kUnreadableDump;
+      }
+      total_bytes += add;
+      if (total_bytes == kUnreadableDump) {
+        // Keep the sentinel reserved for "unreadable".
+        return kUnreadableDump;
+      }
+    }
+    return total_bytes;
+  } catch (const std::exception&) {
     return kUnreadableDump;
   }
-
-  std::ifstream json_file(json_path);
-  if (!json_file.is_open()) {
-    return kUnreadableDump;
-  }
-
-  nlohmann::json root;
-  json_file >> root;
-  if (!root.contains("graph") || !root["graph"].contains("tensors")) {
-    return kUnreadableDump;
-  }
-
-  size_t total_bytes = 0;
-  for (const auto& [name, tensor_json] : root["graph"]["tensors"].items()) {
-    if (tensor_json.value("type", -1) != static_cast<int>(QNN_TENSOR_TYPE_STATIC) ||
-        tensor_json.value("data_type", -1) != static_cast<int>(QNN_DATATYPE_FLOAT_32)) {
-      continue;
-    }
-    size_t num_elems = 1;
-    for (const auto& dim : tensor_json.value("dims", nlohmann::json::array())) {
-      num_elems *= dim.get<size_t>();
-    }
-    total_bytes += num_elems * sizeof(float);
-  }
-  return total_bytes;
 }
 
 }  // namespace

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.cc
@@ -5,6 +5,7 @@
 
 #include <fstream>
 
+#include "QnnTypes.h"
 #include "nlohmann/json.hpp"
 #include "gtest/gtest.h"
 
@@ -68,6 +69,69 @@ void AssertNodeNotInQnnGraph(const std::filesystem::path& dump_dir,
 
   EXPECT_FALSE(root["graph"]["nodes"].contains(node_name))
       << "Unexpected QNN node found: '" << node_name << "' in " << json_path;
+}
+
+namespace {
+
+constexpr size_t kUnreadableDump = static_cast<size_t>(-1);
+
+// Summed from "dims" rather than "params_count": dims is emitted for every tensor, while
+// params_count is a stringified count present only when the dump omits static data.
+size_t SumFp32StaticBytes(const std::filesystem::path& dump_dir) {
+  std::filesystem::path json_path;
+  for (const auto& entry : std::filesystem::directory_iterator{dump_dir}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".json" &&
+        entry.path().filename().string().find("_tensor_log") == std::string::npos) {
+      json_path = entry.path();
+      break;
+    }
+  }
+  if (json_path.empty()) {
+    return kUnreadableDump;
+  }
+
+  std::ifstream json_file(json_path);
+  if (!json_file.is_open()) {
+    return kUnreadableDump;
+  }
+
+  nlohmann::json root;
+  json_file >> root;
+  if (!root.contains("graph") || !root["graph"].contains("tensors")) {
+    return kUnreadableDump;
+  }
+
+  size_t total_bytes = 0;
+  for (const auto& [name, tensor_json] : root["graph"]["tensors"].items()) {
+    if (tensor_json.value("type", -1) != static_cast<int>(QNN_TENSOR_TYPE_STATIC) ||
+        tensor_json.value("data_type", -1) != static_cast<int>(QNN_DATATYPE_FLOAT_32)) {
+      continue;
+    }
+    size_t num_elems = 1;
+    for (const auto& dim : tensor_json.value("dims", nlohmann::json::array())) {
+      num_elems *= dim.get<size_t>();
+    }
+    total_bytes += num_elems * sizeof(float);
+  }
+  return total_bytes;
+}
+
+}  // namespace
+
+void AssertFp32StaticBytesBelow(const std::filesystem::path& dump_dir, size_t max_bytes) {
+  const size_t total_bytes = SumFp32StaticBytes(dump_dir);
+  ASSERT_NE(total_bytes, kUnreadableDump) << "No readable QNN JSON graph in " << dump_dir;
+  EXPECT_LE(total_bytes, max_bytes)
+      << "FP32 STATIC bytes in the QNN graph exceed the budget: a large weight folded to FP32 "
+         "instead of staying compact.";
+}
+
+void AssertFp32StaticBytesAbove(const std::filesystem::path& dump_dir, size_t min_bytes) {
+  const size_t total_bytes = SumFp32StaticBytes(dump_dir);
+  ASSERT_NE(total_bytes, kUnreadableDump) << "No readable QNN JSON graph in " << dump_dir;
+  EXPECT_GT(total_bytes, min_bytes)
+      << "FP32 STATIC bytes in the QNN graph are below the floor: the expected fold did not "
+         "materialize.";
 }
 
 }  // namespace test

--- a/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
+++ b/onnxruntime/test/providers/qnn/qnn_node_group/qnn_graph_checker.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
 #include <string>
 
@@ -20,6 +21,12 @@ void AssertOpInQnnGraph(const std::filesystem::path& dump_dir,
 // the compiled QNN graph JSON (root["graph"]["nodes"]).
 void AssertNodeNotInQnnGraph(const std::filesystem::path& dump_dir,
                              const std::string& node_name);
+
+// Total bytes of FP32 STATIC tensors in the compiled QNN graph JSON, i.e. the DLC cost of
+// constant folding. Use Below to assert a large weight stayed compact, Above to assert an
+// expected fold actually materialized.
+void AssertFp32StaticBytesBelow(const std::filesystem::path& dump_dir, size_t max_bytes);
+void AssertFp32StaticBytesAbove(const std::filesystem::path& dump_dir, size_t min_bytes);
 
 }  // namespace test
 }  // namespace onnxruntime

--- a/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
@@ -120,6 +120,20 @@ TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_UnknownTensor_Fails) {
   EXPECT_FALSE(qnn::GetEffectivelyConstantTensorBytes(*fx.wrapper, "missing", bytes).IsOK());
 }
 
+// Decision table for ShouldSkipConstantDQFold: fold unless large AND faithfully
+// substitutable (per-channel / sub-byte inputs never reach the predicate -- they
+// always fold via CanSubstituteRuntimeDequantize, pinned by the e2e tests).
+TEST(QnnUnit_QdqConstantFoldingTest, SkipPredicate_SmallFolds) {
+  EXPECT_FALSE(qnn::ShouldSkipConstantDQFold(6));           // bias-sized tensors fold
+  EXPECT_FALSE(qnn::ShouldSkipConstantDQFold(256 * 1024));  // exactly at budget: fold
+}
+
+TEST(QnnUnit_QdqConstantFoldingTest, SkipPredicate_LargeSkips) {
+  EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(256 * 1024 + 1));  // just past budget
+  EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(1024 * 1024));     // Qwen q-proj
+  EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(1536 * 6144));     // psx0 FC dims
+}
+
 }  // namespace test
 }  // namespace onnxruntime
 

--- a/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
+++ b/onnxruntime/test/providers/qnn/unit/qdq_constant_folding_test.cc
@@ -79,6 +79,24 @@ std::vector<int8_t> AsInt8(const std::vector<uint8_t>& bytes) {
   return out;
 }
 
+// Minimal DQ input def: the fold decision reads only the input's name, the registered
+// initializer's element type, and the scale's shape (a >1-element scale is per-channel).
+OrtNodeUnitIODef QuantizedInputDef(const std::string& name, const OrtValueInfo* scale) {
+  OrtNodeUnitIODef io_def;
+  io_def.name = name;
+  io_def.type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8;
+  io_def.quant_param = OrtNodeUnitIODef::QuantParam{scale};
+  return io_def;
+}
+
+bool CanSubstitute(qnn::QnnModelWrapper& wrapper, const std::string& name, const OrtValueInfo* scale) {
+  bool can_substitute = false;
+  EXPECT_TRUE(qnn::CanSubstituteRuntimeDequantize(wrapper, QuantizedInputDef(name, scale),
+                                                  can_substitute)
+                  .IsOK());
+  return can_substitute;
+}
+
 }  // namespace
 
 TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_Int4_AreSignExtended) {
@@ -120,9 +138,38 @@ TEST(QnnUnit_QdqConstantFoldingTest, ConstantBytes_UnknownTensor_Fails) {
   EXPECT_FALSE(qnn::GetEffectivelyConstantTensorBytes(*fx.wrapper, "missing", bytes).IsOK());
 }
 
-// Decision table for ShouldSkipConstantDQFold: fold unless large AND faithfully
-// substitutable (per-channel / sub-byte inputs never reach the predicate -- they
-// always fold via CanSubstituteRuntimeDequantize, pinned by the e2e tests).
+// A per-channel or INT4/INT2 constant must fold at any size: QNN has no standalone
+// per-channel Dequantize, and declining would also stop constant-ness from reaching the
+// next Q/DQ hop, which is what keeps chained weights STATIC instead of graph inputs.
+TEST(QnnUnit_QdqConstantFoldingTest, RuntimeDequantizeSubstitute_Refused_MustFold) {
+  MockInitWrapperFixture fx;
+  g_mock_init_reg.AddTensorUint8("w_u8", {4}, {0, 1, 2, 3});
+  g_mock_init_reg.AddTensorInt4As8bit("w_i4", {4}, {-8, -1, 1, 7});
+  const OrtValueInfo* per_tensor_scale = g_mock_init_reg.AddScalarFloat("scale", 0.1f);
+  const OrtValueInfo* per_channel_scale = g_mock_init_reg.AddTensorFloat("scales", {4},
+                                                                         {0.1f, 0.2f, 0.3f, 0.4f});
+
+  EXPECT_FALSE(CanSubstitute(*fx.wrapper, "w_u8", per_channel_scale));
+  EXPECT_FALSE(CanSubstitute(*fx.wrapper, "w_i4", per_tensor_scale));
+}
+
+// Everything else dequantizes identically at runtime, so the size budget may decline it.
+// UINT4 is included deliberately: only the signed sub-byte types carry the high-bit mask
+// hazard that the fold path has to undo.
+TEST(QnnUnit_QdqConstantFoldingTest, RuntimeDequantizeSubstitute_Allowed) {
+  MockInitWrapperFixture fx;
+  g_mock_init_reg.AddTensorUint8("w_u8", {4}, {0, 1, 2, 3});
+  g_mock_init_reg.AddTensorUint4As8bit("w_u4", {4}, {0, 1, 14, 15});
+  const OrtValueInfo* per_tensor_scale = g_mock_init_reg.AddScalarFloat("scale", 0.1f);
+
+  EXPECT_TRUE(CanSubstitute(*fx.wrapper, "w_u8", per_tensor_scale));
+  EXPECT_TRUE(CanSubstitute(*fx.wrapper, "w_u4", per_tensor_scale));
+  // An unregistered name is a previously-folded intermediate: plain bytes, no mask hazard.
+  EXPECT_TRUE(CanSubstitute(*fx.wrapper, "folded_intermediate", per_tensor_scale));
+}
+
+// Size boundary for the inputs the checks above admit. Exact by construction: the budget
+// is compared in elements so an adversarial shape cannot wrap past it.
 TEST(QnnUnit_QdqConstantFoldingTest, SkipPredicate_SmallFolds) {
   EXPECT_FALSE(qnn::ShouldSkipConstantDQFold(6));           // bias-sized tensors fold
   EXPECT_FALSE(qnn::ShouldSkipConstantDQFold(256 * 1024));  // exactly at budget: fold
@@ -130,8 +177,7 @@ TEST(QnnUnit_QdqConstantFoldingTest, SkipPredicate_SmallFolds) {
 
 TEST(QnnUnit_QdqConstantFoldingTest, SkipPredicate_LargeSkips) {
   EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(256 * 1024 + 1));  // just past budget
-  EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(1024 * 1024));     // Qwen q-proj
-  EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(1536 * 6144));     // psx0 FC dims
+  EXPECT_TRUE(qnn::ShouldSkipConstantDQFold(1536 * 6144));     // psx0 FC dims: 36 MB as FP32
 }
 
 }  // namespace test


### PR DESCRIPTION
### Description

Bound constant `DequantizeLinear` folding by output size so it stops embedding oversized FP32 static blobs in the DLC.

`FoldConstantDequantizeLinear` pre-computed every constant DQ at compile time regardless of tensor size, storing the result as an FP32 STATIC tensor 4x the size of the original quantized weight. This adds a 1 MiB / 256K-element budget: a constant DQ above it is declined and left as a runtime QNN `Dequantize`, so the weight stays in the DLC in its compact quantized form.

**Scope — which weights this actually helps.** The budget only applies to inputs where a runtime QNN `Dequantize` is a faithful substitute for the folded constant, i.e. **per-tensor int8/uint8/int16/uint16 (and uint4) constants**. Two categories are exempt and still fold at any size:

- **Per-channel quantized constants.** QNN has no standalone per-channel `Dequantize`. `ExplicitOpCheck` admits a standalone per-channel Q/DQ only on the premise that folding will remove it, and declining also stops constant-ness from propagating to later Q/DQ hops in a chain — those hops then lose QNN support and the consumer's weight resurfaces as an `APP_WRITE` graph input. That is exactly the regression #339 fixed (224 leaked `v_proj` weight inputs on Qwen), so per-channel must keep folding unconditionally.
- **INT4/INT2 constants.** These reach QNN as `SFIXED_POINT_8` with their high bits masked off, to work around a QNN INT4 accuracy bug (see `UnpackInt4ToInt8`). Only the fold path undoes that mask, so a runtime `Dequantize` would decode negative values as `q + 16`.

Because transformer weights are commonly per-channel quantized, **this PR does not reduce DLC size for per-channel models** — including the Qwen models from #339, whose weights continue to fold exactly as before. The win is on per-tensor weights (e.g. the psx0 1536x6144 FC, 36 MB as FP32).

The 1 MiB budget is a fixed compile-time constant (`kQdqFoldMaxFp32Bytes`), not a provider option. It is a deliberate trade: declining a fold moves the dequantized tensor from DLC storage into HTP activation memory at graph-prepare time, so raising it is not free in either direction.

---

### Motivation and Context

The QNN EP constant-folds `DequantizeLinear` nodes fed by constant inputs: it pre-computes the FP32 output at graph-compile time and stores it as a STATIC tensor in the DLC. For small constants (bias vectors, scales, lookup tables) this is beneficial — it avoids repeated dequantization overhead at runtime.

For large per-tensor weight matrices, though, the same optimization produces FP32 static blobs 4x the size of the original INT8 weights. Across many large layers this inflates the DLC to the point where the quantized model is larger than its FP32 equivalent, defeating the purpose of quantization.

---

### Notes for reviewers

- `CanSubstituteRuntimeDequantize()` is the single place the two exemptions are decided, and it gates the size check — a "must fold" input never consults the budget. Its decision table is pinned by unit tests in `qdq_constant_folding_test.cc` (no device needed).
- The decline is only observable in the composed QNN graph, not in EP node assignment: the ONNX DQ node is marked supported either way. The e2e tests therefore assert on the dumped QNN graph JSON via `AssertOpInQnnGraph`.
