### PR TITLE
[QNN EP] Fold static empty Slice output to a STATIC tensor

### DIFF
--- a/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
+++ b/onnxruntime/core/providers/qnn/builder/opbuilder/slice_op_builder.cc
@@ -305,6 +305,51 @@ Ort::Status SliceOpBuilder::ProcessAttributesAndOutputs(QnnModelWrapper& qnn_mod
   PrepareForComputeMetadata compute_metadata(input_dimensions);
   RETURN_IF_ERROR(PrepareForComputeHelper(raw_starts, raw_ends, raw_axes, raw_steps, compute_metadata));
 
+  // HTP rejects StridedSlice with an empty output (QNN error 3110), but a static Slice
+  // whose computed output has a zero extent (e.g. [1,64,128] -> [1,0,128]) holds no
+  // elements: its value is fully determined by the shape. Fold it to a STATIC tensor so
+  // the empty edge stays resident instead of killing the compile. This runs identically
+  // in the validation and compile passes so capability and compile agree. Intermediate
+  // tensors only: a graph output still needs a producing op for IO registration.
+  bool has_empty_output_dim = false;
+  for (const int64_t dim : compute_metadata.output_dims_) {
+    if (dim == 0) {
+      has_empty_output_dim = true;
+      break;
+    }
+  }
+  const auto& slice_output = node_unit.Outputs()[0];
+  if (has_empty_output_dim && !qnn_model_wrapper.IsGraphOutput(slice_output.name)) {
+    // Guard re-entry across the two GetCapability passes sharing one wrapper.
+    if (!qnn_model_wrapper.IsQnnTensorWrapperExist(slice_output.name)) {
+      TensorInfo output_info = {};
+      RETURN_IF_ERROR(qnn_model_wrapper.GetTensorInfo(slice_output, output_info));
+      std::vector<uint32_t> empty_shape;
+      empty_shape.reserve(compute_metadata.output_dims_.size());
+      for (const int64_t dim : compute_metadata.output_dims_) {
+        empty_shape.push_back(static_cast<uint32_t>(dim));
+      }
+      QnnTensorWrapper static_wrapper(slice_output.name,
+                                      QNN_TENSOR_TYPE_STATIC,
+                                      output_info.qnn_data_type,
+                                      output_info.quant_param.Copy(),
+                                      std::move(empty_shape),
+                                      std::vector<uint8_t>{});
+      RETURN_IF_NOT(qnn_model_wrapper.AddTensorWrapper(std::move(static_wrapper)),
+                    "Failed to add folded empty Slice output tensor.");
+    }
+    qnn_model_wrapper.MarkTensorAsFoldedConstant(slice_output.name);
+    return Ort::Status();
+  }
+  if (has_empty_output_dim) {
+    // Graph-output empty Slice: the producing op cannot be elided (see above), and HTP
+    // cannot execute StridedSlice with a zero extent, so decline with a precise diagnostic
+    // instead of the backend's opaque 3110.
+    return MAKE_EP_FAIL(("Slice with empty output is not supported on HTP (output: " +
+                         slice_output.name + ").")
+                            .c_str());
+  }
+
   const size_t input_rank = input_dimensions.size();
   std::vector<uint32_t> ranges_dims{static_cast<uint32_t>(input_rank), 3};
   std::vector<uint32_t> ranges_data;

--- a/onnxruntime/test/providers/qnn/slice_test.cc
+++ b/onnxruntime/test/providers/qnn/slice_test.cc
@@ -3,8 +3,11 @@
 
 #if !defined(ORT_MINIMAL_BUILD)
 
+#include <filesystem>
+#include <limits>
 #include <string>
 
+#include "test/providers/qnn/qnn_node_group/qnn_graph_checker.h"
 #include "test/providers/qnn/qnn_test_utils.h"
 #include "test/unittest_util/qdq_test_utils.h"
 
@@ -12,6 +15,30 @@
 
 namespace onnxruntime {
 namespace test {
+
+// Empty Slice output ([1,64,128] -> [1,0,128]) holds no elements, so the EP folds it to a
+// STATIC tensor instead of submitting StridedSlice (rejected by HTP with error 3110).
+// See https://github.com/qcom-ai-hub/tetracode/issues/20854.
+static GetTestModelFn BuildEmptySliceModelFn() {
+  return [](ModelTestBuilder& builder) {    builder.MakeInput<float>("input0", {1, 64, 128}, 0.0f, 1.0f);
+    builder.Make1DInitializer<int64_t>("starts", {64});
+    builder.Make1DInitializer<int64_t>("ends", {std::numeric_limits<int64_t>::max()});
+    builder.Make1DInitializer<int64_t>("axes", {1});
+    builder.AddNode("Slice", "Slice", {"input0", "starts", "ends", "axes"}, {"slice_out"});
+    builder.MakeOutput("Y");
+    builder.AddNode("Relu", "Relu", {"slice_out"}, {"Y"});
+  };
+}
+
+TEST_F(QnnCPUBackendTests, SliceEmptyOutputFoldsToStatic) {
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "cpu";
+
+  RunQnnModelTest(BuildEmptySliceModelFn(),
+                  provider_options,
+                  13,  // opset
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+}
 
 // Test for "index-out-of-bounds" bug that occurred when a Slice operator
 // shared one of its initializer inputs with another op that was processed by QNN EP first.
@@ -246,6 +273,28 @@ TEST_F(QnnHTPBackendTests, SliceBoolOnHTP) {
                             TestInputDef<int64_t>({2}, true, {0, 1}),  // axes
                             TestInputDef<int64_t>({2}, true, {1, 1}),  // steps
                             ExpectedEPNodeAssignment::All);
+}
+
+// Empty Slice output stays resident: no StridedSlice op reaches the HTP graph.
+TEST_F(QnnHTPBackendTests, SliceEmptyOutputFoldsToStatic) {
+  const std::filesystem::path json_qnn_graph_dir = "SliceEmptyOutputFoldsToStatic";
+  std::filesystem::remove_all(json_qnn_graph_dir);
+  ASSERT_TRUE(std::filesystem::create_directory(json_qnn_graph_dir));
+
+  ProviderOptions provider_options;
+  provider_options["backend_type"] = "htp";
+  provider_options["offload_graph_io_quantization"] = "0";
+  provider_options["dump_json_qnn_graph"] = "1";
+  provider_options["json_qnn_graph_dir"] = json_qnn_graph_dir.string();
+
+  RunQnnModelTest(BuildEmptySliceModelFn(),
+                  provider_options,
+                  13,  // opset
+                  EPVerificationParams{ExpectedEPNodeAssignment::All});
+
+  AssertOpInQnnGraph(json_qnn_graph_dir, "StridedSlice", 0);
+
+  std::filesystem::remove_all(json_qnn_graph_dir);
 }
 #endif  // defined(__aarch64__) || defined(_M_ARM64) || defined(__linux__)
 


### PR DESCRIPTION
## Problem
Valid ONNX Slices with statically-empty output (e.g. input `[1,64,128]`, `starts=[64]`, `ends=[INT64_MAX]`, `axis=1` → `[1,0,128]`) are computed correctly by `slice_op_builder.cc`, then emitted unchanged as QNN `StridedSlice`, which HTP rejects with error 3110 and kills the compile. Native QAIRT succeeds.

## Fix
An empty Slice output holds no elements — its value is fully determined by the shape. In `SliceOpBuilder::ProcessAttributesAndOutputs`, right after `PrepareForComputeHelper`, a computed zero extent now folds the output to a `QNN_TENSOR_TYPE_STATIC` tensor (marked folded-constant, so downstream Q/DQ keep folding) instead of submitting `StridedSlice`. Runs identically in validation and compile passes so capability and compile agree; re-entry guarded for the two GetCapability passes sharing one wrapper. Correct for SingleNode and QDQ-group Slice alike (group outputs are the target outputs + encodings; the Q nodes are never separately built). Graph-output empty Slice cannot elide its producing op, so it declines with a precise diagnostic instead of the opaque 3110 → generic "Failed to add node".

## Tests
- `SliceEmptyOutputFoldsToStatic` on CPU (builder logic) and HTP (residency: asserts zero `StridedSlice` ops in the dumped QNN JSON, full EP assignment, accuracy parity), mirroring the issue shape.