### PR TITLE
[CI] Migrate QDC runner to V2 API and upgrade SDK to 0.4.1

### DIFF
--- a/qcom/packages.yml
+++ b/qcom/packages.yml
@@ -215,6 +215,6 @@ qairt:
   content_root: qairt/{version}
   bindir: bin
 qualcomm_device_cloud_sdk:
-  version: 0.3.0
-  url: https://softwarecenter.qualcomm.com/api/download/software/tools/Qualcomm_Device_Cloud_SDK/Windows/{version}/qualcomm_device_cloud_sdk-{version}.zip
-  sha256: 80e690591a576b8bcbe0357e3a2d364a03768cc801acd15358b4b740e43a9a1b
+  version: 0.4.1
+  url: https://softwarecenter.qualcomm.com/api/download/software/tools/Qualcomm_Device_Cloud_SDK/All/{version}/qualcomm_device_cloud_sdk-{version}.zip
+  sha256: 716a862ce64f9146078cd0b7b7ab18d2672520e068345accbb094e848cc22cfb

--- a/qcom/requirements-qdc.txt
+++ b/qcom/requirements-qdc.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 -r requirements.txt
-qualcomm_device_cloud_sdk==0.3.0
+qualcomm_device_cloud_sdk==0.4.1

--- a/qcom/scripts/all/qdc_runner.py
+++ b/qcom/scripts/all/qdc_runner.py
@@ -269,7 +269,7 @@ class TestRuns:
 
 
 class QdcClient:
-    _QDC_PROD_API_URL = "https://apigwx-aws.qualcomm.com/saga/v1/public/qdc"
+    _QDC_PROD_API_URL = "https://api.qualcomm.com/devicecloud/v2"
 
     def __init__(self, api_url: str | None, on_behalf_of: str | None):
         api_token = os.environ["QDC_API_TOKEN"]


### PR DESCRIPTION
### Description

Migrate the QDC CI runner from the deprecated V1 Apigee proxy endpoint to the V2 endpoint, and upgrade the Qualcomm Device Cloud SDK from 0.3.0 to 0.4.1 which targets the V2 API.

---

### Motivation & Context

QDC (Qualcomm Device Cloud) is deprecating its V1 endpoints:

| V1 (deprecated) | V2 (replacement) |
|---|---|
| `https://apigwx-aws.qualcomm.com/saga/v1/public/qdc` | `https://api.qualcomm.com/devicecloud/v2` |
| `https://api.qualcomm.com/deviceloud/v1` | `https://api.qualcomm.com/devicecloud/v2` |

The SDK upgrade from 0.3.0 to 0.4.1 is required because 0.3.0 internally calls the V1 API paths, upgrading to 0.4.1 is the supported migration path.

The download URL template in `packages.yml` was also corrected from `/Windows/{version}/` to `/All/{version}/`, matching the distribution path used for 0.4.1 onward.