### PR TITLE
[QNN EP] Fix Android build failure when JAVA_HOME points to JDK < 17

### DIFF
--- a/qcom/scripts/linux/build.sh
+++ b/qcom/scripts/linux/build.sh
@@ -243,9 +243,12 @@ case "${target_platform}" in
 
     # JDK 21's jlink is not compatible with Android 34's core modules,
     # so Java 17 is used instead.
+    # JAVA_HOME must be exported unconditionally (not just for --build-java) because
+    # sdkmanager checks JAVA_HOME before PATH; a pre-existing JAVA_HOME pointing to
+    # JDK < 17 causes the NDK install step to fail even when java17 is on PATH.
     PATH="$(get_java17_bindir):${PATH}"
+    export JAVA_HOME="$(get_java17_contentdir)"
     if [ -n "${build_java}" ]; then
-      export JAVA_HOME="$(get_java17_contentdir)"
       export GRADLE_USER_HOME="${build_root}/gradle-home"
     fi
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
- Move the export outside the guard so JAVA_HOME is always overridden to the pinned java17 toolchain for any Android build target.



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
- Sdkmanager checks JAVA_HOME before PATH. When the shell environment has JAVA_HOME pointing to JDK 8, sdkmanager rejects it with "This tool requires JDK 17 or later" and the NDK install step fails — even though get_java17_bindir() was already prepended to PATH.

